### PR TITLE
add missing param checklist for commentTaskWithPreview

### DIFF
--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -484,9 +484,9 @@ const actions = {
 
   commentTaskWithPreview (
     { commit, getters, state, dispatch },
-    { taskId, commentText, taskStatusId, form, attachment }
+    { taskId, commentText, taskStatusId, form, attachment, checklist }
   ) {
-    const data = { taskId, taskStatusId, comment: commentText, attachment }
+    const data = { taskId, taskStatusId, comment: commentText, attachment, checklist }
     commit(ADD_PREVIEW_START)
     let newComment
     return tasksApi.commentTask(data)


### PR DESCRIPTION
**Problem**
Missing param `checklist` for `commentTaskWithPreview`

**Solution**
Added the missing param but it doesn't seem to fix the checklist issue when adding images to a comment. Anyway, it should be added.
