### PR TITLE
Fix typo noone to no one

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -195,7 +195,7 @@ export default {
     delete_error: 'An error occured while deleting this person. There are probably data linked to it. Are you sure this person has no assignation or wrote no comment?',
     delete_text: 'Are you sure you want to remove {personName} from your database?',
     edit_title: 'Edit person',
-    empty_team: 'There is noone listed in the project team.',
+    empty_team: 'There is no one listed in the project team.',
     new_person: 'Add a new employee',
     no_task_assigned: 'There is no assigned running tasks.',
     persons: 'person | persons',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -197,7 +197,7 @@ export default {
     edit_title: 'Edit person',
     empty_team: 'There is no one listed in the project team.',
     new_person: 'Add a new employee',
-    no_task_assigned: 'There is no assigned running tasks.',
+    no_task_assigned: 'There are no assigned running tasks.',
     persons: 'person | persons',
     running_tasks: 'Running tasks',
     select_person: 'Select a person...',


### PR DESCRIPTION
Fix minor typo in empty team message in English locale: `noone` -> `no one`.