### PR TITLE
fix: force break word to shot name in breakdown view

### DIFF
--- a/src/components/pages/breakdown/ShotLine.vue
+++ b/src/components/pages/breakdown/ShotLine.vue
@@ -123,6 +123,7 @@ export default {
   padding-left: 0.4em;
   padding-top: 0;
   flex: 0 0 100px;
+  word-break: break-all;
 }
 
 .asset-type-name {


### PR DESCRIPTION
**Problem**
Long shot name wouldn't break in the breakdown view, causing some layout issue.

**Solution**
Forced breaking words on shot name element.
