### PR TITLE
Allow to save on-the-fly playlists as official playlist

### DIFF
--- a/src/components/modals/EditPlaylistModal.vue
+++ b/src/components/modals/EditPlaylistModal.vue
@@ -30,6 +30,7 @@
         <combobox
           :label="$t('playlists.fields.for_entity')"
           :options="forEntityOptions"
+          :disabled="typeDisabled"
           v-model="form.for_entity"
           v-if="!isEditing"
         />
@@ -65,13 +66,28 @@ export default {
     TextField
   },
 
-  props: [
-    'active',
-    'cancelRoute',
-    'isLoading',
-    'isError',
-    'playlistToEdit'
-  ],
+  props: {
+    active: {
+      type: Boolean,
+      value: false
+    },
+    isError: {
+      type: Boolean,
+      default: false
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
+    },
+    playlistToEdit: {
+      type: Object,
+      default: () => {}
+    },
+    typeDisabled: {
+      type: Boolean,
+      default: false
+    }
+  },
 
   data () {
     return {
@@ -133,7 +149,7 @@ export default {
       } else {
         this.form = {
           name: this.playlistToEdit.name,
-          for_entity: this.defaultForEntity,
+          for_entity: this.playlistToEdit.for_entity || this.defaultForEntity,
           for_client: 'false',
           is_for_all: this.currentEpisode && this.currentEpisode.id === 'all'
         }

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -895,15 +895,16 @@ export default {
       }
       this.loading.editPlaylist = true
       this.errors.editPlaylist = false
-      this.newPlaylist({
-        data: newPlaylist,
-        callback: (err, playlist) => {
-          if (err) this.errors.editPlaylist = true
+      this.newPlaylist(newPlaylist)
+        .then((playlist) => {
           this.$router.push(this.getPlaylistPath(playlist.id))
           this.loading.editPlaylist = false
           this.modals.isEditDisplayed = false
-        }
-      })
+        })
+        .catch((err) => {
+          console.error(err)
+          this.errors.editPlaylist = true
+        })
     },
 
     confirmEditPlaylist (form) {

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -344,10 +344,18 @@
 
     <span class="filler"></span>
 
+    <button-simple
+      @click="$emit('save-clicked')"
+      class="playlist-button flexrow-item"
+      :title="$t('playlists.actions.save_playlist')"
+      icon="save"
+      v-if="isCurrentUserManager"
+    />
     <div
       class="flexrow"
       v-if="!isCurrentUserCGArtist && (isCurrentEntityMovie || isCurrentEntityPicture)"
     >
+      <div class="separator"></div>
       <button-simple
         class="playlist-button flexrow-item"
         icon="undo"
@@ -675,17 +683,18 @@ export default {
       isCommentsHidden: true,
       isComparing: false,
       isDrawing: false,
-      isTyping: false,
+      isEntitiesHidden: false,
       isPlaying: false,
       isRepeating: false,
       isShowingPalette: false,
       isShowingPencilPalette: false,
-      isEntitiesHidden: false,
+      isTyping: false,
       maxDuration: '00:00.000',
       maxDurationRaw: 0,
       palette: ['#ff3860', '#008732', '#5E60BA', '#f57f17'],
       pencil: 'big',
       pencilPalette: ['big', 'medium', 'small'],
+      playlistToEdit: {},
       playingEntityIndex: 0,
       speed: 3,
       task: null,
@@ -693,18 +702,14 @@ export default {
       taskTypeToCompare: null,
       textColor: '#ff3860',
       modals: {
-        edit: false,
         delete: false,
         taskType: false
       },
       loading: {
-        playlists: false,
-        editPlaylist: false,
         deletePlaylist: false
       },
       errors: {
         playlists: false,
-        editPlaylist: false,
         deletePlaylist: false
       },
       forClientOptions: [
@@ -743,10 +748,12 @@ export default {
   computed: {
     ...mapGetters([
       'assetTaskTypes',
+      'currentEpisode',
       'currentProduction',
       'isCurrentUserCGArtist',
       'isCurrentUserClient',
       'isCurrentUserManager',
+      'isTVShow',
       'taskMap',
       'taskTypeMap',
       'shotTaskTypes',
@@ -970,7 +977,6 @@ export default {
     ...mapActions([
       'changePlaylistType',
       'deletePlaylist',
-      'editPlaylist',
       'removeBuildJob',
       'runPlaylistBuild'
     ]),

--- a/src/components/widgets/ButtonSimple.vue
+++ b/src/components/widgets/ButtonSimple.vue
@@ -15,6 +15,10 @@
     :class="iconClass"
     v-if="icon === 'redo'"
   />
+  <save-icon
+    :class="iconClass"
+    v-if="icon === 'save'"
+  />
   <plus-icon
     :class="iconClass"
     v-if="icon === 'plus'"
@@ -146,6 +150,7 @@ import {
   PlayIcon,
   PlusIcon,
   RotateCcwIcon,
+  SaveIcon,
   SkipBackIcon,
   SkipForwardIcon,
   TrashIcon,
@@ -177,6 +182,7 @@ export default {
     PlayIcon,
     PlusIcon,
     RotateCcwIcon,
+    SaveIcon,
     SkipBackIcon,
     SkipForwardIcon,
     TrashIcon,

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -407,6 +407,7 @@ export default {
     created_at: 'Created at:',
     delete_text: 'Are you sure you want to remove {name} from your database?',
     delete_error: 'An error occured while deleting this playlist.',
+    edit_error: 'An error occured while saving this playlist.',
     download_zip: 'Download .zip',
     failed: 'Failed',
     for_client: 'The client',
@@ -457,6 +458,7 @@ export default {
       play: 'Play',
       previous_frame: 'Previous frame',
       previous_shot: 'Previous shot',
+      save_playlist: 'Save playlist',
       speed: 'Change speed',
       split_screen: 'Split screen'
     }

--- a/src/store/api/playlists.js
+++ b/src/store/api/playlists.js
@@ -21,7 +21,7 @@ export default {
     return client.pget(path)
   },
 
-  newPlaylist (playlist, callback) {
+  newPlaylist (playlist) {
     const data = {
       name: playlist.name,
       project_id: playlist.production_id,
@@ -30,7 +30,7 @@ export default {
       for_entity: playlist.for_entity,
       is_for_all: playlist.is_for_all
     }
-    client.post('/api/data/playlists/', data, callback)
+    return client.ppost('/api/data/playlists/', data)
   },
 
   updatePlaylist (playlist, callback) {

--- a/src/store/modules/playlists.js
+++ b/src/store/modules/playlists.js
@@ -95,13 +95,13 @@ const actions = {
     return playlistsApi.getEntityPreviewFiles(entity)
   },
 
-  newPlaylist ({ commit }, { data, callback }) {
+  newPlaylist ({ commit }, data) {
     commit(EDIT_PLAYLIST_START, data)
-    playlistsApi.newPlaylist(data, (err, playlist) => {
-      if (err) commit(EDIT_PLAYLIST_ERROR)
-      else commit(EDIT_PLAYLIST_END, playlist)
-      if (callback) callback(err, playlist)
-    })
+    return playlistsApi.newPlaylist(data)
+      .then((playlist) => {
+        commit(EDIT_PLAYLIST_END, playlist)
+        return Promise.resolve(playlist)
+      })
   },
 
   editPlaylist ({ commit, rootGetters }, { data, callback }) {

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -1601,6 +1601,7 @@ const mutations = {
     let shots = cache.shots
     if (state.searchSequenceFilters.length > 0) {
       shots = applyFilters(cache.shots, state.searchSequenceFilters, {})
+      shots = shots.filter(shot => !shot.canceled)
     }
     state.sequenceStats = computeStats(
       shots,


### PR DESCRIPTION
**Problem**

* It's great to create temp playlists from lists but it's sad they can't be saved in the real playlist list.
* Sequence stats includes canceled shots

**Solution**

* Add a save button to temporary lists that allows to create a new playlist from the temp playlist modal. The playlist includes the current shot selection.
* Remove canceled shots from sequence stats
