### PR TITLE
Fix cancel button in Assets page on import rendering modal

### DIFF
--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -620,6 +620,7 @@ export default {
           isDeleteDisplayed: false,
           isDeleteMetadataDisplayed: false,
           isImportDisplayed: false,
+          isImportRenderDisplayed: false,
           isNewDisplayed: false,
           isRestoreDisplayed: false
         }


### PR DESCRIPTION
**Problem**
The Import render modal on Assets page couldn't be canceled and closed.

**Solution**
The Import render modal on Assets page can be canceled and closed again.
