### PR TITLE
Allow to add previews (feedback) to retakes

### DIFF
--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -25,11 +25,28 @@
         <span class="comment-date">{{ formatDate(comment.created_at) }}</span>
       </p>
 
-      <p v-if="comment.task_status.name === 'Retake'">
-        <span :style="{'color': comment.task_status.color}">
-        {{ $t('comments.retake').toUpperCase }}
-        </span>
-      </p>
+      <div class="level" v-if="comment.task_status.short_name === 'retake'">
+        <div class="level-left">
+          <span class="level-item" :style="{'color': comment.task_status.color}">
+            {{ $t('comments.retake').toUpperCase() }}
+          </span>
+          <span
+            class="revision"
+            v-if="comment.preview"
+          >
+            revision {{ comment.preview.revision }}
+          </span>
+          <button-link
+            class="level-item"
+            :text="$t('tasks.add_preview')"
+            icon="fa-upload"
+            :path="'/tasks/' + comment.object_id + '/comments/' + comment.id + '/add-preview'"
+            v-else
+          >
+          </button-link>
+        </div>
+        </button-link>
+      </div>
 
       <div class="level" v-if="comment.task_status.name === 'Waiting For Approval'">
         <div class="level-left">

--- a/src/components/widgets/PreviewRow.vue
+++ b/src/components/widgets/PreviewRow.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="preview-row has-text-center">
   <button-link
-    :text="'Preview ' + preview.revision"
+    :text="label"
     icon="fa-eye"
     :path="'/tasks/' + taskId + '/previews/' + preview.id"
   >
@@ -21,6 +21,15 @@ export default {
     'preview',
     'taskId'
   ],
+  computed: {
+    label () {
+      let label = `Preview ${this.preview.revision}`
+      if (this.preview.feedback) {
+        label = `${label} (${this.$tc('tasks.feedback')})`
+      }
+      return label
+    }
+  },
   methods: {
   }
 }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -116,6 +116,7 @@ export default {
     add_preview_error: 'An error occured while adding preview.',
     select_preview_file: 'Please select a picture from your hard drive to be used as a preview for the current task:',
     delete_error: 'An error occured while deleting task.',
+    feedback: 'feedback',
     fields: {
       task_type: 'Task Type'
     }

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -109,6 +109,7 @@ export default {
     create_tasks_asset: 'Ajouter des tâches pour les assets affichés',
     create_tasks_asset_explaination: 'Vous allez créer une nouvelle tâche pour chaque asset de la liste affichée. Est-ce que vous voulez continuer ?',
     create_tasks_asset_failed: 'Une erreur serveur est survenue pendant la création des tâches.',
+    feedback: 'retours',
     fields: {
       task_type: 'Type de tâche'
     }

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -187,7 +187,14 @@ const mutations = {
   [LOAD_TASK_COMMENTS_END] (state, {taskId, comments}) {
     state.taskComments[taskId] = comments
     state.taskPreviews[taskId] = comments.reduce((previews, comment) => {
-      if (comment.preview) previews.push(comment.preview)
+      if (comment.preview) {
+        if (comment.task_status.short_name === 'retake') {
+          comment.preview.feedback = true
+        } else {
+          comment.preview.feedback = false
+        }
+        previews.push(comment.preview)
+      }
       return previews
     }, [])
   },


### PR DESCRIPTION
Users want to be able to upload feedback about previews. This commit allows to add previews to retake too. That previews are considered as "feedback previews".