### PR TITLE
Playlist experience redesign and fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1487,6 +1487,25 @@ tbody:last-child .empty-line:last-child {
   height: 100%;
 }
 
+.dark .close-button:hover {
+  background: $dark-grey-lightest;
+}
+
+.close-button {
+  cursor: pointer;
+  display: inline-block;
+  text-align: center;
+  padding-top: 3px;
+  width: 30px;
+  height: 30px;
+}
+
+.close-button:hover {
+  display: inline-block;
+  background: $white-grey;
+  border-radius: 50%;
+}
+
 @media screen and (max-width: 1000px) {
   .button .icon.is-small {
     margin-right: 0;

--- a/src/components/modals/EditPlaylistModal.vue
+++ b/src/components/modals/EditPlaylistModal.vue
@@ -10,7 +10,7 @@
         {{ $t("playlists.edit_title") }} {{ playlistToEdit.name }}
       </h1>
       <h1 class="title" v-else>
-        {{ $t("playlists.no_playlist") }}
+        {{ $t("playlists.create_title") }}
       </h1>
 
       <form v-on:submit.prevent>
@@ -20,8 +20,12 @@
           v-model="form.name"
           @enter="runConfirmation"
           v-focus
-        >
-        </text-field>
+        />
+        <combobox
+          :label="$t('playlists.fields.for_client')"
+          :options="forClientOptions"
+          v-model="forClient"
+        />
       </form>
 
       <p class="has-text-right">
@@ -50,6 +54,7 @@
 </template>
 
 <script>
+import Combobox from '../widgets/Combobox'
 import TextField from '../widgets/TextField'
 
 import { modalMixin } from './base_modal'
@@ -58,6 +63,7 @@ export default {
   name: 'edit-playlist-modal',
   mixins: [modalMixin],
   components: {
+    Combobox,
     TextField
   },
 
@@ -69,9 +75,30 @@ export default {
     'playlistToEdit'
   ],
 
+  data () {
+    return {
+      forClient: 'false',
+      forClientOptions: [
+        { label: this.$t('playlists.for_client'), value: 'true' },
+        { label: this.$t('playlists.for_studio'), value: 'false' }
+      ],
+      form: {
+        name: this.playlistToEdit.name,
+        for_client: this.playlistToEdit.for_client
+      }
+    }
+  },
+
+  methods: {
+    runConfirmation () {
+      this.form.for_client = this.forClient === 'true'
+      this.$emit('confirm', this.form)
+    }
+  },
+
   watch: {
     playlistToEdit () {
-      if (this.playlistToEdit && this.playlistToEdit.id) {
+      if (this.playlistToEdit) {
         this.form.name = this.playlistToEdit.name
       } else {
         this.form = {
@@ -82,32 +109,11 @@ export default {
 
     active () {
       if (this.active) {
+        this.forClient = this.playlistToEdit.for_client ? 'true' : 'false'
         setTimeout(() => {
           this.$refs.nameField.focus()
         }, 100)
       }
-    }
-  },
-
-  data () {
-    if (this.playlistToEdit && this.playlistToEdit.id) {
-      return {
-        form: {
-          name: this.playlistToEdit.name
-        }
-      }
-    } else {
-      return {
-        form: {
-          name: ''
-        }
-      }
-    }
-  },
-
-  methods: {
-    runConfirmation () {
-      this.$emit('confirm', this.form)
     }
   }
 }

--- a/src/components/modals/EditPlaylistModal.vue
+++ b/src/components/modals/EditPlaylistModal.vue
@@ -7,7 +7,7 @@
   <div class="modal-content">
     <div class="box">
       <h1 class="title" v-if="playlistToEdit && playlistToEdit.id">
-        {{ $t("playlists.edit_title") }} {{ playlistToEdit.name }}
+        {{ $t("playlists.edit_title") }}
       </h1>
       <h1 class="title" v-else>
         {{ $t("playlists.create_title") }}

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -202,7 +202,6 @@
 
 <script>
 import moment from 'moment'
-import Papa from 'papaparse'
 import { mapGetters, mapActions } from 'vuex'
 import csv from '../../lib/csv'
 import func from '../../lib/func'
@@ -627,18 +626,6 @@ export default {
       }
     },
 
-    processCSV (data, config) {
-      return new Promise((resolve, reject) => {
-        Papa.parse(data, {
-          config: config,
-          error: reject,
-          complete: (results) => {
-            resolve(results.data)
-          }
-        })
-      })
-    },
-
     cleanUpCsv (data) {
       return data[0].forEach((item, index, data) => {
         data[index] = item[0].toUpperCase() + item.slice(1)
@@ -652,7 +639,7 @@ export default {
       if (mode === 'file') {
         data = data.get('file')
       }
-      this.processCSV(data)
+      csv.processCSV(data)
         .then((results) => {
           this.cleanUpCsv(results)
           this.parsedCSV = results
@@ -863,7 +850,7 @@ export default {
             nameData.splice(3, 0, this.currentEpisode.name)
           }
           const name = slugify(nameData.join('_'))
-          let headers = this.isTVShow ? [this.$t('assets.fields.type')] : []
+          let headers = this.isTVShow ? ['Episode'] : []
           headers = headers.concat([
             this.$t('assets.fields.type'),
             this.$t('assets.fields.name'),
@@ -883,6 +870,15 @@ export default {
             })
           csv.buildCsvFile(name, [headers].concat(assetLines))
         })
+    },
+
+    resetCsVColumns () {
+      const columns = this.isTVShow ? ['Episode'] : []
+      this.columns = columns.concat([
+        'Type',
+        'Name',
+        'Description'
+      ])
     }
   },
 
@@ -894,6 +890,7 @@ export default {
     currentProduction () {
       this.$refs['asset-search-field'].setValue('')
       this.$store.commit('SET_ASSET_LIST_SCROLL_POSITION', 0)
+      this.resetCsVColumns()
 
       if (!this.isTVShow) {
         this.initialLoading = true

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -135,7 +135,7 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 import { range } from '../../lib/time'
-import Papa from 'papaparse'
+import csv from '../../lib/csv'
 import AvailableAssetBlock from './breakdown/AvailableAssetBlock'
 import ButtonHrefLink from '../widgets/ButtonHrefLink.vue'
 import ButtonSimple from '../widgets/ButtonSimple'
@@ -432,18 +432,6 @@ export default {
       this.modals.isImportRenderDisplayed = false
     },
 
-    processCSV (data, config) {
-      return new Promise((resolve, reject) => {
-        Papa.parse(data, {
-          config: config,
-          error: reject,
-          complete: (results) => {
-            resolve(results.data)
-          }
-        })
-      })
-    },
-
     cleanUpCsv (data) {
       return data[0].forEach((item, index, data) => {
         data[index] = item[0].toUpperCase() + item.slice(1)
@@ -456,7 +444,7 @@ export default {
       if (mode === 'file') {
         data = data.get('file')
       }
-      this.processCSV(data)
+      csv.processCSV(data)
         .then((results) => {
           this.cleanUpCsv(results)
           this.parsedCSV = results

--- a/src/components/pages/People.vue
+++ b/src/components/pages/People.vue
@@ -97,10 +97,10 @@
 </template>
 
 <script>
-import Papa from 'papaparse'
 
 import { mapGetters, mapActions } from 'vuex'
 
+import csv from '../../lib/csv'
 import ButtonLink from '../widgets/ButtonLink'
 import ButtonHrefLink from '../widgets/ButtonHrefLink'
 import ButtonSimple from '../widgets/ButtonSimple'
@@ -216,18 +216,6 @@ export default {
       'peopleSearchChange'
     ]),
 
-    processCSV (data, config) {
-      return new Promise((resolve, reject) => {
-        Papa.parse(data, {
-          config: config,
-          error: reject,
-          complete: (results) => {
-            resolve(results.data)
-          }
-        })
-      })
-    },
-
     cleanUpCsv (data) {
       return data[0].forEach((item, index, data) => {
         data[index] = item[0].toUpperCase() + item.slice(1)
@@ -241,7 +229,7 @@ export default {
       if (mode === 'file') {
         data = data.get('file')
       }
-      this.processCSV(data)
+      csv.processCSV(data)
         .then((results) => {
           this.cleanUpCsv(results)
           this.parsedCSV = results

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -1,14 +1,13 @@
 <template>
   <div class="productions page fixed-page">
     <div class="columns">
-
-      <div class="playlist-list-column column">
+      <div class="playlist-list-column column" v-if="playlists.length > 0">
         <button
           :class="{
             button: true,
             'is-loading': loading.addPlaylist
           }"
-          @click="addPlaylist"
+          @click="showAddModal"
           key="new-playlist-button"
           v-if="isCurrentUserManager"
         >
@@ -34,7 +33,8 @@
               {{ playlist.name }}
             </span>
             <span class="playlist-date" title="last modified">
-              {{ formatDate(playlist.updated_at)}}
+              {{ $t('playlists.updated_at') }}
+              {{ formatDate(playlist.updated_at) }}
             </span>
           </router-link>
         </div>
@@ -48,12 +48,91 @@
         />
       </div>
 
-      <div class="playlist-column column">
+      <div
+        class="playlist-column no-selection"
+        v-if="playlists.length > 0 && !currentPlaylist.id"
+      >
+        <h2>{{ $t('playlists.last_creation') }}</h2>
+        <div class="flexrow" v-if="!loading.playlists">
+          <router-link
+            class="recent-playlist flexrow-item"
+            :key="'recent-playlist-' + playlist.id"
+            :to="getPlaylistPath(playlist.id)"
+            v-for="playlist in lastPlaylistsCreated"
+          >
+            <light-entity-thumbnail
+              :preview-file-id="playlist.first_preview_file_id"
+              type="previews"
+              width="300px"
+              height="auto"
+              empty-height="150px"
+            />
+            <h3>{{ playlist.name }}</h3>
+            <span>
+              {{ $t('playlists.created_at') }}
+              {{ formatDate(playlist.created_at) }}
+            </span>
+          </router-link>
+        </div>
+        <spinner class="mt2" v-else />
+
+        <h2>{{ $t('playlists.last_modification') }}</h2>
+        <div class="flexrow" v-if="!loading.playlists">
+          <router-link
+            class="recent-playlist flexrow-item"
+            :key="'recent-modified-playlist-' + playlist.id"
+            :to="getPlaylistPath(playlist.id)"
+            v-for="playlist in lastPlaylistsUpdated"
+          >
+            <light-entity-thumbnail
+              :preview-file-id="playlist.first_preview_file_id"
+              type="previews"
+              width="300px"
+              height="auto"
+              empty-height="150px"
+            />
+            <h3>{{ playlist.name }}</h3>
+            <span>
+              {{ $t('playlists.updated_at') }}
+              {{ formatDate(playlist.updated_at) }}
+            </span>
+          </router-link>
+        </div>
+        <spinner class="mt2" v-else />
+      </div>
+      <div
+        class="playlist-column no-selection has-text-centered"
+        v-else-if="playlists.length === 0"
+      >
+        <div v-if="!loading.playlists">
+          <p class="empty-explaination">
+            {{ $t('playlists.no_playlist') }}
+          </p>
+          <button
+            :class="{
+              big: true,
+              button: true,
+              'is-loading': loading.addPlaylist
+            }"
+            @click="showAddModal"
+            key="new-playlist-button"
+            v-if="isCurrentUserManager"
+          >
+            {{ $t('playlists.new_playlist') }}
+          </button>
+        </div>
+        <spinner class="mt2" v-else />
+      </div>
+
+      <div class="playlist-column column" v-else>
         <playlist-player
           ref="playlist-player"
           :playlist="currentPlaylist"
           :shots="currentShots"
           :is-loading="loading.playlist"
+          :is-adding-shot="isAddingShot"
+          @edit-clicked="showEditModal"
+          @show-add-shots="toggleAddShots"
           @preview-changed="onPreviewChanged"
           @playlist-deleted="goFirstPlaylist"
           @remove-shot="removeShot"
@@ -61,147 +140,178 @@
           @annotationchanged="onAnnotationChanged"
           @for-client-changed="onForClientChanged"
         />
-      </div>
 
-      <div
-        class="addition-column column"
-        v-if="isCurrentUserManager"
-      >
-        <spinner
-          class="mt2"
-          key="shot-loader"
-          v-if="isShotsLoading"
-        />
-        <div v-else>
+        <div
+          v-if="isCurrentUserManager && isAddingShot"
+        >
           <div class="addition-header">
-            <page-subtitle
-              :text="$t('playlists.add_shots')"
-            />
-            <button
-              :class="{
-                button: true,
-                'add-sequence': true,
-                'is-loading': this.loading.addWeekly
-              }"
-              :disabled="isAdditionLoading"
-              @click="addAllPending"
-            >
-              {{ $t('playlists.build_weekly') }}
-            </button>
-            <button
-              :class="{
-                button: true,
-                'add-sequence': true,
-                'is-loading': this.loading.addDaily
-              }"
-              :disabled="isAdditionLoading"
-              @click="addDailyPending"
-            >
-              {{ $t('playlists.build_daily') }}
-            </button>
-            <button
-              v-if="isTVShow"
-              :class="{
-                button: true,
-                'add-sequence': true,
-                'is-loading': this.loading.addEpisode
-              }"
-              :disabled="isAdditionLoading"
-              @click="addEpisodePending"
-            >
-              {{ $t('playlists.add_episode') }}
-            </button>
-
-            <div
-              class="mt1"
-              key="shot-list-header"
-              v-if="episodes.length > 0 || !isTVShow"
-            >
-              <div>
-                <combobox
-                  class="select-sequence-combobox"
-                  :label="$t('shots.fields.sequence')"
-                  :options="sequenceOptions"
-                  v-model="sequenceId"
-                  v-if="sequenceOptions.length > 0"
-                />
-                <div v-if="sequenceOptions.length === 0">
-                  {{ $t('playlists.no_sequence_for_episode') }}
-                </div>
-                <button
-                  :class="{
-                    button: true,
-                    'add-sequence': true,
-                    'is-loading': this.loading.addSequence
-                  }"
-                  :disabled="isAdditionLoading"
-                  @click="addSequence"
-                  v-if="sequenceOptions.length > 0"
-                >
-                  {{ $t('playlists.add_sequence') }}
-                </button>
-              </div>
+            <div class="flexrow">
+              <page-subtitle
+                class="flexrow-item"
+                :text="$t('playlists.add_shots')"
+              />
+              <span class="filler"></span>
+              <button
+              />
+              <a
+                class="close-button"
+                @click="toggleAddShots"
+              >
+                <x-icon />
+              </a>
             </div>
-            <div v-else>
-              {{ $t('playlists.no_shot_for_production') }}
-            </div>
-
-            <div v-if="sequenceShots.length === 0 && sequenceId">
-              {{ $t('playlists.no_shot_for_sequence') }}
+            <div class="flexrow">
+              <search-field
+                class="flexrow-item"
+                ref="search-field"
+                :can-save="false"
+                @change="onSearchChange"
+                placeholder="ex: seq01 anim=wfa"
+              />
+              <button
+                :class="{
+                  button: true,
+                  'flexrow-item': true,
+                  'add-sequence': true
+                }"
+                :disabled="isAdditionLoading"
+                @click="addCurrentSelection"
+                v-if="shotSearchText"
+              >
+                {{ $t('playlists.add_selection') }}
+              </button>
+              <span class="filler"></span>
+              <button
+                :class="{
+                  button: true,
+                  'add-sequence': true,
+                  'is-loading': this.loading.addEpisode
+                }"
+                :disabled="isAdditionLoading"
+                @click="addEpisodePending"
+                v-if="isTVShow"
+              >
+                {{ $t('playlists.add_episode') }}
+              </button>
+              <button
+                :class="{
+                  button: true,
+                  'add-sequence': true,
+                  'is-loading': this.loading.addMovie
+                }"
+                :disabled="isAdditionLoading"
+                @click="addMovie"
+                v-else
+              >
+                {{ $t('playlists.add_movie') }}
+              </button>
             </div>
           </div>
+        </div>
 
+        <div
+          class="addition-section"
+          v-if="isCurrentUserManager && isAddingShot"
+        >
+          <spinner
+            class="mt2"
+            key="shot-loader"
+            v-if="isShotsLoading"
+          />
           <div
-            :class="{
-              'addition-shot': true,
-              playlisted: currentShots[shot.id] !== undefined
-            }"
-            :key="shot.id"
-            @click.prevent="addShotToPlaylist(shot)"
-            v-for="shot in sequenceShots"
+            v-else
           >
-            <span class="thumbnail-wrapper">
-              <light-entity-thumbnail
-                :preview-file-id="shot.preview_file_id"
-                :width="150"
-                :height="100"
-              />
-            </span>
-            {{ shot.name }}
+            <div>
+              <div
+                :key="'sequence-' + i"
+                v-for="(sequenceShots, i) in displayedShotsBySequence"
+              >
+                <h2
+                  class="sequence-title"
+                  v-if="sequenceShots.length > 0"
+                >
+                   {{ sequenceShots[0].sequence_name }}
+                  <button
+                    class="button"
+                    @click="addSequence(sequenceShots)"
+                    :key="'add-sequence-button-' + sequenceShots[0].sequence_id"
+                    v-if="isCurrentUserManager"
+                  >
+                    {{ $t('playlists.add_sequence') }}
+                  </button>
+                </h2>
+                <div
+                 class="addition-shots"
+                >
+                  <div
+                    :class="{
+                      'addition-shot': true,
+                      playlisted: currentShots[shot.id] !== undefined
+                    }"
+                    :key="shot.id"
+                    @click.prevent="addShotToPlaylist(shot)"
+                    v-for="shot in sequenceShots"
+                  >
+                      <light-entity-thumbnail
+                        :preview-file-id="shot.preview_file_id"
+                        width="150px"
+                        height="100px"
+                      />
+                    <span class="playlisted-shot-name">{{ shot.name }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
     </div>
+
+    <edit-playlist-modal
+      ref="edit-playlist-modal"
+      :active="modals.isEditDisplayed"
+      :is-loading="loading.editPlaylist"
+      :is-error="errors.editPlaylist"
+      :playlist-to-edit="playlistToEdit"
+      @cancel="hideEditModal"
+      @confirm="confirmEditPlaylist"
+    />
+
   </div>
 </template>
 <script>
+import Vue from 'vue'
+import firstBy from 'thenby'
 import moment from 'moment-timezone'
 import { mapGetters, mapActions } from 'vuex'
-import { PlusIcon } from 'vue-feather-icons'
+import { PlusIcon, XIcon } from 'vue-feather-icons'
 import { formatDate } from '../../lib/time'
 import {
   updateModelFromList,
   removeModelFromList
 } from '../../lib/models'
 
-import Combobox from '../widgets/Combobox'
-import LightEntityThumbnail from '../widgets/LightEntityThumbnail'
+import EditPlaylistModal from '../modals/EditPlaylistModal'
 import ErrorText from '../widgets/ErrorText'
+import LightEntityThumbnail from '../widgets/LightEntityThumbnail'
 import PageSubtitle from '../widgets/PageSubtitle'
 import PlaylistPlayer from './playlists/PlaylistPlayer'
+import SearchField from '../widgets/SearchField'
 import Spinner from '../widgets/Spinner'
 
 export default {
   name: 'productions',
 
   components: {
-    Combobox,
-    LightEntityThumbnail,
     ErrorText,
+    EditPlaylistModal,
+    LightEntityThumbnail,
     PageSubtitle,
     PlaylistPlayer,
     PlusIcon,
-    Spinner
+    SearchField,
+    Spinner,
+    XIcon
   },
 
   data () {
@@ -209,6 +319,11 @@ export default {
       currentPlaylist: { name: this.$t('playlists.no_selection') },
       currentShot: 0,
       currentShots: {},
+      isAddingShot: true,
+      playlistToEdit: {
+        name: `${moment().format('YYYY-MM-DD HH:mm:ss')}`,
+        for_client: false
+      },
       sequenceId: null,
       sequenceOptions: [],
       sequenceShots: [],
@@ -217,19 +332,22 @@ export default {
         isEditDisplayed: false
       },
       loading: {
-        playlist: false,
-        playlists: false,
         addPlaylist: false,
         addDaily: false,
         addEpisode: false,
+        addMovie: false,
         addSequence: false,
         addWeekly: false,
-        deletePlaylist: false
+        deletePlaylist: false,
+        editPlaylist: false,
+        playlist: false,
+        playlists: false
       },
       errors: {
-        playlistLoading: false,
         addPlaylist: false,
-        deletePlaylist: false
+        editPlaylist: false,
+        deletePlaylist: false,
+        playlistLoading: false
       }
     }
   },
@@ -238,6 +356,8 @@ export default {
     ...mapGetters([
       'currentEpisode',
       'currentProduction',
+      'displayedShots',
+      'displayedShotsBySequence',
       'episodes',
       'isShotsLoading',
       'isTVShow',
@@ -248,6 +368,7 @@ export default {
       'playlistMap',
       'sequences',
       'shotsByEpisode',
+      'shotSearchText',
       'shotMap',
       'taskTypeMap'
     ]),
@@ -259,6 +380,22 @@ export default {
         this.loading.addDaily ||
         this.loading.addEpisode
       )
+    },
+
+    lastPlaylistsUpdated () {
+      return this.playlists
+        .concat()
+        .sort(firstBy('updated_at'))
+        .reverse()
+        .slice(0, 3)
+    },
+
+    lastPlaylistsCreated () {
+      return this.playlists.slice(0, 3)
+    },
+
+    playlistPlayer () {
+      return this.$refs['playlist-player']
     }
   },
 
@@ -268,6 +405,7 @@ export default {
       'addShotPreviewToPlaylist',
       'changePlaylistOrder',
       'changePlaylistPreview',
+      'displayMoreShots',
       'editPlaylist',
       'getPending',
       'loadPlaylist',
@@ -279,6 +417,7 @@ export default {
       'refreshPlaylist',
       'removeShotPreviewFromPlaylist',
       'removeBuildJobFromList',
+      'setShotSearch',
       'updatePreviewAnnotation'
     ]),
 
@@ -303,9 +442,6 @@ export default {
 
     loadShotsData (callback) {
       const loadPlaylists = () => {
-        if (this.episodes.length > 0 || !this.isTVShow) {
-          this.setAdditionSequences()
-        }
         this.loadPlaylistsData()
         if (callback) callback()
       }
@@ -383,7 +519,8 @@ export default {
             previewFile.preview_file_annotations ||
             shot.preview_file_annotations
         }
-        playlistShotMap[previewFile.shot_id] = playlistShot
+        Vue.set(playlistShotMap, previewFile.shot_id, playlistShot)
+        console.log(this.currentShots[shot.id])
         return playlistShot
       } else {
         return null
@@ -398,28 +535,6 @@ export default {
     resetPlaylist () {
       this.clearCurrentPlaylist()
       this.setCurrentPlaylist()
-    },
-
-    addPlaylist () {
-      const newPlaylist = {
-        name: `${moment().format('YYYY-MM-DD HH:mm:ss')}`,
-        production_id: this.currentProduction.id
-      }
-
-      if (this.isTVShow && this.currentEpisode) {
-        newPlaylist.episode_id = this.currentEpisode.id
-      }
-
-      this.loading.addPlaylist = true
-      this.errors.addPlaylist = false
-      this.newPlaylist({
-        data: newPlaylist,
-        callback: (err, playlist) => {
-          if (err) this.errors.addPlaylist = true
-          this.$router.push(this.getPlaylistPath(playlist.id))
-          this.loading.addPlaylist = false
-        }
-      })
     },
 
     setCurrentPlaylist (callback) {
@@ -464,29 +579,6 @@ export default {
       this.sequenceId = null
     },
 
-    setAdditionSequences () {
-      let sequences = []
-      if (this.isTVShow && this.currentEpisode) {
-        sequences = this.sequences.filter((sequence) => {
-          return sequence.parent_id === this.currentEpisode.id
-        })
-      } else {
-        sequences = this.sequences
-      }
-
-      this.sequenceOptions = sequences.map(
-        (sequence) => ({ label: sequence.name, value: sequence.id })
-      )
-      this.sequenceId = sequences.length > 0 ? sequences[0].id : null
-    },
-
-    setAdditionShots () {
-      this.sequenceShots = Object.values(this.shotMap).filter((shot) => {
-        return shot.sequence_id === this.sequenceId
-      })
-    },
-
-    // if (this.currentPlaylist.id && !this.currentShots[shot.id]) {
     addShot (shot) {
       return this.loadShotPreviewFiles(shot)
         .then(previewFiles => this.addShotPreviewToPlaylist({
@@ -509,23 +601,45 @@ export default {
     },
 
     addShotToPlaylist (shot) {
-      this.$options.silent = true
-      this.addShot(shot)
-        .then(() => {
-          setTimeout(() => {
-            this.$options.silent = false
-          }, 500)
-        })
+      if (!this.currentShots[shot.id]) {
+        this.$options.silent = true
+        this.addShot(shot)
+          .then(() => {
+            this.playlistPlayer.scrollToRight()
+            setTimeout(() => {
+              this.$options.silent = false
+            }, 500)
+          })
+      }
     },
 
-    addSequence () {
+    addCurrentSelection (sequenceShots) {
       this.$options.silent = true
-      this.loading.addSequence = true
-      const shots = [...this.sequenceShots].reverse()
+      const currentShotMap = {}
+      this.displayedShots.forEach((shot) => {
+        currentShotMap[shot.id] = true
+      })
+      const shots = Object.values(this.shotMap)
+        .filter(s => currentShotMap[s.id] === true)
+        .reverse()
+
       this.addShots(shots, () => {
-        this.loading.addSequence = false
         this.$options.silent = false
       })
+    },
+
+    addSequence (sequenceShots) {
+      if (sequenceShots.length > 0) {
+        const sequenceId = sequenceShots[0].sequence_id
+        const shots = Object.values(this.shotMap)
+          .filter(s => s.sequence_id === sequenceId)
+          .sort(firstBy('name'))
+          .reverse()
+        this.$options.silent = true
+        this.addShots(shots, () => {
+          this.$options.silent = false
+        })
+      }
     },
 
     addAllPending () {
@@ -558,6 +672,16 @@ export default {
       const shots = [].concat(...this.shotsByEpisode).reverse()
       this.addShots(shots, () => {
         this.loading.addEpisode = false
+        this.$options.silent = false
+      })
+    },
+
+    addMovie () {
+      this.loading.addMovie = true
+      this.$options.silent = true
+      const shots = Object.values(this.shotMap)
+      this.addShots(shots, () => {
+        this.loading.addMovie = false
         this.$options.silent = false
       })
     },
@@ -611,13 +735,96 @@ export default {
           for_client: forClient
         }
       })
+    },
+
+    toggleAddShots () {
+      this.isAddingShot = !this.isAddingShot
+    },
+
+    onSearchChange (searchQuery) {
+      if (searchQuery.length > 1) {
+        this.setShotSearch(searchQuery)
+        this.displayMoreShots()
+      } else {
+        this.setShotSearch('')
+      }
+    },
+
+    confirmEditPlaylist (form) {
+      if (this.playlistToEdit.id) {
+        form.id = this.currentPlaylist.id
+        this.runEditPlaylist(form)
+      } else {
+        this.runAddPlaylist(form)
+      }
+    },
+
+    runEditPlaylist (form) {
+      this.loading.editPlaylist = true
+      this.errors.editPlaylist = false
+      this.editPlaylist({
+        data: {
+          name: form.name,
+          for_client: form.for_client,
+          id: form.id
+        },
+        callback: (err, playlist) => {
+          if (err) this.errors.editPlaylist = true
+          this.loading.editPlaylist = false
+          this.modals.isEditDisplayed = false
+          Object.assign(this.currentPlaylist, playlist)
+        }
+      })
+    },
+
+    runAddPlaylist (form) {
+      const newPlaylist = {
+        name: form.name,
+        production_id: this.currentProduction.id,
+        for_client: form.for_client
+      }
+      if (this.isTVShow && this.currentEpisode) {
+        newPlaylist.episode_id = this.currentEpisode.id
+      }
+      this.loading.editPlaylist = true
+      this.errors.editPlaylist = false
+      this.newPlaylist({
+        data: newPlaylist,
+        callback: (err, playlist) => {
+          if (err) this.errors.editPlaylist = true
+          this.$router.push(this.getPlaylistPath(playlist.id))
+          this.loading.editPlaylist = false
+          this.modals.isEditDisplayed = false
+        }
+      })
+    },
+
+    showAddModal () {
+      this.playlistToEdit = {
+        name: `${moment().format('YYYY-MM-DD HH:mm:ss')}`,
+        for_client: false
+      }
+      this.$refs['edit-playlist-modal'] = true
+      this.modals.isEditDisplayed = true
+    },
+
+    showEditModal () {
+      this.playlistToEdit = this.currentPlaylist
+      this.modals.isEditDisplayed = true
+    },
+
+    hideEditModal () {
+      this.playlistToEdit = {
+        name: `${moment().format('YYYY-MM-DD HH:mm:ss')}`,
+        for_client: false
+      }
+      this.modals.isEditDisplayed = false
     }
   },
 
   mounted () {
     setTimeout(() => { // Needed to ensure playlist is loaded after topbar
       this.loadShotsData(() => {
-        this.setAdditionSequences()
         this.resetPlaylist()
       })
     }, 0)
@@ -628,15 +835,16 @@ export default {
       this.setCurrentPlaylist()
     },
 
-    sequenceId () {
-      this.setAdditionShots()
+    currentPlaylist () {
+      if (this.currentPlaylist.shots) {
+        this.isAddingShot = this.currentPlaylist.shots.length === 0
+      }
     },
 
     currentProduction () {
       this.$store.commit('LOAD_SEQUENCES_END', [])
       this.$store.commit('LOAD_PLAYLISTS_END', [])
       this.loadShotsData(() => {
-        this.setAdditionSequences()
         this.resetPlaylist()
       })
     },
@@ -646,9 +854,14 @@ export default {
       this.$store.commit('LOAD_PLAYLISTS_END', [])
       if (this.currentEpisode) {
         this.loadShotsData(() => {
-          this.setAdditionSequences()
           this.resetPlaylist()
         })
+      }
+    },
+
+    isAddingShot () {
+      if (!this.isAddingShot) {
+        this.resetPlaylist()
       }
     }
   },
@@ -682,6 +895,7 @@ export default {
           this.playlistMap[eventData.playlist_id] &&
           !this.$options.silent
         ) {
+          /*
           this.refreshPlaylist(eventData.playlist_id)
             .then((playlist) => {
               if (this.currentPlaylist.id === playlist.id) {
@@ -689,6 +903,7 @@ export default {
                 this.rebuildCurrentShots()
               }
             })
+          */
         }
       },
 
@@ -755,10 +970,23 @@ export default {
     box-shadow: 0px 0px 6px #333;
   }
 
-  .addition-column {
+  .playlist-column.no-selection {
     background: $dark-grey-light;
-    border-left: 1px solid $dark-grey;
-    box-shadow: 0px 0px 6px #333;
+    overflow-x: scroll;
+
+    h2 {
+      color: white;
+    }
+
+    .recent-playlist {
+      background: $dark-grey-lightmore;
+      border: 2px solid $dark-grey;
+      box-shadow: 0px 0px 6px #333;
+
+      h3 {
+        color: white;
+      }
+    }
   }
 
   span.thumbnail-picture {
@@ -813,26 +1041,25 @@ export default {
   width: 100%;
 }
 
-.addition-column {
-  max-width: 200px;
-  margin-right: 12px;
-  padding: 0;
-  background: #F4F5F9;
-  overflow-y: auto;
-  border-left: 1px solid #DDD;
-  box-shadow: 0px 0px 6px #F0F0F0;
-  overflow-y: scroll;
-  z-index: 201;
+.addition-shots {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  flex-direction: row;
+  max-width: 100%;
+  padding-left: 1em;
 }
 
 .addition-shot {
   padding: 0;
   cursor: pointer;
   text-align: center;
-  margin: 0 0 0.5em 0;
+  margin: 0;
   opacity: 0.5;
+  width: 170px;
   display: flex;
   flex-direction: column;
+  border: 0px solid transparent;
 
   a {
     margin: auto;
@@ -843,17 +1070,18 @@ export default {
   }
 
   &.playlisted {
-    opacity: 1
+    opacity: 1;
+
+    img,
+    span.thumbnail-picture {
+      border: 2px solid $purple;
+    }
   }
 }
 
 span.thumbnail-picture {
   box-shadow: 0px 0px 6px #DDD;
   margin-bottom: 2px;
-}
-
-.addition-column .thumbnail-empty {
-  margin-left: 1.5em;
 }
 
 .addition-header {
@@ -879,7 +1107,11 @@ span.thumbnail-picture {
 }
 
 .playlist-column:last-child {
-  padding-right: 1em;
+  padding-right: 0.7em;
+}
+
+.playlisted-shot-name {
+  padding-right: 20px;
 }
 
 .playlist-date {
@@ -888,6 +1120,74 @@ span.thumbnail-picture {
   font-size: 0.8em;
 }
 
-.thumbnail-wrapper {
+.sequence-title {
+  border-bottom: 1px solid $light-grey-light;
+  color: $grey;
+  margin: 1em;
+  padding-bottom: 0.2em;
+  text-transform: uppercase;
+
+  button {
+    color: $grey;
+    padding: 0.3em 0.8em;
+    font-size: 0.7em;
+  }
+}
+
+.addition-header {
+  height: 110px;
+}
+
+.addition-section {
+  overflow-y: auto;
+  height: calc(100% - 420px);
+}
+
+h2 {
+  font-weight: bold;
+  text-transform: uppercase;
+  color: $grey;
+}
+
+.playlist-column.no-selection {
+  padding: 2em;
+  overflow: auto;
+  background: #F4F5F9;
+
+  h2 {
+    font-size: 2em;
+    margin-top: 1.5em;
+    margin-bottom: 0.3em;
+  }
+
+  .recent-playlist {
+    width: 333px;
+    background: white;
+    border: 2px solid $light-grey-light;
+    box-shadow: 0px 0px 6px #DDD;
+    border-radius: 1em;
+    padding: 1em;
+
+    h3 {
+      color: $grey-strong;
+      font-size: 1.2em;
+      font-weight: bold;
+    }
+    span {
+      display: block;
+    }
+  }
+
+  .empty-explaination {
+    margin-top: 4em;
+    font-size: 1.5em;
+  }
+
+  .big {
+    font-size: 1.2em;
+    margin-top: 1em;
+    padding: 0.5em 1em;
+    height: auto;
+  }
 }
 </style>

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -341,7 +341,7 @@ export default {
         deletePlaylist: false,
         editPlaylist: false,
         playlist: false,
-        playlists: false
+        playlists: true
       },
       errors: {
         addPlaylist: false,
@@ -441,6 +441,7 @@ export default {
     },
 
     loadShotsData (callback) {
+      this.loading.playlists = true
       const loadPlaylists = () => {
         this.loadPlaylistsData()
         if (callback) callback()
@@ -469,6 +470,7 @@ export default {
           if (!err) setFirstPlaylist()
         })
       } else {
+        this.loading.playlists = false
         setFirstPlaylist()
       }
     },
@@ -520,7 +522,6 @@ export default {
             shot.preview_file_annotations
         }
         Vue.set(playlistShotMap, previewFile.shot_id, playlistShot)
-        console.log(this.currentShots[shot.id])
         return playlistShot
       } else {
         return null
@@ -745,6 +746,8 @@ export default {
       if (searchQuery.length > 1) {
         this.setShotSearch(searchQuery)
         this.displayMoreShots()
+        this.displayMoreShots()
+        this.displayMoreShots()
       } else {
         this.setShotSearch('')
       }
@@ -861,7 +864,8 @@ export default {
 
     isAddingShot () {
       if (!this.isAddingShot) {
-        this.resetPlaylist()
+        this.clearCurrentPlaylist()
+        this.setCurrentPlaylist()
       }
     }
   },
@@ -970,9 +974,15 @@ export default {
     box-shadow: 0px 0px 6px #333;
   }
 
+  .playlist-column {
+    button,
+    h2.sequence-title {
+      color: white;
+    }
+  }
+
   .playlist-column.no-selection {
     background: $dark-grey-light;
-    overflow-x: scroll;
 
     h2 {
       color: white;

--- a/src/components/pages/ProductionQuota.vue
+++ b/src/components/pages/ProductionQuota.vue
@@ -302,7 +302,6 @@ export default {
             }
           })
         } else if (this.detailLevel === 'week') {
-          console.log(this.currentYear)
           this.$router.push({
             name: 'quota-week',
             params: {

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -218,7 +218,6 @@
 
 <script>
 import moment from 'moment'
-import Papa from 'papaparse'
 import { mapGetters, mapActions } from 'vuex'
 import csv from '../../lib/csv'
 import func from '../../lib/func'
@@ -687,18 +686,6 @@ export default {
       }
     },
 
-    processCSV (data, config) {
-      return new Promise((resolve, reject) => {
-        Papa.parse(data, {
-          config: config,
-          error: reject,
-          complete: (results) => {
-            resolve(results.data)
-          }
-        })
-      })
-    },
-
     cleanUpCsv (data) {
       return data[0].forEach((item, index, data) => {
         data[index] = item[0].toUpperCase() + item.slice(1)
@@ -712,7 +699,7 @@ export default {
       if (mode === 'file') {
         data = data.get('file')
       }
-      this.processCSV(data)
+      csv.processCSV(data)
         .then((results) => {
           this.cleanUpCsv(results)
           this.parsedCSV = results

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -88,7 +88,7 @@
             />
           </div>
           <div
-            class="flexrow-item"
+            class="flexrow-item zoom-level"
             v-if="isActiveTab('schedule')"
           >
             <combobox-number
@@ -909,5 +909,9 @@ export default {
 
 .task-type-schedule {
   flex: 1;
+}
+
+.zoom-level {
+  margin-top: -8px;
 }
 </style>

--- a/src/components/pages/playlists/AnnotationBar.vue
+++ b/src/components/pages/playlists/AnnotationBar.vue
@@ -35,8 +35,8 @@ export default {
     getAnnotationPosition (annotation) {
       const factor = annotation.time / this.maxDurationRaw
       let width = this.width
-      if (width === 0) {
-        const progressBar = this.$parent.progress
+      const progressBar = this.$parent.progress
+      if (width === 0 && progressBar) {
         const progressCoordinates = progressBar.getBoundingClientRect()
         width = progressCoordinates.width
       }

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1072,8 +1072,6 @@ export default {
       this.resetCanvasSize()
       this.fabricCanvas.renderAll()
       this.clearCanvas()
-      const annotation = this.getAnnotation(this.currentTimeRaw)
-      if (annotation) this.loadAnnotation(annotation)
     },
 
     resetCanvasSize () {

--- a/src/components/pages/playlists/PlaylistedShot.vue
+++ b/src/components/pages/playlists/PlaylistedShot.vue
@@ -31,11 +31,13 @@
       >
         <combobox
           ref="task-type-combobox"
+          :thin="true"
           :options="taskTypeOptions"
           v-model="taskTypeId"
         />
         <combobox
           class="version-combo"
+          :thin="true"
           :options="previewFileOptions"
           v-model="previewFileId"
         />
@@ -255,7 +257,7 @@ export default {
 }
 
 .version-combo {
-  margin-top: 0.6em;
+  margin-top: 0.1em;
 }
 
 .remove-button {

--- a/src/components/pages/playlists/PlaylistedShot.vue
+++ b/src/components/pages/playlists/PlaylistedShot.vue
@@ -17,8 +17,8 @@
           <x-icon />
         </span>
         <light-entity-thumbnail
-          :width="150"
-          :height="103"
+          width="150px"
+          height="103px"
           :preview-file-id="previewFileId"
         />
       </div>

--- a/src/components/pages/playlists/RawVideoPlayer.vue
+++ b/src/components/pages/playlists/RawVideoPlayer.vue
@@ -81,7 +81,6 @@ export default {
 
   methods: {
     emitLoadedEvent (event) {
-      console.log('metatada')
       this.$emit('metadata-loaded', event)
     },
 

--- a/src/components/pages/playlists/RawVideoPlayer.vue
+++ b/src/components/pages/playlists/RawVideoPlayer.vue
@@ -48,11 +48,13 @@ export default {
   // to a HTML5 limitation related to video height.
   mounted () {
     this.resetHeight()
+    this.$refs.player1.addEventListener('loadedmetadata', this.emitLoadedEvent)
     window.addEventListener('resize', this.resetHeight)
   },
 
   beforeDestroy () {
     window.removeEventListener('resize', this.resetHeight)
+    this.$refs.player1.removeEventListener('loadedmetadata', this.emitLoadedEvent)
   },
 
   computed: {
@@ -78,6 +80,11 @@ export default {
   },
 
   methods: {
+    emitLoadedEvent (event) {
+      console.log('metatada')
+      this.$emit('metadata-loaded', event)
+    },
+
     getMoviePath (previewId) {
       return `/api/movies/originals/preview-files/${previewId}.mp4`
     },
@@ -238,6 +245,26 @@ export default {
 
     updateMaxDuration () {
       this.$emit('max-duration-update', this.currentPlayer.duration)
+    },
+
+    getWidth () {
+      return this.currentPlayer.offsetWidth
+    },
+
+    getHeight () {
+      return this.currentPlayer.offsetHeight
+    },
+
+    getVideoRatio () {
+      return this.getVideoWidth() / this.getVideoHeight()
+    },
+
+    getVideoWidth () {
+      return this.currentPlayer.videoWidth
+    },
+
+    getVideoHeight () {
+      return this.currentPlayer.videoHeight
     }
   },
 

--- a/src/components/pages/schedule/Schedule.vue
+++ b/src/components/pages/schedule/Schedule.vue
@@ -1161,17 +1161,7 @@ export default {
 }
 
 .entity-name-list {
-  padding-top: 97px;
-}
-
-.total-man-days {
-  position: fixed;
-  background: white;
-  padding-top: 57px;
-  padding-right: 5px;
-  min-width: 300px;
-  height: 97px;
-  z-index: 2;
+  padding-top: 85px;
 }
 
 .entity-line {
@@ -1434,8 +1424,15 @@ export default {
 }
 
 .total-man-days {
-  padding-bottom: 10px;
+  position: fixed;
+  background: white;
   margin-right: 0.5em;
+  padding-top: 55px;
+  padding-right: 5px;
+  padding-bottom: 10px;
+  min-width: 300px;
+  height: 77px;
+  z-index: 2;
 
   .total-value {
     font-size: 20px;

--- a/src/components/previews/annotation_mixin.js
+++ b/src/components/previews/annotation_mixin.js
@@ -104,6 +104,8 @@ export const annotationMixin = {
 
     stackAddAction ({ target }) {
       this.$options.doneActionStack.push({ type: 'add', obj: target })
+      target.lockMovementX = true
+      target.lockMovementY = true
     },
 
     undoLastAction () {
@@ -136,7 +138,7 @@ export const annotationMixin = {
     },
 
     deleteObject (activeObject) {
-      if (activeObject._objects) {
+      if (activeObject && activeObject._objects) {
         activeObject._objects.forEach((obj) => {
           this.fabricCanvas.remove(obj)
         })

--- a/src/components/sides/PeopleTimesheetInfo.vue
+++ b/src/components/sides/PeopleTimesheetInfo.vue
@@ -181,10 +181,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.dark .close-button:hover {
-  background: $dark-grey-lightest;
-}
-
 .data-list {
   padding-bottom: 5em;
 }
@@ -201,20 +197,5 @@ export default {
 
 .close {
   text-align: right;
-}
-
-.close-button {
-  cursor: pointer;
-  display: inline-block;
-  text-align: center;
-  padding-top: 3px;
-  width: 30px;
-  height: 30px;
-}
-
-.close-button:hover {
-  display: inline-block;
-  background: $white-grey;
-  border-radius: 50%;
 }
 </style>

--- a/src/components/widgets/Combobox.vue
+++ b/src/components/widgets/Combobox.vue
@@ -12,6 +12,7 @@
     >
       <select
         :class="{
+          thin: thin,
           'select-input': true,
           error: this.error
         }"
@@ -66,6 +67,10 @@ export default {
     error: {
       default: false,
       type: Boolean
+    },
+    thin: {
+      default: false,
+      type: Boolean
     }
   },
 
@@ -113,6 +118,11 @@ export default {
 
 .select-input {
   height: 3em;
+
+  &.thin {
+    height: 2.35em;
+    width: 150px;
+  }
 }
 
 .select {

--- a/src/components/widgets/LightEntityThumbnail.vue
+++ b/src/components/widgets/LightEntityThumbnail.vue
@@ -2,8 +2,8 @@
 <img
   class="thumbnail-picture"
   :style="{
-    width: props.width + 'px',
-    height: props.height + 'px'
+    width: props.width,
+    height: props.height
   }"
   v-lazy="'/api/pictures/' + props.type + '/preview-files/' + props.previewFileId + '.png'"
   :key="props.previewFileId"
@@ -16,8 +16,8 @@
     'thumbnail-empty': true
   }"
   :style="{
-    width: props.width + 'px',
-    height: props.height + 'px',
+    width: props.width,
+    height: props.emptyHeight ? props.emptyHeight : props.height,
   }"
   v-bind="data.attrs"
   v-else>
@@ -35,12 +35,15 @@ export default {
       type: String
     },
     width: {
-      default: 150,
-      type: Number
+      default: '150px',
+      type: String
     },
     height: {
-      default: 50,
-      type: Number
+      default: '50px',
+      type: String
+    },
+    emptyHeight: {
+      type: String
     },
     type: {
       default: 'thumbnails',

--- a/src/components/widgets/LightEntityThumbnail.vue
+++ b/src/components/widgets/LightEntityThumbnail.vue
@@ -5,7 +5,7 @@
     width: props.width + 'px',
     height: props.height + 'px'
   }"
-  v-lazy="'/api/pictures/thumbnails/preview-files/' + props.previewFileId + '.png'"
+  v-lazy="'/api/pictures/' + props.type + '/preview-files/' + props.previewFileId + '.png'"
   :key="props.previewFileId"
   v-bind="data.attrs"
   v-if="props.previewFileId"
@@ -41,6 +41,10 @@ export default {
     height: {
       default: 50,
       type: Number
+    },
+    type: {
+      default: 'thumbnails',
+      type: String
     }
   }
 }

--- a/src/lib/csv.js
+++ b/src/lib/csv.js
@@ -1,3 +1,4 @@
+import Papa from 'papaparse'
 import {
   getDayRange,
   getMonthRange,
@@ -184,6 +185,19 @@ const csv = {
       entries.push([''])
     })
     return entries
+  },
+
+  processCSV: (data, config) => {
+    return new Promise((resolve, reject) => {
+      Papa.parse(data, {
+        config: config,
+        encoding: 'ISO-8859-1',
+        error: reject,
+        complete: (results) => {
+          resolve(results.data)
+        }
+      })
+    })
   }
 }
 

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -286,17 +286,24 @@ export default {
 
   playlists: {
     add_shots: 'Schüsse hinzufügen',
-    add_sequence: 'Ganze Sequenz hinzufügen',
+    add_episode: 'Ganze tpisode hinzufügen',
+    add_movie: 'Ganze film hinzufügen',
+    add_sequence: 'Ganze sequenz hinzufügen',
     available_build: 'Verfügbare Builds',
     build_daily: 'Täglich ausstehend',
     build_weekly: 'Alle ausstehend',
     build_mp4: 'Build .mp4',
+    client_playlist: 'Kunde Playlist',
+    created_at: 'Erstellen Sie die:',
+    create_title: 'Playlist erstellen',
     delete_text: 'Sind Sie sicher, dass Sie {name} aus Ihrer Datenbank entfernen möchten?',
     delete_error: 'Beim Löschen dieser Playlist ist ein Fehler aufgetreten.',
     download_zip: 'Download.zip',
     edit_title: 'Wiedergabeliste bearbeiten',
-    for_client: 'Für der Kunde',
-    for_studio: 'Für das Studio',
+    for_client: 'Der Kunde',
+    for_studio: 'Das Studio',
+    last_creation: 'Neueste kreationen',
+    last_modification: 'Neueste änderungen',
     loading_error: 'Es ist ein Serverfehler aufgetreten. Wiedergabelisten können nicht geladen werden.',
     new_playlist: 'Eine Wiedergabeliste hinzufügen',
     no_build: 'Kein Build',
@@ -309,9 +316,11 @@ export default {
     select_shot: 'Bitte wählen Sie einen Schuss in der rechten Spalte aus.',
     select_playlist: 'Bitte wählen Sie eine Playlist in der linken Spalte aus.',
     title: 'Wiedergabelisten',
+    updated_at: 'Geändert am',
     remove: 'entfernen',
     fields: {
-      name: 'Name'
+      name: 'Name',
+      for_client: 'Zum teilen mit'
     }
   },
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -325,16 +325,22 @@ export default {
     add_shots: 'Add shots',
     add_sequence: 'Add whole sequence',
     add_episode: 'Add whole episode',
+    add_movie: 'Add whole movie',
     available_build: 'Available builds',
     build_daily: 'Daily pending',
     build_weekly: 'All Pending',
-    build_mp4: 'Build .mp4',
+    build_mp4: 'Build .mp4 (beta)',
+    client_playlist: 'Client Playlist',
+    created_at: 'Created at:',
+    create_title: 'Create playlist',
     delete_text: 'Are you sure you want to remove {name} from your database?',
     delete_error: 'An error occured while deleting this playlist.',
     download_zip: 'Download .zip',
-    for_client: 'For the client',
-    for_studio: 'For the Studio',
+    for_client: 'The client',
+    for_studio: 'The Studio',
     edit_title: 'Edit playlist',
+    last_creation: 'Last creations',
+    last_modification: 'Last modifications',
     loading_error: 'A server error occured. Playlists cannot be loaded.',
     new_playlist: 'Add a playlist',
     no_build: 'No build',
@@ -347,9 +353,11 @@ export default {
     select_shot: 'Please select a shot in the right column',
     select_playlist: 'Please select a playlist in the left column',
     title: 'Playlists',
+    updated_at: 'Updated at:',
     remove: 'remove',
     fields: {
-      name: 'Name'
+      name: 'Name',
+      for_client: 'To be shared with'
     }
   },
 

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -287,16 +287,23 @@ export default {
   playlists: {
     add_shots: 'Añadir tomas',
     add_sequence: 'Añadir secuencia completa',
+    add_episode: 'Añadir episodio completa',
+    add_movie: 'Añadir film completa',
     available_build: 'Construcciones disponibles',
     build_daily: 'Diario pendiente',
     build_weekly: 'Todos Pendientes',
     build_mp4: 'Construir .mp4',
+    client_playlist: 'Playlist clave',
+    created_at: 'Creado en:',
+    created_title: 'Crear playlist',
     delete_text: '¿Está seguro de que desea eliminar {name} de su base de datos?',
     delete_error: 'Se ha producido un error al eliminar esta lista de reproducción.',
     download_zip: 'Descargar.zip',
     edit_title: 'Editar lista de reproducción',
-    for_client: 'Para el cliente',
-    for_studio: 'Para el estudio',
+    for_client: 'El cliente',
+    for_studio: 'El estudio',
+    last_creation: 'Ultimas creaciones',
+    last_modification: 'Ultimas modificaciones',
     loading_error: 'Se ha producido un error en el servidor. Las listas de reproducción no se pueden cargar.',
     new_playlist: 'Añadir una lista de reproducción',
     no_build: 'Sin construcción',
@@ -309,9 +316,11 @@ export default {
     select_shot: 'Por favor, seleccione una toma en la columna de la derecha',
     select_playlist: 'Por favor, seleccione una lista de reproducción en la columna de la izquierda',
     title: 'Listas de reproducción',
+    updated_at: 'Actualizado en:',
     remove: 'quitar',
     fields: {
-      name: 'Nombre'
+      name: 'Nombre',
+      for_client: 'Par compartir con'
     }
   },
 

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -247,18 +247,24 @@ export default {
 
   playlists: {
     add_shots: 'Sélectonner les plans',
-    add_sequence: 'Ajouter séquence',
     add_episode: 'Ajouter l\'épisode',
+    add_movie: 'Ajouter tout le film',
+    add_sequence: 'Ajouter séquence',
     available_build: 'Builds disponibles',
     build_daily: 'Valid. quotidienne',
     build_weekly: 'Valid. hebodomadaire',
-    build_mp4: 'Construire .mp4',
+    build_mp4: 'Construire .mp4 (beta)',
+    client_playlist: 'Playlist Client',
+    created_at: 'Créé le :',
+    created_title: 'Créer playlist',
     delete_text: 'Êtes vous sûr de vouloir supprimer {name} de la base de données ?',
     delete_error: 'Une erreur est survenue en supprimant la playlist.',
     download_zip: 'Télécharger en .zip',
     edit_title: 'Modifier la playlist',
     for_client: 'Pour le client',
     for_studio: 'Pour le studio',
+    last_creation: 'Dernière créations',
+    last_modification: 'Dernière modifications',
     no_preview: 'Aucun preview',
     remove: 'enlever',
     loading_error: 'Une erreur serveur est apparue, les playlists ne peuvent pas être chargées.',
@@ -271,8 +277,10 @@ export default {
     select_shot: 'Sélectionnez un plan dans la colonne de droite',
     select_playlist: 'Sélectionnez une playlist dans la colonne de gauche',
     title: 'Playlists',
+    updated_at: 'Mis à jour le:',
     fields: {
-      name: 'Nom'
+      name: 'Nom',
+      for_client: 'A partager avec'
     }
   },
 

--- a/src/store/api/playlists.js
+++ b/src/store/api/playlists.js
@@ -30,7 +30,8 @@ export default {
     const data = {
       name: playlist.name,
       project_id: playlist.production_id,
-      episode_id: playlist.episode_id
+      episode_id: playlist.episode_id,
+      for_client: playlist.for_client
     }
     client.post('/api/data/playlists/', data, callback)
   },

--- a/src/store/modules/playlists.js
+++ b/src/store/modules/playlists.js
@@ -226,14 +226,12 @@ const mutations = {
 
   [EDIT_PLAYLIST_END] (state, newPlaylist) {
     const playlist = state.playlistMap[newPlaylist.id]
-
     if (playlist && playlist.id) {
       Object.assign(playlist, newPlaylist)
     } else {
-      state.playlists.push(newPlaylist)
+      state.playlists = [newPlaylist].concat(state.playlists)
       state.playlistMap[newPlaylist.id] = newPlaylist
     }
-    state.playlists = sortPlaylists(state.playlists)
   },
 
   [DELETE_PLAYLIST_START] (state) {

--- a/src/store/modules/playlists.js
+++ b/src/store/modules/playlists.js
@@ -107,7 +107,7 @@ const actions = {
     playlistsApi.updatePlaylist(data, (err, playlist) => {
       if (err) commit(EDIT_PLAYLIST_ERROR)
       else commit(EDIT_PLAYLIST_END, playlist)
-      if (callback) callback(err)
+      if (callback) callback(err, playlist)
     })
   },
 

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -111,9 +111,13 @@ const getters = {
   getTaskPreviews: (state, getters) => (id) => state.taskPreviews[id],
 
   getTaskComment: (state, getters) => (taskId, commentId) => {
-    return state.taskComments[taskId].find(
-      (comment) => comment.id === commentId
-    )
+    if (state.taskComments[taskId]) {
+      return state.taskComments[taskId].find(
+        (comment) => comment.id === commentId
+      )
+    } else {
+      return []
+    }
   },
 
   getTaskStatus: (state, getters) => (id) => {

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -28,5 +28,6 @@ $purple-light: #F4F1FF;
 $purple: #CFD1FF;
 $purple-strong: #8F91EB;
 $dark-purple: #5E60BA;
+$dark-purple-strong: #4A4A6F;
 $blue-light: #92A9FA;
 $blue: #7289DA;


### PR DESCRIPTION
**Problem**

The flow for creating a playlist is a little bit clumsy. When you create a playlist, you have to create it first to be able to change its name. Adding shot is not practical, only a few of them can be displayed and they are filtered by sequence only.

Non-related problems:

* It is not possible to import episode field in asset CSV import.
* CSV import doesn't support special chars anymore.

**Solution**

The first thing you see when you open the playlist page are the last playlist created or modified. Then, when you click on the add playlist button, it opens a modal where you can set the parameters. Then it brings you to the *add shots* mode. From there you can filter like on the shot page your shots and add a whole sequence or a whole movie. You see dozens of shots at the same time, which makes their selection easier.

Non-related problems:

* It is not possible to import episode field in asset CSV import.
* Use the right encoding with paparse.
