### PR TITLE
Fix/dragdrop tasktypes

### DIFF
--- a/src/components/lists/TaskTypeList.vue
+++ b/src/components/lists/TaskTypeList.vue
@@ -166,6 +166,7 @@ export default {
     },
 
     updatePriorityShots () {
+      const forms = []
       this.shotsItems.forEach((item, index) => {
         index += 1
         const form = {
@@ -174,8 +175,9 @@ export default {
           priority: String(index)
         }
         item.priority = index
-        this.$emit('update', form)
+        forms.push(form)
       })
+      this.$emit('update-priorities', forms)
     }
   },
 

--- a/src/components/lists/TaskTypeList.vue
+++ b/src/components/lists/TaskTypeList.vue
@@ -224,6 +224,14 @@ export default {
   width: 100px;
 }
 
+.tasktype-item[draggable=false] {
+  cursor: grab;
+}
+
+.tasktype-item[draggable=true] {
+  cursor: grabbing;
+}
+
 tr {
   cursor: pointer;
 }

--- a/src/components/modals/EditTaskTypeModal.vue
+++ b/src/components/modals/EditTaskTypeModal.vue
@@ -28,6 +28,7 @@
           :options="dedicatedToOptions"
           @enter="confirmClicked"
           v-model="form.for_shots"
+           v-if="!isEditing"
         />
         <combobox-boolean
           :label="$t('task_types.fields.allow_timelog')"

--- a/src/components/modals/EditTaskTypeModal.vue
+++ b/src/components/modals/EditTaskTypeModal.vue
@@ -8,7 +8,7 @@
 
     <div class="box">
 
-      <h1 class="title" v-if="isEditing()">
+      <h1 class="title" v-if="isEditing">
         {{ $t("task_types.edit_title") }} {{ taskTypeToEdit.name }}
       </h1>
       <h1 class="title" v-else>
@@ -125,7 +125,10 @@ export default {
     ...mapGetters([
       'taskTypes',
       'taskTypeStatusOptions'
-    ])
+    ]),
+    isEditing () {
+      return this.taskTypeToEdit && this.taskTypeToEdit.id
+    }
   },
 
   methods: {
@@ -145,10 +148,6 @@ export default {
         this.form.priority = this.newPriority(this.form.for_shots)
       }
       this.$emit('confirm', this.form)
-    },
-
-    isEditing () {
-      return this.taskTypeToEdit && this.taskTypeToEdit.id
     }
   }
 }


### PR DESCRIPTION
**Problem**
- Drag & Dropping Shots task types wasn't registering
- New Tasktypes didn't get the right priority
- Not clear that items are drag & droppable

**Solution**
- `updatePriorityShots` function wasn't up-to-date
- `isEditing` was a method instead of a computed property
- Added `drag` and `dragging` cursors on draggable items
