### PR TITLE
Minor improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "reconnecting-eventsource": "1.0.1",
     "superagent": "3.8.2",
     "thenby": "1.2.3",
+    "v-tooltip": "2.0.0-rc.33",
     "vue": "2.5.13",
     "vue-chartkick": "0.3.1",
     "vue-color": "2.4.3",

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,12 +17,12 @@ export default {
   methods: {
     onAssignation (eventData) {
       const store = this.$store
-      if (store.getters.user.id === eventData.person.id) {
+      if (store.getters.user.id === eventData.person_id) {
         store.dispatch('loadTodos', {forced: true})
       }
-      if (store.getters.route.path.indexOf(eventData.person.id) > 0) {
+      if (store.getters.route.path.indexOf(eventData.person_id) > 0) {
         store.dispatch('loadPersonTasks', {
-          personId: eventData.person.id,
+          personId: eventData.person_id,
           forced: true
         })
       }
@@ -40,7 +40,7 @@ export default {
       },
 
       'comment:new' (eventData) {
-        const commentId = eventData.id
+        const commentId = eventData.comment_id
         this.$store.dispatch('loadComment', {commentId})
       }
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -63,10 +63,6 @@ export default {
   height: 100vh;
 }
 
-.table td {
-  vertical-align: middle;
-}
-
 th.actions {
   min-width: 200px;
 }
@@ -269,6 +265,10 @@ input.search-input:focus {
   margin-top: 2em;
 }
 
+.table td {
+  vertical-align: middle;
+}
+
 .table-header-wrapper {
   overflow: hidden;
 }
@@ -301,6 +301,14 @@ input.search-input:focus {
 
 .table-info {
   margin-top: 1em;
+}
+
+.table-body .table tr:nth-child(even) {
+  background: #F6F6F6;
+}
+
+.table-body .table tr:hover {
+  background: #F0FFF0;
 }
 
 .flexrow {
@@ -357,11 +365,12 @@ input.search-input:focus {
 }
 
 .tooltip .tooltip-inner {
-  background: black;
-  color: white;
+  background: white;
+  color: #333;
   border-radius: 16px;
   padding: 1em;
   max-width: 250px;
+  box-shadow: 0px 2px 3px 2px rgba(0, 0, 0, 0.1)
 }
 
 .tooltip .tooltip-arrow {
@@ -370,7 +379,7 @@ input.search-input:focus {
   border-style: solid;
   position: absolute;
   margin: 5px;
-  border-color: black;
+  border-color: white;
   z-index: 1;
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -351,6 +351,113 @@ input.search-input:focus {
   margin-bottom: 1em;
 }
 
+.tooltip {
+  display: block !important;
+  z-index: 10000;
+}
+
+.tooltip .tooltip-inner {
+  background: black;
+  color: white;
+  border-radius: 16px;
+  padding: 1em;
+  max-width: 250px;
+}
+
+.tooltip .tooltip-arrow {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  position: absolute;
+  margin: 5px;
+  border-color: black;
+  z-index: 1;
+}
+
+.tooltip[x-placement^="top"] {
+  margin-bottom: 5px;
+}
+
+.tooltip[x-placement^="top"] .tooltip-arrow {
+  border-width: 5px 5px 0 5px;
+  border-left-color: transparent !important;
+  border-right-color: transparent !important;
+  border-bottom-color: transparent !important;
+  bottom: -5px;
+  left: calc(50% - 5px);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.tooltip[x-placement^="bottom"] {
+  margin-top: 5px;
+}
+
+.tooltip[x-placement^="bottom"] .tooltip-arrow {
+  border-width: 0 5px 5px 5px;
+  border-left-color: transparent !important;
+  border-right-color: transparent !important;
+  border-top-color: transparent !important;
+  top: -5px;
+  left: calc(50% - 5px);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.tooltip[x-placement^="right"] {
+  margin-left: 5px;
+}
+
+.tooltip[x-placement^="right"] .tooltip-arrow {
+  border-width: 5px 5px 5px 0;
+  border-left-color: transparent !important;
+  border-top-color: transparent !important;
+  border-bottom-color: transparent !important;
+  left: -5px;
+  top: calc(50% - 5px);
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.tooltip[x-placement^="left"] {
+  margin-right: 5px;
+}
+
+.tooltip[x-placement^="left"] .tooltip-arrow {
+  border-width: 5px 0 5px 5px;
+  border-top-color: transparent !important;
+  border-right-color: transparent !important;
+  border-bottom-color: transparent !important;
+  right: -5px;
+  top: calc(50% - 5px);
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.tooltip.popover .popover-inner {
+  background: #f9f9f9;
+  color: black;
+  padding: 24px;
+  border-radius: 5px;
+  box-shadow: 0 5px 30px rgba(black, .1);
+}
+
+.tooltip.popover .popover-arrow {
+  border-color: #f9f9f9;
+}
+
+.tooltip[aria-hidden='true'] {
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity .15s, visibility .15s;
+}
+
+.tooltip[aria-hidden='false'] {
+  visibility: visible;
+  opacity: 1;
+  transition: opacity .15s;
+}
+
 @media screen and (max-width: 1000px) {
   .button .icon.is-small {
     margin-right: 0;

--- a/src/components/ActionTopbar.vue
+++ b/src/components/ActionTopbar.vue
@@ -4,154 +4,155 @@
       'action-topbar': true,
       'hidden': isHidden
     }">
-      <div class="level">
-        <div class="level-left">
-          <div class="level-item more-menu-icon" @click="toggleMenu">
-            <more-vertical-icon></more-vertical-icon>
-          </div>
+      <div class="flexrow action-bar">
 
-          <div class="level-item" v-if="selectedBar === 'assignation'">
-            <div class="flexrow" v-if="isCurrentUserManager">
-              <div class="assignation flexrow-item">
-                {{ $tc('tasks.assign', nbSelectedTasks, {nbSelectedTasks}) }}
-              </div>
-              <div class="flexrow-item combobox-item">
-                <combobox
-                  :options="getPersonOptions"
-                  v-model="personId"
-                >
-                </combobox>
-              </div>
-              <div class="" v-if="isAssignationLoading">
-                <spinner :is-white="true"></spinner>
-              </div>
-              <div class="flexrow-item" v-if="!isAssignationLoading">
-                <button
-                  class="button is-success confirm-button"
-                  @click="confirmAssign"
-                >
-                {{ $t('main.confirmation') }}
-                </button>
-              </div>
-              <div class="flexrow-item" v-if="!isAssignationLoading">
-                {{ $t('main.or') }}
-              </div>
-              <div class="flexrow-item" v-if="!isAssignationLoading">
-                <button
-                  class="button is-link clear-assignation-button"
-                  @click="clearAssignation"
-                >
-                  {{ $t('tasks.clear_assignations') }}
-                </button>
-              </div>
-            </div>
-            <div style="padding-left: 1em;" v-else>
-              {{ $t('tasks.no_assignation_right') }}
-            </div>
-          </div>
-
-          <div
-            class="level-item"
-            v-if="selectedBar === 'change-status'"
-          >
-            <div class="flexrow">
-              <div class="flexrow-item strong bigger">
-                {{ $t('tasks.change_status_to') }}
-              </div>
-              <div class="flexrow-item combobox-item">
-                <combobox
-                  :options="taskStatusOptions"
-                  v-model="taskStatusId"
-                >
-                </combobox>
-              </div>
-              <div class="flexrow-item" v-if="!isChangeStatusLoading">
-                <button
-                  class="button is-success confirm-button"
-                  @click="confirmTaskStatusChange"
-                >
-                  {{ $t('main.confirmation') }}
-                </button>
-
-                <div class="" v-if="isChangeStatusLoading">
-                  <spinner :is-white="true"></spinner>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div
-            class="level-item"
-            v-if="selectedBar === 'tasks'"
-          >
-            <div class="flexrow">
-              <div class="flexrow-item strong bigger">
-                {{ $t('tasks.create_for_selection') }}
-              </div>
-              <div class="flexrow-item" v-if="!isCreationLoading">
-                <button
-                  class="button is-success confirm-button"
-                  @click="confirmTaskCreation"
-                >
-                  {{ $t('main.confirmation') }}
-                </button>
-
-                <div class="" v-if="isCreationLoading">
-                  <spinner :is-white="true"></spinner>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div
-            class="level-item"
-            v-if="selectedBar === 'custom-actions'"
-          >
-            <div class="flexrow">
-              <div class="flexrow-item strong bigger">
-                {{ $t('custom_actions.run_for_selection') }}
-              </div>
-              <div class="flexrow-item combobox-item">
-                <combobox
-                  :options="customActionOptions"
-                  v-model="customActionUrl"
-                >
-                </combobox>
-              </div>
-              <div class="flexrow-item">
-                <form
-                  target="_blank"
-                  method="POST"
-                  :action="customActionUrl"
-                >
-                  <input type="hidden" id="personid" name="personid" :value="user.id">
-                  <input type="hidden" id="personemail" name="personemail" :value="user.email">
-                  <input type="hidden" id="projectid" name="projectid" :value="currentProduction.id">
-                  <input type="hidden" id="currentpath" name="currentpath" :value="currentUrl">
-                  <input type="hidden" id="currentserver" name="currentserver" :value="currentHost">
-                  <input type="hidden" id="selection" name="selection" :value="selectedTaskIds">
-                  <input type="hidden" id="entity_type" name="entity_type" :value="currentEntityType">
-                <button
-                  class="button is-success"
-                  type="submit"
-                >
-                  {{ $t('main.confirmation') }}
-                </button>
-                </form>
-              </div>
-            </div>
-          </div>
-
+        <div class="flexrow-item more-menu-icon" @click="toggleMenu">
+          <more-vertical-icon></more-vertical-icon>
         </div>
 
-        <div class="level-right">
+        <div class="flexrow-item" v-if="selectedBar === 'assignation'">
+          <div class="flexrow" v-if="isCurrentUserManager">
+            <div class="assignation flexrow-item hide-small-screen">
+              {{ $tc('tasks.assign', nbSelectedTasks, {nbSelectedTasks}) }}
+            </div>
+            <div class="flexrow-item combobox-item">
+              <combobox
+                :options="getPersonOptions"
+                v-model="personId"
+              >
+              </combobox>
+            </div>
+            <div class="" v-if="isAssignationLoading">
+              <spinner :is-white="true"></spinner>
+            </div>
+            <div class="flexrow-item" v-if="!isAssignationLoading">
+              <button
+                class="button is-success confirm-button"
+                @click="confirmAssign"
+              >
+              {{ $t('main.confirmation') }}
+              </button>
+            </div>
+            <div class="flexrow-item hide-small-screen" v-if="!isAssignationLoading">
+              {{ $t('main.or') }}
+            </div>
+            <div class="flexrow-item hide-small-screen" v-if="!isAssignationLoading">
+              <button
+                class="button is-link clear-assignation-button hide-small-screen"
+                @click="clearAssignation"
+              >
+                {{ $t('tasks.clear_assignations') }}
+              </button>
+            </div>
+          </div>
+          <div style="padding-left: 1em;" v-else>
+            {{ $t('tasks.no_assignation_right') }}
+          </div>
+        </div>
+
+        <div
+          class="flexrow-item"
+          v-if="selectedBar === 'change-status'"
+        >
+          <div class="flexrow">
+            <div class="flexrow-item strong bigger hide-small-screen">
+              {{ $t('tasks.change_status_to') }}
+            </div>
+            <div class="flexrow-item combobox-item">
+              <combobox
+                :options="taskStatusOptions"
+                v-model="taskStatusId"
+              >
+              </combobox>
+            </div>
+            <div class="flexrow-item" v-if="!isChangeStatusLoading">
+              <button
+                class="button is-success confirm-button"
+                @click="confirmTaskStatusChange"
+              >
+                {{ $t('main.confirmation') }}
+              </button>
+
+              <div class="" v-if="isChangeStatusLoading">
+                <spinner :is-white="true"></spinner>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
+          class="flexrow-item"
+          v-if="selectedBar === 'tasks'"
+        >
+          <div class="flexrow">
+            <div class="flexrow-item strong bigger hide-small-screen">
+              {{ $t('tasks.create_for_selection') }}
+            </div>
+            <div class="flexrow-item" v-if="!isCreationLoading">
+              <button
+                class="button is-success confirm-button"
+                @click="confirmTaskCreation"
+              >
+                {{ $t('main.confirmation') }}
+              </button>
+
+              <div class="" v-if="isCreationLoading">
+                <spinner :is-white="true"></spinner>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
+          class="flexrow-item"
+          v-if="selectedBar === 'custom-actions'"
+        >
+          <div class="flexrow">
+            <div class="flexrow-item strong bigger hide-small-screen">
+              {{ $t('custom_actions.run_for_selection') }}
+            </div>
+            <div class="flexrow-item combobox-item">
+              <combobox
+                :options="customActionOptions"
+                v-model="customActionUrl"
+              >
+              </combobox>
+            </div>
+            <div class="flexrow-item">
+              <form
+                target="_blank"
+                method="POST"
+                :action="customActionUrl"
+              >
+                <input type="hidden" id="personid" name="personid" :value="user.id">
+                <input type="hidden" id="personemail" name="personemail" :value="user.email">
+                <input type="hidden" id="projectid" name="projectid" :value="currentProduction.id">
+                <input type="hidden" id="currentpath" name="currentpath" :value="currentUrl">
+                <input type="hidden" id="currentserver" name="currentserver" :value="currentHost">
+                <input type="hidden" id="selection" name="selection" :value="selectedTaskIds">
+                <input type="hidden" id="entity_type" name="entity_type" :value="currentEntityType">
+              <button
+                class="button is-success"
+                type="submit"
+              >
+                {{ $t('main.confirmation') }}
+              </button>
+              </form>
+            </div>
+          </div>
+        </div>
+
+
+        <div class="flexrow-item clear-selection-container">
           <div
-            class="level-item clear-selection"
+            class="clear-selection flexrow"
             @click="clearSelectedTasks"
           >
-            <x-icon>
+            <x-icon class="flexrow-item">
             </x-icon>
-            {{ $t('main.clear_selection') }}
+            <span class="flexrow-item hide-small-screen">
+              {{ $t('main.clear_selection') }}
+            </span>
           </div>
         </div>
       </div>
@@ -435,16 +436,10 @@ export default {
   box-shadow: 0px 0px 6px rgba(0,0,0,0.2);
   max-height: 60px;
   min-height: 60px;
-  z-index: 200;
+  z-index: 210;
   position: fixed;
   left: 0;
   right: 0;
-}
-
-.level {
-  width: 100%;
-  height: 60px;
-  align-items: center;
 }
 
 div.assignation {
@@ -455,10 +450,6 @@ div.assignation {
 
 div.combobox-item {
   padding-top: 3px;
-}
-
-.level-item {
-  padding: 0.5em;
 }
 
 .hidden {
@@ -489,9 +480,9 @@ div.combobox-item {
   color: white;
 }
 
-.level .more-menu-icon {
+.more-menu-icon {
   cursor: pointer;
-  margin-right: 0;
+  padding-top: 3px;
 }
 
 .more-menu {
@@ -515,9 +506,28 @@ div.combobox-item {
   background: #9f7fdf;
 }
 
-.flexrow-item {
+.action-bar {
+  padding: 0.7em;
+}
+
+.clear-selection-container {
+  flex: 1;
+}
+
+.clear-selection {
+}
+
+.clear-selection .flexrow-item:first-child {
+  margin-left: auto;
 }
 
 @media screen and (max-width: 768px) {
+  .level-item {
+    width: auto;
+  }
+
+  .hide-small-screen {
+    display: none;
+  }
 }
 </style>

--- a/src/components/Episodes.vue
+++ b/src/components/Episodes.vue
@@ -263,7 +263,7 @@ export default {
   socket: {
     events: {
       'comment:new' (eventData) {
-        const commentId = eventData.id
+        const commentId = eventData.comment_id
         this.loadComment({
           commentId,
           callback: () => {

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -175,7 +175,7 @@ export default {
     events: {
       'preview:add' (eventData) {
         const commentId = eventData.comment_id
-        const previewId = eventData.preview.id
+        const previewId = eventData.preview_file_id
         this.$store.commit('NOTIFICATION_ADD_PREVIEW', {
           previewId,
           commentId

--- a/src/components/OpenProductions.vue
+++ b/src/components/OpenProductions.vue
@@ -258,7 +258,7 @@ h1 {
 }
 
 .is-grid .open-production {
-  margin: auto;
+  margin: 1em auto 0 auto;
 }
 
 .avatar {

--- a/src/components/Sequences.vue
+++ b/src/components/Sequences.vue
@@ -263,7 +263,7 @@ export default {
   socket: {
     events: {
       'comment:new' (eventData) {
-        const commentId = eventData.id
+        const commentId = eventData.comment_id
         this.loadComment({
           commentId,
           callback: () => {

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -972,20 +972,26 @@ export default {
     onPreviewAdded (eventData) {
       const taskId = eventData.task_id
       const commentId = eventData.comment_id
-      const preview = eventData.preview
+      const previewId = eventData.preview_file_id
+      const isMovie = eventData.is_movie
+      const revision = eventData.revision
       const comment = this.$store.getters.getTaskComment(taskId, commentId)
 
       if (
-        (!comment.preview || comment.preview.id !== eventData.preview.id) &&
+        (!comment.preview || comment.preview.id !== previewId) &&
         taskId === this.currentTask.id
       ) {
         this.$store.commit('ADD_PREVIEW_END', {
-          preview,
+          preview: {
+            id: previewId,
+            revision,
+            is_movie: isMovie
+          },
           taskId,
           commentId,
           comment
         })
-        this.resetPreview(preview.is_movie, preview)
+        this.resetPreview(isMovie, {id: previewId})
       }
     },
 

--- a/src/components/Topbar.vue
+++ b/src/components/Topbar.vue
@@ -40,6 +40,7 @@
                 name: 'assets',
                 params: {production_id: currentProductionId}
               }"
+              v-if="currentProductionId"
             >
             <img src="../assets/icons/assets.png" />
             </router-link>
@@ -50,6 +51,7 @@
                 name: 'shots',
                 params: {production_id: currentProductionId}
               }"
+              v-if="currentProductionId"
             >
             <img src="../assets/icons/shots.png" />
             </router-link>
@@ -60,6 +62,7 @@
                 name: 'sequences',
                 params: {production_id: currentProductionId}
               }"
+              v-if="currentProductionId"
             >
             <img src="../assets/icons/sequences.png" />
             </router-link>

--- a/src/components/Topbar.vue
+++ b/src/components/Topbar.vue
@@ -221,7 +221,7 @@ export default {
     events: {
       'notifications:new' (eventData) {
         if (this.user.id === eventData.person_id) {
-          const notificationId = eventData.id
+          const notificationId = eventData.notification_id
           this.loadNotification(notificationId)
         }
       }

--- a/src/components/cells/DescriptionCell.vue
+++ b/src/components/cells/DescriptionCell.vue
@@ -4,10 +4,8 @@
     class="description"
     v-if="entry.description && entry.description.length > 0"
     v-html="compileMarkdown(shortenText(entry.description, 20))"
-    v-tooltip="{
-      content: compileMarkdown(entry.description),
-      trigger: 'click'
-    }"
+    v-tooltip="tooltipOptions"
+    @click="onClick"
   >
   </span>
 </td>
@@ -20,6 +18,12 @@ import stringHelpers from '../../lib/string'
 
 export default {
   name: 'description-cell',
+  data () {
+    return {
+      isOpen: false,
+      timeout: null
+    }
+  },
   components: {
   },
   props: [
@@ -27,7 +31,18 @@ export default {
   ],
   computed: {
     ...mapGetters([
-    ])
+    ]),
+
+    tooltipOptions () {
+      return {
+        content: this.compileMarkdown(this.entry.description),
+        show: this.isOpen,
+        trigger: 'manual',
+        delay: {
+          hide: 1000
+        }
+      }
+    }
   },
 
   methods: {
@@ -38,7 +53,18 @@ export default {
       return marked(input || '')
     },
 
-    shortenText: stringHelpers.shortenText
+    shortenText: stringHelpers.shortenText,
+
+    onClick () {
+      this.isOpen = !this.isOpen
+      if (this.isOpen) {
+        this.timeout = setTimeout(() => {
+          this.isOpen = false
+        }, 3000)
+      } else {
+        clearTimeout(this.timeout)
+      }
+    }
   }
 }
 </script>

--- a/src/components/cells/DescriptionCell.vue
+++ b/src/components/cells/DescriptionCell.vue
@@ -1,8 +1,13 @@
 <template>
 <td>
   <span
+    class="description"
     v-if="entry.description && entry.description.length > 0"
-    v-html="compileMarkdown(entry.description)"
+    v-html="compileMarkdown(shortenText(entry.description, 20))"
+    v-tooltip="{
+      content: compileMarkdown(entry.description),
+      trigger: 'click'
+    }"
   >
   </span>
 </td>
@@ -11,6 +16,7 @@
 <script>
 import marked from 'marked'
 import { mapGetters, mapActions } from 'vuex'
+import stringHelpers from '../../lib/string'
 
 export default {
   name: 'description-cell',
@@ -30,7 +36,9 @@ export default {
 
     compileMarkdown (input) {
       return marked(input || '')
-    }
+    },
+
+    shortenText: stringHelpers.shortenText
   }
 }
 </script>
@@ -46,5 +54,9 @@ export default {
 
 .no-comment {
   font-style: italic;
+}
+
+.description {
+  cursor: pointer;
 }
 </style>

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -157,7 +157,7 @@ export default {
 }
 
 td.validation:hover {
-  background: #ecfaec;
+  background: #CCFFCC;
 }
 
 td.selected,

--- a/src/components/widgets/EntityThumbnail.vue
+++ b/src/components/widgets/EntityThumbnail.vue
@@ -2,6 +2,10 @@
 <a
   :href="originalPath"
   target="_blank"
+  :style="{
+    width: emptyWidth + 'px',
+    height: emptyHeight + 'px',
+  }"
   v-if="isPreview && withLink"
 >
   <img
@@ -110,10 +114,17 @@ export default {
 </script>
 
 <style scoped>
+.thumbnail-picture {
+  margin-left: 0.3em;
+  margin-top: 7px;
+  border: 1px solid #CCC;
+}
+
 span.thumbnail-empty {
   background: #F3F3F3;
   display: block;
   margin-bottom: 0.3em;
+  margin-top: 0.3em;
 }
 
 span.square {

--- a/src/lib/string.js
+++ b/src/lib/string.js
@@ -14,5 +14,14 @@ export default {
     } else {
       return ''
     }
+  },
+
+  shortenText (text, maxLength) {
+    let result = text || ''
+    if (text !== undefined && text.length > maxLength) {
+      result = text.slice(0, maxLength) + '...'
+    }
+
+    return result
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,6 @@ import { sync } from 'vuex-router-sync'
 import router from './router'
 import vuescroll from 'vue-scroll'
 import i18n from './lib/i18n'
-// import realtime from './lib/realtime'
 import store from './store'
 import App from './App'
 import VueLazyload from 'vue-lazyload'
@@ -13,6 +12,7 @@ import infiniteScroll from 'vue-infinite-scroll'
 import VueChartkick from 'vue-chartkick'
 import Chart from 'chart.js'
 import VueWebsocket from 'vue-websocket'
+import VTooltip from 'v-tooltip'
 
 Vue.config.productionTip = false
 Vue.use(vuescroll)
@@ -21,6 +21,7 @@ Vue.use(Meta)
 Vue.use(infiniteScroll)
 Vue.use(VueChartkick, {adapter: Chart})
 Vue.use(VueWebsocket, '/events')
+Vue.use(VTooltip)
 
 // Make the current route part of the main state.
 sync(store, router)

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -5,6 +5,7 @@ import init from '../lib/init'
 
 import userStore from '../store/modules/user'
 import taskTypeStore from '../store/modules/tasktypes'
+import store from '../store/'
 
 import Asset from '../components/Asset'
 import Assets from '../components/Assets'
@@ -45,17 +46,25 @@ export const routes = [
         } else {
           timezone.setTimezone()
           lang.setLocale()
-          init((err) => {
-            if (err) {
-              next({name: 'server-down'})
-            } else {
-              if (userStore.getters.isCurrentUserManager(userStore.state)) {
-                next({name: 'open-productions'})
+          if (store.state.productions.openProductions.length === 0) {
+            init((err) => {
+              if (err) {
+                next({name: 'server-down'})
               } else {
-                next({name: 'todos'})
+                if (userStore.getters.isCurrentUserManager(userStore.state)) {
+                  next({name: 'open-productions'})
+                } else {
+                  next({name: 'todos'})
+                }
               }
+            })
+          } else {
+            if (userStore.getters.isCurrentUserManager(userStore.state)) {
+              next({name: 'open-productions'})
+            } else {
+              next({name: 'todos'})
             }
-          })
+          }
         }
       })
     }


### PR DESCRIPTION
**Problems**

* Empty pages are not friendly
* Open production page looks messy when there is many production
* It's slow to use the sidebar to navigate from assets to shots
* Many pages are not well displayed on mobile
* When description are long, it makes lines too big
* New event format from the API is not well supported
* It is not easy to distinguish lines properly in asset and shot tables

**Solution**

* Add a picture to empty pages (asset, shots and open production)
* Switch to a grid layout when, there is many productions. Make style more consistant with the rest.
* Add shortcuts to the top bar as suggested by @mottosso 
* Handle case where screen width is < 768px
* Shorten description and allow to expand them via a tooltip
* Adapt to new API event format
* Add stripes to tables
 