### PR TITLE
Reorganise tv show assets

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -158,7 +158,7 @@
           v-for="(asset, i) in group"
         >
           <td class="episode" v-if="isTVShow">
-            {{ episodeMap[asset.episode_id] ? episodeMap[asset.episode_id].name : $t('main.all') }}
+            {{ episodeMap[asset.episode_id] ? episodeMap[asset.episode_id].name : 'MP' }}
           </td>
           <th
             :class="{

--- a/src/components/modals/EditPlaylistModal.vue
+++ b/src/components/modals/EditPlaylistModal.vue
@@ -63,6 +63,7 @@
 import Combobox from '../widgets/Combobox'
 import TextField from '../widgets/TextField'
 
+import { mapGetters } from 'vuex'
 import { modalMixin } from './base_modal'
 
 export default {
@@ -88,21 +89,34 @@ export default {
         { label: this.$t('playlists.for_client'), value: 'true' },
         { label: this.$t('playlists.for_studio'), value: 'false' }
       ],
-      forEntityOptions: [
-        { label: this.$t('assets.title'), value: 'asset' },
-        { label: this.$t('shots.title'), value: 'shot' }
-      ],
       form: {
         name: this.playlistToEdit.name,
-        for_entity: this.playlistToEdit.for_entity || 'shot',
+        for_entity: this.playlistToEdit.for_entity || 'asset',
         for_client: this.playlistToEdit.for_client
       }
     }
   },
 
   computed: {
+    ...mapGetters([
+      'currentEpisode'
+    ]),
+
     isEditing () {
       return this.playlistToEdit && this.playlistToEdit.id
+    },
+
+    forEntityOptions () {
+      if (this.currentEpisode && this.currentEpisode.id === 'main') {
+        return [
+          { label: this.$t('assets.title'), value: 'asset' }
+        ]
+      } else {
+        return [
+          { label: this.$t('assets.title'), value: 'asset' },
+          { label: this.$t('shots.title'), value: 'shot' }
+        ]
+      }
     }
   },
 
