### PR TITLE
Minor fixes

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -317,9 +317,9 @@ export default {
 }
 
 .type {
-  min-width: 120px;
-  max-width: 120px;
-  width: 120px;
+  min-width: 150px;
+  max-width: 150px;
+  width: 150px;
   font-weight: bold;
 }
 

--- a/src/lib/indexing.js
+++ b/src/lib/indexing.js
@@ -44,8 +44,9 @@ export const buildAssetIndex = (entries) => {
   const index = {}
   const assetIndex = {}
   entries.forEach((asset) => {
-    let stringToIndex = asset.name.replace(/_/g, ' ').replace(/-/g, ' ')
-    let words = stringToIndex.split(' ').concat([asset.asset_type_name])
+    const stringToIndex = asset.name.replace(/_/g, ' ').replace(/-/g, ' ')
+    const assetTypeWords = asset.asset_type_name.split(' ')
+    const words = stringToIndex.split(' ').concat(assetTypeWords)
     indexWords(index, assetIndex, asset, words)
   })
   return index

--- a/src/store/modules/tasktypes.js
+++ b/src/store/modules/tasktypes.js
@@ -1,5 +1,5 @@
 import taskTypesApi from '../api/tasktypes'
-import { sortByName, sortTaskTypes } from '../../lib/sorting'
+import { sortTaskTypes } from '../../lib/sorting'
 
 import {
   LOAD_TASK_TYPES_START,
@@ -192,7 +192,7 @@ const mutations = {
       Object.assign(taskType, newTaskType)
     } else {
       state.taskTypes.push(newTaskType)
-      state.taskTypes = sortByName(state.taskTypes)
+      state.taskTypes = sortTaskTypes(state.taskTypes)
     }
     state.taskTypeMap[newTaskType.id] = newTaskType
     state.editTaskType = {

--- a/test/store/tasktypes.spec.js
+++ b/test/store/tasktypes.spec.js
@@ -61,15 +61,21 @@ describe('taskTypes', () => {
     taskTypes = [
       {
         id: 1,
-        name: 'Modeling'
+        name: 'Modeling',
+        priority: 1,
+        for_shots: true
       },
       {
         id: 2,
-        name: 'Animation'
+        name: 'Animation',
+        priority: 1,
+        for_shots: true
       },
       {
         id: 3,
-        name: 'FX'
+        name: 'FX',
+        priority: 4,
+        for_shots: true
       }
     ]
   })
@@ -172,7 +178,7 @@ describe('taskTypes', () => {
       expect(state.isTaskTypesLoadingError).to.equal(false)
       expect(state.taskTypes).to.deep.equal(taskTypes)
       expect(state.taskTypes[0].name).to.equal('Animation')
-      expect(state.taskTypes[1].name).to.equal('FX')
+      expect(state.taskTypes[1].name).to.equal('Modeling')
     })
 
     it('EDIT_TASK_TYPE_START', () => {
@@ -195,22 +201,27 @@ describe('taskTypes', () => {
       store.commit(LOAD_TASK_TYPES_END, taskTypes)
       store.commit(EDIT_TASK_TYPE_END, {
         id: 4,
-        name: 'New task type'
+        name: 'New task type',
+        priority: 2,
+        for_shots: true
       })
       expect(state.taskTypes.length).to.equal(4)
+      let taskTypeName = state.taskTypes[2].name
+      expect(taskTypeName).to.equal('New task type')
+
       store.commit(EDIT_TASK_TYPE_END, {
         id: 2,
         name: 'Modeling edited'
       })
       expect(state.taskTypes.length).to.equal(4)
-      const taskTypeName = getters.getTaskType(state)(2).name
+      taskTypeName = getters.getTaskType(state)(2).name
       expect(taskTypeName).to.equal('Modeling edited')
 
       expect(state.editTaskType).to.deep.equal({
         isLoading: false,
         isError: false
       })
-      store.commit(DELETE_TASK_TYPE_END, taskTypes[2])
+      store.commit(DELETE_TASK_TYPE_END, taskTypes[1])
     })
 
     it('DELETE_TASK_TYPE_START', () => {


### PR DESCRIPTION
**Problem**

* The task type doesn't appear in logical place after creation.
* If there is a space in the asset type name, the indexation doesn't work on the second name.
* The asset type column is really small.

**Solution**

* Fix task type sorting after creation (sort based on all fields, not only the name).
* Index all asset type words, not the whole string.
* Make asset type column larger. 
