### PR TITLE
Add realtime for comments

### DIFF
--- a/src/lib/init.js
+++ b/src/lib/init.js
@@ -7,6 +7,7 @@ const init = (callback) => {
     'loadTaskStatuses',
     'loadAssetTypes',
     'loadTaskTypes',
+    'loadPeople',
     'loadOpenProductions'
   ]
 

--- a/src/lib/realtime.js
+++ b/src/lib/realtime.js
@@ -1,22 +1,24 @@
 import store from '../store'
 
-let source
-
 const realtime = {
-  subscribe: (eventName, listener) => {
-    source.addEventListener(eventName, (event) => {
-      const data = JSON.parse(event.data)
-      listener(data.data)
-    }, false)
+  createNewSource: () => {
+    return new EventSource('/events')
   },
 
-  init: () => {
-    source = new EventSource('/events')
-
+  init: (source) => {
     realtime.subscribe('comment:new', (eventData) => {
       const commentId = eventData.id
       store.dispatch('loadComment', {id: commentId})
     })
+    return source
+  },
+
+  subscribe: (source, eventName, listener) => {
+    return source.addEventListener(eventName, (event) => {
+      const data = JSON.parse(event.data)
+      listener(data.data)
+    }, false)
+    return source
   }
 }
 

--- a/src/lib/realtime.js
+++ b/src/lib/realtime.js
@@ -1,0 +1,23 @@
+import store from '../store'
+
+let source
+
+const realtime = {
+  subscribe: (eventName, listener) => {
+    source.addEventListener(eventName, (event) => {
+      const data = JSON.parse(event.data)
+      listener(data.data)
+    }, false)
+  },
+
+  init: () => {
+    source = new EventSource('/events')
+
+    realtime.subscribe('comment:new', (eventData) => {
+      const commentId = eventData.id
+      store.dispatch('loadComment', {id: commentId})
+    })
+  }
+}
+
+export default realtime

--- a/src/main.js
+++ b/src/main.js
@@ -41,5 +41,6 @@ new Vue({
   store
 })
 
-// Realtime update conifguration.
-realtime.init()
+// Realtime update configuration.
+const source = realtime.createNewSource()
+realtime.init(source)

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { sync } from 'vuex-router-sync'
 
 import router from './router'
 import i18n from './lib/i18n'
+import realtime from './lib/realtime'
 import store from './store'
 import App from './App'
 
@@ -40,12 +41,5 @@ new Vue({
   store
 })
 
-/*
 // Realtime update conifguration.
-const source = new EventSource('/events')
-source.addEventListener('comment:new', function (event) {
-  const data = JSON.parse(event.data)
-  const commentId = data.data.id
-  console.log(commentId)
-}, false)
-*/
+realtime.init()

--- a/src/store/api/tasks.js
+++ b/src/store/api/tasks.js
@@ -1,36 +1,20 @@
-import superagent from 'superagent'
+import client from './client'
 
 export default {
   getTask (taskId, callback) {
-    superagent
-      .get(`/api/data/tasks/${taskId}/full`)
-      .end((err, res) => {
-        callback(err, res.body)
-      })
+    client.get(`/api/data/tasks/${taskId}/full`, callback)
   },
 
   getTaskStatuses (callback) {
-    superagent
-      .get(`/api/data/task-status`)
-      .end((err, res) => {
-        callback(err, res.body)
-      })
+    client.get(`/api/data/task-status`, callback)
   },
 
   getTaskComments (taskId, callback) {
-    superagent
-      .get(`/api/data/tasks/${taskId}/comments`)
-      .end((err, res) => {
-        callback(err, res.body)
-      })
+    client.get(`/api/data/tasks/${taskId}/comments`, callback)
   },
 
   getTaskPreviews (taskId, callback) {
-    superagent
-      .get(`/api/data/tasks/${taskId}/previews`)
-      .end((err, res) => {
-        callback(err, res.body)
-      })
+    client.get(`/api/data/tasks/${taskId}/previews`, callback)
   },
 
   commentTask (data, callback) {
@@ -38,50 +22,46 @@ export default {
       task_status_id: data.taskStatusId,
       comment: data.comment
     }
-    superagent
-      .post(`/api/actions/tasks/${data.taskId}/comment`)
-      .send(commentData)
-      .end((err, res) => {
-        callback(err, res.body)
-      })
+    client.post(
+      `/api/actions/tasks/${data.taskId}/comment`,
+      commentData,
+      callback
+    )
+  },
+
+  getTaskComment (data, callback) {
+    client.get(`/api/data/comments/${data.id}`, callback)
   },
 
   createTasks (data, callback) {
     const taskTypeId = data.task_type_id
     const type = data.type
-    superagent
-      .post(`/api/actions/task-types/${taskTypeId}/${type}/create-tasks`)
-      .send({})
-      .end((err, res) => {
-        callback(err, res.body)
-      })
+    client.post(
+      `/api/actions/task-types/${taskTypeId}/${type}/create-tasks`,
+      {},
+      callback
+    )
   },
 
   deleteTask (task, callback) {
-    superagent
-      .del(`/api/data/tasks/${task.id}`)
-      .end((err, res) => {
-        callback(err, res.body)
-      })
+    client.del(`/api/data/tasks/${task.id}`, callback)
   },
 
   addPreview (data, callback) {
     const taskId = data.taskId
     const commentId = data.commentId
-    superagent
-      .post(`/api/actions/tasks/${taskId}/comments/${commentId}/add-preview`)
-      .send({})
-      .end((err, res) => {
-        callback(err, res.body)
-      })
+    client.post(
+      `/api/actions/tasks/${taskId}/comments/${commentId}/add-preview`,
+      {},
+      callback
+    )
   },
 
   uploadPreview (previewId, formData, callback) {
-    superagent
-      .post(`/api/thumbnails/preview-files/${previewId}`)
-      .send(formData)
-      .end((err, res) => {
-        callback(err, res.body)
-      })
+    client.post(
+      `/api/thumbnails/preview-files/${previewId}`,
+      formData,
+      callback
+    )
   }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -24,8 +24,8 @@ let modules = {
   people,
   productions,
   shots,
-  taskTypes,
   tasks,
+  taskTypes,
   user
 }
 

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -1,5 +1,7 @@
 import assetsApi from '../api/assets'
 import { sortAssets, sortValidationColumns } from '../../lib/sorting'
+import tasksStore from './tasks'
+
 import {
   LOAD_ASSETS_START,
   LOAD_ASSETS_ERROR,
@@ -24,6 +26,8 @@ import {
   DELETE_ASSET_END,
 
   DELETE_TASK_END,
+
+  NEW_TASK_COMMENT_END,
 
   RESET_ALL
 } from '../mutation-types'
@@ -267,6 +271,17 @@ const mutations = {
         (assetTask) => assetTask.id === task.entity_id
       )
       asset.tasks.splice(taskIndex, 1)
+    }
+  },
+
+  [NEW_TASK_COMMENT_END] (state, {comment, taskId}) {
+    const getTask = tasksStore.getters.getTask(
+      tasksStore.state, tasksStore.getters
+    )
+    const task = getTask(taskId)
+    const asset = getters.getAsset(state)(task.entity_id)
+    if (asset) {
+      asset.validations[task.task_type_name] = task
     }
   },
 

--- a/src/store/modules/people.js
+++ b/src/store/modules/people.js
@@ -69,7 +69,13 @@ const getters = {
   isEditLoadingError: state => state.isEditLoadingError,
   personToEdit: state => state.personToEdit,
 
-  personCsvFormData: state => state.personCsvFormData
+  personCsvFormData: state => state.personCsvFormData,
+
+  getPerson: (state, getters) => (id) => {
+    return state.people.find(
+      (taskStatus) => taskStatus.id === id
+    )
+  }
 }
 
 const sortPeople = (people) => {

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -1,4 +1,6 @@
 import shotsApi from '../api/shots'
+import tasksStore from './tasks'
+
 import { sortShots, sortValidationColumns } from '../../lib/sorting'
 import {
   LOAD_SHOTS_START,
@@ -18,6 +20,8 @@ import {
   DELETE_SHOT_START,
   DELETE_SHOT_ERROR,
   DELETE_SHOT_END,
+
+  NEW_TASK_COMMENT_END,
 
   RESET_ALL
 } from '../mutation-types'
@@ -230,6 +234,17 @@ const mutations = {
     state.deleteShot = {
       isLoading: false,
       isError: false
+    }
+  },
+
+  [NEW_TASK_COMMENT_END] (state, {comment, taskId}) {
+    const getTask = tasksStore.getters.getTask(
+      tasksStore.state, tasksStore.getters
+    )
+    const task = getTask(taskId)
+    const shot = getters.getShot(state)(task.entity_id)
+    if (shot) {
+      shot.validations[task.task_type_name] = task
     }
   },
 

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -67,7 +67,6 @@ const getters = {
 const actions = {
   loadTaskStatuses ({ commit, state }, callback) {
     tasksApi.getTaskStatuses((err, taskStatus) => {
-      console.log(taskStatus)
       if (!err) commit(LOAD_TASK_STATUSES_END, taskStatus)
       if (callback) callback(err)
     })

--- a/test/store/lib/sorting.spec.js
+++ b/test/store/lib/sorting.spec.js
@@ -1,0 +1,179 @@
+import { expect } from 'chai'
+import {
+  sortAssets,
+  sortByName,
+  sortProductions,
+  sortShots,
+  sortValidationColumns
+} from '../../../src/lib/sorting'
+
+
+describe('sorting', () => {
+
+  beforeEach(() => {
+  })
+
+  it('sortByName', () => {
+    const entries = [
+      {name: 'Zou', id: 3},
+      {name: 'Kitsu', id: 2},
+      {name: 'Gazu', id: 1},
+    ]
+    let results = sortByName(entries)
+    expect(results.length).to.equal(3)
+    expect(results[0].id).to.equal(1)
+    expect(results[1].id).to.equal(2)
+    expect(results[2].id).to.equal(3)
+
+    results = sortByName([])
+    expect(results.length).to.equal(0)
+  })
+
+  it('sortAssets', () => {
+    const entries = [
+      {
+        canceled: false,
+        project_name: 'Big Buck Bunny',
+        asset_type_name: 'Props',
+        name: 'Tree',
+        id: 5
+      },
+      {
+        canceled: false,
+        project_name: 'Big Buck Bunny',
+        asset_type_name: 'Props',
+        name: 'Table',
+        id: 4
+      },
+      {
+        canceled: false,
+        project_name: 'Big Buck Bunny',
+        asset_type_name: 'Props',
+        name: 'Chair',
+        id: 3
+      },
+      {
+        canceled: true,
+        project_name: 'Agent 327',
+        asset_type_name: 'Props',
+        name: 'Gun',
+        id: 6
+      },
+      {
+        canceled: false,
+        project_name: 'Big Buck Bunny',
+        asset_type_name: 'Characters',
+        name: 'Bunny',
+        id: 2
+      },
+      {
+        canceled: false,
+        project_name: 'Agent 327',
+        asset_type_name: 'Props',
+        name: 'Mirror',
+        id: 1
+      }
+    ]
+    let results = sortAssets(entries)
+    expect(results.length).to.equal(6)
+    expect(results[0].id).to.equal(1)
+    expect(results[1].id).to.equal(2)
+    expect(results[2].id).to.equal(3)
+    expect(results[3].id).to.equal(4)
+    expect(results[4].id).to.equal(5)
+    expect(results[5].id).to.equal(6)
+
+    results = sortAssets([])
+    expect(results.length).to.equal(0)
+  })
+
+  it('sortShots', () => {
+    const entries = [
+      {
+        canceled: false,
+        project_name: 'Big Buck Bunny',
+        sequence_name: 'SE02',
+        name: 'SH03',
+        id: 5
+      },
+      {
+        canceled: false,
+        project_name: 'Big Buck Bunny',
+        sequence_name: 'SE02',
+        name: 'SH02',
+        id: 4
+      },
+      {
+        canceled: false,
+        project_name: 'Big Buck Bunny',
+        sequence_name: 'SE02',
+        name: 'SH01',
+        id: 3
+      },
+      {
+        canceled: true,
+        project_name: 'Agent 327',
+        sequence_name: 'SE01',
+        name: 'SH01',
+        id: 6
+      },
+      {
+        canceled: false,
+        project_name: 'Big Buck Bunny',
+        sequence_name: 'SE01',
+        name: 'SH01',
+        id: 2
+      },
+      {
+        canceled: false,
+        project_name: 'Agent 327',
+        sequence_name: 'SE01',
+        name: 'SH02',
+        id: 1
+      }
+    ]
+    let results = sortShots(entries)
+    expect(results.length).to.equal(6)
+    expect(results[0].id).to.equal(1)
+    expect(results[1].id).to.equal(2)
+    expect(results[2].id).to.equal(3)
+    expect(results[3].id).to.equal(4)
+    expect(results[4].id).to.equal(5)
+    expect(results[5].id).to.equal(6)
+
+    results = sortShots([])
+    expect(results.length).to.equal(0)
+  })
+
+  it('sortProductions', () => {
+    const entries = [
+      {project_status_name: 'closed', name: 'Big Buck Bunny', id: 3},
+      {project_status_name: 'open', name: 'Cosmos Landromat', id: 2},
+      {project_status_name: 'open', name: 'Agent 327', id: 1},
+    ]
+    let results = sortProductions(entries)
+    expect(results.length).to.equal(3)
+    expect(results[0].id).to.equal(1)
+    expect(results[1].id).to.equal(2)
+    expect(results[2].id).to.equal(3)
+
+    results = sortProductions([])
+    expect(results.length).to.equal(0)
+  })
+
+  it('sortValidationColumns', () => {
+    const entries = [
+      {priority: 2, name: 'Big Buck Bunny', id: 3},
+      {priority: 1, name: 'Cosmos Landromat', id: 2},
+      {priority: 1, name: 'Agent 327', id: 1},
+    ]
+    let results = sortValidationColumns(entries)
+    expect(results.length).to.equal(3)
+    expect(results[0].id).to.equal(1)
+    expect(results[1].id).to.equal(2)
+    expect(results[2].id).to.equal(3)
+
+    results = sortValidationColumns([])
+    expect(results.length).to.equal(0)
+  })
+})

--- a/test/test-store.js
+++ b/test/test-store.js
@@ -7,3 +7,5 @@ import './store/user.spec'
 import './store/productions.spec.js'
 import './store/tasktypes.spec.js'
 import './store/assettypes.spec.js'
+
+import './store/lib/sorting.spec.js'


### PR DESCRIPTION
**Problem**

To see the comment added by others, or having the validation board updated in case of task status change, it required reload the page. Which was annoying.

**Solution**

Plug this frontend on the Server Sent Events stream provided by the Zou API.