### PR TITLE
Slack integration and casting CSV (import / export)

### DIFF
--- a/src/components/modals/ImportModal.vue
+++ b/src/components/modals/ImportModal.vue
@@ -26,27 +26,14 @@
 
       <file-upload @fileselected="onFileSelected"></file-upload>
 
-      <p class="error" v-if="isError">
-        {{ $t("main.csv.error_upload") }}
-      </p>
-
-      <p class="has-text-right">
-        <a
-          :class="{
-            button: true,
-            'is-primary': true,
-            'is-loading': isLoading,
-            'is-disabled': formData == undefined
-          }"
-          @click="onConfirmClicked">
-          {{ $t("main.confirmation") }}
-        </a>
-        <router-link
-          :to="cancelRoute"
-          class="button is-link">
-          {{ $t("main.cancel") }}
-        </router-link>
-      </p>
+      <modal-footer
+        :error-text="$t('productions.metadata.error')"
+        :is-loading="isLoading"
+        :is-disabled="formData === undefined"
+        :is-error="isError"
+        @confirm="onConfirmClicked"
+        @cancel="$emit('cancel')"
+      />
 
     </div>
   </div>
@@ -55,34 +42,52 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
+import { modalMixin } from './base_modal'
 import FileUpload from '../widgets/FileUpload.vue'
