### PR TITLE
Reset password pages and various fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <router-view></router-view>
+  <router-view />
 </template>
 
 <script>
@@ -86,7 +86,11 @@ th.actions {
 }
 
 td.actions {
-    min-width: 100px;
+  min-width: 100px;
+}
+
+.hero {
+  background-color: #CFCFCF;
 }
 
 .avatar {
@@ -104,6 +108,10 @@ td.actions {
 .th-project {
   width: 30px;
   border-radius: 50%;
+}
+
+.grey-background {
+  background-color: #CFCFCF;
 }
 
 td strong {
@@ -146,6 +154,10 @@ a:hover {
 
 .field {
   margin-bottom: 2em;
+}
+
+.mt2 {
+  margin-top: 2em;
 }
 
 input.input:focus {
@@ -195,6 +207,45 @@ input.input:focus {
 
 .footer-info {
   font-style: italic;
+}
+
+.container {
+  max-width: 400px;
+  color: #4a4a4a;
+}
+
+.main-button {
+  border-radius: 2px;
+  min-height: 2.8em;
+  color: white;
+  border-color: #5e60ba;
+  padding: 12px 12px 12px 12px;
+  margin: .3em 0 0em 0;
+  font-size: 16px;
+  font-weight: 500;
+  letter-spacing: 1px;
+  background: #00B242;
+  color: #fff;
+  border: 0;
+  border-bottom: 3px solid #008732;
+  transition: all 0.15s ease;
+  width: 100%;
+  display: block;
+  text-align: center;
+}
+
+.main-button:hover {
+  background: #67BE4B;
+  color: #fff;
+}
+
+.main-button:focus { outline: 0; }
+
+.box {
+  margin-top: 30%;
+  padding: 3em 2em 2em 2em;
+  border-radius: 2px;
+  box-shadow: rgba(0,0,0,0.14902) 0px 1px 1px 0px,rgba(0,0,0,0.09804) 0px 1px 2px 0px;
 }
 
 .button .icon.is-small:first-child:last-child {
@@ -491,6 +542,33 @@ input.search-input:focus {
 
   .level-item:not(:last-child) {
      margin-bottom: 0;
+  }
+}
+
+@media (min-width: 500px) {
+  .container {
+    margin: 0 auto;
+  }
+}
+
+@media (max-width: 500px) {
+  .container {
+    flex: 1;
+    width: 100%;
+    max-width: 100%;
+    display: flex;
+  }
+
+  .box {
+    margin: 0;
+    width: 100%;
+    min-width: 100%;
+    flex: 1;
+  }
+
+  .hero {
+    display: flex;
+    flex-direction: column;
   }
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -248,6 +248,25 @@ input.input:focus {
   box-shadow: rgba(0,0,0,0.14902) 0px 1px 1px 0px,rgba(0,0,0,0.09804) 0px 1px 2px 0px;
 }
 
+.box h1.title {
+  color: #6a6a6a;
+  font-weight: 500;
+  font-size: 1.4em;
+  line-height: 1.6em;
+}
+
+.box .field {
+  margin-bottom: 1em;
+}
+
+.box .input {
+  height: 2.4em;
+}
+
+.box .input:focus {
+  border: 1px solid #00B242;
+}
+
 .button .icon.is-small:first-child:last-child {
   margin-right: 0em;
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,31 @@
 <template>
-  <router-view />
+  <div
+    class="has-text-centered mt2 loading-info"
+    v-if="isLoginLoading"
+  >
+    <span>Loading data...</span>
+    <spinner class="mt2" />
+  </div>
+  <router-view v-else />
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+import Spinner from './components/widgets/Spinner.vue'
+
 export default {
   name: 'app',
+
+  components: {
+    Spinner
+  },
+
+  computed: {
+    ...mapGetters([
+      'isLoginLoading'
+    ])
+  },
+
   metaInfo: {
     link: [
       {
@@ -72,6 +93,10 @@ body {
 
 #app .router-link-active {
   color: #00d1b2;
+}
+
+.loading-info {
+  background: white;
 }
 
 .page {

--- a/src/components/Assets.vue
+++ b/src/components/Assets.vue
@@ -145,7 +145,7 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 
-import AssetList from './lists/AssetList.vue'
+import AssetList from './lists/AssetList'
 import ButtonHrefLink from './widgets/ButtonHrefLink'
 import ButtonLink from './widgets/ButtonLink'
 import CreateTasksModal from './modals/CreateTasksModal'

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -8,7 +8,7 @@
             {{ $t("login.title") }}
           </h1>
         </div>
-        <div class="field">
+        <div class="field mt2">
           <p class="control has-icon">
             <input
               class="input is-medium email"
@@ -18,7 +18,7 @@
               @keyup.enter="logIn"
               v-focus >
             <span class="icon">
-              <i class="fa fa-envelope"></i>
+              <mail-icon width=20 height=20 />
             </span>
           </p>
         </div>
@@ -31,13 +31,12 @@
               @input="updatePassword"
               @keyup.enter="logIn">
             <span class="icon">
-              <i class="fa fa-lock"></i>
+              <lock-icon width=20 height=20 />
             </span>
           </p>
         </div>
         <p class="control">
           <a v-bind:class="{
-            button: true,
             'main-button': true,
             'is-fullwidth': true,
             'is-loading': isLoginLoading
@@ -49,6 +48,15 @@
         <p class="control error" v-show="isLoginError">
           {{ $t("login.login_failed") }}
         </p>
+        <p
+          class="has-text-centered"
+        >
+          <router-link
+            :to="{name: 'reset-password'}"
+          >
+            {{ $t("login.forgot_password")}}
+          </router-link>
+        </p>
       </div>
     </div>
   </div>
@@ -56,15 +64,23 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
+import { MailIcon, LockIcon } from 'vue-feather-icons'
 
 export default {
   name: 'login',
+
+  components: {
+    MailIcon,
+    LockIcon
+  },
+
   computed: {
     ...mapGetters([
       'isLoginLoading',
       'isLoginError'
     ])
   },
+
   methods: {
     ...mapActions([
     ]),
@@ -91,26 +107,6 @@ export default {
 </script>
 
 <style scoped>
-.login {
-  background-color: #CFCFCF;
-}
-
-.login-header {
-  margin-bottom: 2em;
-}
-
-.container {
-  max-width: 400px;
-  color: #4a4a4a;
-}
-
-.box {
-  margin-top: 30%;
-  padding: 3em 2em 2em 2em;
-  border-radius: 2px;
-  box-shadow: rgba(0,0,0,0.14902) 0px 1px 1px 0px,rgba(0,0,0,0.09804) 0px 1px 2px 0px;
-}
-
 .box h1.title {
   color: #6a6a6a;
   font-weight: 500;
@@ -120,18 +116,6 @@ export default {
 .box h2.subtitle {
   color: #4a4a4a;
   margin-bottom: 1em;
-}
-
-.main-button {
-  background: #5e60ba;
-  border-radius: 2px;
-  min-height: 2.8em;
-  color: white;
-  border-color: #5e60ba;
-}
-
-.main-button:hover {
-  background: #67BE4B;
 }
 
 .field {
@@ -145,20 +129,6 @@ export default {
 .input:focus {
   border: 1px solid #00B242;
 }
-
-.button {
-  padding: 24px 24px 24px 12px;
-  margin: .3em 0 0em 0;
-  font-size: 16px;
-  font-weight: 500;
-  letter-spacing: 1px;
-  background: #00B242;
-  color: #fff;
-  border: 0;
-  border-bottom: 3px solid #008732;
-  transition: all 0.15s ease;
-}
-.button:focus { outline: 0; }
 
 img {
   margin-bottom: 2em;

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -27,6 +27,7 @@
             {{ formatDate(notification.created_at) }}
           </span>
           <router-link
+            class="person-name"
             :to="{
               name: 'person',
               params: {person_id: notification.author_id}
@@ -34,7 +35,7 @@
           >
             {{ personName(notification) }}
           </router-link>
-          <span>
+          <span class="comment-explaination">
             {{ $t('notifications.commented_on') }}
           </span>
           <router-link
@@ -62,8 +63,7 @@
             class="validation-tag"
             :task="{
               id: notification.task_id,
-              task_status_short_name: taskStatusMap[notification.task_status_id].short_name,
-              task_status_color: taskStatusMap[notification.task_status_id].color
+              task_status_id: notification.task_status_id
 
             }"
             v-if="notification.change"
@@ -221,6 +221,15 @@ a {
 }
 
 img.thumbnail-picture {
+}
+
+.person-name {
+  margin-left: 0.5em;
+}
+
+.comment-explaination {
+  margin-left: 0.5em;
+  margin-right: 0.5em;
 }
 
 .comment-text {

--- a/src/components/ResetChangePassword.vue
+++ b/src/components/ResetChangePassword.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="hero is-fullheight">
+    <div class="container has-text-centered">
+      <div class="box has-text-left">
+        <div class="has-text-centered">
+          <h1 class="title">
+            {{ $t("login.reset_change_password_title") }}
+          </h1>
+        </div>
+
+        <div class="field mt2">
+          <p class="control has-icon">
+            <input
+              class="input is-medium email"
+              type="password"
+              :placeholder="$t('login.fields.password')"
+              @keyup.enter="confirmResetChangePassword"
+              v-model="password"
+              v-focus
+            />
+            <span class="icon">
+              <lock-icon width=20 height=20 />
+            </span>
+          </p>
+          <p class="control has-icon">
+            <input
+              class="input is-medium email"
+              type="password"
+              :placeholder="$t('login.fields.password2')"
+              @keyup.enter="confirmResetChangePassword"
+              v-model="password2"
+            />
+            <span class="icon">
+              <lock-icon width=20 height=20 />
+            </span>
+          </p>
+        </div>
+
+        <p class="control">
+          <a v-bind:class="{
+            'main-button': true,
+            'is-fullwidth': true,
+            'is-loading': isLoading
+          }"
+            @click="confirmResetChangePassword">
+              {{ $t("login.reset_change_password") }}
+          </a>
+        </p>
+        <p class="error" v-show="isFormError">
+          {{ $t("login.reset_change_password_form_failed") }}
+        </p>
+        <p class="error" v-show="isError">
+          {{ $t("login.reset_change_password_failed") }}
+        </p>
+        <p class="success" v-show="isSuccess">
+          {{ $t("login.reset_change_password_succeed") }}
+        </p>
+        <p
+          class="has-text-centered"
+        >
+          <router-link
+            :to="{name: 'login'}"
+          >
+            {{ $t("login.login_page")}}
+          </router-link>
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+
+import { LockIcon } from 'vue-feather-icons'
+import auth from '../lib/auth'
+
+export default {
+  name: 'reset-password',
+
+  components: {
+    LockIcon
+  },
+
+  data () {
+    return {
+      password: '',
+      password2: '',
+      isLoading: false,
+      isError: false,
+      isFormError: false,
+      isSuccess: false
+    }
+  },
+
+  computed: {
+    ...mapGetters([
+    ])
+  },
+
+  methods: {
+    ...mapActions([
+      'resetChangePassword'
+    ]),
+
+    confirmResetChangePassword () {
+      this.isFormError = false
+      this.isError = false
+      if (auth.isPasswordValid(this.password, this.password2)) {
+        this.isLoading = true
+        this.isSuccess = false
+        this.resetChangePassword({
+          token: this.$route.params.token,
+          password: this.password,
+          password2: this.password2
+        })
+          .then(() => {
+            this.isLoading = false
+            this.isSuccess = true
+            setTimeout(() => {
+              this.$router.push({name: 'login'})
+            }, 3000)
+          })
+          .catch(() => {
+            this.isLoading = false
+            this.isError = true
+            this.isSuccess = false
+          })
+      } else {
+        this.isFormError = true
+      }
+    }
+  },
+
+  metaInfo () {
+    return {
+      title: this.$t('login.reset_change_password_title')
+    }
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/components/ResetPassword.vue
+++ b/src/components/ResetPassword.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="hero is-fullheight">
+    <div class="container has-text-centered">
+      <div class="box has-text-left">
+        <div class="has-text-centered">
+          <h1 class="title">
+            {{ $t("login.reset_password_title") }}
+          </h1>
+        </div>
+
+        <div class="field mt2">
+          <p class="control has-icon">
+            <input
+              class="input is-medium email"
+              type="text"
+              :placeholder="$t('login.fields.email')"
+              @keyup.enter="confirmResetPassword"
+              v-model="email"
+              v-focus
+            />
+            <span class="icon">
+              <mail-icon width=20 height=20 />
+            </span>
+          </p>
+        </div>
+
+        <p class="control">
+          <a v-bind:class="{
+            'main-button': true,
+            'is-fullwidth': true,
+            'is-loading': isLoading
+          }"
+            @click="confirmResetPassword">
+              {{ $t("login.reset_password") }}
+          </a>
+        </p>
+        <p class="error" v-show="isError">
+          {{ $t("login.reset_password_failed") }}
+        </p>
+        <p class="success" v-show="isSuccess">
+          {{ $t("login.reset_password_succeed") }}
+        </p>
+        <p
+          class="has-text-centered"
+        >
+          <router-link
+            :to="{name: 'login'}"
+          >
+            {{ $t("login.login_page")}}
+          </router-link>
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+
+import { MailIcon } from 'vue-feather-icons'
+
+export default {
+  name: 'reset-password',
+
+  components: {
+    MailIcon
+  },
+
+  data () {
+    return {
+      email: '',
+      isLoading: false,
+      isError: false,
+      isSuccess: false
+    }
+  },
+
+  computed: {
+    ...mapGetters([
+    ])
+  },
+
+  methods: {
+    ...mapActions([
+      'resetPassword'
+    ]),
+
+    confirmResetPassword () {
+      this.isLoading = true
+      this.isError = false
+      this.isSuccess = false
+      this.resetPassword(this.email)
+        .then(() => {
+          this.isLoading = false
+          this.isSuccess = true
+        })
+        .catch(() => {
+          this.isLoading = false
+          this.isError = true
+          this.isSuccess = false
+        })
+    }
+  },
+
+  metaInfo () {
+    return {
+      title: this.$t('login.reset_password_title')
+    }
+  }
+}
+</script>
+
+<style scoped>
+.box h1.title {
+  color: #6a6a6a;
+  font-weight: 500;
+  font-size: 1.4em;
+  line-height: 1.6em;
+}
+
+.field {
+  margin-bottom: 1em;
+}
+
+.input {
+  height: 2.4em;
+}
+
+.input:focus {
+  border: 1px solid #00B242;
+}
+</style>

--- a/src/components/ResetPassword.vue
+++ b/src/components/ResetPassword.vue
@@ -111,22 +111,4 @@ export default {
 </script>
 
 <style scoped>
-.box h1.title {
-  color: #6a6a6a;
-  font-weight: 500;
-  font-size: 1.4em;
-  line-height: 1.6em;
-}
-
-.field {
-  margin-bottom: 1em;
-}
-
-.input {
-  height: 2.4em;
-}
-
-.input:focus {
-  border: 1px solid #00B242;
-}
 </style>

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -37,8 +37,7 @@
           :task-type="currentTaskType"
           :production-id="currentProduction.id"
           v-if="currentTaskType"
-        >
-        </task-type-name>
+        />
         <div class="title flexrow-item">
           <router-link :to="taskEntityPath">
             {{ currentTask ? title : 'Loading...'}}
@@ -163,7 +162,7 @@
             <a
               class="button"
               ref="preview-file"
-              :href="getOriginalPath()"
+              :href="currentPreviewPath"
               v-else-if="isDlPreviewFile"
             >
               <download-icon class="icon"></download-icon>
@@ -173,12 +172,12 @@
             </a>
 
             <model-viewer
-              :preview-url="getOriginalPath()"
+              :preview-url="currentPreviewPath"
               v-else-if="currentTaskPreviews.length > 0 && extension === 'obj'"
             />
 
             <a
-              :href="getOriginalPath()"
+              :href="currentPreviewPath"
               target="_blank"
               v-else-if="currentTaskPreviews.length > 0 && extension === 'png'"
             >
@@ -229,8 +228,7 @@
       :form-data="addPreviewFormData"
       @fileselected="selectFile"
       @confirm="createPreview"
-    >
-    </add-preview-modal>
+    />
 
     <add-preview-modal
       ref="change-preview-modal"
@@ -242,8 +240,7 @@
       :is-editing="true"
       @fileselected="selectFile"
       @confirm="changePreview"
-    >
-    </add-preview-modal>
+    />
 
     <edit-comment-modal
       :active="modals.editComment"
@@ -252,8 +249,7 @@
       :cancel-route="taskPath"
       :comment-to-edit="commentToEdit"
       @confirm="confirmEditTaskComment"
-    >
-    </edit-comment-modal>
+    />
 
     <delete-modal
       :active="modals.deleteTask"
@@ -263,8 +259,7 @@
       :text="deleteText"
       :error-text="$t('tasks.delete_error')"
       @confirm="confirmDeleteTask"
-    >
-    </delete-modal>
+    />
 
     <delete-modal
       :active="modals.deleteComment"
@@ -274,8 +269,7 @@
       :text="$t('tasks.delete_comment')"
       :error-text="$t('tasks.delete_comment_error')"
       @confirm="confirmDeleteTaskComment"
-    >
-    </delete-modal>
+    />
 
   </div>
 </template>
@@ -364,7 +358,8 @@ export default {
       currentTaskPreviews: [],
       addPreviewFormData: null,
       changePreviewFormData: null,
-      isSubscribed: false
+      isSubscribed: false,
+      currentPreviewPath: ''
     }
   },
 
@@ -788,6 +783,7 @@ export default {
                   } else {
                     this.currentTaskComments = this.getCurrentTaskComments()
                     this.currentTaskPreviews = this.getCurrentTaskPreviews()
+                    this.currentPreviewPath = this.getOriginalPath()
                     this.taskLoading = {
                       isLoading: false,
                       isError: false
@@ -814,6 +810,7 @@ export default {
             } else {
               this.currentTaskComments = this.getCurrentTaskComments()
               this.currentTaskPreviews = this.getCurrentTaskPreviews()
+              this.currentPreviewPath = this.getOriginalPath()
               this.loadTaskSubscribed({
                 taskId: this.route.params.task_id,
                 callback: (err, subscribed) => {
@@ -898,8 +895,9 @@ export default {
               isLoading: false,
               isError: false
             }
-            this.currentTaskPreviews = this.getCurrentTaskPreviews()
             this.currentTaskComments = this.getCurrentTaskComments()
+            this.currentTaskPreviews = this.getCurrentTaskPreviews()
+            this.currentPreviewPath = this.getOriginalPath()
             this.currentTask = this.getCurrentTask()
           }
         }
@@ -979,8 +977,9 @@ export default {
     },
 
     resetPreview (preview) {
-      this.currentTaskPreviews = this.getCurrentTaskPreviews()
       this.currentTaskComments = this.getCurrentTaskComments()
+      this.currentTaskPreviews = this.getCurrentTaskPreviews()
+      this.currentPreviewPath = this.getOriginalPath()
       this.$router.push(`/tasks/${this.route.params.task_id}` +
                         `/previews/${preview.id}`)
     },
@@ -1050,6 +1049,7 @@ export default {
           } else {
             this.currentTaskComments = this.getCurrentTaskComments()
             this.currentTaskPreviews = this.getCurrentTaskPreviews()
+            this.currentPreviewPath = this.getOriginalPath()
             this.$router.push(this.taskPath)
           }
         }

--- a/src/components/widgets/ModelViewer.vue
+++ b/src/components/widgets/ModelViewer.vue
@@ -24,7 +24,7 @@ import {
   goFullScreen,
   loadObject,
   prepareScene
-} from 'js-3d-model-viewer'
+} from '../../../node_modules/js-3d-model-viewer/src/index'
 
 export default {
   name: 'model-viewer',

--- a/src/components/widgets/PeopleField.vue
+++ b/src/components/widgets/PeopleField.vue
@@ -4,6 +4,9 @@
     :get-label="getAssignationLabel"
     :component-item="assignationItem"
     :min-len="1"
+    :input-attrs="{
+      placeholder: this.$t('Select a person...')
+    }"
     @update-items="update"
     @input="onChange"
     v-model="item"

--- a/src/components/widgets/SearchField.vue
+++ b/src/components/widgets/SearchField.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="flexrow">
   <div class="flexrow-item">
-    <search-icon></search-icon>
+    <search-icon />
   </div>
 
   <div class="flexrow-item search-field">
@@ -27,7 +27,7 @@
 
   <div class="flexrow-item save-search" v-if="canSave">
     <button class="button" @click="onSaveClicked">
-      <save-icon class="icon is-small only-icon"></save-icon>
+      <save-icon class="icon is-small only-icon" />
     </button>
   </div>
 </div>

--- a/src/components/widgets/SubscribeButton.vue
+++ b/src/components/widgets/SubscribeButton.vue
@@ -1,6 +1,7 @@
 <template>
 <button
   class="button"
+  :title="buttonTitle"
   @click="$emit('click')"
 >
   <eye-icon
@@ -32,7 +33,16 @@ export default {
       type: Boolean
     }
   },
-  computed: {}
+
+  computed: {
+    buttonTitle () {
+      if (!this.subscribed) {
+        return this.$t('tasks.subscribe_notifications')
+      } else {
+        return this.$t('tasks.unsubscribe_notifications')
+      }
+    }
+  }
 }
 </script>
 

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -37,6 +37,31 @@ const auth = {
       })
   },
 
+  resetPassword (email) {
+    return new Promise((resolve, reject) => {
+      superagent
+        .post('/api/auth/reset-password')
+        .send({ email })
+        .end((err, res) => {
+          if (err) reject(err)
+          else resolve()
+        })
+    })
+  },
+
+  resetChangePassword (token, password, password2) {
+    return new Promise((resolve, reject) => {
+      console.log({ token, password, password2 })
+      superagent
+        .put('/api/auth/reset-password')
+        .send({ token, password, password2 })
+        .end((err, res) => {
+          if (err) reject(err)
+          else resolve()
+        })
+    })
+  },
+
   isServerLoggedIn (callback) {
     superagent
       .get('/api/auth/authenticated')
@@ -91,6 +116,5 @@ const auth = {
   isPasswordValid (password, password2) {
     return password.length > 6 && password === password2
   }
-
 }
 export default auth

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -3,7 +3,8 @@ import store from '../store'
 import {
   USER_LOGIN,
   USER_LOGOUT,
-  USER_LOGIN_FAIL
+  USER_LOGIN_FAIL,
+  LOGIN_RUN
 } from '../store/mutation-types.js'
 
 const auth = {
@@ -93,6 +94,7 @@ const auth = {
           query: { redirect: to.fullPath }
         })
       } else {
+        store.commit(LOGIN_RUN)
         next()
       }
     }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -96,12 +96,24 @@ export default {
   },
 
   login: {
+    forgot_password: 'Forgot password?',
     login: 'Log in',
     login_failed: 'Log in failed, please verify your credentials',
+    login_page: 'Cancel',
+    reset_change_password: 'Change password',
+    reset_change_password_form_failed: 'There is a problem with the password you gave. Please, verify that it is more than 6 chars long and that both passwords match.',
+    reset_change_password_failed: 'Changing password failed. Please, restart the whole procedure again.',
+    reset_change_password_succeed: 'Your password was changed successfully. Please, go back to the login page to use it.',
+    reset_change_password_title: 'Enter a new password',
+    reset_password: 'Reset Password',
+    reset_password_failed: 'Reset Password failed. Please verify your email.',
+    reset_password_succeed: 'Reset Password succeeded. Please check your inbox.',
+    reset_password_title: 'Enter your email to reset your password',
     title: 'Log in to Kitsu',
     fields: {
       email: 'Email',
-      password: 'Password'
+      password: 'Password',
+      password2: 'Password again'
     }
   },
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -400,11 +400,13 @@ export default {
     no_preview: 'There is currently no preview for this task.',
     preview: 'Previews',
     previous: 'previous task',
+    unsubscribe_notifications: 'Unsubscribe from notifications',
     set_preview: 'Set this preview as thumbnail',
     set_preview_error: 'An error occured while setting preview as thumbnail',
     set_preview_done: 'This preview is used as thumbnail for the current entity.',
     select_preview_file: 'Please select a picture from your hard drive to be used as a preview for the current task:',
     show_assignations: 'Show assignations',
+    subscribe_notifications: 'Subscribe to notifications',
     validation: 'Validation',
     tasks: 'Tasks',
     fields: {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -24,6 +24,8 @@ import Productions from '../components/Productions'
 import ProductionAssetTypes from '../components/ProductionAssetTypes'
 import Playlist from '../components/Playlist'
 import Profile from '../components/Profile'
+import ResetPassword from '../components/ResetPassword'
+import ResetChangePassword from '../components/ResetChangePassword'
 import ServerDown from '../components/ServerDown'
 import Sequences from '../components/Sequences'
 import Shot from '../components/Shot'
@@ -483,6 +485,16 @@ export const routes = [
     path: '/login',
     component: Login,
     name: 'login'
+  },
+  {
+    path: '/reset-password',
+    component: ResetPassword,
+    name: 'reset-password'
+  },
+  {
+    path: '/reset-change-password/:token',
+    component: ResetChangePassword,
+    name: 'reset-change-password'
   },
   {
     path: '/server-down',

--- a/src/store/modules/login.js
+++ b/src/store/modules/login.js
@@ -65,6 +65,22 @@ const actions = {
         callback(null, true)
       }
     })
+  },
+
+  resetPassword ({ commit }, email) {
+    return new Promise((resolve, reject) => {
+      auth.resetPassword(email)
+        .then(resolve)
+        .catch(reject)
+    })
+  },
+
+  resetChangePassword ({ commit }, { token, password, password2 }) {
+    return new Promise((resolve, reject) => {
+      auth.resetChangePassword(token, password, password2)
+        .then(resolve)
+        .catch(reject)
+    })
   }
 }
 

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -549,9 +549,7 @@ const mutations = {
     })
     state.taskComments[taskId] = comments
     state.taskPreviews[taskId] = comments.reduce((previews, comment) => {
-      if (comment.preview) {
-        previews.push(comment.preview)
-      }
+      if (comment.preview) previews.push(comment.preview)
       return previews
     }, [])
   },
@@ -611,6 +609,7 @@ const mutations = {
     const task = state.taskMap[taskId]
     let newStatus = todoStatus
     state.taskComments[taskId] = [...state.taskComments[taskId]].splice(1)
+    state.taskPreviews[taskId] = [...state.taskPreviews[taskId]].splice(1)
 
     if (state.taskComments[taskId].length > 0) {
       const newStatusId = state.taskComments[taskId][0].task_status_id


### PR DESCRIPTION
**Problem**

* There is no UI to reset the password.
* Notifications are not properly displayed anymore (following recent refactoring).
* People field is blank by default which is disapointing.
* Watch notifications button can be confusing
* Preview are not properly remove locally when a comment is deleted
* The model viewer doesn't work in production build
* The page is blank at first loading

**Solution**

* Add traditional UIs for password resest: one to give the email, another to change the password.
* Fix notification display by using task status map.
* Add a placeholder to people field.
* Add a tooltip to the notification button
* Remove preview from local storage
* Try to import directly the sources
* Add a loader when initial data are loaded
