### PR TITLE
New features: canceled elements and scroll position remembering

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -28,17 +28,21 @@
       </tr>
     </thead>
     <tbody>
-      <tr v-for="entry in entries">
+      <tr
+        key="entry.id"
+        :class="{canceled: entry.canceled}"
+        v-for="entry in entries"
+      >
         <production-name-cell
           class="project"
           :only-avatar="true"
           :entry="{name: entry.project_name}"
         >
         </production-name-cell>
-        <td class="type">
+        <td :class="{name: !entry.canceled}">
           {{ entry.asset_type_name }}
         </td>
-        <td class="name">
+        <td :class="{name: !entry.canceled}">
           {{ entry.name }}
         </td>
         <td class="description">
@@ -149,5 +153,9 @@ td.type {
 .validation {
   width: 150px;
   margin-right: 1em;
+}
+
+.canceled {
+  text-decoration: line-through;
 }
 </style>

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -29,17 +29,21 @@
       </tr>
     </thead>
     <tbody>
-      <tr v-for="entry in entries">
+      <tr
+        key="entry.id"
+        :class="{canceled: entry.canceled}"
+        v-for="entry in entries"
+      >
         <production-name-cell
           class="project"
           :only-avatar="true"
           :entry="{name: entry.project_name || ''}"
         >
         </production-name-cell>
-        <td class="sequence">
+        <td :class="{name: !entry.canceled}">
           {{ entry.sequence_name }}
         </td>
-        <td class="name">
+        <td :class="{name: !entry.canceled}">
           {{ entry.name }}
         </td>
         <td class="framein">
@@ -170,5 +174,9 @@ td.sequence {
 .validation {
   width: 150px;
   margin-right: 1em;
+}
+
+.canceled {
+  text-decoration: line-through;
 }
 </style>

--- a/src/lib/sorting.js
+++ b/src/lib/sorting.js
@@ -1,6 +1,8 @@
 export const sortAssets = (assets) => {
   return assets.sort((a, b) => {
-    if (a.project_name !== b.project_name) {
+    if (a.canceled !== b.canceled) {
+      return a.canceled ? 1 : -1
+    } if (a.project_name !== b.project_name) {
       return a.project_name.localeCompare(b.project_name)
     } else if (a.asset_type_name !== b.asset_type_name) {
       return a.asset_type_name.localeCompare(b.asset_type_name)
@@ -12,7 +14,9 @@ export const sortAssets = (assets) => {
 
 export const sortShots = (shots) => {
   return shots.sort((a, b) => {
-    if (a.project_name !== b.project_name) {
+    if (a.canceled !== b.canceled) {
+      return a.canceled ? 1 : -1
+    } if (a.project_name !== b.project_name) {
       return a.project_name.localeCompare(b.project_name)
     } else if (a.sequence_name !== b.sequence_name) {
       return a.sequence_name.localeCompare(b.sequence_name)

--- a/src/router.js
+++ b/src/router.js
@@ -3,6 +3,16 @@ import VueRouter from 'vue-router'
 import { routes } from './routes'
 Vue.use(VueRouter)
 
+const scrollBehavior = (to, from, savedPosition) => {
+  if (savedPosition) {
+    return savedPosition
+  } else {
+    return {x: 0, y: 0}
+  }
+}
+
 export default new VueRouter({
+  mode: 'history',
+  scrollBehavior,
   routes
 })

--- a/src/store/api/assets.js
+++ b/src/store/api/assets.js
@@ -49,7 +49,7 @@ export default {
 
   deleteAsset (asset, callback) {
     superagent
-      .del(`/api/data/entities/${asset.id}`)
+      .del(`/api/data/assets/${asset.id}`)
       .end((err, res) => {
         callback(err, res.body)
       })

--- a/src/store/api/shots.js
+++ b/src/store/api/shots.js
@@ -47,7 +47,7 @@ export default {
 
   deleteShot (shot, callback) {
     superagent
-      .del(`/api/data/entities/${shot.id}`)
+      .del(`/api/data/shots/${shot.id}`)
       .end((err, res) => {
         callback(err, res.body)
       })

--- a/src/store/api/tasks.js
+++ b/src/store/api/tasks.js
@@ -50,7 +50,7 @@ export default {
     const taskTypeId = data.task_type_id
     const type = data.type
     superagent
-      .post(`/api/actions/${type}/task-types/${taskTypeId}/create-tasks`)
+      .post(`/api/actions/task-types/${taskTypeId}/${type}/create-tasks`)
       .send({})
       .end((err, res) => {
         callback(err, res.body)

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -243,7 +243,13 @@ const mutations = {
     const assetToDeleteIndex = state.assets.findIndex(
       (asset) => asset.id === assetToDelete.id
     )
-    state.assets.splice(assetToDeleteIndex, 1)
+    const asset = state.assets[assetToDeleteIndex]
+
+    if (asset.tasks.length > 0) {
+      asset.canceled = true
+    } else {
+      state.assets.splice(assetToDeleteIndex, 1)
+    }
 
     state.deleteAsset = {
       isLoading: false,

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -219,7 +219,13 @@ const mutations = {
     const shotToDeleteIndex = state.shots.findIndex(
       (shot) => shot.id === shotToDelete.id
     )
-    state.shots.splice(shotToDeleteIndex, 1)
+    const shot = state.shots[shotToDeleteIndex]
+
+    if (shot.tasks.length > 0) {
+      shot.canceled = true
+    } else {
+      state.shots.splice(shotToDeleteIndex, 1)
+    }
 
     state.deleteShot = {
       isLoading: false,


### PR DESCRIPTION
**Problems**

* When an element is deleted but still has link, it is marked as canceled. Kitsu didn't display this properly.
* The scroll position is reset to top when the back button is used to browse from task detail to entity list.

**Solutions**

Now Kitsu adds a line-through to entities listed in asset list and shot list. And it puts at the bottom of the list these elements.
For the scroll problem, now Kitsu stores the scroll position and restore it when it can.