### PR TITLE
Add button to add all shots to a playlist

### DIFF
--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -99,6 +99,18 @@
             >
               {{ $t('playlists.build_daily') }}
             </button>
+            <button
+              v-if="isTVShow"
+              :class="{
+                button: true,
+                'add-sequence': true,
+                'is-loading': this.loading.addEpisode
+              }"
+              :disabled="isAdditionLoading"
+              @click="addEpisodePending"
+            >
+              {{ $t('playlists.add_episode') }}
+            </button>
 
             <div
               class="mt1"
@@ -209,6 +221,7 @@ export default {
         playlists: false,
         addPlaylist: false,
         addDaily: false,
+        addEpisode: false,
         addSequence: false,
         addWeekly: false,
         deletePlaylist: false
@@ -234,6 +247,7 @@ export default {
       'playlistsPath',
       'playlistMap',
       'sequences',
+      'shotsByEpisode',
       'shotMap',
       'taskTypeMap'
     ]),
@@ -242,7 +256,8 @@ export default {
       return (
         this.loading.addSequence ||
         this.loading.addWeekly ||
-        this.loading.addDaily
+        this.loading.addDaily ||
+        this.loading.addEpisode
       )
     }
   },
@@ -535,6 +550,16 @@ export default {
             this.$options.silent = false
           })
         })
+    },
+
+    addEpisodePending () {
+      this.loading.addEpisode = true
+      this.$options.silent = true
+      const shots = [].concat(...this.shotsByEpisode).reverse()
+      this.addShots(shots, () => {
+        this.loading.addEpisode = false
+        this.$options.silent = false
+      })
     },
 
     addShots (shots, callback) {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -298,6 +298,7 @@ export default {
   playlists: {
     add_shots: 'Add shots',
     add_sequence: 'Add whole sequence',
+    add_episode: 'Add whole episode',
     available_build: 'Available builds',
     build_daily: 'Daily pending',
     build_weekly: 'All Pending',

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -223,6 +223,7 @@ export default {
   playlists: {
     add_shots: 'Sélectonner les plans',
     add_sequence: 'Ajouter séquence',
+    add_episode: 'Ajouter l\'épisode',
     available_build: 'Builds disponibles',
     build_daily: 'Valid. quotidienne',
     build_weekly: 'Valid. hebodomadaire',


### PR DESCRIPTION
**Problem**
It can be laborious to add every shot from every sequence to a playlist when you want to review the whole episode.

**Solution**
Added a new button that allows to add to the playlist the whole shots form the episode.
