### PR TITLE
Add support for picture when comparing playlists

### DIFF
--- a/src/components/pages/playlists/PlaylistedEntity.vue
+++ b/src/components/pages/playlists/PlaylistedEntity.vue
@@ -260,6 +260,8 @@ export default {
 
 .entity-title {
   margin-bottom: 0.6em;
+  max-width: 150px;
+  word-wrap: anywhere;
 }
 
 .thumbnail-wrapper {

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -43,7 +43,7 @@
           :placeholder="$t('comments.add_comment')"
           :disabled="isLoading"
           v-model="text"
-          @keyup.enter.ctrl="runAddComment(text, attachment, task_status_id)"
+          @keyup.enter.ctrl="runAddComment(text, attachment, checklist, task_status_id)"
           v-focus>
         </textarea>
       </at-ta>
@@ -111,7 +111,7 @@
           :style="{
             'background-color': taskStatusColor
           }"
-          @click="runAddComment(text, attachment, task_status_id)"
+          @click="runAddComment(text, attachment, checklist, task_status_id)"
         >
           {{ $t('comments.post_status') }}
         </button>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -60,7 +60,7 @@ export default {
     add_checklist: 'Add checklist',
     add_attachment: 'Add attachment',
     add_preview: 'Attach preview',
-    task_placeholder: 'Task name',
+    task_placeholder: 'New item...',
     change_preview: 'Change preview',
     comment_from_client: 'Comment from client',
     empty_text: 'This comment is empty',


### PR DESCRIPTION
**Problem**

* Picture cannot be displayed when comparing playlists to a previous step.
* Posting comment is broken
* Entity name of playlisted element breaks the layout when it's too long.

**Solution**

* Add a picture player for the comparison mode. Display video player or picture player depending on the preview.
* Fix call to post comment function following changes related to checklists
* Improve CSS for playilsted entity names (set a max-width and handle word breaks).