### PR TITLE
fix: text annotations consistent ratio

### DIFF
--- a/src/components/previews/VideoPlayer.vue
+++ b/src/components/previews/VideoPlayer.vue
@@ -973,7 +973,8 @@ export default {
               left: obj.left * scaleMultiplierX,
               top: obj.top * scaleMultiplierY,
               fontFamily: obj.fontFamily,
-              fontSize: obj.fontSize
+              fontSize: obj.fontSize,
+              width: obj.width * scaleMultiplierX
             }
           )
           this.fabricCanvas.add(text)

--- a/src/components/previews/annotation_mixin.js
+++ b/src/components/previews/annotation_mixin.js
@@ -178,12 +178,17 @@ export const annotationMixin = {
       const offsetCanvas = canvas.getBoundingClientRect()
       const posX = event.clientX - offsetCanvas.x
       const posY = event.clientY - offsetCanvas.y
+      const baseHeight = 140
+      let fontSize = 9
+      if (this.canvas.height > baseHeight) {
+        fontSize = fontSize * (this.canvas.height / baseHeight)
+      }
       const fabricText = new fabric.IText('Type…', {
         left: posX,
         top: posY,
         fontFamily: 'arial',
         fill: this.textColor,
-        fontSize: 20
+        fontSize: fontSize
       })
       this.fabricCanvas.add(fabricText)
       this.fabricCanvas.setActiveObject(fabricText)


### PR DESCRIPTION
**Problem**
Text annotations written on a player with a given size don't keep a consistent size ratio when opened on a player with a different size.

**Solution**
Fontsize is given to the shape when creating it, but loaded shapes have their width resized instead of changed fontsize.
