### PR TITLE
Add Drag & Drop priority for TaskTypes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15765,6 +15765,11 @@
         "is-plain-obj": "^1.0.0"
       }
     },
+    "sortablejs": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+      "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A=="
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -17492,6 +17497,14 @@
       "integrity": "sha512-oGlySGPgOMjKAS/MfICdntjwKoIK9XYPQk5fdsc2D0dxMUcO5FC6RJdllmnXpT04iGG9Miw0gFOAimY5MO29Ww==",
       "requires": {
         "socket.io-client": "1.5.1"
+      }
+    },
+    "vuedraggable": {
+      "version": "2.23.2",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.23.2.tgz",
+      "integrity": "sha512-PgHCjUpxEAEZJq36ys49HfQmXglattf/7ofOzUrW2/rRdG7tu6fK84ir14t1jYv4kdXewTEa2ieKEAhhEMdwkQ==",
+      "requires": {
+        "sortablejs": "^1.10.1"
       }
     },
     "vuejs-datepicker": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "vue-textarea-autosize": "1.1.1",
     "vue-upload-component": "2.8.20",
     "vue-websocket": "0.2.3",
+    "vuedraggable": "2.23.2",
     "vuejs-datepicker": "1.6.2",
     "vuex": "3.1.2",
     "vuex-router-sync": "5.0.0"

--- a/src/components/lists/TaskTypeList.vue
+++ b/src/components/lists/TaskTypeList.vue
@@ -22,13 +22,19 @@
 
   <div class="table-body" v-scroll="onBodyScroll">
     <table class="table splitted-table">
-      <tbody>
-        <tr class="type-header">
+      <draggable
+        v-model="assetsItems"
+        draggable=".tasktype-item"
+        tag="tbody"
+        :sort="true"
+        @end="updatePriorityAssets"
+      >
+        <tr class="type-header" slot="header">
           <td colspan="30">
             {{ $t('assets.title') }}
           </td>
         </tr>
-        <tr v-for="taskType in assetTaskTypes" :key="taskType.id">
+        <tr class="tasktype-item" v-for="taskType in assetsItems" :key="taskType.id">
           <task-type-name class="name" :entry="taskType" />
           <td class="priority">{{ taskType.priority }}</td>
           <td class="allow-timelog">
@@ -46,17 +52,23 @@
             }"
           />
         </tr>
-      </tbody>
+      </draggable>
     </table>
 
     <table class="table splitted-table">
-      <tbody>
-        <tr class="type-header">
+      <draggable
+        v-model="shotsItems"
+        draggable=".tasktype-item"
+        tag="tbody"
+        :sort="true"
+        @end="updatePriorityShots"
+      >
+        <tr class="type-header" slot="header">
           <td colspan="30">
             {{ $t('shots.title') }}
           </td>
         </tr>
-        <tr v-for="taskType in shotTaskTypes" :key="taskType.id">
+        <tr class="tasktype-item" v-for="taskType in shotsItems" :key="taskType.id">
           <task-type-name class="name" :entry="taskType" />
           <td class="priority">{{ taskType.priority }}</td>
           <td class="allow-timelog">
@@ -74,8 +86,7 @@
             }"
           />
         </tr>
-      </tbody>
-
+      </draggable>
     </table>
   </div>
 
@@ -88,6 +99,7 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
+import draggable from 'vuedraggable'
 import RowActions from '../widgets/RowActions'
 import TableInfo from '../widgets/TableInfo'
 import TaskTypeName from '../cells/TaskTypeName'
@@ -102,14 +114,20 @@ export default {
   ],
 
   data () {
-    return {}
+    return {
+      assetsItems: [],
+      shotsItems: []
+    }
   },
 
   components: {
+    draggable,
     RowActions,
     TableInfo,
     TaskTypeName
   },
