### PR TITLE
Improve task view layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kitsu",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Production Management Software (user interface)",
   "author": "Frank Rousseau <frank@cg-wire.com>",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -89,6 +89,10 @@ input.input:focus {
   border-color: #00B242;
 }
 
+.button:focus {
+  box-shadow: none;
+}
+
 .button.is-primary {
   border-radius: 2px;
   background: #00B242;

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -66,9 +66,11 @@
         </div>
 
         <div class="preview-picture">
-          <img
-            v-if="currentTaskPreviews.length > 0"
-            :src="getPreviewPath()" />
+          <a :href="getOriginalPath()" target="_blank">
+            <img
+              v-if="currentTaskPreviews.length > 0"
+              :src="getPreviewPath()" />
+          </a>
         </div>
 			</div>
 
@@ -366,13 +368,19 @@ export default {
         return ''
       }
     },
-    getPreviewPath () {
-      const previewId = this.route.params.preview_id
-      if (previewId) {
-        return `/api/thumbnails/preview-files/${previewId}.png`
-      } else {
-        return `/api/thumbnails/preview-files/${this.currentTaskPreviews[0].id}.png`
+    getOriginalPath () {
+      let previewId = this.route.params.preview_id
+      if (!previewId && this.currentTaskPreviews.length > 0) {
+        previewId = this.currentTaskPreviews[0].id
       }
+      return `/api/pictures/originals/preview-files/${previewId}.png`
+    },
+    getPreviewPath () {
+      let previewId = this.route.params.preview_id
+      if (!previewId && this.currentTaskPreviews.length > 0) {
+        previewId = this.currentTaskPreviews[0].id
+      }
+      return `/api/pictures/previews/preview-files/${previewId}.png`
     },
     addComment (comment, taskStatusId) {
       this.addCommentLoading = {
@@ -529,5 +537,6 @@ video {
 
 .preview-list {
   display: flex;
+  flex-wrap: wrap;
 }
 </style>

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="page">
+  <div class="page fixed-page">
     <h1 class="title">
        <div class="level">
          <div class="level-left">
@@ -44,8 +44,8 @@
        </div>
     </h1>
 
-    <div class="columns">
-      <div class="column">
+    <div class="column-container">
+      <div class="task-column">
         <h2 class="subtitle">
           {{ $t('tasks.preview') }}
         </h2>
@@ -71,7 +71,7 @@
 			</div>
 
 
-      <div class="column">
+      <div class="task-column">
         <h2 class="subtitle validation-title">
           {{ $t('tasks.validation') }}
         </h2>
@@ -504,5 +504,16 @@ video {
 .comments,
 .no-comment {
   margin-top: 2em;
+}
+
+.column-container {
+  display: flex;
+  flex-direction: row;
+}
+
+.task-column {
+  width: 50%;
+  padding: 1em;
+  overflow-y: auto;
 }
 </style>

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -26,6 +26,8 @@
              <people-avatar
                :key="personId"
                :person="personMap[personId]"
+               :size="30"
+               :font-size="16"
                v-for="personId in currentTask.assignees">
              </people-avatar>
            </div>

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -44,21 +44,17 @@
        </div>
     </h1>
 
-    <div class="column-container">
+    <div class="task-columns">
       <div class="task-column">
         <h2 class="subtitle">
           {{ $t('tasks.preview') }}
         </h2>
-        <div class="preview-picture">
-          <img
-            v-if="currentTaskPreviews.length > 0"
-            :src="getPreviewPath()" />
-        </div>
         <div class="preview-list" v-if="currentTaskPreviews.length > 0">
           <preview-row
+            :key="preview.id"
             :preview="preview"
             :taskId="currentTask ? currentTask.id : ''"
-            :key="preview.id"
+            :selected="preview.id === currentPreviewId"
             v-for="preview in currentTaskPreviews"
           >
           </preview-row>
@@ -67,6 +63,12 @@
           <em>
             {{ $t('tasks.no_preview')}}
           </em>
+        </div>
+
+        <div class="preview-picture">
+          <img
+            v-if="currentTaskPreviews.length > 0"
+            :src="getPreviewPath()" />
         </div>
 			</div>
 
@@ -104,6 +106,7 @@
             <div class="comments" v-if="currentTaskComments.length > 0">
               <comment
                 :comment="comment"
+                :highlighted="comment.preview && comment.preview.id === currentPreviewId"
                 :key="comment.id"
                 v-for="comment in currentTaskComments"
               >
@@ -311,6 +314,9 @@ export default {
       'getTaskComment',
       'personMap'
     ]),
+    currentPreviewId () {
+      return this.route.params.preview_id
+    },
     title () {
       if (this.currentTask) {
         return `${this.currentTask.project_name} / ${this.currentTask.entity_name}`
@@ -506,7 +512,7 @@ video {
   margin-top: 2em;
 }
 
-.column-container {
+.task-columns {
   display: flex;
   flex-direction: row;
 }
@@ -515,5 +521,13 @@ video {
   width: 50%;
   padding: 1em;
   overflow-y: auto;
+}
+
+.task-column:first-child {
+  padding-left: 0;
+}
+
+.preview-list {
+  display: flex;
 }
 </style>

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -21,6 +21,7 @@
       key="task.id + '-' + personId"
       :person="personMap[personId]"
       :size="20"
+      :font-size="10"
       v-if="nbSelectedTasks > 0"
       v-for="personId in assignees"
     >
@@ -114,6 +115,5 @@ td.selected.validation:hover {
 
 .person-avatar {
   margin-left: 3px;
-  font-size: 10px;
 }
 </style>

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -87,6 +87,19 @@
             }"
           >
           </row-actions>
+          <row-actions v-else
+            :entry-id="entry.id"
+            :hide-edit="true"
+            :restore-route="{
+              name: 'restore-asset',
+              params: {
+                production_id: currentProduction.id,
+                asset_id: entry.id
+              }
+            }"
+          >
+          aa
+          </row-actions>
         </tr>
       </tbody>
     </table>

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -87,19 +87,6 @@
             }"
           >
           </row-actions>
-          <row-actions v-else
-            :entry-id="entry.id"
-            :hide-edit="true"
-            :restore-route="{
-              name: 'restore-asset',
-              params: {
-                production_id: currentProduction.id,
-                asset_id: entry.id
-              }
-            }"
-          >
-          aa
-          </row-actions>
         </tr>
       </tbody>
     </table>

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -1,6 +1,10 @@
 <template>
 <article
-  class="media comment"
+  :class="{
+    media: true,
+    comment: true,
+    highlighted: highlighted
+  }"
   :style="{
     'border-left': '3px solid ' + comment.task_status.color
   }"
@@ -30,12 +34,13 @@
           <span class="level-item" :style="{'color': comment.task_status.color}">
             {{ $t('comments.retake').toUpperCase() }}
           </span>
-          <span
+          <router-link
+            :to="previewRoute"
             class="revision"
             v-if="comment.preview"
           >
             revision {{ comment.preview.revision }}
-          </span>
+          </router-link>
           <button-link
             class="level-item"
             :text="$t('tasks.add_preview')"
@@ -57,12 +62,13 @@
             {{ $t('comments.validation_required') }}
           </span>
 
-          <span
+          <router-link
+            :to="previewRoute"
             class="revision"
             v-if="comment.preview"
           >
             revision {{ comment.preview.revision }}
-          </span>
+          </router-link>
           <button-link
             class="level-item"
             :text="$t('tasks.add_preview')"
@@ -108,9 +114,31 @@ export default {
     PeopleName,
     ButtonLink
   },
-  props: [
-    'comment'
-  ],
+  props: {
+    comment: {
+      type: Object,
+      default: () => {}
+    },
+    highlighted: {
+      type: Boolean,
+      default: false
+    }
+  },
+  computed: {
+    previewRoute () {
+      if (this.comment.preview) {
+        return {
+          name: 'task-preview',
+          params: {
+            task_id: this.comment.object_id,
+            preview_id: this.comment.preview.id
+          }
+        }
+      } else {
+        return {name: 'task', params: {task_id: this.comment.object_id}}
+      }
+    }
+  },
   methods: {
     formatDate (date) {
       return moment(date).fromNow()
@@ -128,16 +156,28 @@ export default {
   border-left: 3px solid #CCC;
 }
 
+.comment.highlighted {
+  background: #F1EEFF;
+}
+
+.comment:first-child {
+  padding-top: 1em;
+}
+
 .comment-date {
   color: #999;
   font-style: italic;
   margin-left: 0.5em;
 }
 
-span.revision {
+a.revision {
   color: #999;
   font-size: 0.8em;
   font-style: italic;
   margin: 0;
+}
+
+a.revision:hover {
+  text-decoration: underline;
 }
 </style>

--- a/src/components/widgets/PeopleAvatar.vue
+++ b/src/components/widgets/PeopleAvatar.vue
@@ -3,7 +3,8 @@
    :style="{
      background: getAvatarColor(person),
      width: (size || 40) +'px',
-     height: (size || 40) + 'px'
+     height: (size || 40) + 'px',
+     'font-size': (fontSize || 18) + 'px'
    }">
    <span>
      {{ generateAvatar(person) }}
@@ -18,6 +19,7 @@ import { mapGetters, mapActions } from 'vuex'
 export default {
   name: 'person-avatar',
   props: [
+    'font-size',
     'person',
     'size'
   ],

--- a/src/components/widgets/PreviewRow.vue
+++ b/src/components/widgets/PreviewRow.vue
@@ -1,8 +1,11 @@
 <template>
-<div class="preview-row has-text-center">
+<div :class="{
+  'preview-row': true,
+  'has-text-center': true,
+  selected: selected
+}">
   <button-link
     :text="label"
-    icon="fa-eye"
     :path="'/tasks/' + taskId + '/previews/' + preview.id"
   >
   </button-link>
@@ -17,16 +20,23 @@ export default {
   components: {
     ButtonLink
   },
-  props: [
-    'preview',
-    'taskId'
-  ],
+  props: {
+    preview: {
+      type: Object,
+      default: () => {}
+    },
+    selected: {
+      type: Boolean,
+      default: false
+    },
+    taskId: {
+      type: String,
+      default: ''
+    }
+  },
   computed: {
     label () {
-      let label = `Preview ${this.preview.revision}`
-      if (this.preview.feedback) {
-        label = `${label} (${this.$tc('tasks.feedback')})`
-      }
+      let label = `v${this.preview.revision}`
       return label
     }
   },
@@ -36,10 +46,19 @@ export default {
 </script>
 
 <style scoped>
+.preview-row {
+  margin-right: 0.5em;
+}
+
 .preview-row a {
-  display: block;
-  width: 100%;
-  display: flex;
-  margin-bottom: 1em;
+  border: 3px solid #CCC;
+}
+
+.preview-row:hover a {
+  border: 3px solid #E1D4F9;
+}
+
+.preview-row.selected a {
+  border: 3px solid #8F91EB;
 }
 </style>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -144,13 +144,23 @@ export const routes = [
         name: 'restore-shots'
       },
 
-      { path: '/tasks/:task_id', component: Task },
-      { path: '/tasks/:task_id/delete', component: Task },
       {
+        name: 'task',
+        path: '/tasks/:task_id',
+        component: Task
+      },
+      {
+        name: 'task-delete',
+        path: '/tasks/:task_id/delete',
+        component: Task
+      },
+      {
+        name: 'task-add-preview',
         path: '/tasks/:task_id/comments/:comment_id/add-preview',
         component: Task
       },
       {
+        name: 'task-preview',
         path: '/tasks/:task_id/previews/:preview_id',
         component: Task
       },

--- a/src/store/api/tasks.js
+++ b/src/store/api/tasks.js
@@ -60,7 +60,7 @@ export default {
 
   uploadPreview (previewId, formData, callback) {
     client.post(
-      `/api/thumbnails/preview-files/${previewId}`,
+      `/api/pictures/preview-files/${previewId}`,
       formData,
       callback
     )

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -360,6 +360,28 @@ const mutations = {
     state.assetIndex = buildNameIndex(state.assets)
   },
 
+  [RESTORE_ASSET_START] (state) {
+    state.restoreAsset = {
+      isLoading: true,
+      isError: false
+    }
+  },
+  [RESTORE_ASSET_ERROR] (state) {
+    state.restoreAsset = {
+      isLoading: false,
+      isError: true
+    }
+  },
+  [RESTORE_ASSET_END] (state, assetToRestore) {
+    const asset = state.assetMap[assetToRestore.id]
+    asset.canceled = false
+    state.restoreAsset = {
+      isLoading: false,
+      isError: false
+    }
+    state.assetIndex = buildNameIndex(state.assets)
+  },
+
   [DELETE_TASK_END] (state, task) {
     const asset = state.assets.find(
       (asset) => asset.id === task.entity_id


### PR DESCRIPTION
**Problem**

* Navigating among previews of a given task was not user-friendly.

**Solution**

* Display version number above the preview 
* Make version button smaller
* Allow to display a revision directly from the linked comment
* Allow to see the full size original picture
* Adapt preview path to new upcoming API for previews