### PR TITLE
Replace tutorial link form Slack to Youtube

### DIFF
--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -117,7 +117,10 @@
           </a>
         </li>
         <li>
-          <a href="https://slack.cg-wire.com" target="_blank">
+          <a
+            href="https://www.youtube.com/playlist?list=PLp_1gB5ZBHXqnQgZ4TCrAt7smxesaDo29"
+            target="_blank"
+          >
             {{ $t('main.tutorials') }}
           </a>
         </li>


### PR DESCRIPTION
Fix #379

**Problem**
The tutorials link in the menu points to CG Wire's Slack.

**Solution**
The tutorials link points now to the Youtube playlist of tutorial videos.
