### PR TITLE
Improve estimation workflow

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1146,7 +1146,7 @@ tbody:last-child .empty-line:last-child {
     .thumbnail-wrapper,
     .thumbnail-picture,
     .thumbnail-picture.thumbnail-empty {
-      margin: .35rem .35rem .35rem 0;
+      margin: 0 .35rem 0 0;
     }
 
     .thumbnail-wrapper {
@@ -1272,6 +1272,18 @@ tbody:last-child .empty-line:last-child {
     max-width: 30px;
     width: 30px;
     padding: .3rem;
+  }
+
+  .numeric-cell {
+    min-width: 80px;
+    max-width: 80px;
+    width: 80px;
+  }
+
+  .input.stylehidden {
+    border-color: transparent;
+    background-color: transparent;
+    box-shadow: none;
   }
 }
 

--- a/src/components/mixins/dom.js
+++ b/src/components/mixins/dom.js
@@ -1,0 +1,44 @@
+export const domMixin = {
+
+  created () {
+  },
+
+  mounted () {
+  },
+
+  beforeDestroy () {
+  },
+
+  computed: {
+  },
+
+  methods: {
+    focusInput (inputEl) {
+      inputEl.focus()
+      inputEl.setSelectionRange(0, inputEl.value.length)
+      inputEl.className = 'input'
+    },
+
+    onInputBlur (event) {
+      event.target.className = 'input stylehidden'
+    },
+
+    onInputMouseOut (event) {
+      if (document.activeElement !== event.target) {
+        event.target.className = 'input stylehidden'
+      }
+    },
+
+    onInputMouseOver (event) {
+      event.target.className = 'input'
+    },
+
+    pauseEvent (e) {
+      if (e.stopPropagation) e.stopPropagation()
+      if (e.preventDefault) e.preventDefault()
+      e.cancelBubble = true
+      e.returnValue = false
+      return false
+    }
+  }
+}

--- a/src/components/pages/Asset.vue
+++ b/src/components/pages/Asset.vue
@@ -39,9 +39,11 @@
       <div class="flexrow-item">
         <page-subtitle :text="$t('main.info')" />
         <div class="table-body">
-          <table class="table" v-if="currentAsset">
-            <tbody>
-              <tr>
+          <table class="datatable" v-if="currentAsset">
+            <tbody class="table-body">
+              <tr
+                class="datatable-row"
+              >
                 <td class="field-label">{{ $t('assets.fields.description') }}</td>
                 <description-cell
                   :entry="currentAsset"
@@ -50,6 +52,7 @@
               </tr>
               <tr
                 :key="descriptor.id"
+                class="datatable-row"
                 v-for="descriptor in assetMetadataDescriptors"
               >
                 <td class="field-label">{{ descriptor.name }}</td>

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1,5 +1,4 @@
 <template>
-
 <div class="task-type columns fixed-page">
   <div class="column main-column">
     <div class="task-type page" ref="page">
@@ -44,6 +43,11 @@
             <li :class="{'is-active': isActiveTab('schedule')}">
               <router-link :to="schedulePath">
                 {{ $t('schedule.title')}}
+              </router-link>
+            </li>
+            <li :class="{'is-active': isActiveTab('estimation')}">
+              <router-link :to="estimationPath">
+                {{ $t('estimation.title')}}
               </router-link>
             </li>
           </ul>
@@ -135,6 +139,18 @@
           @root-element-expanded="expandPersonElement"
         />
       </div>
+
+      <div
+        class="task-type-estimation flexrow-item"
+        v-if="isActiveTab('estimation')"
+      >
+        <estimation-helper
+          ref="estimation-widget"
+          :is-assets="isAssets"
+          :tasks="tasks"
+        />
+      </div>
+
     </div>
   </div>
 
@@ -173,10 +189,11 @@ import { ChevronLeftIcon } from 'vue-feather-icons'
 import ButtonSimple from '../widgets/ButtonSimple'
 import Combobox from '../widgets/Combobox'
 import ComboboxNumber from '../widgets/ComboboxNumber'
-import TaskInfo from '../sides/TaskInfo'
+import EstimationHelper from './tasktype/EstimationHelper'
 import Schedule from './schedule/Schedule'
 import SearchField from '../widgets/SearchField'
 import SearchQueryList from '../widgets/SearchQueryList'
+import TaskInfo from '../sides/TaskInfo'
 import TaskList from '../lists/TaskList'
 import TaskTypeName from '../widgets/TaskTypeName'
 
@@ -188,6 +205,7 @@ export default {
     ChevronLeftIcon,
     Combobox,
     ComboboxNumber,
+    EstimationHelper,
     Schedule,
     SearchField,
     SearchQueryList,
@@ -245,9 +263,7 @@ export default {
 
   mounted () {
     this.isAssets = this.$route.path.includes('assets')
-    if (this.$route.path.includes('schedule')) {
-      this.activeTab = 'schedule'
-    }
+    this.updateActiveTab()
     setTimeout(() => {
       this.initData(false)
     }, 100)
@@ -312,6 +328,10 @@ export default {
 
     schedulePath () {
       return this.getRoute('task-type-schedule')
+    },
+
+    estimationPath () {
+      return this.getRoute('task-type-estimation')
     },
 
     // Helpers
@@ -402,6 +422,8 @@ export default {
     updateActiveTab () {
       if (this.$route.path.indexOf('schedule') > 0) {
         this.activeTab = 'schedule'
+      } else if (this.$route.path.indexOf('estimation') > 0) {
+        this.activeTab = 'estimation'
       } else {
         this.activeTab = 'tasks'
       }
@@ -883,6 +905,7 @@ export default {
 .task-type {
   display: flex;
   flex-direction: column;
+  max-height: 100%;
 }
 
 .columns {
@@ -910,6 +933,7 @@ export default {
 
 .query-list {
   margin-bottom: 0;
+  margin-top: 0.2em;
   margin-left: 1em;
   min-height: 25px;
 }
@@ -925,5 +949,10 @@ export default {
 
 .zoom-level {
   margin-top: -8px;
+}
+
+.task-type-estimation {
+  display: flex;
+  max-height: calc(100% - 200px);
 }
 </style>

--- a/src/components/pages/tasktype/EstimationHelper.vue
+++ b/src/components/pages/tasktype/EstimationHelper.vue
@@ -1,0 +1,496 @@
+<template>
+<div class="estimation-wrapper">
+  <div
+    class="estimation-helper columns"
+  >
+    <div ref="body" class="task-list column datatable-wrapper">
+      <table class="datatable">
+        <thead ref="thead" class="datatable-head">
+          <tr>
+            <th class="assignees" ref="th-assignees">
+              {{ $t('tasks.fields.assignees') }}
+            </th>
+            <th class="thumbnail" ref="th-thumbnail">
+            </th>
+            <th class="asset-type" ref="th-type" v-if="isAssets">
+              {{ $t('tasks.fields.asset_type') }}
+            </th>
+            <th class="sequence" ref="th-type" v-else>
+              {{ $t('tasks.fields.sequence') }}
+            </th>
+            <th class="name" ref="th-name">
+              {{ $t('tasks.fields.entity_name') }}
+            </th>
+            <th class="frames numeric-cell" ref="th-frames" v-if="!isAssets">
+              {{ $t('tasks.fields.frames') }}
+            </th>
+            <th class="estimation numeric-cell" ref="th-estimation">
+              {{ $t('tasks.fields.estimation').substring(0, 3) }}.
+            </th>
+            <th class="empty" ref="">
+              &nbsp;
+            </th>
+          </tr>
+        </thead>
+
+        <tbody
+          class="datatable-body"
+        >
+          <tr
+            :ref="'task-' + task.id"
+            :key="task.id"
+            :class="{
+              'datatable-row': true,
+              selected: selectionGrid[task.id],
+              'task-line': true
+            }"
+            v-for="(task, index) in tasksByPerson"
+          >
+            <td class="assignees flexrow">
+              <people-avatar
+                class="flexrow-item"
+                :person="personMap[personId]"
+                :size="30"
+                :font-size="17"
+                v-for="personId in task.assignees"
+                :key="task.id + '-' + personId"
+                v-if="task.assignees.length > 1"
+              />
+              <span
+                class="flexrow"
+                :key="task.id + '-' + personId"
+                v-for="personId in task.assignees"
+                v-else
+              >
+                <people-avatar
+                  class="flexrow-item"
+                  :person="personMap[personId]"
+                  :size="30"
+                  :font-size="17"
+                />
+                <people-name
+                  class="flexrow-item"
+                  :person="personMap[personId]"
+                />
+              </span>
+            </td>
+            <td class="thumbnail">
+              <entity-thumbnail
+                :entity="getEntity(task.entity.id)"
+                :width="50"
+                :height="33"
+                :empty-width="50"
+                :empty-height="31"
+              />
+            </td>
+            <td class="asset-type" v-if="isAssets">
+              {{ getEntity(task.entity.id).asset_type_name }}
+            </td>
+            <td class="sequence" v-else>
+              {{ getEntity(task.entity.id).sequence_name }}
+            </td>
+            <td class="name">
+              {{ getEntity(task.entity.id).name }}
+            </td>
+            <td class="frames numeric-cell" v-if="!isAssets">
+              {{ getEntity(task.entity.id).nb_frames }}
+            </td>
+            <td
+              @click="selectTask($event, task, index)"
+              class="estimation numeric-cell"
+            >
+              <input
+                :ref="task.id + '-estimation'"
+                class="input stylehidden"
+                @blur="onInputBlur"
+                @change="estimationUpdated($event, task, index)"
+                @keydown="onKeyDown"
+                @mouseout="onInputMouseOut"
+                @mouseover="onInputMouseOver"
+                :value="formatEstimation(task.estimation)"
+              />
+            </td>
+            <td>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="person-list column datatable-wrapper">
+      <table class="datatable">
+        <thead ref="thead" class="datatable-head">
+          <tr>
+            <th class="assignees">
+              {{ $t('tasks.fields.assignees') }}
+            </th>
+            <th class="count numeric-cell">
+              {{ $t('tasks.fields.count') }}
+            </th>
+            <th class="estimation numeric-cell">
+              {{ $t('tasks.fields.estimation').substring(0, 3) }}.
+            </th>
+            <th class="quota numeric-cell">
+              {{ $t('tasks.fields.estimated_quota') }}.
+            </th>
+            <th class="empty">
+              &nbsp;
+            </th>
+          </tr>
+        </thead>
+
+        <tbody
+          class="datatable-body"
+        >
+          <tr
+            :ref="'person-' + person.id"
+            :key="person.id"
+            :class="{
+              'datatable-row': true,
+              'task-line': true
+            }"
+            v-for="person in assignees"
+          >
+            <td class="person flexrow">
+              <people-avatar
+                class="flexrow-item"
+                :person="person"
+                :size="30"
+                :font-size="17"
+              />
+              <people-name
+                class="flexrow-item"
+                :person="person"
+              />
+            </td>
+            <td class="count numeric-cell">
+              {{ person.count }}
+            </td>
+            <td class="estimation numeric-cell">
+              {{ person.estimation }}
+            </td>
+            <td class="quota numeric-cell">
+              {{ person.quota }}
+            </td>
+            <td>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+</template>
+
+<script>
+import Vue from 'vue'
+import { mapGetters, mapActions } from 'vuex'
+
+import EntityThumbnail from '@/components/widgets/EntityThumbnail'
+import PeopleAvatar from '@/components/widgets/PeopleAvatar'
+import PeopleName from '@/components/widgets/PeopleName'
+
+import { domMixin } from '@/components/mixins/dom'
+import { range } from '@/lib/time'
+import { frameToSeconds } from '@/lib/video'
+import firstBy from 'thenby'
+
+export default {
+  name: 'estimation-helper',
+
+  mixins: [domMixin],
+
+  components: {
+    EntityThumbnail,
+    PeopleAvatar,
+    PeopleName
+  },
+
+  props: {
+    isAssets: {
+      type: Boolean,
+      default: true
+    },
+    tasks: {
+      type: Array,
+      default: () => []
+    }
+  },
+
+  data () {
+    return {
+      lastSelection: 0,
+      lastShiftSelection: 0,
+      selectionGrid: {}
+    }
+  },
+
+  mounted () {
+    // this.clearSelection()
+  },
+
+  computed: {
+    ...mapGetters([
+      'assetMap',
+      'currentProduction',
+      'personMap',
+      'shotMap'
+    ]),
+
+    assignees () {
+      const assigneeSet = new Set()
+      const countMap = new Map()
+      const secondMap = new Map()
+      const estimationMap = new Map()
+      const assignees = []
+      this.tasks.forEach(task => {
+        const entity = this.getEntity(task.entity_id)
+        task.assignees.forEach(personId => {
+          assigneeSet.add(personId)
+          countMap.set(personId, (countMap.get(personId) || 0) + 1)
+          estimationMap.set(
+            personId,
+            (estimationMap.get(personId) || 0) + task.estimation
+          )
+          if (!this.isAssets) {
+            const seconds = frameToSeconds(
+              entity.nb_frames,
+              this.currentProduction,
+              entity
+            )
+            secondMap.set(personId, (secondMap.get(personId) || 0) + seconds)
+          }
+        })
+      })
+      assigneeSet.forEach(
+        (val, personId) => assignees.push(this.personMap[personId])
+      )
+      return assignees
+        .sort(firstBy('name'))
+        .map(person => {
+          const estimation = estimationMap.get(person.id) || 0
+          const nbSeconds = secondMap.get(person.id) || 0
+          return {
+            ...person,
+            count: countMap.get(person.id) || 0,
+            estimation,
+            quota: nbSeconds > 0 ? (estimation / nbSeconds).toFixed(2) : 0
+          }
+        })
+    },
+
+    tasksByPerson () {
+      return [...this.tasks].sort(firstBy(this.compareFirstAssignees))
+    }
+  },
+
+  methods: {
+    ...mapActions([
+      'updateTask'
+    ]),
+
+    getEntity (entityId) {
+      if (this.isAssets) {
+        return this.assetMap[entityId]
+      } else {
+        return this.shotMap[entityId]
+      }
+    },
+
+    compareFirstAssignees (a, b) {
+      if (a.assignees.length > 0 && b.assignees.length > 0) {
+        const personA = this.personMap[a.assignees[0]]
+        const personB = this.personMap[b.assignees[0]]
+        return personA.name.localeCompare(personB.name)
+      } else if (a.assignees.length > 0) {
+        return -1
+      } else if (b.assignees.length > 0) {
+        return 1
+      } else {
+        return 1
+      }
+    },
+
+    formatEstimation (estimation) {
+      if (estimation) {
+        return estimation
+      } else {
+        return 0
+      }
+    },
+
+    estimationUpdated (event, task) {
+      const value = event.target.value
+      if (value && value.length > 0) {
+        const estimation = Number(event.target.value)
+        this.saveEstimations(estimation, task)
+      }
+    },
+
+    saveEstimations (estimation, task) {
+      const selection = Object.keys(this.selectionGrid)
+      if (selection.length > 1) {
+        selection.forEach(taskId => {
+          this.updateTask({ taskId, data: { estimation } })
+            .catch(console.error)
+        })
+      } else {
+        this.updateTask({ taskId: task.id, data: { estimation } })
+          .catch(console.error)
+      }
+    },
+
+    onKeyDown (event) {
+      if (event.key === 'Tab') {
+        this.pauseEvent(event)
+        if (event.shiftKey) {
+          this.selectPrevious()
+        } else {
+          this.selectNext()
+        }
+      } else if (event.key === 'ArrowDown') {
+        this.pauseEvent(event)
+        this.selectNext(event.shiftKey)
+      } else if (event.key === 'ArrowUp') {
+        this.pauseEvent(event)
+        this.selectPrevious(event.shiftKey)
+      }
+    },
+
+    clearSelection () {
+      this.selectionGrid = {}
+    },
+
+    addToSelection (taskId) {
+      Vue.set(this.selectionGrid, taskId, true)
+    },
+
+    selectTask (event, task, index) {
+      if (event.shiftKey) {
+        if (!event.ctrlKey) this.clearSelection()
+        this.selectTaskRange(index)
+      } else {
+        if (!event.ctrlKey) this.clearSelection()
+        this.selectSingleTask(index)
+      }
+      this.focusInput(
+        this.$refs[this.tasksByPerson[index].id + '-estimation'][0]
+      )
+    },
+
+    selectPrevious (shiftKey) {
+      let index = this.lastSelection
+      index = (index - 1) < 0 ? index =
+        this.tasksByPerson.length - 1 : index - 1
+      this.selectTask({ shiftKey }, this.tasksByPerson[index], index)
+    },
+
+    selectNext (shiftKey) {
+      let index = this.lastSelection
+      index = (index + 1) >= this.tasksByPerson.length ? index = 0 : index + 1
+      this.selectTask({ shiftKey }, this.tasksByPerson[index], index)
+    },
+
+    selectSingleTask (index) {
+      const task = this.tasksByPerson[index]
+      this.addToSelection(task.id)
+      this.lastSelection = index
+      this.lastShiftSelection = index
+    },
+
+    selectTaskRange (index) {
+      let taskIndices = []
+      this.lastSelection = index
+      if (this.lastShiftSelection > index) {
+        taskIndices = range(index, this.lastShiftSelection)
+      } else {
+        taskIndices = range(this.lastShiftSelection, index)
+      }
+      const selection = taskIndices.map(i => this.tasksByPerson[i].id)
+      selection.forEach(taskId => {
+        this.addToSelection(taskId)
+      })
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+th {
+  padding: 0.4em 0;
+}
+
+td {
+  padding: 0;
+
+  &.thumbnail {
+    padding-top: 0.2em;
+  }
+
+  &.assignees {
+    padding-left: 0.4em;
+    padding-top: 0.2em;
+  }
+}
+
+.assignees {
+  min-width: 160px;
+  max-width: 220px;
+  width: 220px;
+
+  span {
+    margin-top: 0.2em;
+    margin-bottom: 0.2em;
+  }
+}
+
+.thumbnail {
+  min-width: 80px;
+  max-width: 80px;
+  width: 80px;
+}
+
+.asset-type {
+  min-width: 120px;
+  width: 120px;
+}
+
+.sequence {
+  min-width: 120px;
+  width: 120px;
+}
+
+.name {
+  min-width: 120px;
+  width: 120px;
+  font-weight: bold;
+}
+
+.estimation-helper {
+  max-height: 100%;
+}
+
+.estimation-wrapper {
+  flex: 1;
+}
+
+.columns {
+  margin-top: 1em;
+}
+
+.column {
+  padding: 0 1em 1em 1em;
+}
+
+.task-list {
+  flex: 2;
+}
+
+.person-list {
+  flex: 1;
+
+  td {
+    padding: 0.2em;
+  }
+}
+</style>

--- a/src/components/previews/PictureViewer.vue
+++ b/src/components/previews/PictureViewer.vue
@@ -835,6 +835,7 @@ export default {
         const previewId = this.preview.previews[this.currentIndex - 1].id
         this.picturePath = `/api/pictures/previews/preview-files/${previewId}.png`
       }
+      this.setPictureDlPath()
     },
 
     setPictureDlPath () {

--- a/src/components/previews/VideoPlayer.vue
+++ b/src/components/previews/VideoPlayer.vue
@@ -283,10 +283,11 @@ import Combobox from '../widgets/Combobox'
 import Spinner from '../widgets/Spinner'
 
 import { annotationMixin } from './annotation_mixin'
+import { domMixin } from '@/components/mixins/dom'
 
 export default {
   name: 'video-player',
-  mixins: [annotationMixin],
+  mixins: [annotationMixin, domMixin],
 
   components: {
     AnnotationBar,
@@ -1086,14 +1087,6 @@ export default {
 
     changeCurrentPreview (previewFile) {
       this.$emit('change-current-preview', previewFile)
-    },
-
-    pauseEvent (e) {
-      if (e.stopPropagation) e.stopPropagation()
-      if (e.preventDefault) e.preventDefault()
-      e.cancelBubble = true
-      e.returnValue = false
-      return false
     },
 
     onProgressMouseDown (e) {

--- a/src/components/widgets/EntityThumbnail.vue
+++ b/src/components/widgets/EntityThumbnail.vue
@@ -143,11 +143,11 @@ span.thumbnail-empty {
 }
 
 table .thumbnail-picture.thumbnail-empty {
-  margin: 5px;
+  margin: 0px;
 }
 
 table .thumbnail-picture {
-  margin: 7px 5px 0 5px;
+  margin: 0px;
 }
 
 </style>

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -76,3 +76,89 @@ export const getEndDateFromString = (startDate, endDateString) => {
     return startDate.clone().add('days', 1)
   }
 }
+
+export const formatSimpleDate = (date) => {
+  return moment(date).format('YYYY-MM-DD')
+}
+
+export const getDatesFromStartDate = (startDate, dueDate, estimation) => {
+  if (estimation && estimation > 0) {
+    dueDate = addBusinessDays(startDate, Math.ceil(estimation))
+  }
+
+  if (!startDate || !dueDate) {
+    const start = startDate ? formatSimpleDate(startDate) || startDate : null
+    const end = dueDate ? formatSimpleDate(dueDate) || dueDate : null
+    return {
+      start_date: start,
+      due_date: end
+    }
+  } else if (startDate.isAfter(dueDate)) {
+    return {
+      start_date: formatSimpleDate(startDate),
+      due_date: formatSimpleDate(startDate)
+    }
+  } else {
+    return {
+      start_date: formatSimpleDate(startDate),
+      due_date: formatSimpleDate(dueDate)
+    }
+  }
+}
+
+export const getDatesFromEndDate = (startDate, dueDate, estimation) => {
+  if (estimation && estimation > 0) {
+    startDate = removeBusinessDays(dueDate, Math.ceil(estimation))
+  }
+
+  if (!startDate || !dueDate) {
+    const start = startDate ? formatSimpleDate(startDate) || startDate : null
+    const end = dueDate ? formatSimpleDate(dueDate) || dueDate : null
+    return {
+      start_date: start,
+      due_date: end
+    }
+  } else if (startDate.isAfter(dueDate)) {
+    return {
+      start_date: formatSimpleDate(dueDate),
+      due_date: formatSimpleDate(dueDate)
+    }
+  } else {
+    return {
+      start_date: formatSimpleDate(startDate),
+      due_date: formatSimpleDate(dueDate)
+    }
+  }
+}
+
+export const addBusinessDays = (originalDate, numDaysToAdd) => {
+  const Sunday = 0
+  const Saturday = 6
+  let daysRemaining = numDaysToAdd
+  const newDate = originalDate.clone()
+
+  while (daysRemaining > 0) {
+    newDate.add(1, 'days')
+    if (newDate.day() !== Sunday && newDate.day() !== Saturday) {
+      daysRemaining--
+    }
+  }
+
+  return newDate
+}
+
+export const removeBusinessDays = (originalDate, numDaysToRemove) => {
+  const Sunday = 0
+  const Saturday = 6
+  let daysRemaining = numDaysToRemove
+  const newDate = originalDate.clone()
+
+  while (daysRemaining > 0) {
+    newDate.subtract(1, 'days')
+    if (newDate.day() !== Sunday && newDate.day() !== Saturday) {
+      daysRemaining--
+    }
+  }
+
+  return newDate
+}

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -136,6 +136,10 @@ export default {
     }
   },
 
+  estimation: {
+    title: 'Estimation'
+  },
+
   episodes: {
     all_episodes: 'All episodes',
     delete_error: 'An error occured while deleting this episode. There are probably data linked to it. Are you sure this episode has no sequence linked to it?',
@@ -740,11 +744,13 @@ export default {
     fields: {
       asset_type: 'Asset type',
       assignees: 'Assignees',
+      count: 'Count',
       due_date: 'Due date',
       duration: 'Duration',
       end_date: 'Validation date',
       entity: 'Entity',
       entity_name: 'Name',
+      estimated_quota: 'Avg. Quota',
       estimation: 'Estimation',
       frames: 'Fram.',
       last_comment: 'Last comment',

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -600,6 +600,11 @@ export const routes = [
             name: 'task-type-schedule',
             path: 'schedule',
             component: TaskType
+          },
+          {
+            name: 'task-type-estimation',
+            path: 'estimation',
+            component: TaskType
           }
         ]
       },
@@ -809,9 +814,14 @@ export const routes = [
         name: 'episode-task-type',
         children: [
           {
+            name: 'episode-task-type-schedule',
             path: 'schedule',
-            component: TaskType,
-            name: 'episode-task-type-schedule'
+            component: TaskType
+          },
+          {
+            name: 'episode-task-type-estimation',
+            path: 'estimation',
+            component: TaskType
           }
         ]
       },

--- a/src/store/api/tasks.js
+++ b/src/store/api/tasks.js
@@ -6,7 +6,7 @@ export default {
   },
 
   updateTask (taskId, data, callback) {
-    client.put(`/api/data/tasks/${taskId}`, data, callback)
+    return client.pput(`/api/data/tasks/${taskId}`, data, callback)
   },
 
   getTaskStatuses (callback) {

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -394,12 +394,11 @@ const actions = {
       const taskType = rootGetters.taskTypeMap[task.task_type_id]
 
       if (task && task.priority !== priority) {
-        tasksApi.updateTask(taskId, { priority }, (err, task) => {
-          if (!err) {
+        tasksApi.updateTask(taskId, { priority })
+          .then(task => {
             commit(EDIT_TASK_END, { task, taskType })
-          }
-          next(err)
-        })
+          })
+          .catch(next)
       } else {
         next()
       }
@@ -409,9 +408,11 @@ const actions = {
   },
 
   updateTask ({ commit }, { taskId, data }) {
-    return tasksApi.updateTask(taskId, data, () => {
-      commit(EDIT_TASK_DATES, { taskId, data })
-    })
+    commit(EDIT_TASK_DATES, { taskId, data })
+    return tasksApi.updateTask(taskId, data)
+      .then((task) => {
+        commit(EDIT_TASK_DATES, { taskId, data })
+      })
   },
 
   changeSelectedEstimations ({ commit, state, rootGetters }, estimation) {
@@ -420,10 +421,11 @@ const actions = {
         const task = state.taskMap[taskId]
         const taskType = rootGetters.taskTypeMap[task.task_type_id]
         if (task && task.estimation !== estimation) {
-          tasksApi.updateTask(taskId, { estimation }, (err, task) => {
-            if (!err) commit(EDIT_TASK_END, { task, taskType })
-            next(err)
-          })
+          tasksApi.updateTask(taskId, { estimation })
+            .then(task => {
+              commit(EDIT_TASK_END, { task, taskType })
+            })
+            .catch(next)
         } else {
           next()
         }


### PR DESCRIPTION
**Problem**

* There is no simple way to set estimations while seeing the impact on quotas.
* Dates cannot be edited through tables

**Solution**

* Add an estimation screen to task type pages. It allows to set estimations and see the implied quota in a panel nearby.
* Allow to edit dates through a date picker right from task table