### PR TITLE
Schedule fixes

### DIFF
--- a/src/components/pages/MainSchedule.vue
+++ b/src/components/pages/MainSchedule.vue
@@ -49,7 +49,7 @@
       :zoom-level="zoomLevel"
       :is-loading="loading.schedule"
       :is-error="errors.schedule"
-      @item-changed="saveScheduleItem"
+      @item-changed="onScheduleItemChanged"
       @change-zoom="changeZoom"
       @root-element-expanded="expandProductionElement"
     />
@@ -131,6 +131,7 @@ export default {
 
   methods: {
     ...mapActions([
+      'editProduction',
       'loadScheduleItems',
       'saveScheduleItem'
     ]),
@@ -160,7 +161,7 @@ export default {
           endDate: endDate,
           expanded: false,
           loading: false,
-          editable: false,
+          editable: true,
           route: getProductionSchedulePath(item.id),
           children: []
         }
@@ -181,7 +182,7 @@ export default {
           endDate: endDate,
           expanded: false,
           loading: false,
-          editable: false,
+          editable: true,
           children: []
         }
       })
@@ -199,6 +200,20 @@ export default {
           })
       } else {
         productionElement.expanded = false
+      }
+    },
+
+    onScheduleItemChanged (item) {
+      if (item.type !== 'Project') {
+        this.saveScheduleItem(item)
+      } else {
+        this.editProduction({
+          data: {
+            id: item.id,
+            start_date: item.startDate.format('YYYY-MM-DD'),
+            end_date: item.endDate.format('YYYY-MM-DD')
+          }
+        })
       }
     }
   },

--- a/src/components/pages/MainSchedule.vue
+++ b/src/components/pages/MainSchedule.vue
@@ -66,6 +66,7 @@ import { mapGetters, mapActions } from 'vuex'
 import moment from 'moment-timezone'
 import { en, fr } from 'vuejs-datepicker/dist/locale'
 import Datepicker from 'vuejs-datepicker'
+import { getProductionSchedulePath } from '../../lib/path'
 
 import {
   getFirstStartDate,
@@ -160,6 +161,7 @@ export default {
           expanded: false,
           loading: false,
           editable: false,
+          route: getProductionSchedulePath(item.id),
           children: []
         }
       })

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -87,6 +87,7 @@ import { en, fr } from 'vuejs-datepicker/dist/locale'
 import Datepicker from 'vuejs-datepicker'
 
 import { sortScheduleItems } from '../../lib/sorting'
+import { getTaskTypeSchedulePath } from '../../lib/path'
 
 import ComboboxNumber from '../widgets/ComboboxNumber'
 import TaskInfo from '../sides/TaskInfo'
@@ -181,6 +182,7 @@ export default {
             } else {
               endDate = startDate.clone().add(1, 'days')
             }
+
             return {
               ...item,
               color: taskType.color,
@@ -192,6 +194,12 @@ export default {
               editable: this.isCurrentUserManager,
               expanded: false,
               loading: false,
+              route: getTaskTypeSchedulePath(
+                taskType.id,
+                this.currentProduction.id,
+                this.currentEpisode.id,
+                taskType.for_shots ? 'shots' : 'assets'
+              ),
               children: []
             }
           })

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -197,7 +197,7 @@ export default {
               route: getTaskTypeSchedulePath(
                 taskType.id,
                 this.currentProduction.id,
-                this.currentEpisode.id,
+                this.currentEpisode ? this.currentEpisode.id : null,
                 taskType.for_shots ? 'shots' : 'assets'
               ),
               children: []

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -566,8 +566,8 @@ export default {
           this.buildPersonElement({ id: 'unassigned' }, taskAssignationMap)
         ])
       }
-      this.resetScheduleDates()
       this.schedule.scheduleItems = scheduleItems
+      this.resetScheduleDates()
     },
 
     resetScheduleDates () {
@@ -581,7 +581,7 @@ export default {
           mainEndDate = personElement.endDate.clone()
         }
       })
-      this.schedule.startDate = mainStartDate
+      this.schedule.startDate = mainStartDate.add('days', -1)
       this.schedule.endDate = mainEndDate
     },
 

--- a/src/components/pages/schedule/Schedule.vue
+++ b/src/components/pages/schedule/Schedule.vue
@@ -62,9 +62,19 @@
               v-else
             />
           </span>
-          <span class="filler flexrow-item root-element-name">
+          <span
+            class="filler flexrow-item root-element-name"
+            v-if="!rootElement.route"
+          >
             {{ rootElement.name }}
           </span>
+          <router-link
+            class="filler flexrow-item root-element-name"
+            :to="rootElement.route"
+            v-else
+          >
+            {{ rootElement.name }}
+          </router-link>
           <input
             class="flexrow-item"
             type="number"
