### PR TITLE
Minor improvements

### DIFF
--- a/src/components/lists/PeopleTimesheetList.vue
+++ b/src/components/lists/PeopleTimesheetList.vue
@@ -19,6 +19,7 @@
 
           <th
             class="daytime"
+            :title="getWeekTitle(week)"
             :key="'week-' + week"
             v-for="week in weekRange"
             v-if="detailLevel === 'week'"
@@ -179,16 +180,6 @@ export default {
 
   data () {
     return {
-      detailOptions: [
-        {
-          label: 'Day',
-          value: 'day'
-        },
-        {
-          label: 'Month',
-          value: 'month'
-        }
-      ],
       currentMonth: moment().month() + 1,
       currentYear: moment().year(),
       currentWeek: moment().week()
@@ -322,6 +313,11 @@ export default {
         this.$route.params.year === year &&
         this.$route.params.month === month
       )
+
+    getWeekTitle (week) {
+      const beginning = moment(this.currentYear + '-' + week, 'YYYY-W')
+      const end = beginning.clone().add(6, 'days')
+      return beginning.format('YYYY-MM-DD') + ' - ' + end.format('YYYY-MM-DD')
     }
   },
 

--- a/src/components/lists/PeopleTimesheetList.vue
+++ b/src/components/lists/PeopleTimesheetList.vue
@@ -9,6 +9,15 @@
           </th>
 
           <th
+            class="time year"
+            :key="'year-' + year"
+            v-for="year in yearRange"
+            v-if="detailLevel === 'year'"
+          >
+            {{ year }}
+          </th>
+
+          <th
             class="time month"
             :key="'month-' + month"
             v-for="month in monthRange"
@@ -51,6 +60,35 @@
       <tbody>
           <tr v-for="person in people" :key="person.id">
           <people-name-cell class="name" :person="person" />
+
+          <td
+            :class="{
+              time: true,
+              year: true,
+              selected: isYearSelected(person.id, year)
+            }"
+            :key="'year-' + year + '-' + person.id"
+            v-for="year in yearRange"
+            v-if="detailLevel === 'year'"
+          >
+            <router-link
+              class="duration"
+              :to="{
+                name: 'timesheets-year-person',
+                params: {
+                  person_id: person.id,
+                  year: year
+                }
+              }"
+              v-if="yearDuration(year, person.id) > 0"
+            >
+              {{ yearDuration(year, person.id) }}
+            </router-link>
+            <span v-else>
+            -
+            </span>
+          </td>
+
           <td
             :class="{
               time: true,
@@ -165,7 +203,8 @@ import {
   monthToString,
   getMonthRange,
   getWeekRange,
-  getDayRange
+  getDayRange,
+  range
 } from '../../lib/time'
 import PeopleNameCell from '../cells/PeopleNameCell'
 import TableInfo from '../widgets/TableInfo'
@@ -230,6 +269,10 @@ export default {
       'route'
     ]),
 
+    yearRange () {
+      return range(2018, moment().year())
+    },
+
     monthRange () {
       return getMonthRange(this.year, this.currentYear, this.currentMonth)
     },
@@ -257,6 +300,11 @@ export default {
     },
 
     monthToString,
