### PR TITLE
Make status more explicit

### DIFF
--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -22,6 +22,7 @@
     >
       <span
         class="tag"
+        :title="taskStatus.name"
         :style="{
           background: backgroundColor,
           color: color

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -559,6 +559,7 @@ export default {
       const taskAssignationMap = this.buildAssignationMap()
       let scheduleItems = this.scheduleTeam
         .map(person => this.buildPersonElement(person, taskAssignationMap))
+        .filter(item => item)
         .filter(item => item.children.length > 0)
 
       if (taskAssignationMap.unassigned.length !== 0) {
@@ -588,7 +589,7 @@ export default {
     buildAssignationMap () {
       const taskAssignationMap = { unassigned: [] }
       this.scheduleTeam.forEach((person) => {
-        taskAssignationMap[person.id] = []
+        if (person) taskAssignationMap[person.id] = []
       })
       this.tasks.forEach((task) => {
         if (task.assignees.length > 0) {
@@ -606,6 +607,8 @@ export default {
     },
 
     buildPersonElement (person, taskAssignationMap) {
+      if (!person) return null
+
       let manDays = 0
       let minStartDate
       let maxEndDate

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -9,15 +9,25 @@
     'border-left': '6px solid ' + comment.task_status.color
   }"
 >
-  <div class="media">
-  <figure class="media-left">
-    <people-avatar class="level-item" :person="comment.person" />
+  <div class="flexrow">
+  <figure class="flexrow-item comment-left">
+    <people-avatar class="" :person="comment.person" />
+    <span class="filler"></span>
+    <span
+      class="task-status-name"
+      :style="{
+        color: comment.task_status.color
+      }"
+      v-if="comment.task_status.short_name !== 'todo'"
+    >
+      {{ comment.task_status.short_name }}
+    </span>
   </figure>
 
-  <div class="media-content">
+  <div class="flexrow-item comment-content">
     <div class="content">
       <div class="comment-person flexrow">
-        <div class="flexrow-item">
+        <div class="flexrow-item infos">
           <strong class="">
             <people-name class="" :person="comment.person" />
           </strong>
@@ -32,7 +42,7 @@
             {{ $t('comments.revision') }} {{ comment.previews[0].revision }}
           </router-link>
         </div>
-        <span class="filler"></span>
+        <div class="filler"></div>
         <div class="flexrow-item menu-wrapper">
           <chevron-down-icon
             class="menu-icon"
@@ -532,6 +542,30 @@ a.revision:hover {
   font-size: 0.8em;
   padding: 0.3em 0.6em;
   text-transform: uppercase;
+}
+
+.task-status-name {
+  font-size: 0.8em;
+  text-transform: uppercase;
+}
+
+.flexrow {
+  align-items: stretch;
+}
+
+.comment-left {
+  display: flex;
+  flex-direction: column;
+  padding: 0.5em 0 0.5em 0.5em;
+}
+
+.comment-content {
+  padding: 0.5em;
+  flex: 1;
+}
+
+.infos {
+  padding-top: 0.3em;
 }
 
 @media screen and (max-width: 768px) {

--- a/src/lib/indexing.js
+++ b/src/lib/indexing.js
@@ -61,7 +61,7 @@ export const buildSupervisorTaskIndex = (tasks, personMap) => {
     ])
     task.assignees.forEach((personId) => {
       const person = personMap[personId]
-      words.push(person.first_name, person.last_name)
+      if (person) words.push(person.first_name, person.last_name)
     })
     indexWords(index, taskIndex, task, words)
   })


### PR DESCRIPTION
**Problem**

* Validation tag doesn't give the full name of the status. Short names are sometimes not explicit enough
* The comment color doesn't say enough information about the status

**Solution**

* Display a tooltip with full status name when the mouse is over a status
* Add status short name to comment widget
