### PR TITLE
Allow to delete shots

### DIFF
--- a/src/components/Shots.vue
+++ b/src/components/Shots.vue
@@ -216,7 +216,7 @@ export default {
       this.$store.dispatch('deleteShot', {
         shot: this.shotToDelete,
         callback: (err) => {
-          if (!err) this.modals.isDeleteDisplayed = false
+          if (!err) this.$router.push('/shots')
         }
       })
     },

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -419,6 +419,8 @@ export default {
     confirmDeleteTask () {
       this.loading.deleteTask = true
       this.errors.deleteTask = false
+      const type = this.currentTask.entity_type_name
+
       this.$store.dispatch('deleteTask', {
         task: this.currentTask,
         callback: (err) => {
@@ -426,13 +428,19 @@ export default {
             this.loading.deleteTask = false
             this.errors.deleteTask = true
           } else {
-            this.$router.push('/assets')
+            if (type === 'Shot') {
+              this.$router.push('/shots')
+            } else {
+              this.$router.push('/assets')
+            }
           }
         }
       })
     }
   },
-  mounted () { this.handleModalsDisplay() },
+  mounted () {
+    this.handleModalsDisplay()
+  },
   watch: {
     $route () { this.handleModalsDisplay() }
   }

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -56,8 +56,13 @@
           >
           </validation-tag>
         </td>
-        <td class="actions">
-        </td>
+        <row-actions
+          :entry-id="entry.id"
+          :edit-route="'/shots/edit/' + entry.id"
+          :delete-route="'/shots/delete/' + entry.id"
+          :hide-edit="true"
+        >
+        </row-actions>
       </tr>
     </tbody>
   </table>

--- a/src/components/widgets/RowActions.vue
+++ b/src/components/widgets/RowActions.vue
@@ -1,7 +1,7 @@
 <template>
 <td class="actions">
   <p class="field">
-    <router-link class="button" :to="editRoute">
+    <router-link class="button" :to="editRoute" v-if="!hideEdit">
       <span class="icon is-small">
         <i class="fa fa-edit"></i>
       </span>
@@ -23,7 +23,8 @@ export default {
   props: [
     'editRoute',
     'deleteRoute',
-    'entryId'
+    'entryId',
+    'hideEdit'
   ],
   computed: {
     ...mapGetters([

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -178,7 +178,7 @@ export default {
       description: 'Description'
     },
     delete_text: 'Are you sure you want to remove {name} from your database?',
-    delete_error: 'An error occured while deleting this shot. There are probably data linked to it. Are you sure this shot type has no task linked to it?'
+    delete_error: 'An error occured while deleting this shot. There are probably data linked to it. Are you sure this shot has no task linked to it?'
   },
 
   server_down: {

--- a/src/routes.js
+++ b/src/routes.js
@@ -77,6 +77,7 @@ export const routes = [
       { path: '/shots', component: Shots },
       { path: '/shots/import', component: Shots },
       { path: '/shots/create-tasks', component: Shots },
+      { path: '/shots/delete/:shot_id', component: Shots },
 
       { path: '/asset-types', component: AssetTypes },
       { path: '/asset-types/delete/:asset_type_id', component: AssetTypes },

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -149,6 +149,7 @@ const mutations = {
       asset.tasks.forEach((task) => {
         task.project_name = asset.project_name
         task.entity_name = `${asset.asset_type_name} / ${asset.name}`
+        task.entity_type_name = asset.entity_type_name
         state.taskMap[task.id] = task
       })
     })
@@ -159,6 +160,7 @@ const mutations = {
       shot.tasks.forEach((task) => {
         task.project_name = shot.project_name
         task.entity_name = `${shot.sequence_name} / ${shot.name}`
+        task.entity_type_name = 'Shot'
         state.taskMap[task.id] = task
       })
     })
@@ -171,7 +173,8 @@ const mutations = {
       task_status_short_name: task.task_status.short_name,
       task_type_name: task.task_type.name,
       task_status_color: task.task_status.color,
-      task_type_color: task.task_type.color
+      task_type_color: task.task_type.color,
+      entity_type_name: task.entity_type.name
     })
     if (task.entity_type.name === 'Shot') {
       task.entity_name = `${task.entity_parent.name} / ${task.entity.name}`


### PR DESCRIPTION
There was no way to delete a shot from the web GUI. This PR aims to solve that problem. 

It fixes another bug. To delete a shot you need to delete all its tasks. It was annoying because when you delete the tasks, even if it was related to a shot, it returned to the asset list. Now, it returns to the shot or asset list depending on the entity type related to the task.