### PR TITLE
Hide empty columns in asset and shot list (and fixes)

### DIFF
--- a/src/components/Shots.vue
+++ b/src/components/Shots.vue
@@ -88,7 +88,7 @@
       :cancel-route="shotsPath"
       :text="deleteText()"
       :error-text="$t('shots.delete_error')"
-      @confirm="confirmDeleteAllTasks"
+      @confirm="confirmDeleteShot"
     />
 
     <delete-modal

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -258,6 +258,7 @@ export default {
   computed: {
     ...mapGetters([
       'assets',
+      'assetFilledColumns',
       'assetSearchText',
       'assetSelectionGrid',
       'episodeMap',

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -250,6 +250,7 @@ export default {
       'isSingleEpisode',
       'isTVShow',
       'nbSelectedTasks',
+      'shotFilledColumns',
       'shotMap',
       'shotSearchText',
       'shotSelectionGrid',

--- a/src/components/lists/base.js
+++ b/src/components/lists/base.js
@@ -4,8 +4,8 @@ import Vue from 'vue'
 export const entityListMixin = {
   computed: {
     sortedValidationColumns () {
-      const columns = [...this.validationColumns]
-      return columns.sort((a, b) => {
+      let columns = [...this.validationColumns]
+      columns = columns.sort((a, b) => {
         const taskTypeA = this.taskTypeMap[a]
         const taskTypeB = this.taskTypeMap[b]
         if (taskTypeA.priority === taskTypeB.priority) {
@@ -16,6 +16,13 @@ export const entityListMixin = {
           return -1
         }
       })
+      if (this.assetFilledColumns) {
+        return columns.filter(c => this.assetFilledColumns[c])
+      } else if (this.shotFilledColumns) {
+        return columns.filter(c => this.shotFilledColumns[c])
+      } else {
+        return columns
+      }
     }
   },
 

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -135,3 +135,20 @@ export const getWeekRange = (year, currentYear) => {
 export const remove = (items, valueToRemove) => {
   return items.filter(item => item !== valueToRemove)
 }
+
+export const getFilledColumns = (entries) => {
+  const filledColumns = {}
+  entries.forEach((entry) => {
+    if (entry.validations) {
+      Object.assign(
+        filledColumns,
+        entry.validations
+      )
+    } else {
+      entry.tasks.forEach((task) => {
+        filledColumns[task.task_type_id] = task.id
+      })
+    }
+  })
+  return filledColumns
+}

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+
 import assetsApi from '../api/assets'
 import peopleApi from '../api/people'
 import tasksStore from './tasks'
@@ -16,6 +17,7 @@ import {
   appendSelectionGrid,
   buildSelectionGrid,
   clearSelectionGrid,
+  getFilledColumns,
   computeStats
 } from '../../lib/helpers'
 import {
@@ -149,6 +151,7 @@ const initialState = {
   filteredAssets: [],
   displayedAssets: [],
   displayedAssetsLength: 0,
+  assetFilledColumns: {},
   assetSearchText: '',
   assetSelectionGrid: {},
   assetSearchQueries: [],
@@ -198,6 +201,7 @@ const getters = {
 
   displayedAssets: state => state.displayedAssets,
   displayedAssetsLength: state => state.displayedAssetsLength,
+  assetFilledColumns: state => state.assetFilledColumns,
 
   displayedAssetTypes: state => state.displayedAssetTypes,
   displayedAssetTypesLength: state => state.displayedAssetTypesLength,
@@ -467,6 +471,7 @@ const mutations = {
 
     cache.assetIndex = {}
     state.displayedAssets = []
+    state.assetFilledColumns = {}
     state.displayedAssetsLength = 0
     state.assetSearchQueries = []
   },
@@ -505,6 +510,8 @@ const mutations = {
     state.nbValidationColumns = Object.keys(validationColumns).length
 
     cache.assetIndex = buildAssetIndex(assets)
+    state.assetFilledColumns =
+      getFilledColumns(cache.assets.slice(0, PAGE_SIZE))
     state.displayedAssets = cache.assets.slice(0, PAGE_SIZE)
     state.displayedAssetsLength = cache.assets ? cache.assets.length : 0
 
@@ -576,6 +583,7 @@ const mutations = {
       cache.assets = sortAssets(cache.assets)
       state.displayedAssets.push(newAsset)
       state.displayedAssets = sortAssets(state.displayedAssets)
+      state.assetFilledColumns = getFilledColumns(state.displayedAssets)
       state.displayedAssetsLength = state.displayedAssets.length
 
       const maxX = state.displayedAssets.length
@@ -616,6 +624,7 @@ const mutations = {
       )
       cache.assets.splice(assetToDeleteIndex, 1)
       state.displayedAssets.splice(displayAssetToDeleteIndex, 1)
+      state.assetFilledColumns = getFilledColumns(state.displayedAssets)
       state.assetMap[assetToDelete.id] = undefined
     }
 
@@ -711,6 +720,7 @@ const mutations = {
     result = applyFilters(result, filters, taskMap)
 
     state.displayedAssets = result.slice(0, PAGE_SIZE)
+    state.assetFilledColumns = getFilledColumns(state.displayedAssets)
     state.displayedAssetsLength = result ? result.length : 0
     state.assetSearchText = query
 
@@ -762,6 +772,7 @@ const mutations = {
       0,
       state.displayedAssets.length + PAGE_SIZE
     )
+    state.assetFilledColumns = getFilledColumns(state.displayedAssets)
     const previousX = state.displayedAssets.length - PAGE_SIZE
     const maxX = state.displayedAssets.length
     const maxY = state.nbValidationColumns

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -16,7 +16,8 @@ import {
   appendSelectionGrid,
   buildSelectionGrid,
   clearSelectionGrid,
-  computeStats
+  computeStats,
+  getFilledColumns
 } from '../../lib/helpers'
 import {
   buildShotIndex,
@@ -192,6 +193,7 @@ const initialState = {
   displayedEpisodes: [],
   displayedEpisodesLength: 0,
   sequenceIndex: {},
+  shotFilledColumns: {},
 
   sequenceMap: {},
   episodeMap: {},
@@ -256,6 +258,7 @@ const getters = {
   displayedSequencesLength: state => state.displayedSequencesLength,
   displayedEpisodes: state => state.displayedEpisodes,
   displayedEpisodesLength: state => state.displayedEpisodesLength,
+  shotFilledColumns: state => state.shotFilledColumns,
 
   isShotsLoading: state => state.isShotsLoading,
   isShotsLoadingError: state => state.isShotsLoadingError,
@@ -753,6 +756,7 @@ const mutations = {
 
     state.displayedShots = shots.slice(0, PAGE_SIZE)
     state.displayedShotsLength = shots.length
+    state.shotFilledColumns = getFilledColumns(state.displayedShots)
     cache.shots = shots
 
     const maxX = state.displayedShots.length
@@ -1010,6 +1014,7 @@ const mutations = {
 
     state.displayedShots = result.slice(0, PAGE_SIZE)
     state.displayedShotsLength = result.length
+    state.shotFilledColumns = getFilledColumns(state.displayedShots)
     state.shotSearchText = shotSearch
 
     const maxX = state.displayedShots.length
@@ -1056,6 +1061,7 @@ const mutations = {
     cache.shots.push(shot)
     cache.shots = sortShots(cache.shots)
     state.displayedShots = cache.shots.slice(0, PAGE_SIZE)
+    state.shotFilledColumns = getFilledColumns(state.displayedShots)
     state.shotMap[shot.id] = shot
     cache.shotIndex = buildShotIndex(cache.shots)
 
@@ -1129,6 +1135,7 @@ const mutations = {
       0,
       state.displayedShots.length + PAGE_SIZE
     )
+    state.shotFilledColumns = getFilledColumns(state.displayedShots)
 
     const previousX = state.displayedShots.length - PAGE_SIZE
     const maxX = state.displayedShots.length

--- a/tests/store/lib/helpers.spec.js
+++ b/tests/store/lib/helpers.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai'
 import test from '../../../src/lib/string'
-import { populateTask } from '../../../src/lib/helpers'
+import {
+  getFilledColumns,
+  populateTask
+} from '../../../src/lib/helpers'
 
 describe('lib/helpers', () => {
 
@@ -28,5 +31,33 @@ describe('lib/helpers', () => {
     }
     populateTask(task)
     expect(task.full_entity_name).to.equal('SQ01 / SH01')
+  })
+
+  it('getFilledColumns', () => {
+    const assets = [
+      {
+        id: 'asset-1',
+        validations: {
+          'task-type-1': 'task-1'
+        }
+      },
+      {
+        id: 'asset-2',
+        validations: {
+          'task-type-2': 'task-2'
+        }
+      },
+      {
+        id: 'asset-3',
+        tasks: [{
+          id: 'task-3',
+          task_type_id: 'task-type-3'
+        }]
+      }
+    ]
+    const filledColumns = getFilledColumns(assets)
+    expect(filledColumns['task-type-1']).to.be.ok
+    expect(filledColumns['task-type-2']).to.be.ok
+    expect(filledColumns['task-type-3']).to.be.ok
   })
 })


### PR DESCRIPTION
**Problem**

* When browsing assets or shots if a column is empty for current filter, it should be hidden.
* It ist not possible to delete shot anymore.

**Solution**

* Everytime the list change, it now builds a map to identify which column is filled or not.
* Run the right function when requesting for deletion.
