### PR TITLE
Add trimming clean up function to avoid import rejection

### DIFF
--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -627,9 +627,15 @@ export default {
     },
 
     cleanUpCsv (data) {
-      return data[0].forEach((item, index, data) => {
+      data.forEach(item => {
+        item.forEach((item, index, data) => {
+          data[index] = item.trim()
+        })
+      })
+      data[0].forEach((item, index, data) => {
         data[index] = item[0].toUpperCase() + item.slice(1)
       })
+      return data
     },
 
     renderImport (data, mode) {

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -433,9 +433,15 @@ export default {
     },
 
     cleanUpCsv (data) {
-      return data[0].forEach((item, index, data) => {
+      data.forEach(item => {
+        item.forEach((item, index, data) => {
+          data[index] = item.trim()
+        })
+      })
+      data[0].forEach((item, index, data) => {
         data[index] = item[0].toUpperCase() + item.slice(1)
       })
+      return data
     },
 
     renderImport (data, mode) {

--- a/src/components/pages/People.vue
+++ b/src/components/pages/People.vue
@@ -217,9 +217,15 @@ export default {
     ]),
 
     cleanUpCsv (data) {
-      return data[0].forEach((item, index, data) => {
+      data.forEach(item => {
+        item.forEach((item, index, data) => {
+          data[index] = item.trim()
+        })
+      })
+      data[0].forEach((item, index, data) => {
         data[index] = item[0].toUpperCase() + item.slice(1)
       })
+      return data
     },
 
     renderImport (data, mode) {

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -687,9 +687,15 @@ export default {
     },
 
     cleanUpCsv (data) {
-      return data[0].forEach((item, index, data) => {
+      data.forEach(item => {
+        item.forEach((item, index, data) => {
+          data[index] = item.trim()
+        })
+      })
+      data[0].forEach((item, index, data) => {
         data[index] = item[0].toUpperCase() + item.slice(1)
       })
+      return data
     },
 
     renderImport (data, mode) {


### PR DESCRIPTION
**Problem**
If a CSV had newline inside a cell it would be rejected when trying to import.

**Solution**
Added a clean up CSV function to trim cells from the CSV data to avoid rejection.
