### PR TITLE
Various fixes and sequence grouping

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -446,33 +446,15 @@ export default {
     },
 
     resizeHeaders () {
-      if (
-        this.$refs['body-tbody'] &&
-        this.$refs['body-tbody'][0] &&
-        this.$refs['body-tbody'][0].children.length > 0
-      ) {
-        if (this.$refs['th-episode']) {
-          const episodeWidth =
-            this.$refs['body-tbody'][0].children[1].children[0].offsetWidth
-          this.$refs['th-episode'].style['min-width'] = `${episodeWidth}px`
-          const nameWidth =
-            this.$refs['body-tbody'][0].children[1].children[2].offsetWidth
-          this.$refs['th-name'].style['min-width'] =
-            `${Math.max(nameWidth, 120)}px`
-        } else {
-          const thumbnailWidth =
-            this.$refs['body-tbody'][0].children[1].children[0].offsetWidth
-          this.$refs['th-thumbnail'].style['min-width'] = `${thumbnailWidth}px`
-          const nameWidth =
-            this.$refs['body-tbody'][0].children[1].children[1].offsetWidth
-          this.$refs['th-name'].style['min-width'] = `${nameWidth}px`
-          if (this.$refs['th-description']) {
-            const descriptionWidth =
-              this.$refs['body-tbody'][0].children[1].children[2].offsetWidth
-            this.$refs['th-description'].style['min-width'] =
-              `${descriptionWidth}px`
-          }
-        }
+      if (this.$refs['th-episode']) {
+        this.resizeSplittedTableHeaders([
+          { index: 0, name: 'episode' },
+          { index: 2, name: 'name' }
+        ])
+      } else {
+        this.resizeSplittedTableHeaders([
+          { index: 1, name: 'name' }
+        ])
       }
     }
   },
