### PR TITLE
Rotate Delete Search Filter button to show as "X"

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -631,7 +631,7 @@ input.search-input:focus {
 
 .query-list .tag .delete {
   margin-left: 0.5em;
-  transform: scale(0.6)
+  transform: rotate(45deg) scale(0.7)
 }
 
 .query-list .tag:hover {


### PR DESCRIPTION
Correctly rotate the "delete search filter query-list" button so it looks like an X instead of a +. Also increased size slightly so it's relatively similar size as before it was rotated.

**Problem**
The remove search query list filter shows as a Plus (+) instead of a Cross (X).

**Solution**
Change the CSS so it's a rotated plus.

See image below:

![search_query_list_delete_rotate](https://user-images.githubusercontent.com/2439881/52704112-1ec42080-2f80-11e9-9d2f-e2dbc4f1a0ad.png)

---

Note: I only tested the CSS in my browser and have **not** tested this on a live Kitsu server. I also don't know if this CSS is used elsewhere in the theme.
