### PR TITLE
Various fixes and improvements

### DIFF
--- a/src/components/ActionTopbar.vue
+++ b/src/components/ActionTopbar.vue
@@ -459,7 +459,7 @@ export default {
     },
 
     setCurrentTeam () {
-      if (this.people.length > 10) {
+      if (this.people.length > 10 && this.currentProduction) {
         this.currentTeam = sortPeople(
           this.currentProduction.team.map((personId) => {
             return this.personMap[personId]

--- a/src/components/Assets.vue
+++ b/src/components/Assets.vue
@@ -107,12 +107,14 @@
   <create-tasks-modal
     :active="modals.isCreateTasksDisplayed"
     :is-loading="loading.creatingTasks"
+    :is-loading-stay="loading.taskStay"
     :is-error="errors.creatingTasks"
     :cancel-route="assetsPath"
     :title="$t('tasks.create_tasks_asset')"
     :text="$t('tasks.create_tasks_asset_explaination')"
     :error-text="$t('tasks.create_tasks_asset_failed')"
     @confirm="confirmCreateTasks"
+    @confirm-and-stay="confirmCreateTasksAndStay"
   />
 </div>
 </template>
@@ -162,7 +164,8 @@ export default {
         creatingTasks: false,
         importing: false,
         edit: false,
-        stay: false
+        stay: false,
+        taskStay: false
       },
       errors: {
         creatingTasks: false,
@@ -342,22 +345,35 @@ export default {
 
     confirmCreateTasks (form) {
       this.loading.creatingTasks = true
+      this.runTasksCreation(form, (err) => {
+        if (!err) this.$router.push(this.assetsPath)
+        this.loading.creatingTasks = false
+      })
+    },
+
+    confirmCreateTasksAndStay (form) {
+      this.loading.taskStay = true
+      this.runTasksCreation(form, () => {
+        this.loading.taskStay = false
+      })
+    },
+
+    runTasksCreation (form, callback) {
       this.errors.creatingTasks = false
       this.$store.dispatch('createTasks', {
         task_type_id: form.task_type_id,
         type: 'assets',
         project_id: this.currentProduction.id,
         callback: (err) => {
-          this.loading.creatingTasks = false
           if (err) {
             this.errors.creatingTasks = true
           } else {
             this.modals.isCreateTasks = false
-            this.$router.push(this.assetsPath)
             this.loadAssets(() => {
               this.resizeHeaders()
             })
           }
+          callback(err)
         }
       })
     },

--- a/src/components/Assets.vue
+++ b/src/components/Assets.vue
@@ -248,9 +248,11 @@ export default {
             this.handleModalsDisplay()
             this.onSearchChange()
             setTimeout(() => {
-              this.$refs['asset-list'].setScrollPosition(
-                this.assetListScrollPosition
-              )
+              if (this.$refs['asset-list']) {
+                this.$refs['asset-list'].setScrollPosition(
+                  this.assetListScrollPosition
+                )
+              }
             }, 500)
           }
           setTimeout(() => {
@@ -474,11 +476,13 @@ export default {
     onSearchChange () {
       const searchQuery = this.$refs['asset-search-field'].getValue()
       this.setAssetSearch(searchQuery)
+      this.resizeHeaders()
     },
 
     changeSearch (searchQuery) {
       this.$refs['asset-search-field'].setValue(searchQuery.search_query)
       this.$refs['asset-search-field'].$emit('change', searchQuery.search_query)
+      this.resizeHeaders()
     },
 
     saveSearchQuery (searchQuery) {
@@ -561,6 +565,10 @@ export default {
           }
         })
       }
+    },
+
+    displayedAssets () {
+      this.resizeHeaders()
     }
   },
 

--- a/src/components/Assets.vue
+++ b/src/components/Assets.vue
@@ -10,7 +10,7 @@
             :can-save="true"
             @change="onSearchChange"
             @save="saveSearchQuery"
-            placeholder="ex: props, modeling=wip"
+            placeholder="ex: props modeling=wip"
           />
         </div>
 

--- a/src/components/Sequences.vue
+++ b/src/components/Sequences.vue
@@ -6,7 +6,7 @@
           <search-field
             ref="sequence-search-field"
             @change="onSearchChange"
-            placeholder="ex: e01 s01, anim=wip"
+            placeholder="ex: e01 s01 anim=wip"
           />
         </div>
       </div>

--- a/src/components/Sequences.vue
+++ b/src/components/Sequences.vue
@@ -156,6 +156,7 @@ export default {
       this.editSequence(form)
         .then(() => {
           this.loading.edit = false
+          this.resizeHeaders()
           this.navigateToList()
         }).catch(() => {
           this.loading.edit = false
@@ -168,6 +169,7 @@ export default {
       this.deleteSequence(this.sequenceToDelete)
         .then(() => {
           this.loading.del = false
+          this.resizeHeaders()
           this.navigateToList()
         }).catch(() => {
           this.loading.del = false

--- a/src/components/Shots.vue
+++ b/src/components/Shots.vue
@@ -115,12 +115,14 @@
     <create-tasks-modal
       :active="modals.isCreateTasksDisplayed"
       :is-loading="loading.creatingTasks"
+      :is-loading-stay="loading.creatingTasksStay"
       :is-error="errors.creatingTasks"
       :cancel-route="shotsPath"
       :title="$t('tasks.create_tasks_shot')"
       :text="$t('tasks.create_tasks_shot_explaination')"
       :error-text="$t('tasks.create_tasks_shot_failed')"
       @confirm="confirmCreateTasks"
+      @confirm-and-stay="confirmCreateTasksAndStay"
     />
 
   </div>
@@ -180,7 +182,8 @@ export default {
         creatingTasks: false,
         edit: false,
         importing: false,
-        stay: false
+        stay: false,
+        creatingTasksStay: false
       },
       errors: {
         creatingTasks: false,
@@ -385,22 +388,35 @@ export default {
 
     confirmCreateTasks (form) {
       this.loading.creatingTasks = true
+      this.runTasksCreation(form, (err) => {
+        if (!err) this.$router.push(this.shotsPath)
+        this.loading.creatingTasks = false
+      })
+    },
+
+    confirmCreateTasksAndStay (form) {
+      this.loading.creatingTasksStay = true
+      this.runTasksCreation(form, () => {
+        this.loading.creatingTasksStay = false
+      })
+    },
+
+    runTasksCreation (form, callback) {
       this.errors.creatingTasks = false
       this.$store.dispatch('createTasks', {
         task_type_id: form.task_type_id,
         project_id: this.currentProduction.id,
         type: 'shots',
         callback: (err) => {
-          this.loading.creatingTasks = false
           if (err) {
             this.errors.creatingTasks = true
           } else {
             this.modals.isCreateTasks = false
-            this.$router.push(this.shotsPath)
             this.loadShots(() => {
               this.resizeHeaders()
             })
           }
+          callback(err)
         }
       })
     },

--- a/src/components/Shots.vue
+++ b/src/components/Shots.vue
@@ -8,7 +8,7 @@
               ref="shot-search-field"
               :can-save="true"
               @change="onSearchChange"
-              placeholder="ex: e01 s01, anim=wip"
+              placeholder="ex: e01 s01 anim=wip"
               @save="saveSearchQuery"
             />
           </div>

--- a/src/components/Shots.vue
+++ b/src/components/Shots.vue
@@ -511,6 +511,7 @@ export default {
     onSearchChange (event) {
       const searchQuery = this.$refs['shot-search-field'].getValue()
       this.setShotSearch(searchQuery)
+      this.resizeHeaders()
     },
 
     saveScrollPosition (scrollPosition) {

--- a/src/components/Shots.vue
+++ b/src/components/Shots.vue
@@ -285,6 +285,7 @@ export default {
             this.onSearchChange()
             this.handleModalsDisplay()
             setTimeout(() => {
+              this.resizeHeaders()
               this.$refs['shot-list'].setScrollPosition(
                 this.shotListScrollPosition
               )
@@ -506,6 +507,7 @@ export default {
     changeSearch (searchQuery) {
       this.$refs['shot-search-field'].setValue(searchQuery.search_query)
       this.$refs['shot-search-field'].$emit('change', searchQuery.search_query)
+      this.resizeHeaders()
     },
 
     saveSearchQuery (searchQuery) {
@@ -567,6 +569,10 @@ export default {
           }
         })
       }
+    },
+
+    displayedShots () {
+      this.resizeHeaders()
     }
   },
 

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -99,7 +99,7 @@
               :isAddCommentLoading="addCommentLoading.isLoading"
               :user="user"
               :task="currentTask"
-              :taskStatusOptions="taskStatusOptions"
+              :taskStatusOptions="taskStatusOptionsForCurrentUser"
               v-if="isCommentingAllowed"
             />
             <div class="comments" v-if="currentTaskComments.length > 0">
@@ -726,6 +726,14 @@ export default {
         })
       }
       return currentPreview
+    },
+
+    taskStatusOptionsForCurrentUser () {
+      if (this.isCurrentUserManager) {
+        return this.taskStatusOptions
+      } else {
+        return this.taskStatusOptions.filter(status => status.isArtistAllowed)
+      }
     }
   },
 

--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -638,9 +638,9 @@ export default {
 
     deleteText () {
       if (this.currentTask) {
+        const taskType = this.taskTypeMap[this.currentTask.task_type_id]
         return this.$t('main.delete_text', {
-          name: `${this.currentTask.entity_name}` +
-                ` / ${this.currentTask.task_type_name}`
+          name: `${this.currentTask.entity_name} / ${taskType.name}`
         })
       } else {
         return ''

--- a/src/components/TaskStatus.vue
+++ b/src/components/TaskStatus.vue
@@ -121,7 +121,7 @@ export default {
           if (err) {
             this.editStatus.isError = true
           } else {
-            this.$router.push('/task-status') // Close modal
+            this.$router.push({name: 'task-status'}) // Close modal
           }
         }
       })
@@ -137,7 +137,7 @@ export default {
           if (err) {
             this.deleteStatus.isError = true
           } else {
-            this.$router.push('/task-status') // Close modal
+            this.$router.push({name: 'task-status'}) // Close modal
           }
         }
       })

--- a/src/components/Topbar.vue
+++ b/src/components/Topbar.vue
@@ -157,6 +157,7 @@ export default {
 
   computed: {
     ...mapGetters([
+      'assetsPath',
       'currentEpisode',
       'currentProduction',
       'episodes',
@@ -351,7 +352,9 @@ export default {
           this.updateComboFromRoute()
         })
       } else {
-        this.setProduction(routeProductionId)
+        if (this.assetsPath.name === 'open-productions' && routeProductionId) {
+          this.setProduction(routeProductionId)
+        }
         this.setEpisodeFromRoute()
         this.updateComboFromRoute()
       }

--- a/src/components/Topbar.vue
+++ b/src/components/Topbar.vue
@@ -351,6 +351,7 @@ export default {
           this.updateComboFromRoute()
         })
       } else {
+        this.setProduction(routeProductionId)
         this.setEpisodeFromRoute()
         this.updateComboFromRoute()
       }

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -435,6 +435,7 @@ export default {
     resizeHeaders () {
       if (
         this.$refs['body-tbody'] &&
+        this.$refs['body-tbody'][0] &&
         this.$refs['body-tbody'][0].children.length > 0
       ) {
         if (this.$refs['th-episode']) {

--- a/src/components/lists/TaskStatusList.vue
+++ b/src/components/lists/TaskStatusList.vue
@@ -53,6 +53,7 @@
               name: 'delete-task-status',
               params: {task_status_id: entry.id}
             }"
+            :hide-delete="entry.short_name === 'todo'"
           />
         </tr>
       </tbody>

--- a/src/components/lists/TaskStatusList.vue
+++ b/src/components/lists/TaskStatusList.vue
@@ -16,6 +16,9 @@
           <th class="is-done">
             {{ $t('task_status.fields.is_done') }}
           </th>
+          <th class="is-artist-allowed">
+            {{ $t('task_status.fields.is_artist_allowed') }}
+          </th>
           <th class="actions"></th>
         </tr>
       </thead>
@@ -35,13 +38,15 @@
           <td class="name">
             {{ entry.name }}
           </td>
-          <task-status-name class="short-name" :entry="entry">
-          </task-status-name>
+          <task-status-name class="short-name" :entry="entry" />
           <td class="is-reviewable">
             {{ translateBoolean(entry.is_reviewable) }}
           </td>
           <td class="is-done">
             {{ translateBoolean(entry.is_done) }}
+          </td>
+          <td class="is-artist-allowed">
+            {{ translateBoolean(entry.is_artist_allowed) }}
           </td>
           <row-actions
             :entry-id="entry.id"
@@ -95,9 +100,11 @@ export default {
   methods: {
     ...mapActions([
     ]),
+
     onBodyScroll (event, position) {
       this.$refs.headerWrapper.style.left = `-${position.scrollLeft}px`
     },
+
     translateBoolean (booleanValue) {
       return booleanValue ? this.$t('main.yes') : this.$t('main.no')
     }
@@ -116,13 +123,10 @@ export default {
   min-width: 150px;
 }
 
-.is-reviewable {
-  width: 120px;
-  min-width: 120px;
-}
-
-.is-done {
-  width: 120px;
-  min-width: 120px;
+.is-reviewable,
+.is-done,
+.is-artist-allowed {
+  width: 140px;
+  min-width: 140px;
 }
 </style>

--- a/src/components/modals/AddPreviewModal.vue
+++ b/src/components/modals/AddPreviewModal.vue
@@ -22,7 +22,7 @@
         ref="preview-field"
         :accept="extensions"
         @fileselected="onFileSelected"
-      ></file-upload>
+      />
 
       <p class="error" v-if="isError">
         {{ $t("tasks.add_preview_error") }}
@@ -85,7 +85,7 @@ export default {
     },
     extensions: {
       type: String,
-      default: '.png,.jpg,.mp4,.mov,.obj,.pdf,.ma,.mb,.zip,.rar,.jpeg'
+      default: '.png,.jpg,.mp4,.mov,.obj,.pdf,.ma,.mb,.zip,.rar,.jpeg,.blend'
     }
   },
 

--- a/src/components/modals/CreateTasksModal.vue
+++ b/src/components/modals/CreateTasksModal.vue
@@ -25,6 +25,16 @@
           :class="{
             button: true,
             'is-primary': true,
+            'is-loading': isLoadingStay
+          }"
+          @click="confirmAndStayClicked"
+        >
+          {{ $t("main.confirmation_and_stay") }}
+        </a>
+        <a
+          :class="{
+            button: true,
+            'is-primary': true,
             'is-loading': isLoading
           }"
           @click="confirmClicked"
@@ -60,15 +70,16 @@ export default {
   },
 
   props: [
-    'onConfirmClicked',
-    'text',
-    'title',
     'active',
     'cancelRoute',
+    'errorText',
     'isError',
     'isLoading',
+    'isLoadingStay',
     'isSuccess',
-    'errorText'
+    'onConfirmClicked',
+    'text',
+    'title'
   ],
 
   data () {
@@ -93,10 +104,14 @@ export default {
   methods: {
     ...mapActions([
     ]),
+
     confirmClicked () {
       this.$emit('confirm', this.form)
-    }
+    },
 
+    confirmAndStayClicked () {
+      this.$emit('confirm-and-stay', this.form)
+    }
   },
 
   mounted () {

--- a/src/components/modals/EditTaskStatusModal.vue
+++ b/src/components/modals/EditTaskStatusModal.vue
@@ -22,35 +22,36 @@
           :label="$t('task_status.fields.name')"
           v-model="form.name"
           v-focus
-        >
-        </text-field>
+        />
         <text-field
           ref="shortNameField"
           input-class="task-status-short-name"
           :label="$t('task_status.fields.short_name')"
           v-model="form.short_name"
           v-focus
-        >
-        </text-field>
-        <combobox
-          :label="$t('task_status.fields.is_reviewable')"
-          :options="isReviewableOptions"
-          v-model="form.is_reviewable"
-        >
-        </combobox>
+        />
         <combobox
           :label="$t('task_status.fields.is_done')"
           :options="isDoneOptions"
           v-model="form.is_done"
-        >
-        </combobox>
+        />
+        <combobox
+          :label="$t('task_status.fields.is_reviewable')"
+          :options="isReviewableOptions"
+          v-model="form.is_reviewable"
+        />
+        <combobox
+          :label="$t('task_status.fields.is_artist_allowed')"
+          :options="isArtistAllowedOptions"
+          v-model="form.is_artist_allowed"
+        />
+
         <color-field
           ref="colorField"
           :label="$t('task_status.fields.color')"
           :colors="colors"
           v-model="form.color"
-        >
-        </color-field>
+        />
       </form>
 
       <p class="has-text-right">
@@ -119,6 +120,10 @@ export default {
         {label: this.$t('main.yes'), value: 'true'},
         {label: this.$t('main.no'), value: 'false'}
       ],
+      isArtistAllowedOptions: [
+        {label: this.$t('main.yes'), value: 'true'},
+        {label: this.$t('main.no'), value: 'false'}
+      ],
       colors: [
         '#000000',
         '#E81123',
@@ -163,7 +168,8 @@ export default {
           short_name: this.taskStatusToEdit.short_name,
           color: this.taskStatusToEdit.color,
           is_reviewable: String(this.taskStatusToEdit.is_reviewable),
-          is_done: String(this.taskStatusToEdit.is_done)
+          is_done: String(this.taskStatusToEdit.is_done),
+          is_artist_allowed: String(this.taskStatusToEdit.is_artist_allowed)
         }
       }
     }

--- a/src/components/modals/EditTaskTypeModal.vue
+++ b/src/components/modals/EditTaskTypeModal.vue
@@ -73,6 +73,7 @@ import { mapGetters, mapActions } from 'vuex'
 import TextField from '../widgets/TextField'
 import Combobox from '../widgets/Combobox.vue'
 import ColorField from '../widgets/ColorField'
+import { range } from '../../lib/helpers'
 
 export default {
   name: 'edit-task-type-modal',
@@ -116,28 +117,9 @@ export default {
         for_shots: 'false',
         allow_timelog: 'false'
       },
-      priorityOptions: [
-        {label: '1', value: '1'},
-        {label: '2', value: '2'},
-        {label: '3', value: '3'},
-        {label: '4', value: '4'},
-        {label: '5', value: '5'},
-        {label: '6', value: '6'},
-        {label: '7', value: '7'},
-        {label: '8', value: '8'},
-        {label: '9', value: '9'},
-        {label: '10', value: '10'},
-        {label: '11', value: '11'},
-        {label: '12', value: '12'},
-        {label: '13', value: '13'},
-        {label: '14', value: '14'},
-        {label: '15', value: '15'},
-        {label: '16', value: '16'},
-        {label: '17', value: '17'},
-        {label: '18', value: '18'},
-        {label: '19', value: '19'},
-        {label: '20', value: '20'}
-      ],
+      priorityOptions: range(1, 100).map((v) => {
+        return { label: `${v}`, value: `${v}` }
+      }),
       dedicatedToOptions: [
         {label: this.$t('assets.title'), value: 'false'},
         {label: this.$t('shots.title'), value: 'true'}

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -3,8 +3,7 @@
     <figure class="media-left">
       <div class="level">
         <div class="level-left">
-          <people-avatar class="level-item" :person="user">
-          </people-avatar>
+          <people-avatar class="level-item" :person="user" />
         </div>
       </div>
     </figure>

--- a/src/components/widgets/RowActions.vue
+++ b/src/components/widgets/RowActions.vue
@@ -11,7 +11,7 @@
   <router-link
     class="button"
     :to="props.restoreRoute"
-    v-if="!props.entry.canceled"
+    v-if="props.entry.canceled"
   >
     <img src="../../assets/icons/rotate-ccw.svg" class="icon is-small" />
   </router-link>
@@ -19,7 +19,7 @@
   <router-link
     class="button"
     :to="props.deleteRoute"
-    v-if="!props.hideDelete && props.entry.canceled && isCurrentUserAdmin"
+    v-if="!props.hideDelete && !props.entry.canceled && isCurrentUserAdmin"
   >
     <img src="../../assets/icons/trash.svg" class="icon is-small" />
   </router-link>

--- a/src/components/widgets/RowActions.vue
+++ b/src/components/widgets/RowActions.vue
@@ -11,7 +11,7 @@
   <router-link
     class="button"
     :to="props.restoreRoute"
-    v-if="props.entry.canceled"
+    v-if="!props.entry.canceled"
   >
     <img src="../../assets/icons/rotate-ccw.svg" class="icon is-small" />
   </router-link>
@@ -19,7 +19,7 @@
   <router-link
     class="button"
     :to="props.deleteRoute"
-    v-if="props.entry.canceled && isCurrentUserAdmin"
+    v-if="!props.hideDelete && props.entry.canceled && isCurrentUserAdmin"
   >
     <img src="../../assets/icons/trash.svg" class="icon is-small" />
   </router-link>
@@ -27,7 +27,7 @@
   <router-link
     class="button"
     :to="props.deleteRoute"
-    v-else
+    v-else-if="!props.hideDelete"
   >
     <img src="../../assets/icons/trash.svg" class="icon is-small" />
   </router-link>
@@ -63,6 +63,10 @@ export default {
       default: null
     },
     hideEdit: {
+      type: Boolean,
+      default: false
+    },
+    hideDelete: {
       type: Boolean,
       default: false
     }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -309,8 +309,9 @@ export default {
     title: 'Task Status',
     fields: {
       color: 'Color',
-      is_reviewable: 'Is reviewable',
       is_done: 'Is done',
+      is_reviewable: 'Is reviewable',
+      is_artist_allowed: 'Is artist allowed',
       name: 'Name',
       short_name: 'Short name'
     }

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -266,7 +266,8 @@ export default {
       short_name: 'Nom court',
       color: 'Couleur',
       is_reviewable: 'Est vérifiable',
-      is_done: 'Est terminé'
+      is_done: 'Est terminé',
+      is_artist_allowed: 'Autorisé aux artistes'
     },
     delete_text: 'Êtes vous sur de vouloir retirer {name} de la base de données ?',
     delete_error: 'Une erreur est survenue lors de la suppression du statut de tâche. Êtes vous sûr qu\'aucune tâche n\'est lié à ce statut de tâche ?'

--- a/src/store/api/assets.js
+++ b/src/store/api/assets.js
@@ -42,7 +42,7 @@ export default {
       entity_type_id: asset.entity_type_id,
       project_id: asset.project_id
     }
-    if (asset.source_id === 'null' && asset.source_id) {
+    if (asset.source_id === 'null' || asset.source_id) {
       data.source_id = asset.source_id
     }
     client.put(`/api/data/entities/${asset.id}`, data, callback)

--- a/src/store/api/taskstatus.js
+++ b/src/store/api/taskstatus.js
@@ -6,6 +6,7 @@ const sanitizeTaskStatus = (taskStatus) => {
     short_name: taskStatus.short_name,
     is_reviewable: Boolean(taskStatus.is_reviewable === 'true'),
     is_done: Boolean(taskStatus.is_done === 'true'),
+    is_artist_allowed: Boolean(taskStatus.is_artist_allowed === 'true'),
     color: taskStatus.color
   }
 }

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -309,11 +309,10 @@ const actions = {
   },
 
   editAsset ({ commit, state, rootState }, { data, callback }) {
-    if (
-      data.name && cache.assets.find((asset) => {
-        return asset.name === data.name && data.id !== asset.id
-      })
-    ) {
+    const existingAsset = data.name && cache.assets.find((asset) => {
+      return asset.name === data.name && data.id !== asset.id
+    })
+    if (existingAsset) {
       return callback()
     }
 
@@ -710,8 +709,10 @@ const mutations = {
   },
 
   [SAVE_ASSET_SEARCH_END] (state, { searchQuery }) {
-    state.assetSearchQueries.push(searchQuery)
-    state.assetSearchQueries = sortByName(state.assetSearchQueries)
+    if (!state.assetSearchQueries.includes(searchQuery)) {
+      state.assetSearchQueries.push(searchQuery)
+      state.assetSearchQueries = sortByName(state.assetSearchQueries)
+    }
   },
 
   [REMOVE_ASSET_SEARCH_END] (state, { searchQuery }) {

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -797,6 +797,7 @@ const mutations = {
 
   [LOAD_EPISODES_END] (state, episodes) {
     const episodeMap = {}
+    if (!episodes) episodes = []
     episodes.forEach((episode) => {
       episodeMap[episode.id] = episode
     })

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -108,7 +108,8 @@ const getters = {
     return {
       label: status.name,
       value: status.id,
-      color: status.color
+      color: status.color,
+      isArtistAllowed: status.is_artist_allowed
     }
   }),
 

--- a/src/store/modules/taskstatus.js
+++ b/src/store/modules/taskstatus.js
@@ -95,6 +95,9 @@ const mutations = {
     state.taskStatus = sortByName(taskStatus)
     state.taskStatusMap = {}
     taskStatus.forEach((taskStatus) => {
+      if (taskStatus.is_artist_allowed === null) {
+        taskStatus.is_artist_allowed = true
+      }
       state.taskStatusMap[taskStatus.id] = taskStatus
     })
   },

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -50,6 +50,10 @@ import {
 
   SET_TODO_LIST_SCROLL_POSITION,
 
+  SAVE_ASSET_SEARCH_END,
+  SAVE_SHOT_SEARCH_END,
+  REMOVE_ASSET_SEARCH_END,
+
   RESET_ALL
 } from '../mutation-types'
 
@@ -469,6 +473,31 @@ const mutations = {
     state.timeSpentTotal = Object
       .values(state.timeSpentMap)
       .reduce((acc, timeSpent) => timeSpent.duration + acc, 0) / 60
+  },
+
+  [SAVE_ASSET_SEARCH_END] (state, { searchQuery, production }) {
+    if (!state.userFilters.asset[production.id]) {
+      state.userFilters.asset[production.id] = []
+    }
+    if (!state.userFilters.asset[production.id].includes(searchQuery)) {
+      state.userFilters.asset[production.id].push(searchQuery)
+      state.userFilters.asset[production.id] =
+        sortByName(state.userFilters.asset[production.id])
+    }
+  },
+
+  [SAVE_SHOT_SEARCH_END] (state, { searchQuery, production }) {
+    if (!state.userFilters.shot[production.id]) {
+      state.userFilters.shot[production.id] = []
+    }
+    if (!state.userFilters.shot[production.id].includes(searchQuery)) {
+      state.userFilters.shot[production.id].push(searchQuery)
+      state.userFilters.shot[production.id] =
+        sortByName(state.userFilters.shot[production.id])
+    }
+  },
+
+  [REMOVE_ASSET_SEARCH_END] (state) {
   },
 
   [RESET_ALL] (state) {


### PR DESCRIPTION
**Problem**

* There are not enough levels of priority for task types.
* It is not possible to set `.blend` files as preview.
* Sometimes assignation field is broken
* Todo task status is expected to be present by the API. Nevertheless it's possible to delete it.
* Commas in search placeholder are misleading
* Sometimes current production is not set properly (related paths are not built)
* It's annoying to open the create tasks modal several time in a row
* Task name in task deletion modal is wrong
* Header size in shot list sometimes broke
* Artists should not see all task status when changing a status
* Saving filter has an unexpected behaviour

**Solution**

* Allow to set 100 level of priorities
* Add `.blend` files to the list of files allowed for task types
* When setting assignation field content, handle the case where no current production is set
* Remove delete button for todo status
* Remove commas from search placeholder
* Build current production paths if they are not built each time the route change
* Add a confirm and stay button to create tasks modal
* Set properly task type when displaying task name in deletion modal
* Rebuild headers each time the shot list change
* Add a flag *Is artist allowed* to task status
* Handle properly search filter changes in stores
