### PR TITLE
fix: Ensure annotation bar appearance on resize

### DIFF
--- a/src/components/pages/playlists/AnnotationBar.vue
+++ b/src/components/pages/playlists/AnnotationBar.vue
@@ -67,6 +67,7 @@ export default {
   position: relative;
   background: $dark-grey;
   overflow: hidden;
+  flex-shrink: 0;
 }
 
 .annotation-mark {


### PR DESCRIPTION
fix: #385

**Problem**
When resizing your browser's window the annotation bar could shrink and disappear.

**Solution**
Added a CSS property `flex-shrink: 0` to ensure it never shrinks.