+
+  mounted () {},
 
   computed: {
     ...mapGetters([
@@ -130,6 +148,47 @@ export default {
 
     onBodyScroll (event, position) {
       this.$refs.headerWrapper.style.left = `-${position.scrollLeft}px`
+    },
+
+    updatePriorityAssets () {
+      this.assetsItems.forEach((item, index) => {
+        index += 1
+        const form = {
+          id: item.id,
+          name: item.name,
+          priority: String(index),
+          allow_timelog: String(item.allow_timelog || 'true')
+        }
+        item.priority = index
+        this.$emit('update', form)
+      })
+    },
+
+    updatePriorityShots () {
+      this.shotsItems.forEach((item, index) => {
+        index += 1
+        const form = {
+          id: item.id,
+          name: item.name,
+          priority: String(index),
+          for_shots: String(item.for_shots || 'true'),
+          allow_timelog: String(item.allow_timelog || 'true')
+        }
+        item.priority = index
+        this.$emit('update', form)
+      })
+    }
+  },
+
+  watch: {
+    entries: {
+      immediate: true,
+      handler () {
+        setTimeout(() => {
+          this.assetsItems = JSON.parse(JSON.stringify(this.assetTaskTypes))
+          this.shotsItems = JSON.parse(JSON.stringify(this.shotTaskTypes))
+        }, 100)
+      }
     }
   }
 }

--- a/src/components/modals/EditTaskTypeModal.vue
+++ b/src/components/modals/EditTaskTypeModal.vue
@@ -24,12 +24,6 @@
           v-focus
         />
         <combobox
-          :label="$t('task_types.fields.priority')"
-          :options="priorityOptions"
-          @enter="confirmClicked"
-          v-model="form.priority"
-        />
-        <combobox
           :label="$t('task_types.fields.dedicated_to')"
           :options="dedicatedToOptions"
           @enter="confirmClicked"
@@ -77,7 +71,6 @@ import { mapGetters, mapActions } from 'vuex'
 import TextField from '../widgets/TextField'
 import Combobox from '../widgets/Combobox.vue'
 import ColorField from '../widgets/ColorField'
-import { range } from '../../lib/time'
 
 export default {
   name: 'edit-task-type-modal',
@@ -95,7 +88,8 @@ export default {
     'isLoading',
     'isError',
     'errorText',
-    'taskTypeToEdit'
+    'taskTypeToEdit',
+    'entries'
   ],
 
   watch: {
@@ -104,7 +98,6 @@ export default {
         this.form = {
           name: this.taskTypeToEdit.name,
           color: this.taskTypeToEdit.color,
-          priority: String(this.taskTypeToEdit.priority),
           for_shots: String(this.taskTypeToEdit.for_shots),
           allow_timelog: String(this.taskTypeToEdit.allow_timelog || 'true')
         }
@@ -121,9 +114,6 @@ export default {
         for_shots: 'false',
         allow_timelog: 'false'
       },
-      priorityOptions: range(1, 100).map((v) => {
-        return { label: `${v}`, value: `${v}` }
-      }),
       dedicatedToOptions: [
         { label: this.$t('assets.title'), value: 'false' },
         { label: this.$t('shots.title'), value: 'true' }
@@ -145,7 +135,15 @@ export default {
   methods: {
     ...mapActions([
     ]),
+    newPriority (forShots) {
+      if (forShots === 'true') {
+        return this.entries.filter(taskType => taskType.for_shots).length + 1
+      } else {
+        return this.entries.filter(taskType => !taskType.for_shots).length + 1
+      }
+    },
     confirmClicked () {
+      this.form.priority = this.newPriority(this.form.for_shots)
       this.$emit('confirm', this.form)
     },
     isEditing () {

--- a/src/components/pages/TaskTypes.vue
+++ b/src/components/pages/TaskTypes.vue
@@ -20,12 +20,14 @@
       :entries="taskTypes"
       :is-loading="loading.taskTypes"
       :is-error="errors.taskTypes"
+      @update="updatePriority"
     />
 
     <edit-task-type-modal
       :active="modals.isNewDisplayed"
       :is-loading="editTaskType.isLoading"
       :is-error="editTaskType.isError"
+      :entries="taskTypes"
       :cancel-route="'/task-types'"
       :task-type-to-edit="taskTypeToEdit"
       @confirm="confirmEditTaskType"
@@ -123,10 +125,20 @@ export default {
         })
     },
 
+    updatePriority (form) {
+      setTimeout(() => {
+        this.$store.dispatch('editTaskType', form)
+          .then(() => {
+            this.loadTaskTypes()
+          })
+      }, 100)
+    },
+
     confirmDeleteTaskType () {
       this.deleteTaskType(this.taskTypeToDelete)
         .then(() => {
           this.modals.isDeleteDisplayed = false
+          this.$router.push('/task-types')
         })
     },
 

--- a/src/store/modules/tasktypes.js
+++ b/src/store/modules/tasktypes.js
@@ -215,6 +215,7 @@ const mutations = {
 
     if (taskType && taskType.id) {
       Object.assign(taskType, newTaskType)
+      state.taskTypes = sortTaskTypes(state.taskTypes)
     } else {
       state.taskTypes.push(newTaskType)
       state.taskTypes = sortTaskTypes(state.taskTypes)


### PR DESCRIPTION
**Problem**
In order to change the priority of a task type, the user must edit each task type manually.

**Solution**
Added a drag & drop functionnnality that allow the user to quickly change the order of task types and therefore their own priority level.
