### PR TITLE
Minor fixes

### DIFF
--- a/src/components/Productions.vue
+++ b/src/components/Productions.vue
@@ -113,7 +113,7 @@ export default {
 
     confirmEditProduction (form) {
       let action = 'newProduction'
-      if (this.productionToEdit) {
+      if (this.productionToEdit && this.productionToEdit.id) {
         action = 'editProduction'
         form.id = this.productionToEdit.id
       }
@@ -152,6 +152,7 @@ export default {
       const productionId = this.$store.state.route.params.production_id
 
       if (path.indexOf('new') > 0) {
+        this.productionToEdit = {}
         this.modals.isNewDisplayed = true
       } else if (path.indexOf('edit') > 0) {
         this.productionToEdit = this.getProduction(productionId)

--- a/src/components/TaskStatus.vue
+++ b/src/components/TaskStatus.vue
@@ -92,7 +92,7 @@ export default {
   computed: {
     ...mapGetters([
       'taskStatus',
-      'getTaskStatus'
+      'taskStatusMap'
     ])
   },
 
@@ -162,10 +162,10 @@ export default {
         this.taskStatusToEdit = {color: '#000000'}
         this.modals.isNewDisplayed = true
       } else if (path.indexOf('edit') > 0) {
-        this.taskStatusToEdit = this.getTaskStatus(taskStatusId)
+        this.taskStatusToEdit = this.taskStatusMap[taskStatusId]
         this.modals.isNewDisplayed = true
       } else if (path.indexOf('delete') > 0) {
-        this.taskStatusToDelete = this.getTaskStatus(taskStatusId)
+        this.taskStatusToDelete = this.taskStatusMap[taskStatusId]
         this.modals.isDeleteDisplayed = true
       } else {
         this.modals.isNewDisplayed = false

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -72,13 +72,7 @@
           v-for="entry in entries"
         >
           <td class="thumbnail">
-            <img
-              class="thumbnail-picture"
-              v-lazy="'/api/pictures/thumbnails/preview-files/' + entry.preview_file_id + '.png'"
-              v-if="entry.preview_file_id && entry.preview_file_id.length > 0"
-            />
-            <span class="thumbnail-picture thumbnail-empty" v-else>
-            </span>
+            <entity-thumbnail :entity="entry"></entity-thumbnail>
           </td>
           <td :class="{type: !entry.canceled}">
             {{ entry.asset_type_name }}
@@ -140,11 +134,12 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 import RowActions from '../widgets/RowActions'
-import ValidationCell from '../cells/ValidationCell'
 import ButtonLink from '../widgets/ButtonLink'
 import ButtonHrefLink from '../widgets/ButtonHrefLink'
+import EntityThumbnail from '../widgets/EntityThumbnail'
 import PageTitle from '../widgets/PageTitle'
 import TableInfo from '../widgets/TableInfo'
+import ValidationCell from '../cells/ValidationCell'
 
 export default {
   name: 'asset-list',
@@ -162,8 +157,9 @@ export default {
   components: {
     ButtonLink,
     ButtonHrefLink,
-    RowActions,
+    EntityThumbnail,
     PageTitle,
+    RowActions,
     TableInfo,
     ValidationCell
   },
@@ -260,13 +256,6 @@ td.type {
 
 .thumbnail img {
   margin-top: 5px;
-}
-
-span.thumbnail-empty {
-  display: block;
-  width: 50px;
-  height: 30px;
-  background: #F3F3F3;
 }
 
 .info {

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -76,13 +76,7 @@
           v-for="entry in entries"
         >
           <td class="thumbnail">
-            <img
-              class="thumbnail-picture"
-              v-lazy="'/api/pictures/thumbnails/preview-files/' + entry.preview_file_id + '.png'"
-              v-if="entry.preview_file_id && entry.preview_file_id.length > 0"
-            />
-            <span class="thumbnail-picture thumbnail-empty" v-else>
-            </span>
+            <entity-thumbnail :entity="entry"></entity-thumbnail>
           </td>
           <td :class="{name: !entry.canceled}" v-if="entries[0].episode_name.length > 0">
             {{ entry.episode_name }}
@@ -161,6 +155,7 @@ import ButtonLink from '../widgets/ButtonLink'
 import ButtonHrefLink from '../widgets/ButtonHrefLink'
 import PageTitle from '../widgets/PageTitle'
 import TableInfo from '../widgets/TableInfo'
+import EntityThumbnail from '../widgets/EntityThumbnail'
 
 export default {
   name: 'shot-list',
@@ -178,6 +173,7 @@ export default {
   components: {
     ButtonLink,
     ButtonHrefLink,
+    EntityThumbnail,
     PageTitle,
     RowActions,
     TableInfo,

--- a/src/components/lists/TaskStatusList.vue
+++ b/src/components/lists/TaskStatusList.vue
@@ -47,7 +47,7 @@
               name: 'delete-task-status',
               params: {task_status_id: entry.id}
             }"
-            v-if="!['done', 'retake', 'todo'].includes(entry.short_name)"
+            v-if="!['done', 'todo'].includes(entry.short_name)"
           >
           </row-actions>
           <td class="actions" v-else></td>

--- a/src/components/modals/EditAssetModal.vue
+++ b/src/components/modals/EditAssetModal.vue
@@ -174,7 +174,6 @@ export default {
         this.form.name = ''
         this.form.description = ''
       } else {
-        console.log(this.assetToEdit)
         this.form = {
           entity_type_id: this.assetToEdit.asset_type_id,
           project_id: this.assetToEdit.project_id,

--- a/src/components/modals/EditProductionModal.vue
+++ b/src/components/modals/EditProductionModal.vue
@@ -6,7 +6,7 @@
   <div class="modal-background"></div>
   <div class="modal-content">
     <div class="box">
-      <h1 class="title" v-if="productionToEdit">
+      <h1 class="title" v-if="productionToEdit && productionToEdit.id">
         {{ $t("productions.edit_title") }} {{ productionToEdit.name }}
       </h1>
       <h1 class="title" v-else>
@@ -18,7 +18,7 @@
           ref="nameField"
           :label="$t('productions.fields.name')"
           v-model="form.name"
-          @enter="confirmClicked"
+          @enter="runConfirmation"
           v-focus
         >
         </text-field>
@@ -26,6 +26,7 @@
           :label="$t('productions.fields.status')"
           :options="getProductionStatusOptions"
           localeKeyPrefix="productions.status."
+          @enter="runConfirmation"
           v-model="form.project_status_id"
         >
         </combobox>
@@ -38,7 +39,7 @@
             'is-primary': true,
             'is-loading': isLoading
           }"
-          @click="confirmClicked">
+          @click="runConfirmation">
           {{ $t("main.confirmation") }}
         </a>
         <router-link
@@ -46,6 +47,9 @@
           class="button is-link">
           {{ $t("main.cancel") }}
         </router-link>
+      </p>
+      <p class="error has-text-right info-message" v-if="isError">
+        {{ $t("assets.edit_fail") }}
       </p>
     </div>
   </div>
@@ -77,9 +81,14 @@ export default {
 
   watch: {
     productionToEdit () {
-      if (this.productionToEdit) {
+      if (this.productionToEdit && this.productionToEdit.id) {
         this.form.name = this.productionToEdit.name
         this.form.project_status_id = this.productionToEdit.project_status_id
+      } else {
+        this.form = {
+          name: '',
+          project_status_id: this.getProductionStatusOptions[0].value
+        }
       }
     },
 
@@ -93,10 +102,10 @@ export default {
   },
 
   data () {
-    if (this.productionToEdit) {
+    if (this.productionToEdit && this.productionToEdit.id) {
       return {
         form: {
-          name: '',
+          name: this.productionToEdit.name,
           project_status_id: this.productionToEdit.project_status_id
         }
       }
@@ -121,7 +130,7 @@ export default {
   methods: {
     ...mapActions([
     ]),
-    confirmClicked () {
+    runConfirmation () {
       this.$emit('confirm', this.form)
     }
   },

--- a/src/components/modals/EditTaskStatusModal.vue
+++ b/src/components/modals/EditTaskStatusModal.vue
@@ -93,33 +93,13 @@ export default {
     'taskStatusToEdit'
   ],
 
-  watch: {
-    taskStatusToEdit () {
-      if (this.taskStatusToEdit) {
-        this.form = {
-          name: this.taskStatusToEdit.name,
-          short_name: this.taskStatusToEdit.short_name,
-          color: this.taskStatusToEdit.color,
-          is_reviewable: String(this.taskStatusToEdit.is_reviewable)
-        }
-      }
-    },
-    active () {
-      if (this.active) {
-        setTimeout(() => {
-          this.$refs.nameField.focus()
-        }, 100)
-      }
-    }
-  },
-
   data () {
     return {
       form: {
         name: '',
         short_name: '',
         color: '#999999',
-        is_reviewable: 'false'
+        is_reviewable: 'true'
       },
       isReviewableOptions: [
         {label: this.$tc('main.yes'), value: 'true'},
@@ -156,7 +136,30 @@ export default {
     confirmClicked () {
       this.$emit('confirm', this.form)
     },
-    isEditing: () => this.taskStatusToEdit && this.taskStatusToEdit.id
+    isEditing: () => this.taskStatusToEdit && this.taskStatusToEdit.id,
+    resetForm () {
+      if (this.taskStatusToEdit) {
+        this.form = {
+          name: this.taskStatusToEdit.name,
+          short_name: this.taskStatusToEdit.short_name,
+          color: this.taskStatusToEdit.color,
+          is_reviewable: String(this.taskStatusToEdit.is_reviewable)
+        }
+      }
+    }
+  },
+
+  watch: {
+    taskStatusToEdit () {
+      this.resetForm()
+    },
+    active () {
+      if (this.active) {
+        setTimeout(() => {
+          this.$refs.nameField.focus()
+        }, 100)
+      }
+    }
   }
 }
 </script>

--- a/src/components/widgets/EntityThumbnail.vue
+++ b/src/components/widgets/EntityThumbnail.vue
@@ -1,0 +1,37 @@
+<template>
+<a
+  :href="'/api/pictures/originals/preview-files/' + entity.preview_file_id + '.png'"
+  target="_blank"
+  v-if="entity.preview_file_id && entity.preview_file_id.length > 0"
+>
+  <img
+    class="thumbnail-picture"
+    v-lazy="'/api/pictures/thumbnails/preview-files/' + entity.preview_file_id + '.png'"
+  />
+</a>
+<span class="thumbnail-picture thumbnail-empty" v-else>
+</span>
+</template>
+
+<script>
+export default {
+  name: 'entity-thumbnail',
+  props: {
+    entity: {
+      default: () => {},
+      type: Object
+    }
+  }
+}
+</script>
+
+<style scoped>
+span.thumbnail-empty {
+  display: block;
+  width: 50px;
+  height: 30px;
+  background: #F3F3F3;
+}
+
+
+</style>

--- a/src/lib/sorting.js
+++ b/src/lib/sorting.js
@@ -15,7 +15,7 @@ export const sortShots = (shots) => {
         if (a.episode_name) {
           return a.episode_name.localeCompare(b.episode_name)
         } else {
-          return 1
+          return 0
         }
       })
       .thenBy((a, b) => a.sequence_name.localeCompare(b.sequence_name))

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -42,6 +42,8 @@ import {
 
   DISPLAY_MORE_ASSETS,
 
+  SET_PREVIEW,
+
   RESET_ALL
 } from '../mutation-types'
 
@@ -480,6 +482,13 @@ const mutations = {
 
   [SET_CURRENT_PRODUCTION] (state, production) {
     state.assetSearchText = ''
+  },
+
+  [SET_PREVIEW] (state, {entityId, taskId, previewId}) {
+    const asset = state.assetMap[entityId]
+    if (asset) {
+      asset.preview_file_id = previewId
+    }
   },
 
   [RESET_ALL] (state) {

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -51,6 +51,8 @@ import {
   CREATE_TASKS_END,
   DISPLAY_MORE_SHOTS,
 
+  SET_PREVIEW,
+
   RESET_ALL
 } from '../mutation-types'
 
@@ -526,6 +528,13 @@ const mutations = {
 
   [SET_CURRENT_PRODUCTION] (state, production) {
     state.assetSearchText = ''
+  },
+
+  [SET_PREVIEW] (state, {entityId, taskId, previewId}) {
+    const shot = state.shotMap[entityId]
+    if (shot) {
+      shot.preview_file_id = previewId
+    }
   },
 
   [RESET_ALL] (state) {

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -251,7 +251,7 @@ const actions = {
       if (err && callback) {
         callback(err)
       } else if (callback) {
-        commit(SET_PREVIEW, {taskId, previewId})
+        commit(SET_PREVIEW, {taskId, entityId, previewId})
         callback(err, entity)
       }
     })

--- a/src/store/modules/taskstatus.js
+++ b/src/store/modules/taskstatus.js
@@ -106,6 +106,7 @@ const mutations = {
 
     if (taskStatus && taskStatus.id) {
       Object.assign(taskStatus, newTaskStatus)
+      taskStatus.is_reviewable = Boolean(newTaskStatus.is_reviewable)
     } else {
       state.taskStatus.push(newTaskStatus)
       state.taskStatus = sortByName(state.taskStatus)

--- a/test/store/lib/sorting.spec.js
+++ b/test/store/lib/sorting.spec.js
@@ -132,6 +132,67 @@ describe('lib/sorting', () => {
     expect(results.length).to.equal(0)
   })
 
+  it('sortShots - without episodes', () => {
+    const entries = [
+      {
+        canceled: false,
+        sequence_name: 'SE02',
+        name: 'SH01',
+        id: 4
+      },
+      {
+        canceled: false,
+        sequence_name: 'SE03',
+        name: 'SH02',
+        id: 6
+      },
+      {
+        canceled: false,
+        sequence_name: 'SE01',
+        name: 'SH01',
+        id: 1
+      },
+      {
+        canceled: false,
+        sequence_name: 'SE03',
+        name: 'SH01',
+        id: 5
+      },
+      {
+        canceled: true,
+        sequence_name: 'SE01',
+        name: 'SH04',
+        id: 7
+      },
+      {
+        canceled: false,
+        sequence_name: 'SE01',
+        name: 'SH02',
+        id: 2
+      },
+      {
+        canceled: false,
+        sequence_name: 'SE01',
+        name: 'SH03',
+        id: 3
+      }
+    ]
+    let results = sortShots(entries)
+
+    console.log(results)
+    expect(results.length).to.equal(7)
+    expect(results[0].id).to.equal(1)
+    expect(results[1].id).to.equal(2)
+    expect(results[2].id).to.equal(3)
+    expect(results[3].id).to.equal(4)
+    expect(results[4].id).to.equal(5)
+    expect(results[5].id).to.equal(6)
+    expect(results[6].id).to.equal(7)
+
+    results = sortShots([])
+    expect(results.length).to.equal(0)
+  })
+
   it('sortProductions', () => {
     const entries = [
       {project_status_name: 'closed', name: 'Big Buck Bunny', id: 3},


### PR DESCRIPTION
**Problem**

* Shot sorting is wrong when there is no episode.
* Task status modal doesn't allow to properly edit the is reviewable field
* Thumbnail do not update in asset / shot list after change
* There is no way to see bigger version of thumbnail

**Solution**

* Sorting function returns wrong result (0 instead of 1) when the episode is null.
* Task status form is now properly set when modal is displayed.
* Asset and shot states mutate related asset/shot when a preview is set
* Clicking on a thumbnail open a new tab with original file.
