### PR TITLE
fix: path stroke ratio on videoplayer for annotation

### DIFF
--- a/src/components/previews/VideoPlayer.vue
+++ b/src/components/previews/VideoPlayer.vue
@@ -933,7 +933,7 @@ export default {
           fill: 'transparent',
           stroke: obj.stroke,
           strokeWidth: obj.strokeWidth,
-          radius: obj.radius,
+          radius: obj.radius * scaleMultiplierX,
           width: obj.width,
           height: obj.height,
           scaleX: obj.scaleX * scaleMultiplierX,
@@ -942,7 +942,7 @@ export default {
         if (obj.type === 'path') {
           let strokeMultiplier = 1
           if (obj.canvasWidth) {
-            strokeMultiplier = obj.canvasWidth / this.fabricCanvas.width
+            strokeMultiplier = annotation.width / this.fabricCanvas.width
           }
           const path = new fabric.Path(
             obj.path,


### PR DESCRIPTION
**Problem**
When a user draws an annotation path on smaller videoplayer then draw another one on the bigger player, stroke ratio is not respected.

**Solution**
Correction of the `strokeMutliplier` var with the right data, which would be `annnotation.width` instead of `obj.canvasWidth`
