### PR TITLE
Various fixes

### DIFF
--- a/src/components/ActionTopbar.vue
+++ b/src/components/ActionTopbar.vue
@@ -474,6 +474,7 @@ export default {
 
   mounted () {
     this.customActionUrl = this.defaultCustomActionUrl
+    this.setCurrentTeam()
   },
 
   watch: {

--- a/src/components/modals/EditProductionModal.vue
+++ b/src/components/modals/EditProductionModal.vue
@@ -133,6 +133,7 @@ export default {
         }
       ]
     }
+
     if (this.productionToEdit && this.productionToEdit.id) {
       data.form = {
         name: this.productionToEdit.name,
@@ -140,19 +141,39 @@ export default {
         fps: this.productionToEdit.fps,
         ratio: this.productionToEdit.ratio,
         resolution: this.productionToEdit.resolution,
-        production_type: this.productionToEdit.production_type
+        production_type: this.productionToEdit.production_type || 'short'
       }
     } else {
       data.form = {
         name: '',
-        project_status_id: '',
+        project_status_id: this.productionStatus ? this.productionStatus[0].id : null,
         fps: '',
         ratio: '',
         resolution: '',
         production_type: 'short'
       }
     }
+
     return data
+  },
+
+  created () {
+    this.resetForm()
+
+    this.productionTypeOptions = [
+      {
+        label: 'short',
+        value: 'short'
+      },
+      {
+        label: 'featurefilm',
+        value: 'featurefilm'
+      },
+      {
+        label: 'tvshow',
+        value: 'tvshow'
+      }
+    ]
   },
 
   mounted () {
@@ -163,9 +184,9 @@ export default {
 
   computed: {
     ...mapGetters([
-      'productionStatusOptions',
       'productions',
-      'productionStatus'
+      'productionStatus',
+      'productionStatusOptions'
     ])
   },
 
@@ -180,11 +201,9 @@ export default {
     onFileSelected (formData) {
       this.formData = formData
       this.$emit('fileselected', formData)
-    }
-  },
+    },
 
-  watch: {
-    productionToEdit () {
+    resetForm () {
       if (this.productionToEdit && this.productionToEdit.id) {
         this.form = {
           name: this.productionToEdit.name,
@@ -192,7 +211,7 @@ export default {
           fps: this.productionToEdit.fps,
           ratio: this.productionToEdit.ratio,
           resolution: this.productionToEdit.resolution,
-          production_type: this.productionToEdit.production_type
+          production_type: this.productionToEdit.production_type || 'short'
         }
       } else {
         this.form = {
@@ -204,6 +223,12 @@ export default {
           production_type: 'short'
         }
       }
+    }
+  },
+
+  watch: {
+    productionToEdit () {
+      this.resetForm()
     },
 
     active () {

--- a/src/store/modules/productions.js
+++ b/src/store/modules/productions.js
@@ -378,7 +378,7 @@ const mutations = {
       }
 
       Object.assign(production, newProduction)
-      Object.assign(openProduction, newProduction)
+      if (openProduction) Object.assign(openProduction, newProduction)
     } else {
       state.productions.push(newProduction)
       state.productionMap[newProduction.id] = newProduction

--- a/src/store/modules/productions.js
+++ b/src/store/modules/productions.js
@@ -316,6 +316,10 @@ const mutations = {
       productionMap[production.id] = production
     })
     state.productionMap = productionMap
+
+    if (!state.currentProduction && state.openProductions.length > 0) {
+      state.currentProduction = state.openProductions[0]
+    }
   },
 
   [LOAD_PRODUCTION_STATUS_START] (state) {


### PR DESCRIPTION
**Problem**

* Assignation field is sometimes empty.
* Adding or removing someone from the team sometimes fail
* Production modal for edition has a weird behaviour.

**Solution**

* Init properly assignation field (doesn't wait for a production change to set person list)
* Set a default current production, if it is set to null after loading open productions
* Init production modal at creation step to avoid empty values
