### PR TITLE
Fix scroll on Thumbnails modal

### DIFF
--- a/src/components/modals/AddThumbnailsModal.vue
+++ b/src/components/modals/AddThumbnailsModal.vue
@@ -305,6 +305,7 @@ export default {
 }
 
 .modal-content {
-  max-height: 900px;
+  max-height: calc(100vh - 7rem);
+  margin-top: 3rem;
 }
 </style>


### PR DESCRIPTION
fix: #369

**Problem**
If the `AddThumbnailsModal` had too much content, the user can't scroll to the confirm button.

**Solution**
Review `max-height` of the modal to allow a better scrolling
