### PR TITLE
Fix inverted for field options

### DIFF
--- a/src/components/modals/EditTaskTypeModal.vue
+++ b/src/components/modals/EditTaskTypeModal.vue
@@ -125,8 +125,8 @@ export default {
         {label: '10', value: '10'}
       ],
       dedicatedToOptions: [
-        {label: this.$tc('shots.title'), value: 'false'},
-        {label: this.$tc('assets.title'), value: 'true'}
+        {label: this.$tc('assets.title'), value: 'false'},
+        {label: this.$tc('shots.title'), value: 'true'}
       ]
     }
   },


### PR DESCRIPTION
When selecting for which kind of entities a task type is dedicated to, the option was inverted. Selecting shots led to selectiong assets and vice versa. This PR put things in the right order.