### PR TITLE
Minor fixes

### DIFF
--- a/src/components/OpenProductions.vue
+++ b/src/components/OpenProductions.vue
@@ -177,10 +177,15 @@ export default {
     confirmEditProduction (form) {
       this.newProduction({
         data: form,
-        callback: (err) => {
+        callback: (err, production) => {
           if (!err) {
             this.modals.isNewDisplayed = false
-            this.$router.push({name: 'open-productions'})
+            this.$router.push({
+              name: 'assets',
+              params: {
+                production_id: production.id
+              }
+            })
           }
         }
       })

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -29,7 +29,10 @@
 
           <th class="actions">
             <button-link
-              class="is-small"
+              :class="{
+                'is-small': true,
+                highlighted: isEmptyTask
+              }"
               icon="plus"
               :text="$t('tasks.create_tasks')"
               :path="{
@@ -208,11 +211,18 @@ export default {
       'assetSelectionGrid',
       'assets'
     ]),
+
     isEmptyList () {
       return this.entries.length === 0 &&
              !this.isLoading &&
              !this.isError &&
              (!this.assetSearchText || this.assetSearchText.length === 0)
+    },
+
+    isEmptyTask () {
+      return !this.emptyList &&
+      this.validationColumns &&
+      this.validationColumns.length === 0
     }
   },
 
@@ -351,5 +361,10 @@ td.type {
 
 .asset-link {
   color: inherit
+}
+
+.highlighted {
+  background: #00B242;
+  color: white;
 }
 </style>

--- a/src/components/modals/EditAssetModal.vue
+++ b/src/components/modals/EditAssetModal.vue
@@ -146,10 +146,12 @@ export default {
     ]),
 
     runConfirmation () {
-      if (this.isEditing()) {
-        this.confirmClicked()
-      } else {
-        this.confirmAndStayClicked()
+      if (this.form.name.length > 0) {
+        if (this.isEditing()) {
+          this.confirmClicked()
+        } else {
+          this.confirmAndStayClicked()
+        }
       }
     },
 

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -447,7 +447,7 @@ const mutations = {
     state.editAsset.isSuccess = true
     state.assetCreated = newAsset.name
 
-    const asset = getters.getAsset(state)(newAsset.id)
+    const asset = state.assetMap[newAsset.id]
     const assetType = state.assetTypes.find(
       (assetType) => assetType.id === newAsset.entity_type_id
     )
@@ -466,13 +466,13 @@ const mutations = {
       const maxX = state.displayedAssets.length
       const maxY = state.nbValidationColumns
       state.assetSelectionGrid = buildSelectionGrid(maxX, maxY)
+      state.assetMap[newAsset.id] = newAsset
     }
     state.editAsset = {
       isLoading: false,
       isError: false
     }
     cache.assetIndex = buildAssetIndex(cache.assets)
-    state.assetMap[newAsset.id] = asset
   },
 
   [DELETE_ASSET_START] (state) {

--- a/src/store/modules/productions.js
+++ b/src/store/modules/productions.js
@@ -153,15 +153,15 @@ const actions = {
     })
   },
 
-  newProduction ({ commit, state }, payload) {
-    commit(EDIT_PRODUCTION_START, payload.data)
-    productionsApi.newProduction(payload.data, (err, production) => {
+  newProduction ({ commit, state }, { data, callback }) {
+    commit(EDIT_PRODUCTION_START, data)
+    productionsApi.newProduction(data, (err, production) => {
       if (err) {
         commit(EDIT_PRODUCTION_ERROR)
       } else {
         commit(EDIT_PRODUCTION_END, production)
       }
-      if (payload.callback) payload.callback(err)
+      if (callback) callback(err, production)
     })
   },
 


### PR DESCRIPTION
**Problem**

* It is not possible to delete an asset right after creating it.
* When a new production is created, it doesn't open it directly.
* It is possible to create asset with empty name.
* The add task button isn't easy to see the first time.

**Solution**

* Fix asset creation: asset local storage was not done properly after remote asset creation
* Open the production right after its creation
* Do no run asset creation if name is empty
* Highlight the add task button if there is no task in the asset page