### PR TITLE
fix: Text Annotation on fullscreen for chrome

### DIFF
--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1193,9 +1193,27 @@ export default {
     },
 
     onFullscreenClicked () {
+      /** @lends fabric.IText.prototype */
+      // fix for : IText not editable when canvas is in a fullscreen
+      // element on chrome
+      // https://github.com/fabricjs/fabric.js/issues/5126
+      const originalInitHiddenTextarea =
+        fabric.IText.prototype.initHiddenTextarea
       if (this.isFullScreen()) {
+        fabric.util.object.extend(fabric.IText.prototype, {
+          initHiddenTextarea: function () {
+            originalInitHiddenTextarea.call(this)
+            fabric.document.body.appendChild(this.hiddenTextarea)
+          }
+        })
         this.exitFullScreen()
       } else {
+        fabric.util.object.extend(fabric.IText.prototype, {
+          initHiddenTextarea: function () {
+            originalInitHiddenTextarea.call(this)
+            this.canvas.wrapperEl.appendChild(this.hiddenTextarea)
+          }
+        })
         this.setFullScreen()
       }
     },

--- a/src/components/previews/PictureViewer.vue
+++ b/src/components/previews/PictureViewer.vue
@@ -399,9 +399,27 @@ export default {
     },
 
     onFullscreenClicked () {
+      /** @lends fabric.IText.prototype */
+      // fix for : IText not editable when canvas is in a fullscreen
+      // element on chrome
+      // https://github.com/fabricjs/fabric.js/issues/5126
+      const originalInitHiddenTextarea =
+        fabric.IText.prototype.initHiddenTextarea
       if (this.isFullScreen()) {
+        fabric.util.object.extend(fabric.IText.prototype, {
+          initHiddenTextarea: function () {
+            originalInitHiddenTextarea.call(this)
+            fabric.document.body.appendChild(this.hiddenTextarea)
+          }
+        })
         this.exitFullScreen()
       } else {
+        fabric.util.object.extend(fabric.IText.prototype, {
+          initHiddenTextarea: function () {
+            originalInitHiddenTextarea.call(this)
+            this.canvas.wrapperEl.appendChild(this.hiddenTextarea)
+          }
+        })
         this.setFullScreen()
       }
     },

--- a/src/components/previews/VideoPlayer.vue
+++ b/src/components/previews/VideoPlayer.vue
@@ -792,9 +792,27 @@ export default {
     },
 
     onFullscreenClicked () {
+      /** @lends fabric.IText.prototype */
+      // fix for : IText not editable when canvas is in a fullscreen
+      // element on chrome
+      // https://github.com/fabricjs/fabric.js/issues/5126
+      const originalInitHiddenTextarea =
+        fabric.IText.prototype.initHiddenTextarea
       if (this.isFullScreen()) {
+        fabric.util.object.extend(fabric.IText.prototype, {
+          initHiddenTextarea: function () {
+            originalInitHiddenTextarea.call(this)
+            fabric.document.body.appendChild(this.hiddenTextarea)
+          }
+        })
         this.exitFullScreen()
       } else {
+        fabric.util.object.extend(fabric.IText.prototype, {
+          initHiddenTextarea: function () {
+            originalInitHiddenTextarea.call(this)
+            this.canvas.wrapperEl.appendChild(this.hiddenTextarea)
+          }
+        })
         this.setFullScreen()
       }
     },


### PR DESCRIPTION
**Problem**
When on chrome and the player onn fullscreen, the user can't type Text annotation.

**Solution**
Added a patch that triggers on fullscreen and revert on exiting fullscreen allowing to type on chrome.
