### PR TITLE
Fix: first team members added are displayed

### DIFF
--- a/src/store/modules/productions.js
+++ b/src/store/modules/productions.js
@@ -506,6 +506,7 @@ const mutations = {
       Object.assign(production, newProduction)
       if (openProduction) Object.assign(openProduction, newProduction)
     } else {
+      newProduction.team = []
       state.productions.push(newProduction)
       state.productionMap[newProduction.id] = newProduction
       if (!openProduction) {


### PR DESCRIPTION
fix: #377

**Problem**
When you add persons to a production's team for the first time `this.currentProduction.team` is updated but its update does not trigger the `teamPersons` computed property. It should but it doesn't.

**Solution**
`state.currentProduction.team` being undefined for new production it can't be reactive. Declaring an empty value for a new production's team makes it reactive.