@@ -1489,6 +1499,7 @@ export default {
 
 .root-element-name {
   padding-left: 10px;
+  color: white;
 }
 
 .date-widget {

--- a/src/components/pages/schedule/Schedule.vue
+++ b/src/components/pages/schedule/Schedule.vue
@@ -609,16 +609,27 @@ export default {
       )
     },
 
+    getDisplayedDaysIndex (date) {
+      if (date.isoWeekday() === 6) {
+        date = date.add('days', -1)
+      }
+      if (date.isoWeekday() === 7) {
+        date = date.add('days', -2)
+      }
+      const dateString = date.format('YYYY-MM-DD')
+      return this.displayedDaysIndex[dateString]
+    },
+
     changeDates (event) {
       const change = event.clientX - this.initialClientX - this.cellWidth / 2
       const dayChange = Math.ceil(change / this.cellWidth)
 
-      const startDateString = this.lastStartDate.format('YYYY-MM-DD')
-      const endDateString = this.lastEndDate.format('YYYY-MM-DD')
-      const startDateIndex = this.displayedDaysIndex[startDateString]
-      const endDateIndex = this.displayedDaysIndex[endDateString]
+      const startDate = this.lastStartDate
+      const endDate = this.lastEndDate
+      const startDateIndex = this.getDisplayedDaysIndex(startDate)
+      const endDateIndex = this.getDisplayedDaysIndex(endDate)
       const length = endDateIndex - startDateIndex
-      let currentIndex = this.displayedDaysIndex[startDateString]
+      let currentIndex = this.getDisplayedDaysIndex(startDate)
 
       currentIndex += dayChange
       if (currentIndex < 0) currentIndex = 0
@@ -638,11 +649,10 @@ export default {
       const change = event.clientX - this.initialClientX + this.cellWidth / 2
       const dayChange = Math.floor(change / this.cellWidth)
 
-      const startDateString = this.lastStartDate.format('YYYY-MM-DD')
-      const endDateString =
-        this.currentElement.endDate.format('YYYY-MM-DD')
-      let currentIndex = this.displayedDaysIndex[startDateString]
-      let endDateIndex = this.displayedDaysIndex[endDateString]
+      const startDate = this.lastStartDate
+      const endDate = this.currentElement.endDate
+      let currentIndex = this.getDisplayedDaysIndex(startDate)
+      let endDateIndex = this.getDisplayedDaysIndex(endDate)
 
       currentIndex += dayChange
       if (currentIndex > endDateIndex) currentIndex = endDateIndex - 1
@@ -659,11 +669,10 @@ export default {
       const change = event.clientX - this.initialClientX + this.cellWidth / 2
       const dayChange = Math.ceil(change / this.cellWidth)
 
-      const startDateString =
-        this.currentElement.startDate.format('YYYY-MM-DD')
-      const endDateString = this.lastEndDate.format('YYYY-MM-DD')
-      let startDateIndex = this.displayedDaysIndex[startDateString]
-      let currentIndex = this.displayedDaysIndex[endDateString]
+      const startDate = this.currentElement.startDate
+      const endDate = this.lastEndDate
+      let startDateIndex = this.getDisplayedDaysIndex(startDate)
+      let currentIndex = this.getDisplayedDaysIndex(endDate)
 
       currentIndex += dayChange - 1
       if (currentIndex < startDateIndex) currentIndex = startDateIndex + 1

--- a/src/lib/path.js
+++ b/src/lib/path.js
@@ -74,3 +74,40 @@ export const getEntityPath = (entityId, productionId, section, episodeId) => {
 
   return route
 }
+
+const getProductionRoute = (name, productionId) => {
+  return {
+    name: name,
+    params: {
+      production_id: productionId
+    }
+  }
+}
+
+const episodifyRoute = (route, episodeId) => {
+  if (episodeId) {
+    route.name = `episode-${route.name}`
+    route.params.episode_id = episodeId
+  }
+  return route
+}
+
+const getContextRoute = (name, productionId, episodeId) => {
+  return episodifyRoute(getProductionRoute(name, productionId), episodeId)
+}
+
+export const getTaskTypeSchedulePath = (
+  taskTypeId,
+  productionId,
+  episodeId,
+  type
+) => {
+  const route = getContextRoute('task-type-schedule', productionId, episodeId)
+  route.params.task_type_id = taskTypeId
+  route.params.type = type
+  return route
+}
+
+export const getProductionSchedulePath = (productionId) => {
+  return getProductionRoute('schedule', productionId)
+}


### PR DESCRIPTION
**Problem**

* If a bar has a start or end date during a weekend, it cannot be modified anymore.
* Browsing between schedules could be smoother.
* The main schedule cannot be edited.
 
**Solution**

* When a modification occurs, always make sure that the date is not set during the weekend.
* Clicking on a name on the left part of the planning leads to the related planning.
* Allow to edit the main schedule.