@@ -119,7 +133,7 @@ export default {
       } else {
         this.form = {
           name: this.playlistToEdit.name,
-          for_entity: 'shot',
+          for_entity: 'asset',
           for_client: 'false'
         }
       }

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -391,22 +391,19 @@ export default {
       )
     ) {
       setTimeout(() => {
-        this.loadAssets((err) => {
-          if (!err) {
+        this.loadAssets()
+          .then(() => {
             this.handleModalsDisplay()
             setTimeout(() => {
+              this.initialLoading = false
+              this.resizeHeaders()
               if (this.$refs['asset-list']) {
                 this.$refs['asset-list'].setScrollPosition(
                   this.assetListScrollPosition
                 )
               }
             }, 500)
-          }
-          setTimeout(() => {
-            this.initialLoading = false
-            this.resizeHeaders()
-          }, 200)
-        })
+          })
       }, 0)
     } else {
       if (!this.isAssetsLoading) this.initialLoading = false
@@ -527,9 +524,8 @@ export default {
           if (err) {
             this.errors.creatingTasks = true
           } else {
-            this.loadAssets(() => {
-              this.resizeHeaders()
-            })
+            this.loadAssets()
+              .then(this.resizeHeaders)
           }
           callback(err)
         }
@@ -544,9 +540,8 @@ export default {
       this.deleteAllTasks({ projectId, taskTypeId })
         .then(() => {
           this.loading.deleteAllTasks = false
-          this.loadAssets(() => {
-            this.resizeHeaders()
-          })
+          this.loadAssets()
+            .then(this.resizeHeaders)
           this.$router.push(this.assetsPath)
         }).catch((err) => {
           console.error(err)
@@ -688,7 +683,6 @@ export default {
       const formData = new FormData()
       const filename = 'import.csv'
       const csvContent = csv.turnEntriesToCsvString(data)
-      console.log(csvContent)
       const file = new File([csvContent], filename, { type: 'text/csv' })
 
       formData.append('file', file)
@@ -701,9 +695,8 @@ export default {
         .then(() => {
           this.hideImportRenderModal()
           this.loading.importing = false
-          this.loadAssets(() => {
-            this.resizeHeaders()
-          })
+          this.loadAssets()
+            .then(this.resizeHeaders)
         })
         .catch((err) => {
           console.error(err)
@@ -889,6 +882,18 @@ export default {
 
     onChangeSortClicked (sortInfo) {
       this.changeAssetSort(sortInfo)
+    },
+
+    reset () {
+      this.initialLoading = true
+      this.loadAssets()
+        .then(() => {
+          this.handleModalsDisplay()
+          this.initialLoading = false
+          this.resizeHeaders()
+          this.setSearchFromUrl()
+          this.onSearchChange()
+        })
     }
   },
 
@@ -902,36 +907,13 @@ export default {
       this.$store.commit('SET_ASSET_LIST_SCROLL_POSITION', 0)
       this.resetCsVColumns()
 
-      if (!this.isTVShow) {
-        this.initialLoading = true
-        this.loadAssets((err) => {
-          this.initialLoading = false
-          this.resizeHeaders()
-          this.setSearchFromUrl()
-          this.onSearchChange()
-          if (!err) {
-            this.handleModalsDisplay()
-          }
-        })
-      }
+      if (!this.isTVShow) this.reset()
     },
 
     currentEpisode () {
       this.$refs['asset-search-field'].setValue('')
       this.$store.commit('SET_ASSET_LIST_SCROLL_POSITION', 0)
-
-      if (this.isTVShow && this.currentEpisode) {
-        this.initialLoading = true
-        this.loadAssets((err) => {
-          if (!err) {
-            this.handleModalsDisplay()
-            this.initialLoading = false
-            this.resizeHeaders()
-            this.setSearchFromUrl()
-            this.onSearchChange()
-          }
-        })
-      }
+      if (this.isTVShow && this.currentEpisode) this.reset()
     },
 
     displayedAssets () {

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -289,13 +289,15 @@ export default {
     filteredCasting () {
       const casting = {}
       this.castingEntities.forEach(entity => {
-        this.castingByType[entity.id].forEach(type => {
-          type.forEach(item => {
-            const castKey =
-              `${item.asset_name}${item.asset_type_name}${item.name}`
-            casting[castKey] = true
+        if (this.castingByType[entity.id]) {
+          this.castingByType[entity.id].forEach(type => {
+            type.forEach(item => {
+              const castKey =
+                `${item.asset_name}${item.asset_type_name}${item.name}`
+              casting[castKey] = true
+            })
           })
-        })
+        }
       })
       return casting
     }
@@ -338,12 +340,13 @@ export default {
         } else {
           this.setCastingEpisode(null)
         }
-        this.loadAssets(() => {
-          this.isLoading = false
-          this.displayMoreAssets()
-          this.setCastingAssetTypes()
-          this.resetSelection()
-        })
+        this.loadAssets(true)
+          .then(() => {
+            this.isLoading = false
+            this.displayMoreAssets()
+            this.setCastingAssetTypes()
+            this.resetSelection()
+          })
       })
     },
 
@@ -563,7 +566,7 @@ export default {
       this.modals.isEditLabelDisplayed = true
     },
 
-    confirmEditLabel (form) {
+    confirmEditLabel (form = {}) {
       const label = form.label
       this.loading.editLabel = true
       this.setAssetLinkLabel({

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -516,17 +516,23 @@ export default {
 
     loadShotsData (callback) {
       if (this.displayedShots.length === 0) {
-        this.loadShots(callback)
+        console.log('playlists loadShotsData', this.currentEpisode)
+        if (this.currentEpisode &&
+            this.currentEpisode.id === 'main') {
+          callback()
+        } else {
+          this.loadShots(callback)
+        }
       } else {
         callback()
       }
     },
 
     loadAssetsData (callback) {
-      if (this.displayedAssets.length === 0) {
-        this.loadAssets(callback)
+      if (this.isTVShow || this.displayedAssets.length === 0) {
+        return this.loadAssets()
       } else {
-        callback()
+        return Promise.resolve()
       }
     },
 
@@ -931,11 +937,12 @@ export default {
 
     reloadAll () {
       this.loadShotsData(() => {
-        this.loadAssetsData(() => {
-          this.loadPlaylistsData(() => {
-            this.resetPlaylist()
+        this.loadAssetsData()
+          .then(() => {
+            this.loadPlaylistsData(() => {
+              this.resetPlaylist()
+            })
           })
-        })
       })
     }
   },

--- a/src/components/pages/ProductionAssetTypes.vue
+++ b/src/components/pages/ProductionAssetTypes.vue
@@ -93,11 +93,7 @@ export default {
     this.setDefaultSearchText()
     this.setDefaultListScrollPosition()
     setTimeout(() => {
-      this.initAssetTypes()
-        .then(this.handleModalsDisplay)
-        .then(() => {
-          this.initialLoading = false
-        })
+      this.reset()
     }, 100)
   },
 
@@ -158,34 +154,28 @@ export default {
         this.assetTypeMap,
         this.countMode
       )
+    },
+
+    reset () {
+      this.initialLoading = true
+      this.$refs['asset-type-search-field'].setValue('')
+      this.loadAssets()
+        .then(this.handleModalsDisplay)
+        .then(() => {
+          this.computeAssetTypeStats()
+          this.setAssetTypeListScrollPosition(0)
+          this.initialLoading = false
+        })
     }
   },
 
   watch: {
     currentProduction () {
-      this.$refs['asset-type-search-field'].setValue('')
-
-      if (!this.isTVShow) {
-        this.initialLoading = true
-        this.loadAssets(() => {
-          this.computeAssetTypeStats()
-          this.setAssetTypeListScrollPosition(0)
-          this.initialLoading = false
-        })
-      }
+      if (!this.isTVShow) this.reset()
     },
 
     currentEpisode () {
-      if (this.isTVShow) {
-        this.initialLoading = true
-        this.$refs['asset-type-search-field'].setValue('')
-        this.setAssetTypeListScrollPosition(0)
-
-        this.loadAssets(() => {
-          this.computeAssetTypeStats()
-          this.initialLoading = false
-        })
-      }
+      if (this.isTVShow) this.reset()
     }
   },
 

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -753,7 +753,10 @@ export default {
           callback: (err, task) => {
             if (err) console.error(err)
 
-            let loadingFunction = this.loadAssets
+            let loadingFunction = (callback) => {
+              this.loadAssets()
+                .then(callback)
+            }
 
             if (task.entity_type_name === 'Shot') {
               loadingFunction = (callback) => {

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1048,7 +1048,7 @@ export default {
     },
 
     onTimeUpdate () {
-      if (this.rawPlayer.currentPlayer) {
+      if (this.rawPlayer && this.rawPlayer.currentPlayer) {
         this.currentTimeRaw = this.rawPlayer.currentPlayer.currentTime
       } else {
         this.currentTimeRaw = 0

--- a/src/components/pages/playlists/RawVideoPlayer.vue
+++ b/src/components/pages/playlists/RawVideoPlayer.vue
@@ -172,11 +172,13 @@ export default {
     },
 
     goNextFrame () {
-      const newTime = this.currentPlayer.currentTime + 1 / this.fps
-      if (newTime > this.currentPlayer.duration) {
-        this.setCurrentTime(this.video.duration)
-      } else {
-        this.setCurrentTime(newTime)
+      if (this.currentPlayer) {
+        const newTime = this.currentPlayer.currentTime + 1 / this.fps
+        if (newTime > this.currentPlayer.duration) {
+          this.setCurrentTime(this.video.duration)
+        } else {
+          this.setCurrentTime(newTime)
+        }
       }
     },
 

--- a/src/components/widgets/ComboboxStyled.vue
+++ b/src/components/widgets/ComboboxStyled.vue
@@ -16,7 +16,7 @@
       <div
         class="selected-line flexrow-item"
       >
-        {{ selectedOption.label }}
+        {{ selectedOption ? selectedOption.label : '' }}
       </div>
       <chevron-down-icon class="down-icon flexrow-item"/>
     </div>

--- a/src/store/api/assets.js
+++ b/src/store/api/assets.js
@@ -1,7 +1,7 @@
 import client from './client'
 
 export default {
-  getAssets (production, episode, callback) {
+  getAssets (production, episode) {
     let path = '/api/data/assets/with-tasks'
     if (production) {
       path += `?project_id=${production.id}`
@@ -9,7 +9,7 @@ export default {
     if (episode) {
       path += `&episode_id=${episode.id}`
     }
-    client.get(path, callback)
+    return client.pget(path)
   },
 
   getAsset (assetId) {

--- a/src/store/modules/breakdown.js
+++ b/src/store/modules/breakdown.js
@@ -16,6 +16,7 @@ import {
   CASTING_ADD_TO_CASTING,
   CASTING_REMOVE_FROM_CASTING,
 
+  LOAD_SHOTS_START,
   LOAD_SHOT_CASTING_END,
   LOAD_ASSET_CAST_IN_END,
 
@@ -146,6 +147,9 @@ const actions = {
 }
 
 const mutations = {
+  [LOAD_SHOTS_START] (state) {
+    Object.assign(state, initialState)
+  },
 
   [CASTING_SET_SHOTS] (state, shots) {
     const casting = []

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -539,7 +539,12 @@ const actions = {
     const taskMap = rootGetters.taskMap
     const personMap = rootGetters.personMap
     const isTVShow = rootGetters.isTVShow
-    const episode = isTVShow ? rootGetters.currentEpisode : null
+    let episode = isTVShow ? rootGetters.currentEpisode : null
+
+    if (episode && ['all', 'main'].includes(episode.id)) {
+      episode = state.episodes.length > 0 ? state.episodes[0] : null
+      commit(SET_CURRENT_EPISODE, episode.id)
+    }
 
     if (isTVShow && !episode) {
       return callback()
@@ -1724,7 +1729,13 @@ const mutations = {
 
   [SET_CURRENT_EPISODE] (state, episodeId) {
     if (episodeId) {
-      state.currentEpisode = state.episodeMap[episodeId]
+      if (episodeId === 'main') {
+        state.currentEpisode = { id: 'main' }
+      } else if (episodeId === 'all') {
+        state.currentEpisode = { id: 'all' }
+      } else {
+        state.currentEpisode = state.episodeMap[episodeId]
+      }
     }
   },
 


### PR DESCRIPTION
**Problem**

Assets in TV shows are not properly organized. The main pack is melted with other assets.

**Solution**

* Add a "Main pack" episode for assets for TV series
* Add an All asset section for TV series
* Show only assets of current episode when listing episode assets (do not include the main pack anymore.
