### PR TITLE
fix: canceled style on th

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -747,7 +747,8 @@ a:hover {
   font-size: 1.4em;
 }
 
-.canceled td:not(.actions) {
+.canceled td:not(.actions),
+.canceled th {
   text-decoration: line-through;
 }
 


### PR DESCRIPTION
**Problem**
Canceled items in tables doesn't get line-through if its a `th`

**Solution**
Add canceled styles on canceled `th`
