### PR TITLE
fix: quotas in seconds are now always rounded

### DIFF
--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -1012,6 +1012,12 @@ const actions = {
             if (isNewQuotaDay) personQuotas[COUNT][period]++
             personQuotas[endDateString] += quota
             personQuotas[TOTAL][period] += quota
+            if (countMode === 'seconds') {
+              personQuotas[TOTAL][period] =
+                Math.round(personQuotas[TOTAL][period] * 100) / 100
+              personQuotas[endDateString] =
+                Math.round(personQuotas[endDateString] * 100) / 100
+            }
             personQuotas[AVERAGE][period] =
               personQuotas[TOTAL][period] / personQuotas[COUNT][period]
           }


### PR DESCRIPTION
**Problem**
When expressed in seconds, quotas were not always rounded due to the [floating point](https://floating-point-gui.de/)

**Solution**
Enforced a round number when seconds are displayed
