### PR TITLE
Allow to delete a task column only for current list

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -241,6 +241,13 @@ export default {
         }
       },
 
+      'task:delete' (eventData) {
+        const task = this.taskMap[eventData.task_id]
+        if (task) {
+          this.$store.commit('DELETE_TASK_END', task)
+        }
+      },
+
       'task-type:new' (eventData) {
         if (!this.taskTypeMap[eventData.task_type_id]) {
           this.loadTaskType(eventData.task_type_id)

--- a/src/components/lists/EntityTaskList.vue
+++ b/src/components/lists/EntityTaskList.vue
@@ -29,7 +29,7 @@
     <table class="datatable">
       <tbody class="datatable-body">
         <tr
-          :key="taskId"
+          :key="typeof (taskId) === 'string' ? taskId : taskId.id"
           :class="{
             selected: currentTask && currentTask.id === taskId,
             'datatable-row': true,

--- a/src/components/modals/EditAssetModal.vue
+++ b/src/components/modals/EditAssetModal.vue
@@ -175,6 +175,7 @@ export default {
       'currentProduction',
       'currentEpisode',
       'episodes',
+      'productionAssetTypes',
       'productionAssetTypeOptions',
       'isTVShow',
       'openProductions'
@@ -237,8 +238,9 @@ export default {
 
     resetForm () {
       if (!this.isEditing()) {
-        if (!this.form.entity_type_id && this.assetTypes.length > 0) {
-          this.form.entity_type_id = this.assetTypes[0].id
+        if (!this.form.entity_type_id &&
+            this.productionAssetTypes.length > 0) {
+          this.form.entity_type_id = this.productionAssetTypes[0].id
         }
         if (this.openProductions.length > 0) {
           this.form.project_id =

--- a/src/components/modals/HardDeleteModal.vue
+++ b/src/components/modals/HardDeleteModal.vue
@@ -18,7 +18,15 @@
         />
       </p>
       <p class="is-danger" v-if="isError">{{ errorText }}</p>
-      <p class="has-text-right">
+      <div class="has-text-right flexrow">
+        <div class="filler"></div>
+        <combobox
+          class="flexrow-item"
+          :options="selectionOptions"
+          :with-margin="false"
+          v-model="selectionOnly"
+          v-if="selectionOption"
+        />
         <a
           :class="{
             button: true,
@@ -26,7 +34,7 @@
             'is-loading': isLoading
           }"
           :disabled="isLocked"
-          @click="$emit('confirm')">
+          @click="$emit('confirm', selectionOnly === 'true')">
           {{ $t("main.confirmation") }}
         </a>
         <button
@@ -35,7 +43,7 @@
         >
           {{ $t('main.cancel') }}
         </button>
-      </p>
+      </div>
     </div>
   </div>
 </div>
@@ -43,15 +51,26 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import { modalMixin } from './base_modal'
+import { modalMixin } from '@/components/modals/base_modal'
+
+import Combobox from '@/components/widgets/Combobox'
 
 export default {
   name: 'hard-delete-modal',
   mixins: [modalMixin],
 
+  components: {
+    Combobox
+  },
+
   data () {
     return {
-      userLockText: ''
+      userLockText: '',
+      selectionOnly: 'true',
+      selectionOptions: [
+        { label: this.$t('tasks.for_selection'), value: 'true' },
+        { label: this.$t('tasks.for_project'), value: 'false' }
+      ]
     }
   },
 
@@ -79,6 +98,10 @@ export default {
     lockText: {
       type: String,
       default: 'locked'
+    },
+    selectionOption: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -115,6 +138,11 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.flexrow {
+  align-items: center;
+  justify-content: center;
+}
+
 .input {
   margin-bottom: 1em;
 }

--- a/src/components/pages/Asset.vue
+++ b/src/components/pages/Asset.vue
@@ -317,18 +317,16 @@ export default {
       form.id = this.currentAsset.id
       this.loading.edit = true
       this.errors.edit = false
-      this.editAsset({
-        data: form,
-        callback: (err) => {
-          if (err) {
-            this.loading.edit = false
-            this.errors.edit = true
-          } else {
-            this.loading.edit = false
-            this.modals.edit = false
-          }
-        }
-      })
+      this.editAsset(form)
+        .then(() => {
+          this.loading.edit = false
+          this.modals.edit = false
+        })
+        .catch((err) => {
+          console.error(err)
+          this.loading.edit = false
+          this.errors.edit = true
+        })
     },
 
     onTaskSelected (task) {

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -147,6 +147,7 @@
     :text="deleteAllTasksText()"
     :error-text="$t('tasks.delete_all_error')"
     :lock-text="deleteAllTasksLockText"
+    :selection-option="true"
     @confirm="confirmDeleteAllTasks"
     @cancel="modals.isDeleteAllTasksDisplayed = false"
   />
@@ -470,7 +471,7 @@ export default {
       'changeAssetSort',
       'commentTaskWithPreview',
       'createTasks',
-      'deleteAllTasks',
+      'deleteAllAssetTasks',
       'deleteAsset',
       'deleteMetadataDescriptor',
       'editAsset',
@@ -616,17 +617,17 @@ export default {
       })
     },
 
-    confirmDeleteAllTasks () {
+    confirmDeleteAllTasks (selectionOnly) {
       const taskTypeId = this.taskTypes.find(
         t => t.name === this.deleteAllTasksLockText
       ).id
       const projectId = this.currentProduction.id
       this.errors.deleteAllTasks = false
       this.loading.deleteAllTasks = true
-      this.deleteAllTasks({ projectId, taskTypeId })
+      this.deleteAllAssetTasks({ projectId, taskTypeId, selectionOnly })
         .then(() => {
           this.loading.deleteAllTasks = false
-          this.loadAssets()
+          if (!selectionOnly) this.loadAssets()
           this.modals.isDeleteAllTasksDisplayed = false
         }).catch((err) => {
           console.error(err)

--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -325,18 +325,16 @@ export default {
       form.id = this.currentShot.id
       this.loading.edit = true
       this.errors.edit = false
-      this.editShot({
-        data: form,
-        callback: (err) => {
-          if (err) {
-            this.loading.edit = false
-            this.errors.edit = true
-          } else {
-            this.loading.edit = false
-            this.modals.edit = false
-          }
-        }
-      })
+      this.editShot(form)
+        .then(() => {
+          this.loading.edit = false
+          this.modals.edit = false
+        })
+        .catch((err) => {
+          console.error(err)
+          this.loading.edit = false
+          this.errors.edit = true
+        })
     },
 
     onTaskSelected (task) {

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -163,6 +163,7 @@
     :text="deleteAllTasksText()"
     :error-text="$t('tasks.delete_all_error')"
     :lock-text="deleteAllTasksLockText"
+    :selection-option="true"
     @cancel="modals.isDeleteAllTasksDisplayed = false"
     @confirm="confirmDeleteAllTasks"
   />
@@ -488,7 +489,7 @@ export default {
       'addMetadataDescriptor',
       'changeShotSort',
       'commentTaskWithPreview',
-      'deleteAllTasks',
+      'deleteAllShotTasks',
       'deleteShot',
       'deleteMetadataDescriptor',
       'editShot',
@@ -589,16 +590,15 @@ export default {
         })
     },
 
-    confirmDeleteAllTasks () {
+    confirmDeleteAllTasks (selectionOnly) {
       const taskTypeId = this.taskTypeForTaskDeletion.id
       const projectId = this.currentProduction.id
       this.errors.deleteAllTasks = false
       this.loading.deleteAllTasks = true
-      this.deleteAllTasks({ projectId, taskTypeId })
+      this.deleteAllShotTasks({ projectId, taskTypeId, selectionOnly })
         .then(() => {
           this.loading.deleteAllTasks = false
           this.modals.isDeleteAllTasksDisplayed = false
-          this.loadShots()
         }).catch((err) => {
           console.error(err)
           this.loading.deleteAllTasks = false

--- a/src/components/widgets/Combobox.vue
+++ b/src/components/widgets/Combobox.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="field">
+<div :class="{ field: withMargin }">
   <label class="label" v-if="label.length > 0">
     {{ label }}
   </label>
@@ -77,6 +77,10 @@ export default {
     },
     width: {
       type: Number
+    },
+    withMargin: {
+      default: true,
+      type: Boolean
     }
   },
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -748,6 +748,8 @@ export default {
     download_pdf_file: 'Download .{extension} file',
     feedback: 'feedback',
     full_screen: 'Display in full screen',
+    for_selection: 'For selection',
+    for_project: 'For project',
     hide_assignations: 'Hide assignations',
     hide_infos: 'Hide additional information',
     my_tasks: 'My tasks',

--- a/src/store/api/shots.js
+++ b/src/store/api/shots.js
@@ -80,7 +80,8 @@ export default {
         fps: shot.fps
       })
     }
-    return client.pput(`/api/data/entities/${shot.id}`, data)
+    const path = `/api/data/entities/${shot.id}`
+    return client.pput(path, data)
   },
 
   updateSequence (sequence) {

--- a/src/store/api/tasks.js
+++ b/src/store/api/tasks.js
@@ -124,11 +124,17 @@ export default {
     client.del(`/api/data/tasks/${task.id}?force=true`, callback)
   },
 
-  deleteAllTasks (projectId, taskTypeId, callback) {
-    client.del(
-      `/api/data/projects/${projectId}/task-types/${taskTypeId}/tasks`,
-      callback
-    )
+  deleteAllTasks (projectId, taskTypeId, taskIds) {
+    if (taskIds.length > 0) {
+      return client.ppost(
+        `/api/actions/projects/${projectId}/delete-tasks`,
+        taskIds
+      )
+    } else {
+      return client.pdel(
+        `/api/actions/projects/${projectId}/task-types/${taskTypeId}/delete-tasks`
+      )
+    }
   },
 
   addPreview (data) {

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -606,6 +606,18 @@ const actions = {
     commit(CHANGE_ASSET_SORT, {
       taskStatusMap, taskTypeMap, taskMap, production, persons, sorting
     })
+  },
+
+  deleteAllAssetTasks (
+    { commit, dispatch, state }, { projectId, taskTypeId, selectionOnly }
+  ) {
+    let taskIds = []
+    if (selectionOnly) {
+      taskIds = cache.result
+        .filter(a => a.validations[taskTypeId])
+        .map(a => a.validations[taskTypeId])
+    }
+    return dispatch('deleteAllTasks', { projectId, taskTypeId, taskIds })
   }
 }
 

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -1024,6 +1024,18 @@ const actions = {
     commit(CHANGE_SHOT_SORT, {
       taskStatusMap, taskTypeMap, taskMap, persons, production, sorting
     })
+  },
+
+  deleteAllShotTasks (
+    { commit, dispatch, state }, { projectId, taskTypeId, selectionOnly }
+  ) {
+    let taskIds = []
+    if (selectionOnly) {
+      taskIds = cache.result
+        .filter(a => a.validations[taskTypeId])
+        .map(a => a.validations[taskTypeId])
+    }
+    return dispatch('deleteAllTasks', { projectId, taskTypeId, taskIds })
   }
 }
 

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -335,13 +335,8 @@ const actions = {
     })
   },
 
-  deleteAllTasks ({ commit, state }, { projectId, taskTypeId }) {
-    return new Promise((resolve, reject) => {
-      tasksApi.deleteAllTasks(projectId, taskTypeId, (err) => {
-        if (err) reject(err)
-        else resolve()
-      })
-    })
+  deleteAllTasks ({ commit, state }, { projectId, taskTypeId, taskIds }) {
+    return tasksApi.deleteAllTasks(projectId, taskTypeId, taskIds)
   },
 
   createTask (


### PR DESCRIPTION
**Problem**

* When you delete tasks via the task column deletion, it deletes tasks for the whole project. Which is very annoying when you do that while working on a TV Show.
* When you limit the asset types in a production, the default asset type used for creation is not the first of the list. It's still the first of your studio-wide asset type list.

**Solution**

* Add a combobox to deletion modal to tell if you want to delete tasks for the whole project or for current selection.
* Use the right asset type as default one
