### PR TITLE
Fix: quota day display when the day date is 1 digit

### DIFF
--- a/src/components/pages/quota/Quota.vue
+++ b/src/components/pages/quota/Quota.vue
@@ -360,16 +360,20 @@ export default {
     },
     monthToString,
 
+    dateDigit (date) {
+      return date.toString().padStart(2, '0')
+    },
+
     getQuota (personId, opt = {}) {
       if (opt.day) {
         const yearKey =
-          `${opt.year}-${opt.month.toString().padStart(2, '0')}-${opt.day}`
+          `${opt.year}-${this.dateDigit(opt.month)}-${this.dateDigit(opt.day)}`
         return this.quotaMap[personId][yearKey]
       } else if (opt.week) {
         const weekKey = `${opt.year}-${opt.week}`
         return this.quotaMap[personId][weekKey]
       } else {
-        const dayKey = `${opt.year}-${opt.month.toString().padStart(2, '0')}`
+        const dayKey = `${opt.year}-${this.dateDigit(opt.month)}`
         return this.quotaMap[personId][dayKey]
       }
     },
@@ -377,7 +381,7 @@ export default {
     getQuotaAverage (personId, opt = {}) {
       let average
       if (opt.month) {
-        const monthKey = opt.year + '-' + opt.month.toString().padStart(2, '0')
+        const monthKey = opt.year + '-' + this.dateDigit(opt.month)
         average = this.quotaMap[personId].average[monthKey]
       } else if (opt.week) {
         const weekKey = `${opt.year}-${opt.week}`

--- a/tests/unit/pages/quota.spec.js
+++ b/tests/unit/pages/quota.spec.js
@@ -1,0 +1,93 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+import Vuex from 'vuex'
+import VueRouter from 'vue-router'
+import i18n from '../../../src/lib/i18n'
+import Quota from '../../../src/components/pages/quota/Quota'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+localVue.use(VueRouter)
+const router = new VueRouter()
+
+describe('Quota', () => {
+  let store, shotStore, peopleStore
+  let wrapper
+
+  beforeEach(() => {
+    shotStore = {
+      getters: {
+        currentEpisode: () => ({}),
+        isShotsLoading: () => false,
+        shotMap: () => ({
+          '24ec56f9-0c00-43e5-9233-3dec2ee06a98': {},
+          '32c5b3a2-eaa7-49b6-8f86-03f2b1c4b7bd': {}
+        })
+      },
+      actions: {
+        loadShots: jest.fn(),
+        computeQuota: () => ({
+          'cd5f95f0-8293-4cf2-8220-6928b594ede7': {
+            '2020-02-03': 70,
+            average: {
+              '2020-02': 50
+            },
+            count: {
+              '2020-02': 1
+            },
+            total: {
+              '2020-02': 70
+            }
+          }
+        })
+      }
+    }
+    peopleStore = {
+      getters: {
+        personMap: () => ({
+          'cd5f95f0-8293-4cf2-8220-6928b594ede7': {
+            full_name: 'Alicia Cooper'
+          }
+        })
+      },
+      actions: {
+      }
+    }
+    store = new Vuex.Store({
+      strict: true,
+      modules: {
+        shots: shotStore,
+        people: peopleStore
+      }
+    })
+
+    wrapper = shallowMount(Quota, {
+      store,
+      localVue,
+      router,
+      i18n,
+      propsData: {
+        detailLevel: 'day',
+        countMode: 'frames',
+        taskTypeId: '9a3a5d14-a9ff-4cd8-a14f-487724d0c184',
+        year: 2020,
+        month: 2,
+        week: 32,
+        day: 3
+      }
+    })
+  })
+
+  describe('Mount', () => {
+    test('mounted', () => {
+    })
+  })
+
+  describe('Quota displayed', () => {
+    test('The 3rd column of the table should have a quota displayed', () => {
+      const dayCell = wrapper.findAll(
+        '.quota-scrolled .quota-row:not(.quota-header) .row-cell'
+      )
+      expect(dayCell.at(2).text()).toMatch('70')
+    })
+  })
+})


### PR DESCRIPTION
fix: #403

**Problem**
When displaying quotas by day, quotas in the first 9 days didn't display because it was 1 digit for the day date when the data sent was 2 digits for the day date, so it didn't match.

**Solution**
Enforcing date format of 2 digits for days as well.