+
+    yearDuration (year, personId) {
+      const yearString = `${year}`
+      return this.getDuration(yearString, personId)
+    },
 
     monthDuration (month, personId) {
       const monthString = `${month}`
@@ -313,6 +361,15 @@ export default {
         this.$route.params.year === year &&
         this.$route.params.month === month
       )
+    },
+
+    isYearSelected (personId, year) {
+      return (
+        this.$route.params.person_id &&
+        this.$route.params.person_id === personId &&
+        this.$route.params.year === year
+      )
+    },
 
     getWeekTitle (week) {
       const beginning = moment(this.currentYear + '-' + week, 'YYYY-W')
@@ -361,6 +418,11 @@ export default {
   &.month {
     width: 80px;
     min-width: 80px;
+  }
+
+  &.year {
+    width: 90px;
+    min-width: 90px;
   }
 }
 

--- a/src/components/lists/TodosList.vue
+++ b/src/components/lists/TodosList.vue
@@ -21,6 +21,9 @@
           <th class="estimation">
             {{ $t('tasks.fields.estimation').substring(0, 3) }}.
           </th>
+          <th class="estimation">
+            {{ $t('tasks.fields.duration').substring(0, 3) }}.
+          </th>
           <th class="due-date">
             {{ $t('tasks.fields.due_date') }}
           </th>
@@ -84,6 +87,9 @@
           />
           <td class="estimation">
             {{ formatDuration(entry.estimation) }}
+          </td>
+          <td class="estimation">
+            {{ formatDuration(entry.time) }}
           </td>
           <td class="due-date">
             {{ formatDate(entry.due_date) }}

--- a/src/components/pages/Timesheets.vue
+++ b/src/components/pages/Timesheets.vue
@@ -16,6 +16,7 @@
             :label="$t('timesheets.year')"
             :options="yearOptions"
             v-model="yearString"
+            v-if="detailLevelString !== 'year'"
           />
 
           <combobox
@@ -102,6 +103,10 @@ export default {
         {
           label: 'Month',
           value: 'month'
+        },
+        {
+          label: 'Year',
+          value: 'year'
         }
       ],
 
@@ -228,6 +233,7 @@ export default {
       if (this.$route.path.indexOf('week') > 0) this.detailLevel = 'week'
       if (this.$route.path.indexOf('month') > 0) this.detailLevel = 'month'
       if (this.$route.path.indexOf('day') > 0) this.detailLevel = 'day'
+      if (this.$route.path.indexOf('year') > 0) this.detailLevel = 'year'
 
       this.currentPerson = this.getCurrentPerson()
       this.detailLevelString = this.detailLevel
@@ -346,6 +352,13 @@ export default {
             params: {
               year: this.currentYear,
               month: this.currentMonth
+            }
+          })
+        } else if (this.detailLevelString === 'year') {
+          this.$router.push({
+            name: 'timesheets-year',
+            params: {
+              year: this.currentYear
             }
           })
         }

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -222,6 +222,16 @@ export const routes = [
         name: 'timesheets',
         children: [
           {
+            path: 'year/:year',
+            component: Timesheets,
+            name: 'timesheets-year'
+          },
+          {
+            path: 'year/:year/persons/:person_id',
+            component: Timesheets,
+            name: 'timesheets-year-person'
+          },
+          {
             path: 'month/:year',
             component: Timesheets,
             name: 'timesheets-month'

--- a/src/store/api/people.js
+++ b/src/store/api/people.js
@@ -228,6 +228,10 @@ export default {
     })
   },
 
+  getYearTable (year) {
+    return client.pget(`/api/data/persons/time-spents/year-table`)
+  },
+
   getAggregatedPersonTimeSpents (
     personId,
     detailLevel,
@@ -239,7 +243,9 @@ export default {
     return new Promise((resolve, reject) => {
       let path = `/api/data/persons/${personId}/time-spents/`
 
-      if (detailLevel === 'month') {
+      if (detailLevel === 'year') {
+        path += `year/${year}`
+      } else if (detailLevel === 'month') {
         path += `month/${year}/${month}`
       } else if (detailLevel === 'week') {
         path += `week/${year}/${week}`

--- a/src/store/modules/people.js
+++ b/src/store/modules/people.js
@@ -491,6 +491,9 @@ const actions = {
       if (detailLevel === 'week') {
         mainFunc = peopleApi.getWeekTable
       }
+      if (detailLevel === 'year') {
+        mainFunc = peopleApi.getYearTable
+      }
       mainFunc(year, monthString)
         .then((table) => {
           commit(PEOPLE_TIMESHEET_LOADED, table)


### PR DESCRIPTION
**Problem**

* Time spent on a task is not visible from the todo list.
* In timesheets recap, the week number is not descriptive enough. It's hard to figure out which dates it matches.
* It's not possible to see a yearly aggregation of all time spents.

**Solution**

* Add duration field to todo lists
* Add a tooltip on week number to display the beginning and the end of the week.
* Add a yearly detail level in timesheets and use new related routes
