### PR TITLE
fix: text annotation position according to canvas size

### DIFF
--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1584,8 +1584,8 @@ export default {
               {
                 ...base,
                 fill: obj.fill,
-                left: obj.left,
-                top: obj.top,
+                left: obj.left * scaleMultiplierX,
+                top: obj.top * scaleMultiplierY,
                 fontFamily: obj.fontFamily,
                 fontSize: obj.fontSize
               }

--- a/src/components/previews/PictureViewer.vue
+++ b/src/components/previews/PictureViewer.vue
@@ -627,8 +627,8 @@ export default {
               {
                 ...base,
                 fill: obj.fill,
-                left: obj.left,
-                top: obj.top,
+                left: obj.left * scaleMultiplierX,
+                top: obj.top * scaleMultiplierY,
                 fontFamily: obj.fontFamily,
                 fontSize: obj.fontSize
               }

--- a/src/components/previews/VideoPlayer.vue
+++ b/src/components/previews/VideoPlayer.vue
@@ -952,8 +952,8 @@ export default {
             {
               ...base,
               fill: obj.fill,
-              left: obj.left,
-              top: obj.top,
+              left: obj.left * scaleMultiplierX,
+              top: obj.top * scaleMultiplierY,
               fontFamily: obj.fontFamily,
               fontSize: obj.fontSize
             }


### PR DESCRIPTION
**Problem**
Text annotations can be misplaced when resizing the video player.

**Solution**
Recalculate text annotations position according to the video player's size.
