### PR TITLE
fix: load more shots on scroll in playlist view

### DIFF
--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -224,6 +224,8 @@
         <div
           class="addition-section"
           v-if="isCurrentUserManager && isAddingShot"
+          v-scroll="onBodyScroll"
+          ref="shotList"
         >
           <spinner
             class="mt2"
@@ -231,6 +233,7 @@
             v-if="isShotsLoading"
           />
           <div
+            ref="shotListContent"
             v-else
           >
             <div>
@@ -730,6 +733,15 @@ export default {
       })
     },
 
+    onBodyScroll (event, position) {
+      const maxHeight =
+        this.$refs.shotListContent.scrollHeight -
+        this.$refs.shotList.offsetHeight
+      if (maxHeight < position.scrollTop) {
+        this.displayMoreShots()
+      }
+    },
+
     onOrderChange (info) {
       this.changePlaylistOrder({
         playlist: this.currentPlaylist,
@@ -761,8 +773,6 @@ export default {
     onSearchChange (searchQuery) {
       if (searchQuery.length > 1) {
         this.setShotSearch(searchQuery)
-        this.displayMoreShots()
-        this.displayMoreShots()
         this.displayMoreShots()
       } else {
         this.setShotSearch('')


### PR DESCRIPTION
**Problem**
When the user wants to add shots to a playlist there's only 30 shots displayed and no way to get more by scrolling further.

**Solution**
Added `displayMoreShots` on scrolling in the "add shots" area.

Fix: #397 
