### PR TITLE
Fix typo for English no_assignation_right

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -455,7 +455,7 @@ export default {
     hide_infos: 'Hide additional information',
     my_tasks: 'My tasks',
     next: 'next task',
-    no_assignation_right: 'you are no allowed to manage assignations',
+    no_assignation_right: 'You are not allowed to manage assignations',
     no_comment: 'There is currently no comment for this task.',
     no_preview: 'There is currently no preview for this task.',
     preview: 'Previews',


### PR DESCRIPTION
Fix typo "no allowed" to "not allowed" + Also made first character uppercase.

**Problem**
The English sentence for not being allowed to assign tasks was a bit odd with a typo.

**Solution**
Fix typo "no allowed" to "not allowed" + Also made first character uppercase.
