### PR TITLE
feat: Add Metadata option hidden from client

### DIFF
--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -47,7 +47,7 @@
             class="metadata-descriptor"
             :key="descriptor.id"
             v-for="descriptor in shotMetadataDescriptors"
-            v-if="!isCurrentUserClient && isShowInfos"
+            v-if="isShowInfos"
           >
             <div class="flexrow">
               <span class="flexrow-item descriptor-name">
@@ -193,7 +193,7 @@
             class="metadata-descriptor"
             :key="shot.id + '-' + descriptor.id"
             v-for="descriptor in shotMetadataDescriptors"
-            v-if="!isCurrentUserClient && isShowInfos"
+            v-if="isShowInfos"
           >
             {{ shot.data ? shot.data[descriptor.field_name] : '' }}
           </td>

--- a/src/components/modals/AddMetadataModal.vue
+++ b/src/components/modals/AddMetadataModal.vue
@@ -28,6 +28,14 @@
         v-focus
       />
 
+      <combobox-boolean
+        ref="hiddenField"
+        :label="$t('assets.fields.hidden_from_client')"
+        v-model="form.hiddenFromClient"
+        @enter="confirm"
+        v-focus
+      />
+
       <div v-if="type === 'choices'">
         <p class="strong">
           {{ $t('productions.metadata.available_values') }}
@@ -85,6 +93,7 @@ import { modalMixin } from './base_modal'
 import { remove } from '../../lib/models'
 
 import Combobox from '../widgets/Combobox'
+import ComboboxBoolean from '../widgets/ComboboxBoolean'
 import ModalFooter from './ModalFooter'
 import TextField from '../widgets/TextField'
 
@@ -94,6 +103,7 @@ export default {
 
   components: {
     Combobox,
+    ComboboxBoolean,
     ModalFooter,
     TextField
   },
@@ -121,6 +131,7 @@ export default {
     return {
       form: {
         name: '',
+        hiddenFromClient: false,
         values: []
       },
       valueToAdd: '',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -24,7 +24,8 @@ export default {
       name: 'Name',
       production: 'Prod',
       time_spent: 'Time',
-      type: 'Type'
+      type: 'Type',
+      hidden_from_client: 'Hidden from client'
     }
   },
 

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -37,7 +37,8 @@ export default {
       name: 'Nom',
       production: 'Prod',
       time_spent: 'Jours',
-      type: 'Type'
+      type: 'Type',
+      hidden_from_client: 'Caché au client'
     }
   },
 


### PR DESCRIPTION
**Problem**
A user can't hide a metadata column from a client

**Solution**
Added an option "hidden from client" in metadata modal creation/edition
