### PR TITLE
fix: Display gifs in task page

### DIFF
--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -195,7 +195,7 @@
               @add-preview="onAddExtraPreview"
               @remove-extra-preview="showRemoveExtraPreviewModal"
               ref="preview-picture"
-              v-else-if="currentTaskPreviews && currentTaskPreviews.length > 0 && extension === 'png'"
+              v-else-if="currentTaskPreviews && currentTaskPreviews.length > 0 && ['png', 'gif'].includes(this.extension)"
             />
           </div>
         </div>


### PR DESCRIPTION
**Problem**
If a task preview is a animated gif, it won't get display on the task page.

**Solution**
Added gif support on the task page.
