### PR TITLE
disable csv update for Breakdown

### DIFF
--- a/src/components/modals/ImportRenderModal.vue
+++ b/src/components/modals/ImportRenderModal.vue
@@ -17,12 +17,14 @@
             {{ $t("main.csv.preview_description") }} <br />
             {{ $t("main.csv.preview_required") }}
           </p>
-          <h2 class="legend-title">{{ $t('main.csv.options.title') }}</h2>
-          <checkbox
-            :toggle="true"
-            :label="$t('main.csv.options.update')"
-            v-model="updateData"
-          />
+          <div v-show="!disableUpdate">
+            <h2 class="legend-title">{{ $t('main.csv.options.title') }}</h2>
+            <checkbox
+              :toggle="true"
+              :label="$t('main.csv.options.update')"
+              v-model="updateData"
+            />
+          </div>
         </div>
         <div class="flex-item">
           <ul class="legend">
@@ -42,7 +44,7 @@
               <span class="legend-term disabled"></span>
               {{ $t('main.csv.legend_disabled') }}
             </li>
-            <li class="legend-definition">
+            <li v-show="!disableUpdate" class="legend-definition">
               <span class="legend-term overwrite"></span>
               {{ $t('main.csv.legend_overwrite') }}
             </li>
@@ -186,6 +188,10 @@ export default {
     database: {
       type: Object,
       default: () => {}
+    },
+    disableUpdate: {
+      type: Boolean,
+      default: false
     },
     isLoading: {
       type: Boolean,

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -105,6 +105,7 @@
       :columns="csvColumns"
       :dataMatchers="dataMatchers"
       :database="filteredCasting"
+      :disable-update=true
       @reupload="resetImport"
       @cancel="hideImportRenderModal"
       @confirm="uploadImportFile"


### PR DESCRIPTION
**Problem**
Breakdown view shouldn't be abe to update existing data on CSV import

**Solution**
Added a prop `disableUpdate` to `importRenderModal` to disable updates and add it to Breakdown view.