+import ModalFooter from './ModalFooter'
 
 export default {
   name: 'import-people-modal',
-  props: [
-    'active',
-    'cancelRoute',
-    'isLoading',
-    'isError',
-    'columns'
-  ],
-  watch: {
+  mixins: [modalMixin],
+  components: {
+    FileUpload,
+    ModalFooter
   },
+
   data () {
     return {
       formData: null
     }
   },
-  components: {
-    FileUpload
+
+  props: {
+    active: {
+      type: Boolean,
+      default: false
+    },
+    columns: {
+      type: Array,
+      default: () => []
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
+    },
+    isError: {
+      type: Boolean,
+      default: false
+    }
   },
+
+  mounted () {
+    this.formData = null
+  },
+
   computed: {
     ...mapGetters([
     ])
   },
-  mounted () {
-    this.formData = null
-  },
+
   methods: {
     ...mapActions([
     ]),
@@ -93,6 +98,9 @@ export default {
     onConfirmClicked () {
       this.$emit('confirm')
     }
+  },
+
+  watch: {
   }
 }
 </script>

--- a/src/components/modals/ManageShotsModal.vue
+++ b/src/components/modals/ManageShotsModal.vue
@@ -294,7 +294,7 @@ export default {
       } else {
         this.selectedEpisodeId = episodeId
         this.$router.push({
-          name: 'episode-manage-shots',
+          name: 'episode-shots',
           params: {
             production_id: this.currentProduction.id,
             episode_id: episodeId

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -23,12 +23,13 @@
               <div class="flexrow-item"></div>
             </div>
             <div class="flexrow" v-if="isCurrentUserManager">
-            <button-link
+            <button-simple
               class="flexrow-item"
               :title="$t('main.csv.import_file')"
               icon="upload"
               :is-responsive="true"
               :path="importPath"
+              @click="showImportModal"
             />
             <button-href-link
               class="flexrow-item"
@@ -143,11 +144,11 @@
     :active="modals.isImportDisplayed"
     :is-loading="loading.importing"
     :is-error="errors.importing"
-    :cancel-route="assetsPath"
     :form-data="assetsCsvFormData"
     :columns="columns"
     @fileselected="selectFile"
     @confirm="uploadImportFile"
+    @cancel="hideImportModal"
   />
 
   <create-tasks-modal
@@ -182,6 +183,7 @@ import AssetList from '../lists/AssetList'
 import AddMetadataModal from '../modals/AddMetadataModal'
 import ButtonHrefLink from '../widgets/ButtonHrefLink'
 import ButtonLink from '../widgets/ButtonLink'
+import ButtonSimple from '../widgets/ButtonSimple'
 import CreateTasksModal from '../modals/CreateTasksModal'
 import DeleteModal from '../widgets/DeleteModal'
 import EditAssetModal from '../modals/EditAssetModal'
@@ -201,6 +203,7 @@ export default {
     AddMetadataModal,
     ButtonLink,
     ButtonHrefLink,
+    ButtonSimple,
     CreateTasksModal,
     DeleteModal,
     EditAssetModal,
@@ -562,8 +565,6 @@ export default {
       } else if (path.indexOf('restore') > 0) {
         this.assetToRestore = this.assetMap[assetId]
         this.modals.isRestoreDisplayed = true
-      } else if (path.indexOf('import') > 0) {
-        this.modals.isImportDisplayed = true
       } else if (path.indexOf('create-tasks') > 0) {
         this.modals.isCreateTasksDisplayed = true
       } else {
@@ -594,7 +595,7 @@ export default {
           this.loadAssets(() => {
             this.resizeHeaders()
           })
-          this.$router.push(this.assetsPath)
+          this.hideImportModal()
         } else {
           this.loading.importing = false
           this.errors.importing = true
@@ -698,6 +699,14 @@ export default {
         d => d.id === descriptorId
       )
       this.modals.isAddMetadataDisplayed = true
+    },
+
+    showImportModal () {
+      this.modals.isImportDisplayed = true
+    },
+
+    hideImportModal () {
+      this.modals.isImportDisplayed = false
     }
   },
 

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -4,12 +4,20 @@
 
       <div class="breakdown-column shot-column">
         <div class="flexrow mb1">
+          <span class="filler"></span>
           <button-simple
             class="flexrow-item"
             :title="$t('main.csv.import_file')"
             icon="upload"
             :is-responsive="true"
             @click="showImportModal"
+          />
+          <button-href-link
+            class="flexrow-item"
+            :title="$t('main.csv.export_file')"
+            icon="download"
+            :is-responsive="true"
+            :path="exportUrlPath"
           />
         </div>
         <spinner class="mt1" v-if="isShotsLoading" />
@@ -138,6 +146,7 @@ import { mapGetters, mapActions } from 'vuex'
 
 import AssetBlock from './breakdown/AssetBlock'
 import AvailableAssetBlock from './breakdown/AvailableAssetBlock'
+import ButtonHrefLink from '../widgets/ButtonHrefLink.vue'
 import ButtonSimple from '../widgets/ButtonSimple'
 import Combobox from '../widgets/Combobox'
 import ErrorText from '../widgets/ErrorText'
@@ -152,6 +161,7 @@ export default {
   components: {
     AssetBlock,
     AvailableAssetBlock,
+    ButtonHrefLink,
     ButtonSimple,
     Combobox,
     ErrorText,
@@ -232,6 +242,12 @@ export default {
         if (newGroup.length > 0) result.push(newGroup)
       })
       return result
+    },
+
+    exportUrlPath () {
+      return (
+        `/api/export/csv/projects/${this.currentProduction.id}/casting.csv`
+      )
     }
   },
 

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -1,10 +1,19 @@
 <template>
   <div class="breakdown page">
-    <div class="breakdown-columns mt2">
+    <div class="breakdown-columns mt1">
 
       <div class="breakdown-column shot-column">
-        <spinner v-if="isShotsLoading" />
-        <div v-else>
+        <div class="flexrow mb1">
+          <button-simple
+            class="flexrow-item"
+            :title="$t('main.csv.import_file')"
+            icon="upload"
+            :is-responsive="true"
+            @click="showImportModal"
+          />
+        </div>
+        <spinner class="mt1" v-if="isShotsLoading" />
+        <div class="mt1" v-else>
           <combobox
             :label="$t('shots.fields.sequence')"
             :options="castingSequenceOptions"
@@ -78,13 +87,11 @@
           {{ $t('breakdown.all_assets') }}
         </h2>
 
-        <div class="filters-area">
-          <div class="level">
-            <search-field
-              @change="onSearchChange"
-            >
-            </search-field>
-          </div>
+        <div class="filters-area flexrow">
+          <search-field
+            class="flexrow-item"
+            @change="onSearchChange"
+          />
         </div>
 
         <spinner v-if="isAssetsLoading" />
@@ -112,6 +119,17 @@
       </div>
 
     </div>
+
+    <import-modal
+      :active="modals.importing"
+      :is-loading="loading.importing"
+      :is-error="errors.importing"
+      :form-data="importCsvFormData"
+      :columns="csvColumns"
+      @fileselected="selectFile"
+      @confirm="uploadImportFile"
+      @cancel="hideImportModal"
+    />
   </div>
 </template>
 
@@ -120,8 +138,10 @@ import { mapGetters, mapActions } from 'vuex'
 
 import AssetBlock from './breakdown/AssetBlock'
 import AvailableAssetBlock from './breakdown/AvailableAssetBlock'
+import ButtonSimple from '../widgets/ButtonSimple'
 import Combobox from '../widgets/Combobox'
 import ErrorText from '../widgets/ErrorText'
+import ImportModal from '../modals/ImportModal'
 import SearchField from '../widgets/SearchField.vue'
 import ShotLine from './breakdown/ShotLine'
 import Spinner from '../widgets/Spinner'
@@ -132,8 +152,10 @@ export default {
   components: {
     AssetBlock,
     AvailableAssetBlock,
+    ButtonSimple,
     Combobox,
     ErrorText,
+    ImportModal,
     SearchField,
     ShotLine,
     Spinner
@@ -141,13 +163,37 @@ export default {
 
   data () {
     return {
+      csvColumns: [
+        'Episode',
+        'Parent',
+        'Name',
+        'Asset Type',
+        'Asset',
+        'Occurences',
+        'Label'
+      ],
+      importCsvFormData: {},
       isLoading: false,
       isSaving: false,
       isSavingError: false,
       sequenceId: '',
       episodeId: '',
-      shotId: ''
+      shotId: '',
+      modals: {
+        importing: false
+      },
+      loading: {
+        importing: false
+      },
+      errors: {
+        importing: false
+      }
     }
+  },
+
+  mounted () {
+    this.reset()
+    this.setLastProductionScreen('breakdown')
   },
 
   computed: {
@@ -189,24 +235,20 @@ export default {
     }
   },
 
-  mounted () {
-    this.reset()
-    this.setLastProductionScreen('breakdown')
-  },
-
   methods: {
     ...mapActions([
+      'addAssetToCasting',
       'displayMoreAssets',
       'loadShots',
       'loadAssets',
+      'removeAssetFromCasting',
       'saveCasting',
       'setAssetSearch',
       'setCastingEpisode',
       'setCastingSequence',
       'setCastingShot',
-      'addAssetToCasting',
-      'removeAssetFromCasting',
-      'setLastProductionScreen'
+      'setLastProductionScreen',
+      'uploadCastingFile'
     ]),
 
     reset () {
@@ -296,6 +338,34 @@ export default {
       if (maxHeight < (position.scrollTop + 100)) {
         this.displayMoreAssets()
       }
+    },
+
+    showImportModal () {
+      this.modals.importing = true
+    },
+
+    hideImportModal () {
+      this.modals.importing = false
+    },
+
+    selectFile (formData) {
+      this.importCsvFormData = formData
+    },
+
+    uploadImportFile () {
+      this.loading.importing = true
+      this.errors.importing = false
+      this.uploadCastingFile(this.importCsvFormData)
+        .then(() => {
+          this.loading.importing = false
+          this.hideImportModal()
+          this.reloadShots()
+        })
+        .catch(() => {
+          console.log('bad 2')
+          this.loading.importing = false
+          this.errors.importing = true
+        })
     }
   },
 
@@ -370,10 +440,10 @@ export default {
   bottom: 0;
   display: flex;
   flex-direction: column;
-}
-
-.title {
-  margin-top: 1em;
+  background: #FAFAFA;
+  padding-left: 1em;
+  padding-right: 1em;
+  padding-bottom: 1em;
 }
 
 .breakdown-columns {
@@ -386,23 +456,26 @@ export default {
 .breakdown-column {
   flex: 1;
   overflow-y: auto;
+  padding: 1em;
+  background: white;
+  border: 1px solid #EEE;
+  box-shadow: 0px 0px 6px #E0E0E0;
+  border-radius: 1em;
+  margin-left: 0.5em;
 }
 
 .breakdown-column:first-child {
   max-width: 250px;
+  margin-left: 0;
 }
 
 .shot-column {
-  padding: 0 1em 0 0;
 }
 
 .casting-column {
-  padding: 0 1em;
 }
 
 .assets-column {
-  border-left: 4px solid $white-grey;
-  padding-left: 1em;
 }
 
 .asset-type,

--- a/src/components/pages/People.vue
+++ b/src/components/pages/People.vue
@@ -7,12 +7,13 @@
 
       <div class="level-right">
         <div class="level-item">
-          <button-link v-if="isCurrentUserAdmin"
+          <button-simple
             class="level-item"
             :title="$t('main.csv.import_file')"
             :is-responsive="true"
             icon="upload"
-            path="/people/import"
+            @click="showImportModal"
+            v-if="isCurrentUserAdmin"
           />
           <button-href-link
             class="level-item"
@@ -20,12 +21,13 @@
             icon="download"
             path="/api/export/csv/persons.csv"
           />
-          <button-link v-if="isCurrentUserAdmin"
+          <button-link
             class="level-item"
             :text="$t('people.new_person')"
             :is-responsive="true"
             icon="plus"
             path="/people/new"
+            v-if="isCurrentUserAdmin"
           />
         </div>
       </div>
@@ -48,14 +50,14 @@
     />
 
     <import-modal
-      :active="isImportPeopleModalShown"
+      :active="modals.importModal"
       :is-loading="isImportPeopleLoading"
       :is-error="isImportPeopleLoadingError"
-      :cancel-route="'/people'"
       :form-data="personCsvFormData"
       :columns="csvColumns"
       @fileselected="selectFile"
       @confirm="uploadImportFile"
+      @cancel="hideImportModal"
     />
 
     <edit-person-modal
@@ -94,19 +96,21 @@ import EditPersonModal from '../modals/EditPersonModal'
 import ImportModal from '../modals/ImportModal'
 import ButtonLink from '../widgets/ButtonLink'
 import ButtonHrefLink from '../widgets/ButtonHrefLink'
+import ButtonSimple from '../widgets/ButtonSimple'
 import PageTitle from '../widgets/PageTitle'
 import SearchField from '../widgets/SearchField'
 
 export default {
   name: 'people',
   components: {
-    PeopleList,
-    DeleteModal,
-    EditPersonModal,
-    ImportModal,
     ButtonLink,
     ButtonHrefLink,
+    ButtonSimple,
+    EditPersonModal,
+    DeleteModal,
+    ImportModal,
     PageTitle,
+    PeopleList,
     SearchField
   },
 
@@ -119,6 +123,9 @@ export default {
         createAndInvite: false,
         edit: false,
         invite: false
+      },
+      modals: {
+        importModal: false
       },
       success: {
         invite: false
@@ -198,7 +205,7 @@ export default {
       this.$store.dispatch('uploadPersonFile', (err) => {
         if (!err) {
           this.$store.dispatch('loadPeople')
-          this.$router.push('/people')
+          this.hideImportModal()
         }
       })
     },
@@ -262,14 +269,6 @@ export default {
       this.$store.commit('PERSON_CSV_FILE_SELECTED', formData)
     },
 
-    showImportModalIfNeeded (path) {
-      if (path.indexOf('import') > 0) {
-        this.$store.dispatch('showPersonImportModal')
-      } else {
-        this.$store.dispatch('hidePersonImportModal')
-      }
-    },
-
     showDeleteModalIfNeeded (path, personId) {
       if (path.indexOf('delete') > 0) {
         this.$store.dispatch('showPersonDeleteModal', personId)
@@ -295,11 +294,18 @@ export default {
       const personId = this.$store.state.route.params.person_id
       this.showDeleteModalIfNeeded(path, personId)
       this.showEditModalIfNeeded(path, personId)
-      this.showImportModalIfNeeded(path, personId)
     },
 
     onSearchChange () {
       this.peopleSearchChange(this.$refs['people-search-field'].getValue())
+    },
+
+    showImportModal () {
+      this.modals.importModal = true
+    },
+
+    hideImportModal () {
+      this.modals.importModal = false
     }
   },
 

--- a/src/components/pages/Profile.vue
+++ b/src/components/pages/Profile.vue
@@ -85,6 +85,19 @@
           />
         </div>
 
+        <div class="field">
+          <combobox-boolean
+            :label="$t('profile.notifications_slack_enabled')"
+            v-model="form.notifications_slack_enabled"
+          />
+        </div>
+
+        <text-field
+          :label="$t('profile.notifications_slack_user')"
+          v-model="form.notifications_slack_userid"
+          v-if="form.notifications_slack_enabled === 'true'"
+        />
+
         <button
           :class="{
             button: true,
@@ -208,6 +221,8 @@ export default {
         first_name: '',
         last_name: '',
         notifications_enabled: 'false',
+        notifications_slack_enabled: 'false',
+        notifications_slack_userid: '',
         email: '',
         phone: '',
         timezone: 'Europe/Paris',
@@ -311,6 +326,8 @@ export default {
     this.form = Object.assign(this.form, this.user)
     this.form.notifications_enabled =
       this.form.notifications_enabled ? 'true' : 'false'
+    this.form.notifications_slack_enabled =
+      this.form.notifications_slack_enabled ? 'true' : 'false'
   },
 
   metaInfo () {

--- a/src/components/pages/Settings.vue
+++ b/src/components/pages/Settings.vue
@@ -39,6 +39,14 @@
           @enter="saveSettings()"
           v-model="form.use_original_file_name"
         />
+        <h2>
+          {{ $t('settings.integrations') }}
+        </h2>
+        <text-field
+          :label="$t('settings.fields.slack_token')"
+          @enter="saveSettings()"
+          v-model="form.chat_token_slack"
+        />
 
         <button
           :class="{
@@ -98,7 +106,8 @@ export default {
       form: {
         name: '',
         hours_by_day: 0,
-        original_file_name: 'false'
+        original_file_name: 'false',
+        chat_token_slack: ''
       },
       errors: {
         save: false,
@@ -223,6 +232,7 @@ strong {
   margin-top: 2em;
   margin-bottom: 2em;
   box-shadow: rgba(0,0,0,0.15) 0px 1px 4px 2px;
+  border-radius: 1em;
 }
 
 .settings-body {

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -23,12 +23,12 @@
               <div class="flexrow-item"></div>
             </div>
             <div class="flexrow" v-if="isCurrentUserManager">
-              <button-link
+              <button-simple
                 class="flexrow-item"
                 :title="$t('main.csv.import_file')"
                 icon="upload"
                 :is-responsive="true"
-                :path="importPath"
+                @click="showImportModal"
               />
               <button-href-link
                 class="flexrow-item"
@@ -42,7 +42,6 @@
                 :text="$t('shots.manage')"
                 icon="plus"
                 :is-responsive="true"
-                :path="manageShotsPath"
                 @click="showManageShots"
               />
             </div>
@@ -153,9 +152,9 @@
     :active="modals.isImportDisplayed"
     :is-loading="loading.importing"
     :is-error="errors.importing"
-    :cancel-route="shotsPath"
     :form-data="shotsCsvFormData"
     :columns="columns"
+    @cancel="hideImportModal"
     @fileselected="selectFile"
     @confirm="uploadImportFile"
   />
@@ -190,7 +189,6 @@ import { mapGetters, mapActions } from 'vuex'
 
 import AddMetadataModal from '../modals/AddMetadataModal'
 import ButtonHrefLink from '../widgets/ButtonHrefLink'
-import ButtonLink from '../widgets/ButtonLink'
 import ButtonSimple from '../widgets/ButtonSimple'
 import CreateTasksModal from '../modals/CreateTasksModal'
 import DeleteModal from '../widgets/DeleteModal'
@@ -210,7 +208,6 @@ export default {
 
   components: {
     AddMetadataModal,
-    ButtonLink,
     ButtonHrefLink,
     ButtonSimple,
     CreateTasksModal,
@@ -301,15 +298,7 @@ export default {
       'shotValidationColumns',
       'shotListScrollPosition',
       'taskTypeMap'
-    ]),
-
-    importPath () {
-      return this.getPath('import-shots')
-    },
-
-    manageShotsPath () {
-      return this.getPath('manage-shots')
-    }
+    ])
   },
 
   created () {
@@ -572,7 +561,6 @@ export default {
         isDeleteAllTasksDisplayed: false,
         isDeleteDisplayed: false,
         isDeleteMetadataDisplayed: false,
-        isImportDisplayed: false,
         isNewDisplayed: false,
         isRestoreDisplayed: false
       })
@@ -591,8 +579,6 @@ export default {
       } else if (path.indexOf('restore') > 0) {
         this.shotToRestore = this.shotMap[shotId]
         this.modals.isRestoreDisplayed = true
-      } else if (path.indexOf('import') > 0) {
-        this.modals.isImportDisplayed = true
       } else if (path.indexOf('create-tasks') > 0) {
         this.modals.isCreateTasksDisplayed = true
       }
@@ -609,7 +595,7 @@ export default {
       this.$store.dispatch('uploadShotFile', (err) => {
         if (!err) {
           this.loading.importing = false
-          this.modals.isImportDisplayed = false
+          this.hideImportModal()
           this.loadShots(() => {
             this.resizeHeaders()
           })
@@ -694,8 +680,15 @@ export default {
     },
 
     hideManageShots () {
-      console.log('cancel')
       this.modals.isManageDisplayed = false
+    },
+
+    showImportModal () {
+      this.modals.isImportDisplayed = true
+    },
+
+    hideImportModal () {
+      this.modals.isImportDisplayed = false
     }
   },
 

--- a/src/components/widgets/SearchField.vue
+++ b/src/components/widgets/SearchField.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="flexrow search-field-wrapper">
+<div class="flexrow search-field-wrapper" ref="wrapper" @click="focus">
   <div class="flexrow-item">
     <search-icon class="search-icon" />
   </div>
@@ -12,6 +12,8 @@
       :placeholder="placeholder"
       @input="onSearchChange"
       @keyup.enter="onSaveClicked"
+      @focus="setFocusedStyle"
+      @blur="unsetFocusedStyle"
       v-focus
     />
   </div>
@@ -38,6 +40,11 @@ import { SaveIcon, SearchIcon } from 'vue-feather-icons'
 
 export default {
   name: 'search-field',
+
+  data () {
+    return {
+    }
+  },
 
   props: {
     placeholder: {
@@ -85,6 +92,14 @@ export default {
     clearSearch () {
       this.setValue('')
       this.onSearchChange()
+    },
+
+    setFocusedStyle () {
+      this.$refs['wrapper'].className = 'flexrow search-field-wrapper focused'
+    },
+
+    unsetFocusedStyle () {
+      this.$refs['wrapper'].className = 'flexrow search-field-wrapper'
     }
   }
 }
@@ -147,6 +162,12 @@ export default {
   border: 1px solid #DDD;
   border-radius: 2em;
   padding: 0.2em 1em;
+
+  &.focused {
+    border: 1px solid $green;
+    box-shadow: 0 0 4px 3px #EEE;
+    transition: all 0.5s ease-in-out;
+  }
 }
 
 .search-field-wrapper:focus,

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -361,6 +361,8 @@ export default {
     info_title: 'Information',
     language: 'Language',
     notifications_enabled: 'Email notifications enabled',
+    notifications_slack_enabled: 'Notifications Slack activées',
+    notifications_slack_user: 'Nom d\'utilisateur Slack',
     password_title: 'Change password',
     timezone: 'Timezone',
     title: 'Your Profile',
@@ -382,6 +384,7 @@ export default {
 
   settings: {
     change_logo: 'Change logo',
+    integrations: 'Integrations',
     logo: 'Studio logo',
     no_logo: 'There is no logo set.',
     set_logo: 'Set studio logo',
@@ -389,6 +392,7 @@ export default {
     fields: {
       name: 'Studio name',
       hours_by_day: 'Hours by day',
+      slack_token: 'Slack Token (Optional)',
       use_original_name: 'Use original file name for downloads'
     },
     save: {

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -230,6 +230,7 @@ export default {
   people: {
     active: 'Présents',
     add_member_to_team: 'Ajouter un membre à l\'équipe: ',
+    create_invite: 'Créer et envoyer une invitation',
     delete_text: 'Êtes vous sûr de vouloir retirer {personName} de la base de données?',
     delete_error: 'Une erreur est survenue lors de la suppression. Il y a probablement des données liées à elle. Etes vous sur que cette personne n\'a aucune tâche assignée et n\'a fait aucun commentaire ?',
     edit_title: 'Modifier les informations de',
@@ -331,6 +332,8 @@ export default {
     info_title: 'Informations',
     language: 'Langue',
     notifications_enabled: 'Notifications mail activées',
+    notifications_slack_enabled: 'Notifications Slack activées',
+    notifications_slack_user: 'Nom d\'utilisateur Slack',
     password_title: 'Changement de mot de passe',
     timezone: 'Fuseau horaire',
     title: 'Votre Profil',
@@ -367,12 +370,14 @@ export default {
 
   settings: {
     change_logo: 'Changer logo',
+    integrations: 'Intégrations',
     logo: 'Logo du studio',
     no_logo: 'Aucun logo n\' a été positionné.',
     set_logo: 'Changer le logo',
     title: 'Paramètres',
     fields: {
       name: 'Nom du studio',
+      slack_token: 'Token Slack (optionnel)',
       hours_by_day: 'Heures par jour',
       use_original_name: 'Utiliser les noms de fichiers originaux pour le téléchargement'
     },

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -134,11 +134,6 @@ export const routes = [
         component: People
       },
       {
-        path: '/people/import',
-        component: People,
-        name: 'import-people'
-      },
-      {
         path: '/people/:person_id',
         component: Person,
         name: 'person'
@@ -283,11 +278,6 @@ export const routes = [
         name: 'restore-asset'
       },
       {
-        path: '/productions/:production_id/assets/import',
-        component: Assets,
-        name: 'import-assets'
-      },
-      {
         path: '/productions/:production_id/assets/create-tasks',
         component: Assets,
         name: 'create-asset-tasks'
@@ -331,11 +321,6 @@ export const routes = [
         name: 'episode-restore-asset'
       },
       {
-        path: '/productions/:production_id/episodes/:episode_id/assets/import',
-        component: Assets,
-        name: 'episode-import-assets'
-      },
-      {
         path: '/productions/:production_id/episodes/:episode_id/assets/create-tasks',
         component: Assets,
         name: 'episode-create-asset-tasks'
@@ -361,11 +346,6 @@ export const routes = [
         path: '/productions/:production_id/shots',
         component: Shots,
         name: 'shots'
-      },
-      {
-        path: '/productions/:production_id/shots/import',
-        component: Shots,
-        name: 'import-shots'
       },
       {
         path: '/productions/:production_id/shots/create-tasks',
@@ -408,11 +388,6 @@ export const routes = [
         path: '/productions/:production_id/episodes/:episode_id/shots/manage',
         component: Shots,
         name: 'episode-manage-shots'
-      },
-      {
-        path: '/productions/:production_id/episodes/:episode_id/shots/import',
-        component: Shots,
-        name: 'episode-import-shots'
       },
       {
         path: '/productions/:production_id/episodes/:episode_id/shots/create-tasks',

--- a/src/store/api/people.js
+++ b/src/store/api/people.js
@@ -11,7 +11,8 @@ export default {
             name: 'Kitsu',
             hours_by_day: 8,
             has_avatar: false,
-            use_original_file_name: false
+            use_original_file_name: false,
+            chat_token_slack: ''
           }
           if (organisations.length > 0) organisation = organisations[0]
           organisation.use_original_file_name =
@@ -27,7 +28,8 @@ export default {
       const data = {
         name: organisation.name,
         hours_by_day: organisation.hours_by_day,
-        use_original_file_name: organisation.use_original_file_name === 'true'
+        use_original_file_name: organisation.use_original_file_name === 'true',
+        chat_token_slack: organisation.chat_token_slack
       }
       client.put(
         `/api/data/organisations/${organisation.id}`,
@@ -98,7 +100,9 @@ export default {
         locale: person.locale,
         role: person.role,
         active: person.active,
-        notifications_enabled: person.notifications_enabled === 'true'
+        notifications_enabled: person.notifications_enabled === 'true',
+        notifications_slack_enabled: person.notifications_slack_enabled === 'true',
+        notifications_slack_userid: person.notifications_slack_userid
       }
       client.put(`/api/data/persons/${person.id}`, data, (err, person) => {
         if (err) reject(err)

--- a/src/store/api/shots.js
+++ b/src/store/api/shots.js
@@ -145,5 +145,18 @@ export default {
         }
       )
     })
+  },
+
+  postCastingCsv (production, formData) {
+    return new Promise((resolve, reject) => {
+      client.post(
+        `/api/import/csv/projects/${production.id}/casting`,
+        formData,
+        (err) => {
+          if (err) reject(err)
+          else resolve()
+        }
+      )
+    })
   }
 }

--- a/src/store/modules/breakdown.js
+++ b/src/store/modules/breakdown.js
@@ -208,6 +208,11 @@ const actions = {
 
       if (callback) callback(err)
     })
+  },
+
+  uploadCastingFile ({ commit, state, rootGetters }, formData) {
+    const currentProduction = rootGetters.currentProduction
+    return shotsApi.postCastingCsv(currentProduction, formData)
   }
 }
 


### PR DESCRIPTION
**Problem**

* It was not clear when the user focused on the search widget
* There is no way to set the Slack bot token and the userid in the api.
* There is no way to use the casting import from the API.
* There is no way to use the casting CSV export from the API.

**Solution**

* When the input is focused, all the widget takes a distinctive style
* Add needed fields in Settings and Profile sections.
* Add an import modal to the breakdown section
* Add a CSV export button (href link) to the breakdown page
