### PR TITLE
Allow to set the number of asset occurences in a casting

### DIFF
--- a/src/store/api/shots.js
+++ b/src/store/api/shots.js
@@ -36,9 +36,12 @@ export default {
     client.put(`/api/data/entities/${shot.id}`, data, callback)
   },
 
-  updateCasting (shot, callback) {
-    const data = shot.entities_out
-    client.put(`/api/actions/shots/${shot.id}/casting`, data, callback)
+  getCasting (shot, callback) {
+    client.get(`/api/data/shots/${shot.id}/casting`, callback)
+  },
+
+  updateCasting (shot, casting, callback) {
+    client.put(`/api/data/shots/${shot.id}/casting`, casting, callback)
   },
 
   deleteShot (shot, callback) {

--- a/test/test-store.js
+++ b/test/test-store.js
@@ -1,6 +1,5 @@
 import expect from 'chai'
 
-/*
 import './store/login.spec'
 import './store/main.spec'
 import './store/people.spec'
@@ -8,7 +7,8 @@ import './store/user.spec'
 import './store/productions.spec.js'
 import './store/tasktypes.spec.js'
 import './store/assettypes.spec.js'
-*/
+/*
 import './store/assets.spec.js'
+*/
 
 // import './store/lib/sorting.spec.js'


### PR DESCRIPTION
**Problem**

There is no way to set the number of occurences of an asset listed in a casting.

**Solution**

* When the user clicks on an asset to add it, he has two choices: removing 1 or 10 occurences.  
* When the user clicks on an asset to add it, he has two choices: adding 1 or 10 occurences.  
* Display the number of occurences when it is superior to 1.