### PR TITLE
Add Selectboxes in CSV render headers to switch columns

### DIFF
--- a/src/components/modals/ImportModal.vue
+++ b/src/components/modals/ImportModal.vue
@@ -124,7 +124,6 @@ export default {
     },
     onFileSelected (formData) {
       this.formData = formData
-      this.$emit('fileselected', formData)
     },
     onConfirmClicked () {
       let mode = ''

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -692,6 +692,12 @@ export default {
       })
     },
 
+    cleanUpCsv (data) {
+      return data[0].forEach((item, index, data) => {
+        data[index] = item[0].toUpperCase() + item.slice(1)
+      })
+    },
+
     renderImport (data, mode) {
       this.loading.importing = true
       this.errors.importing = false
@@ -701,6 +707,7 @@ export default {
       }
       this.processCSV(data)
         .then((results) => {
+          this.cleanUpCsv(results)
           this.parsedCSV = results
           this.hideImportModal()
           this.loading.importing = false

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -734,6 +734,7 @@ export default {
     },
 
     resetImport () {
+      this.errors.importing = false
       this.hideImportRenderModal()
       this.$store.commit('SHOT_CSV_FILE_SELECTED', null)
       this.$refs['import-modal'].reset()

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -173,7 +173,6 @@
     :form-data="shotsCsvFormData"
     :columns="columns"
     @cancel="hideImportModal"
-    @fileselected="selectFile"
     @confirm="renderImport"
   />
 
@@ -681,10 +680,6 @@ export default {
       }
     },
 
-    selectFile (formData) {
-      this.$store.commit('SHOT_CSV_FILE_SELECTED', formData)
-    },
-
     processCSV (data, config) {
       return new Promise((resolve, reject) => {
         Papa.parse(data, {
@@ -703,33 +698,26 @@ export default {
       this.formData = data
       if (mode === 'file') {
         data = data.get('file')
-        this.processCSV(data)
-          .then((results) => {
-            this.parsedCSV = results
-            this.hideImportModal()
-            this.loading.importing = false
-            this.showImportRenderModal()
-          })
-      } else if (mode === 'text') {
-        const formData = new FormData()
-        const filename = 'import.csv'
-        this.processCSV(data)
-          .then((results) => {
-            this.parsedCSV = results
-            this.hideImportModal()
-            this.loading.importing = false
-            this.showImportRenderModal()
-            const file =
-              new File([results.join('\n')], filename, { type: 'text/csv' })
-            formData.append('file', file)
-            this.$store.commit('SHOT_CSV_FILE_SELECTED', formData)
-          })
       }
+      this.processCSV(data)
+        .then((results) => {
+          this.parsedCSV = results
+          this.hideImportModal()
+          this.loading.importing = false
+          this.showImportRenderModal()
+        })
     },
 
-    uploadImportFile () {
+    uploadImportFile (data) {
+      const formData = new FormData()
+      const filename = 'import.csv'
+      const file = new File([data.join('\n')], filename, { type: 'text/csv' })
+
+      formData.append('file', file)
+
       this.loading.importing = true
       this.errors.importing = false
+      this.$store.commit('SHOT_CSV_FILE_SELECTED', formData)
 
       this.uploadShotFile((err) => {
         if (!err) {

--- a/src/components/widgets/Combobox.vue
+++ b/src/components/widgets/Combobox.vue
@@ -11,7 +11,10 @@
       }"
     >
       <select
-        class="select-input"
+        :class="{
+          'select-input': true,
+          error: this.error
+        }"
         ref="select"
         :disabled="disabled"
         @keyup.enter="emitEnter()"
@@ -57,6 +60,10 @@ export default {
       type: Boolean
     },
     disabled: {
+      default: false,
+      type: Boolean
+    },
+    error: {
       default: false,
       type: Boolean
     }
@@ -123,5 +130,9 @@ export default {
   border-right: 0;
   border-top: 0;
   margin-top: -4px;
+}
+
+.error {
+  border-color: $red;
 }
 </style>

--- a/src/components/widgets/FileUpload.vue
+++ b/src/components/widgets/FileUpload.vue
@@ -75,7 +75,6 @@ export default {
       uploadedFiles: []
     }
   },
-
   mounted () {
     this.reset()
     const events = [
@@ -89,9 +88,7 @@ export default {
       })
     })
   },
-
   computed: {},
-
   methods: {
     filesChange (name, files) {
       const forms = []
@@ -131,7 +128,6 @@ export default {
       }
     }
   },
-
   watch: {}
 }
 </script>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -205,6 +205,8 @@ export default {
     white_theme: 'White Theme',
     yes: 'Yes',
     csv: {
+      choose: 'Choose',
+      unknown: 'Unknown column',
       error_upload: 'An error occured while uploading your CSV.',
       export_file: 'Export',
       import_file: 'Import',

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -186,6 +186,8 @@ export default {
     white_theme: 'Thème blanc',
     yes: 'oui',
     csv: {
+      choose: 'Choisir',
+      unknown: 'Colonne inconnue',
       error_upload: 'Une erreur est survenue en téleversant votre fichier .csv.',
       export_file: 'Exporter',
       import_file: 'Importer',


### PR DESCRIPTION
**Problem**
If a user made a mistake in the name of a column in its imported CSV, the CSV must be updated then reuploaded.

**Solution**
The user can switch a wrong column header to one of the required columns header.
