### PR TITLE
Change preview import label to something less final

### DIFF
--- a/src/components/modals/ImportModal.vue
+++ b/src/components/modals/ImportModal.vue
@@ -44,6 +44,7 @@
       </tabs>
 
       <modal-footer
+        :confirm-label="$t('main.csv.preview')"
         :error-text="$t('main.csv.error_upload')"
         :is-loading="isLoading"
         :is-disabled="formData === undefined"

--- a/src/components/modals/ModalFooter.vue
+++ b/src/components/modals/ModalFooter.vue
@@ -14,13 +14,13 @@
       }"
       @click="$emit('confirm')"
     >
-      {{ $t("main.confirmation") }}
+      {{ confirmLabel || $t("main.confirmation") }}
     </a>
     <button
       @click="$emit('cancel')"
       class="button is-link"
     >
-      {{ $t("main.cancel") }}
+      {{ cancelLabel || $t('main.cancel') }}
     </button>
   </p>
 </div>
@@ -35,6 +35,14 @@ export default {
   components: {},
 
   props: {
+    cancelLabel: {
+      type: String,
+      default: ''
+    },
+    confirmLabel: {
+      type: String,
+      default: ''
+    },
     errorText: {
       type: String,
       default: ''

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -217,6 +217,7 @@ export default {
       legend_missing: 'Missing column',
       paste: 'Paste',
       paste_code: 'Please paste here your CSV data:',
+      preview: 'Preview',
       preview_episode_name: 'Episode name',
       preview_title: 'Preview of your imported data',
       preview_description: 'Upload a .csv file to populate your board with posts.',

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -198,6 +198,7 @@ export default {
       legend_missing: 'Colonne manquante',
       paste: 'Coller',
       paste_code: 'Coller vos données CSV :',
+      preview: 'Aperçu',
       preview_episode_name: 'Nom de l\'épisode',
       preview_title: 'Aperçu de vos données à importer',
       preview_description: 'Importer un fichier .csv pour peupler votre board avec des posts. Vous pouvez aussi ajouter de nouvelles colonnes.',


### PR DESCRIPTION
**Problem**
The import CSV modal has a confirm button with a label that seems too much "*final*", even though it only leads to the Import CSV render modal afterwards and not actually posting anything yet.

**Solution**
Changed the label from "*Confirm*" to "*Preview*"