@@ -579,9 +561,6 @@ thead tr a {
   padding-top: 1em;
   position: relative;
   z-index: 1;
-}
-
-tbody:first-child tr:first-child {
 }
 
 tbody:last-child .empty-line:last-child {

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -449,10 +449,12 @@ export default {
       if (this.$refs['th-episode']) {
         this.resizeSplittedTableHeaders([
           { index: 0, name: 'episode' },
+          { index: 1, name: 'thumbnail' },
           { index: 2, name: 'name' }
         ])
       } else {
         this.resizeSplittedTableHeaders([
+          { index: 0, name: 'thumbnail' },
           { index: 1, name: 'name' }
         ])
       }

--- a/src/components/lists/base.js
+++ b/src/components/lists/base.js
@@ -223,6 +223,20 @@ export const entityListMixin = {
     onDeleteMetadataClicked () {
       this.$emit('delete-metadata', this.lastMetadaDataHeaderMenuDisplayed)
       this.showMetadataHeaderMenu()
+    },
+
+    resizeSplittedTableHeaders (columnDescriptors) {
+      if (
+        this.$refs['body-tbody'] &&
+        this.$refs['body-tbody'].length > 0 &&
+        this.$refs['body-tbody'][0].children.length > 1
+      ) {
+        const bodyElement = this.$refs['body-tbody'][0].children[1]
+        columnDescriptors.forEach(desc => {
+          const width = bodyElement.children[desc.index].offsetWidth
+          this.$refs['th-' + desc.name].style['min-width'] = `${width}px`
+        })
+      }
     }
   }
 }

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -59,8 +59,7 @@
           :align-right="true"
           :hidden="!isSavingError"
           :text="$t('breakdown.save_error')"
-        >
-        </error-text>
+        />
         <spinner v-if="isLoading" />
         <div
           class="type-assets"
@@ -79,8 +78,7 @@
               @remove-one="removeOneAsset"
               @remove-ten="removeTenAssets"
               v-for="asset in typeAssets"
-            >
-            </asset-block>
+            />
           </div>
         </div>
       </div>
@@ -416,6 +414,7 @@ export default {
     },
 
     castingSequenceOptions () {
+      console.log('options changed', this.castingSequenceOptions)
       if (this.castingSequenceOptions.length > 0) {
         const shot = this.shotMap[this.shotId]
         if (this.shotId && shot) {
@@ -436,6 +435,10 @@ export default {
       if (this.currentEpisode && this.episodeId !== this.currentEpisode.id) {
         this.reset()
       }
+    },
+
+    sequences () {
+      this.$store.commit('CASTING_SET_SEQUENCES', this.sequences)
     }
   },
 

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -47,7 +47,7 @@
           </li>
           <li
             :class="{'is-active': isActiveTab('timesheets')}"
-            @click="selectTab('timesheet')"
+            @click="selectTab('timesheets')"
             v-if="isCurrentUserManager"
           >
             <router-link :to="{

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -60,7 +60,7 @@
 
       <shot-list
         ref="shot-list"
-        :entries="displayedShots"
+        :displayed-shots="displayedShotsBySequence"
         :is-loading="isShotsLoading || initialLoading"
         :is-error="isShotsLoadingError"
         :validation-columns="shotValidationColumns"
@@ -277,7 +277,7 @@ export default {
       'currentEpisode',
       'currentProduction',
       'deleteShot',
-      'displayedShots',
+      'displayedShotsBySequence',
       'editShot',
       'episodeMap',
       'episodes',

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -160,7 +160,6 @@ export default {
 
   computed: {
     ...mapGetters([
-      'assetsByType',
       'assetMap',
       'assetsPath',
       'currentEpisode',

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -58,3 +58,24 @@ export const getFilledColumns = (entries) => {
   })
   return filledColumns
 }
+
+export const groupEntitiesByParents = (entities, parentNameField) => {
+  const entitiesByParents = []
+  let parentEntities = []
+  let previousEntity = null
+
+  for (let entity of entities) {
+    if (
+      previousEntity &&
+      entity[parentNameField] !== previousEntity[parentNameField]
+    ) {
+      entitiesByParents.push(parentEntities.slice(0))
+      parentEntities = []
+    }
+    parentEntities.push(entity)
+    previousEntity = entity
+  }
+  entitiesByParents.push(parentEntities)
+
+  return entitiesByParents
+}

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -490,7 +490,7 @@ export default {
       frame_in: 'In',
       frame_out: 'Out',
       fps: 'FPS',
-      name: 'Shot',
+      name: 'Name',
       production: 'Prod',
       sequence: 'Sequence',
       time_spent: 'Time'

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -179,19 +179,23 @@ export const routes = [
             name: 'delete-person',
             path: 'delete/:person_id',
             component: People
-          },
+          }
+        ]
+      },
+
+      {
+        path: 'people/:person_id',
+        component: Person,
+        name: 'person',
+        children: [
           {
-            path: ':person_id',
-            component: Person,
-            name: 'person'
-          },
-          {
-            path: ':person_id/:tab',
+            path: ':tab',
             component: Person,
             name: 'person-tab'
           }
         ]
       },
+
       {
         path: '/timesheets',
         component: Timesheets,

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -20,7 +20,8 @@ import {
   clearSelectionGrid
 } from '../../lib/selection'
 import {
-  getFilledColumns
+  getFilledColumns,
+  groupEntitiesByParents
 } from '../../lib/models'
 import {
   computeStats
@@ -124,27 +125,6 @@ const helpers = {
     })
 
     return task
-  },
-
-  groupAssetsByType: (assets) => {
-    const assetsByType = []
-    let assetTypeAssets = []
-    let previousAsset = null
-
-    for (let asset of assets) {
-      if (
-        previousAsset &&
-        asset.asset_type_name !== previousAsset.asset_type_name
-      ) {
-        assetsByType.push(assetTypeAssets.slice(0))
-        assetTypeAssets = []
-      }
-      assetTypeAssets.push(asset)
-      previousAsset = asset
-    }
-    assetsByType.push(assetTypeAssets)
-
-    return assetsByType
   }
 }
 
@@ -225,11 +205,14 @@ const getters = {
   assetListScrollPosition: state => state.assetListScrollPosition,
 
   displayedAssetsByType: state => {
-    return helpers.groupAssetsByType(state.displayedAssets)
+    return groupEntitiesByParents(state.displayedAssets, 'asset_type_name')
   },
 
   assetsByType: state => {
-    return helpers.groupAssetsByType(Object.values(state.displayedAssets))
+    return groupEntitiesByParents(
+      Object.values(state.displayedAssets),
+      'asset_type_name'
+    )
   },
 
   editAsset: state => state.editAsset,

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -20,7 +20,8 @@ import {
   clearSelectionGrid
 } from '../../lib/selection'
 import {
-  getFilledColumns
+  getFilledColumns,
+  groupEntitiesByParents
 } from '../../lib/models'
 import {
   computeStats
@@ -292,6 +293,10 @@ const getters = {
   displayedEpisodes: state => state.displayedEpisodes,
   displayedEpisodesLength: state => state.displayedEpisodesLength,
   shotFilledColumns: state => state.shotFilledColumns,
+
+  displayedShotsBySequence: state => {
+    return groupEntitiesByParents(state.displayedShots, 'sequence_name')
+  },
 
   isShotsLoading: state => state.isShotsLoading,
   isShotsLoadingError: state => state.isShotsLoadingError,


### PR DESCRIPTION
**Problem**

* In shot list, shots are not grouped like assets in asset list.
* Stat export returns messy columns
* Person page is no more accessible
* Asset list headers sometimes break
* Switching production in breakdow page, breaks the sequence combo

**Solution**

* Use split tables to display shots by sequence
* Refactor and fix the stat export function
* Fix person page route following recent refactoring
* Reset all headers size when switching from a tv-series to a short (and vice-versa)
* Reset sequence combo each time sequences are reloaded.