### PR TITLE
Fixes

### DIFF
--- a/src/components/ActionTopbar.vue
+++ b/src/components/ActionTopbar.vue
@@ -141,8 +141,7 @@
               <combobox
                 :options="customActionOptions"
                 v-model="customActionUrl"
-              >
-              </combobox>
+              />
             </div>
             <div class="flexrow-item">
               <form
@@ -517,6 +516,17 @@ export default {
           this.customActionOptions = this.shotCustomActionOptions
         } else {
           this.customActionOptions = this.assetCustomActionOptions
+        }
+
+        if (this.customActionOptions.length > 0) {
+          const isUrlSelected =
+            this.customActionOptions.findIndex((action) => {
+              return action.url === this.customActionUrl
+            }) >= 0
+
+          if (!isUrlSelected) {
+            this.customActionUrl = this.customActionOptions[0].value
+          }
         }
       }
     },

--- a/src/components/AssetTypes.vue
+++ b/src/components/AssetTypes.vue
@@ -1,6 +1,19 @@
 <template>
   <div class="asset-types page fixed-page">
     <div class="level page-header">
+      <div class="level-left">
+        <page-title :text="$t('asset_types.title')" />
+      </div>
+      <div class="level-right">
+        <div class="level-item">
+          <button-link
+            class="level-item"
+            icon="plus"
+            :text="$t('asset_types.new_asset_type')"
+            path="/asset-types/new"
+          />
+        </div>
+      </div>
     </div>
 
     <asset-type-list

--- a/src/components/Shots.vue
+++ b/src/components/Shots.vue
@@ -267,9 +267,6 @@ export default {
     if (this.shotSearchText.length > 0) {
       this.$refs['shot-search-field'].setValue(this.shotSearchText)
     }
-    this.$refs['shot-list'].setScrollPosition(
-      this.shotListScrollPosition
-    )
 
     if (
       Object.keys(this.shotMap).length < 2 ||
@@ -286,12 +283,20 @@ export default {
           this.resizeHeaders()
           if (!err) {
             this.handleModalsDisplay()
+            setTimeout(() => {
+              this.$refs['shot-list'].setScrollPosition(
+                this.shotListScrollPosition
+              )
+            }, 500)
           }
         })
       }, 100)
     } else {
       if (!this.isShotsLoading) this.initialLoading = false
       this.resizeHeaders()
+      this.$refs['shot-list'].setScrollPosition(
+        this.shotListScrollPosition
+      )
     }
   },
 

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -1027,7 +1027,7 @@ export default {
           if (err) {
             this.errors.editComment = true
           } else {
-            this.$router.push(this.taskPath)
+            this.$router.push(this.taskPath())
           }
         }
       })
@@ -1049,7 +1049,7 @@ export default {
             this.currentTaskComments = this.getCurrentTaskComments()
             this.currentTaskPreviews = this.getCurrentTaskPreviews()
             this.currentPreviewPath = this.getOriginalPath()
-            this.$router.push(this.taskPath)
+            this.$router.push(this.taskPath())
           }
         }
       })

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -86,7 +86,6 @@
   <div
     ref="body"
     class="table-body"
-    v-infinite-scroll="loadMoreShots"
     v-scroll="onBodyScroll"
     v-if="!isLoading"
   >
@@ -308,6 +307,11 @@ export default {
     onBodyScroll (event, position) {
       this.$refs.headerWrapper.style.left = `-${position.scrollLeft}px`
       this.$emit('scroll', position.scrollTop)
+      const maxHeight =
+        this.$refs.body.scrollHeight - this.$refs.body.offsetHeight
+      if (maxHeight < (position.scrollTop + 100)) {
+        this.loadMoreShots()
+      }
     },
 
     loadMoreShots () {

--- a/src/components/modals/EditProductionModal.vue
+++ b/src/components/modals/EditProductionModal.vue
@@ -149,7 +149,7 @@ export default {
         fps: '',
         ratio: '',
         resolution: '',
-        production_type: ''
+        production_type: 'short'
       }
     }
     return data
@@ -191,7 +191,8 @@ export default {
           project_status_id: this.productionToEdit.project_status_id,
           fps: this.productionToEdit.fps,
           ratio: this.productionToEdit.ratio,
-          resolution: this.productionToEdit.resolution
+          resolution: this.productionToEdit.resolution,
+          production_type: this.productionToEdit.production_type
         }
       } else {
         this.form = {
@@ -199,7 +200,8 @@ export default {
           project_status_id: this.productionStatusOptions[0].value,
           fps: '',
           ratio: '',
-          resolution: ''
+          resolution: '',
+          production_type: 'short'
         }
       }
     },

--- a/src/store/modules/productions.js
+++ b/src/store/modules/productions.js
@@ -341,6 +341,9 @@ const mutations = {
     const productionStatus = getters.getProductionStatus(state)(
       newProduction.project_status_id
     )
+    const openProduction = state.openProductions.find(
+      (openProduction) => openProduction.id === newProduction.id
+    )
     newProduction.project_status_name = productionStatus.name
 
     if (production) {
@@ -361,7 +364,17 @@ const mutations = {
         }
       }
 
+      if (
+        newProduction.production_type &&
+        newProduction.production_type !== production.production_type &&
+        newProduction.production_type === 'short'
+      ) {
+        production.first_episode_id = undefined
+        openProduction.first_episode_id = undefined
+      }
+
       Object.assign(production, newProduction)
+      Object.assign(openProduction, newProduction)
     } else {
       state.productions.push(newProduction)
       state.productionMap[newProduction.id] = newProduction


### PR DESCRIPTION
**Problem**

* After editing a comment, the screen is blank.
* Modifying a production, especially its type led to weird behaviour.

**Solution**

* The taskPath function is no more a getter, so it needs to be called. That's why the routing was broken at the end of the comment edition.
* Update the production in the production list and in the open production list. Remove first_episode_id field when the type is modified to something different than TV show.