### PR TITLE
Feature/russian locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,21 @@ To install the development environment, follow [the dedicated guide](https://kit
 
 ## Sponsors
 
-[![Les Fées Spéciales](https://www.cg-wire.com/images/logo-les-fees-speciales.png | width=100)](http://les-fees-speciales.coop)
-[![Cube](https://www.cg-wire.com/images/logo-cube.png | width=100)](https://www.cube-creative.com)
-[![TNZPV](https://www.cg-wire.com/images/logo-tnzpv.png | width=100)](https://nousvoir.com/en/home/)
-[![Karlab](https://www.cg-wire.com/images/logo-karlab.png | width=100)](https://www.karlab.fr)
-[![Lee Film](https://www.cg-wire.com/images/logo-lee.png | width=100)](https://leefilm.se)
-[![Miyu](https://www.cg-wire.com/images/logo-miyu.png | width=100)](https://miyu.fr)
+<a href="http://www.les-fees-speciales.coop">
+<img alt="Les Fées Spéciales" src="https://www.cg-wire.com/images/logo-les-fees-speciales.png" width=100 />
+</a>
+<a href="https://www.cube-creative.com">
+<img alt="Cube Creative" src="https://www.cg-wire.com/images/logo-cube.png" width=100 />
+</a>
+<a href="http://nousvoir.com/en/home">
+<img alt="TNZPV" src="https://www.cg-wire.com/images/logo-tnzpv.png" width=100 />
+</a>
+<a href="http://leefilm.se">
+<img alt="Lee Film" src="https://www.cg-wire.com/images/logo-lee.png" width=100 />
+</a>
+<a href="http://miyu.fr">
+<img alt="Miyu" src="https://www.cg-wire.com/images/logo-miyu" width=100 />
+</a>
 
 ## About authors
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To install the development environment, follow [the dedicated guide](https://kit
 <img alt="Lee Film" src="https://www.cg-wire.com/images/logo-lee.png" width=100 />
 </a>
 <a href="http://miyu.fr">
-<img alt="Miyu" src="https://www.cg-wire.com/images/logo-miyu" width=100 />
+<img alt="Miyu" src="https://www.cg-wire.com/images/logo-miyu.png" width=100 />
 </a>
 
 ## About authors

--- a/src/components/pages/Profile.vue
+++ b/src/components/pages/Profile.vue
@@ -76,6 +76,7 @@
               <option value="de_DE">German</option>
               <option value="fa_IR">Persian</option>
               <option value="es_ES">Spanish</option>
+              <option value="ru_RU">Russian</option>
               <option value="zh_Hans_CN">Chinese</option>
             </select>
           </span>

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -4,6 +4,7 @@ import de from './de'
 import fa from './fa'
 import fr from './fr'
 import zh from './zh'
+import ru from './ru'
 
 export default {
   de: de,
@@ -11,5 +12,6 @@ export default {
   es: es,
   fa: fa,
   fr: fr,
-  zh: zh
+  zh: zh,
+  ru: ru
 }

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -3,341 +3,341 @@ export default {
   assets: {
     cast_in: 'Используется в', // Cast in
     delete_error: 'Ошибка при удалении ассета. Вероятнее всего к нему привязаны какие-то данные. Вы уверены что этот ассет не связан с текущей задачей?', // An error occured while deleting this asset. There are probably data linked to it. Are you sure this asset type has no task linked to it?
-    delete_text: 'Are you sure you want to remove {name} from your database?',
-    edit_fail: 'Saving failed, it may be due to the fact that an asset with a similar name already exists.',
-    edit_success: 'Asset {name} successfully edited.',
-    edit_title: 'Edit asset',
-    empty_list: 'There is no asset in the production. What about creating some?',
-    empty_list_client: 'There is no asset in this production.',
-    new_asset: 'Create an asset',
-    new_assets: 'Add assets',
-    new_success: 'Asset {name} successfully created.',
-    no_cast_in: 'This asset is not cast in any shot.',
-    number: 'asset | assets',
-    restore_text: 'Are you sure you want to restore {name} into your database?',
-    restore_error: 'An error occured while restoring this asset.',
-    tasks: 'Asset tasks',
-    title: 'Assets',
+    delete_text: 'Уверены, что хотите удалить {name} из своей базы данных?', // Are you sure you want to remove {name} from your database?
+    edit_fail: 'Не удалось сохранить. Возможно, что файл с таким же названием уже существует.', // Saving failed, it may be due to the fact that an asset with a similar name already exists.
+    edit_success: 'Ассет {name} успешно изменён.', // Asset {name} successfully edited.
+    edit_title: 'Редактировать ассет', // Edit asset
+    empty_list: 'В проекте нет ни одного ассета. Не хотите ли создать?', // There is no asset in the production. What about creating some?
+    empty_list_client: 'В этом проекте нет ни одного ассета.', // There is no asset in this production.
+    new_asset: 'Создать ассет', // Create an asset
+    new_assets: 'Добавить ассеты', // Add assets
+    new_success: 'Ассет {name} успешно создан.', // Asset {name} successfully created.
+    no_cast_in: 'Этот ассет не задействован ни в одном шоте.', // This asset is not cast in any shot.
+    number: 'ассет | ассеты', // asset | assets
+    restore_text: 'Вы уверены, что хотите восстановить {name} в вашей базе данных?', // Are you sure you want to restore {name} into your database?
+    restore_error: 'Ошибка при восстановлении ассета.', // An error occured while restoring this asset.
+    tasks: 'Задачи ассета', // Asset tasks
+    title: 'Ассеты', // Assets
     fields: {
-      description: 'Description',
-      episode: 'Ep.',
-      name: 'Name',
-      production: 'Prod',
-      time_spent: 'Time',
-      type: 'Type',
-      hidden_from_client: 'Displayed to client'
+      description: 'Описание', // Description
+      episode: 'Эп.', // Ep.
+      name: 'Назв.', // Name
+      production: 'Проект', // Prod
+      time_spent: 'Время', // Time
+      type: 'Тип', // Type
+      hidden_from_client: 'Отображено клиенту' // Displayed to client
     }
   },
 
   asset_types: {
-    all_asset_types: 'All asset types',
-    create_error: 'An error occured while saving this asset type. Are you sure there is no asset type with similar name?',
-    delete_text: 'Are you sure you want to remove {name} from your database?',
-    delete_error: 'An error occured while deleting this asset type. There are probably data linked to it. Are you sure this asset type has no asset linked to it?',
-    edit_title: 'Edit asset type',
-    new_asset_type: 'Add an asset type',
-    number: 'asset type | asset types',
-    title: 'Asset Types',
-    production_title: 'Asset Types Stats',
+    all_asset_types: 'Все типы ассетов', // All asset types
+    create_error: 'Ошибка при сохранении этого типа ассетов. Вы уверены, что нет типа ассетов с таким же названием?', // An error occured while saving this asset type. Are you sure there is no asset type with similar name?
+    delete_text: 'Вы уверены, что хотите удалить {name} из своей базы данных?', // Are you sure you want to remove {name} from your database?
+    delete_error: 'Ошибка при удалении этого типа ассетов. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот тип ассетов не связан с каким-либо ассетом?', // An error occured while deleting this asset type. There are probably data linked to it. Are you sure this asset type has no asset linked to it?
+    edit_title: 'Редактировать тип ассетов', // Edit asset type
+    new_asset_type: 'Добавить тип ассетов', // Add an asset type
+    number: 'тип ассетов | типы ассетов', // asset type | asset types
+    title: 'Типы Ассетов', // Asset Types
+    production_title: 'Стат. Типов Ассетов', // Asset Types Stats
     fields: {
-      name: 'Name'
+      name: 'Назв.' // Name
     }
   },
 
   breakdown: {
-    all_assets: 'All available assets',
-    edit_label: 'Change the asset\'s label',
+    all_assets: 'Все доступные ассеты', // All available assets
+    edit_label: 'Изменить метку ассета', // Change the asset\'s label
     empty: 'Empty casting',
-    label: 'Label',
-    picture_mode: 'Switch to picture mode',
-    text_mode: 'Switch to text mode',
+    label: 'Метка', // Label
+    picture_mode: 'Перепключиться в режим изображения', // Switch to picture mode
+    text_mode: 'Перепключиться в режим текста', // Switch to text mode
     title: 'Breakdown',
     options: {
       fixed: 'fixed',
-      animate: 'animate'
+      animate: 'анимировать' // animate
     }
   },
 
   comments: {
-    add_attachment: 'Add attachment',
-    add_checklist: 'Add checklist',
-    add_comment: 'Add a comment...',
-    add_preview: 'Attach preview',
-    change_preview: 'Change preview',
-    comment_from_client: 'Comment from client',
-    edit_title: 'Edit comment',
-    empty_text: 'This comment is empty',
-    edit_error: 'An error occured while editing comment. Please contact our support team.',
-    error: 'An error occured while posting comment',
-    no_file_attached: 'No file attached',
-    pin: 'Pin',
-    pinned: 'Pinned',
-    post_status: 'Post comment',
+    add_attachment: 'Добавить вложение', // Add attachment
+    add_checklist: 'Добавить чеклист', // Add checklist
+    add_comment: 'Оставить комментарий...', // Add a comment...
+    add_preview: 'Добавить превью', // Attach preview
+    change_preview: 'Изменить превью', // Change preview
+    comment_from_client: 'Комментарий клиента', // Comment from client
+    edit_title: 'Редактировать комментарий', // Edit comment
+    empty_text: 'Этот комментарий пустой', // This comment is empty
+    edit_error: 'Ошибка при редактировании комментария. Пожалуйста, обратитесь в поддержку.', // An error occured while editing comment. Please contact our support team.
+    error: 'Ошибка при размещении комментария', // An error occured while posting comment
+    no_file_attached: 'Файл не прикреплён', // No file attached
+    pin: 'Закрепить', // Pin
+    pinned: 'Закреплено', // Pinned
+    post_status: 'Опубликовать комментарий', // Post comment
     retake: 'Retake',
-    revision: 'revision',
-    set_status_to: 'Set status to',
+    revision: 'ревизия', // revision
+    set_status_to: 'Установить статус', // Set status to
     task_placeholder: 'New item...',
-    text: 'Text',
-    unpin: 'Unpin',
-    validated: 'Validated!',
-    validation_required: 'Validation Required',
+    text: 'Текст', // Text
+    unpin: 'Открепить', // Unpin
+    validated: 'Проверено!', // Validated!
+    validation_required: 'Необходима Проверка', // Validation Required
     fields: {
-      text: 'text'
+      text: 'текст' // text
     }
   },
 
   custom_actions: {
-    create_error: 'An error occured while saving this custom custom action. Are you sure that there is no other action with the same name?',
-    delete_text: 'Are you sure you want to remove custom action {name} from your database?',
-    delete_error: 'An error occured while deleting this custom custom action.',
-    edit_title: 'Edit a custom action',
-    new_custom_action: 'Add a custom action',
-    number: 'custom action | custom actions',
-    run_for_selection: 'Run custom action for selected tasks:',
-    title: 'Custom Actions',
+    create_error: 'Ошибка при сохранении этого специального действия. Вы уверены, что нет действия с таким же названием?', // An error occured while saving this custom custom action. Are you sure that there is no other action with the same name?
+    delete_text: 'Уверены, что хотите удалить специальное действие {name} из своей базы данных?', // Are you sure you want to remove custom action {name} from your database?
+    delete_error: 'Ошибка при удалении этого специального действия', // An error occured while deleting this custom custom action.
+    edit_title: 'Редактировать специальное действие', // Edit a custom action
+    new_custom_action: 'Добавить специальное действие', // Add a custom action
+    number: 'специальное действие | специальные действия', // custom action | custom actions
+    run_for_selection: 'Выполнить специальное действие для следующих задач:', // Run custom action for selected tasks:
+    title: 'Специальные Действия', // Custom Actions
     fields: {
-      name: 'Name',
+      name: 'Назв.', // Name
       url: 'URL',
-      entity_type: 'Entity Type',
-      is_ajax: 'Use AJAX'
+      entity_type: 'Тип Объекта', // Entity Type
+      is_ajax: 'Исп. AJAX' // Use AJAX
     },
     entity_types: {
-      all: 'All',
-      shot: 'Shot',
-      asset: 'Asset'
+      all: 'Все', // All
+      shot: 'Шот', // Shot
+      asset: 'Ассет' // Asset
     }
   },
 
   entities: {
     build_filter: {
-      asset_type: 'Asset type',
-      all_types: 'All asset types',
-      assignation: 'Assignation',
+      asset_type: 'Тип ассетов', // Asset type
+      all_types: 'Все типы ассетов', // All asset types
+      assignation: 'Назначение', // Assignation
       assignation_exists_for: 'Assignations exists for',
       assigned_to: 'Assigned to',
       descriptor: 'Metadata',
       equal: 'Equal',
-      in: 'In',
+      in: 'В', // In
       no_assignation_for: 'No assignation exists for',
-      no_filter: 'No filter',
+      no_filter: 'Нет фильтра', // No filter
       not_equal: 'Not equal',
       not_assigned_to: 'Not assigned to',
-      status: 'Task status',
+      status: 'Статус задачи', // Task status
       thumbnail: 'Thumbnail presence',
       title: 'Filter on...',
       union_and: 'Match all the following filters',
       union_or: 'Match one of the following filters',
-      with_thumbnail: 'With thumbnail',
-      without_thumbnail: 'Without thumbnail'
+      with_thumbnail: 'С ярлыком', // With thumbnail
+      without_thumbnail: 'Без ярлыка' // Without thumbnail
     },
 
     thumbnails: {
       error: 'An error occured while uploading thumbnails',
-      explaination: 'Adding a thumbnail requires to set a new preview. In order to set several thumbnails at the same time, you must chose first a task type that will be used to create the new previews. The thumbnails will be set from this new preview.',
-      explaination_two: 'Then you have to select the files you want to upload. To find the right entities, the file names must match the following pattern:',
-      shots_pattern: '"SequenceName ShotName" eg. SQ01_SH01.',
-      assets_pattern: '"AssetType AssetName" eg. Environment_Forest.',
-      select_files: 'Select Files',
-      selected_files: 'Selected Files',
-      select_task_type: 'Select Task Type',
-      title: 'Add Thumbnails',
-      undefined: 'Undefined',
-      undefined_pattern: 'Undefined',
-      upload: 'Add Thumbnails'
+      explaination: 'Для добавления ярлыка нужно новое превью. Чтобы сделать сразу несколько ярлыков, необходимо сначала выбрать тип задачи для создания новых превью. Ярлыки будут сделаны на основании этого нового превью.', // Adding a thumbnail requires to set a new preview. In order to set several thumbnails at the same time, you must chose first a task type that will be used to create the new previews. The thumbnails will be set from this new preview.
+      explaination_two: 'Далее выберите файлы для использования. Чтобы найти правильные объекты, имена файлов должны соответсвовать шаблону:', // Then you have to select the files you want to upload. To find the right entities, the file names must match the following pattern:
+      shots_pattern: '"SequenceName ShotName" пр. SQ01_SH01.', // "SequenceName ShotName" eg. SQ01_SH01.
+      assets_pattern: '"AssetType AssetName" пр. Окружение_Лес.', // "AssetType AssetName" eg. Environment_Forest.
+      select_files: 'Выбрать Файлы', // Select Files
+      selected_files: 'Выбранные Файлы', // Selected Files
+      select_task_type: 'Выбрать Тип Задачи', // Select Task Type
+      title: 'Добавить Ярлыки', // Add Thumbnails
+      undefined: 'Неопределён', // Undefined
+      undefined_pattern: 'Неопределён', // Undefined
+      upload: 'Добавить Ярлыки' // Add Thumbnails
     }
   },
 
   estimation: {
-    title: 'Estimation'
+    title: 'Вычисление' // Estimation
   },
 
   episodes: {
-    all_episodes: 'All episodes',
-    edit_error: 'An error occured while saving this episode. Are you sure there is no episode with similar name?',
-    delete_error: 'An error occured while deleting this episode. There are probably data linked to it. Are you sure this episode has no sequence linked to it?',
-    delete_text: 'Are you sure you want to remove {name} from your database? Every related shots and previews will be deleted. Pleas confirm by typing the episode name below.',
-    edit_title: 'Edit episode',
-    empty_list: 'There is no episode in the production. What about creating some?',
-    empty_list_client: 'There is no episode in this production.',
-    new_episode: 'New episode',
-    number: 'episode | episodes',
-    title: 'Episode Stats',
+    all_episodes: 'Все эпизоды', // All episodes
+    edit_error: 'Ошибка при сохранении этого эпизода. Вы уверены, что нет эпизода с таким же названием?', // An error occured while saving this episode. Are you sure there is no episode with similar name?
+    delete_error: 'Ошибка при удалении этого эпизода. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот тип ассетов не связан с какой-либо секвенция?', // An error occured while deleting this episode. There are probably data linked to it. Are you sure this episode has no sequence linked to it?
+    delete_text: 'Are you sure you want to remove {name} from your database? Every related shots and previews will be deleted. Pleas confirm by typing the episode name below.', // Are you sure you want to remove {name} from your database? Every related shots and previews will be deleted. Pleas confirm by typing the episode name below.
+    edit_title: 'Редактировать эпизод', // Edit episode
+    empty_list: 'В проекте нет ни одного эпизода. Не хотите ли создать?', // There is no episode in the production. What about creating some?
+    empty_list_client: 'В этом проекте нет ни одного эпизода.', // There is no episode in this production.
+    new_episode: 'Новый эпизод', // New episode
+    number: 'эпизод | эпизоды', // episode | episodes
+    title: 'Статистика эпизода', // Episode Stats
     fields: {
-      name: 'name',
-      description: 'description'
+      name: 'назв.', // name
+      description: 'описание' // description
     }
   },
 
   keyboard: {
     altdown: 'Move task selection down',
-    altj: 'Select previous preview',
-    altk: 'Select next preview',
+    altj: 'Выбрать предыдущее превью ', // Select previous preview
+    altk: 'Выбрать следующее превью', // Select next preview
     altleft: 'Move task selection left',
     altright: 'Move task selection right',
     altup: 'Move task selection up',
-    annotations: 'Annotations',
+    annotations: 'Аннотации', // Annotations
     draw: 'Set draw mode on',
-    navigation: 'Navigation',
-    redo: 'Redo',
-    undo: 'Undo',
-    playlist_navigation: 'Playlist navigation',
-    remove_annotation: 'Remove annotation',
-    shortcuts: 'Shortcuts'
+    navigation: '', // Navigation
+    redo: 'Повторить', // Redo
+    undo: 'Отменить', // Undo
+    playlist_navigation: 'Навигация по плейлисту', // Playlist navigation
+    remove_annotation: 'Убрать аннотацию', // Remove annotation
+    shortcuts: 'Ссылки' // Shortcuts
   },
 
   login: {
-    back_to_login: 'Go back to login page',
-    forgot_password: 'Forgot password?',
-    login: 'Log in',
-    login_failed: 'Log in failed, please verify your credentials',
-    login_page: 'Cancel',
-    redirecting: 'Redirecting in {secondsLeft} seconds...',
-    reset_change_password: 'Change password',
-    reset_change_password_form_failed: 'There is a problem with the password you gave. Please, verify that it is at least 7 chars long and that both passwords match.',
-    reset_change_password_failed: 'Changing password failed. Please, restart the whole procedure again.',
-    reset_change_password_succeed: 'Your password was changed successfully. Please, go back to the login page to use it.',
-    reset_change_password_title: 'Enter a new password',
-    reset_password: 'Reset Password',
+    back_to_login: 'Вернуться к регистрации', // Go back to login page
+    forgot_password: 'Забыли пароль?', // Forgot password?
+    login: 'Войти', // Log in
+    login_failed: 'Ошибка входа. Пожалуйста, подтвердите ваши полномочия', // Log in failed, please verify your credentials
+    login_page: 'Отмена', // Cancel
+    redirecting: 'Перенаправление через {secondsLeft} секунд...', // Redirecting in {secondsLeft} seconds...
+    reset_change_password: 'Сменить пароль', // Change password
+    reset_change_password_form_failed: 'С паролем, который вы дали, возникла проблема. Убедитесь в том, что он состоит как минимум из 7 знаков и что оба пароля совпадают', // There is a problem with the password you gave. Please, verify that it is at least 7 chars long and that both passwords match.
+    reset_change_password_failed: 'Не удалось изменить пароль. Пожалуйста, пройдите процедуру ещё раз.', // Changing password failed. Please, restart the whole procedure again.
+    reset_change_password_succeed: 'Ваш пароль успешно изменён. Пожалуйста вернитесь к регистрации, чтобы использовать его.', // Your password was changed successfully. Please, go back to the login page to use it.
+    reset_change_password_title: 'Введите новый пароль', // Enter a new password
+    reset_password: 'Сбросить Пароль', // Reset Password
     reset_password_failed: 'Resetting you password failed. Please verify your email.',
-    reset_password_succeed: 'Resetting your password succeeded. Please check your inbox.',
-    reset_password_title: 'Enter your email to reset your password',
-    title: 'Log in to Kitsu',
+    reset_password_succeed: 'Пароль успешно сброшен. Пожалуйста, проверьте вашу почту.', // Resetting your password succeeded. Please check your inbox.
+    reset_password_title: 'Введите вашу почту, чтобы сбросить пароль', // Enter your email to reset your password
+    title: 'Войти в Kitsu', // Log in to Kitsu
     fields: {
-      email: 'Email',
-      password: 'Password',
-      password2: 'Password again'
+      email: 'Почта', // Email
+      password: 'Пароль', // Password
+      password2: 'Пароль повторно' // Password again
     }
   },
 
   main: {
     about: 'About',
-    add: 'add',
-    all: 'All',
-    all_assets: 'All assets',
-    admin: 'Admin',
-    cancel: 'Cancel',
-    clear_selection: 'Clear current selection',
-    close: 'Close',
-    confirmation: 'Confirm',
-    confirmation_and_stay: 'Confirm and stay',
-    date: 'Date',
-    dark_theme: 'Dark Theme',
-    days_spent: 'day spent | days spent',
-    days_estimated: 'day estimated | days estimated',
-    delete: 'Delete',
-    delete_all: 'Delete all',
-    delete_text: 'Are you sure you want to remove {name} from your database?',
-    documentation: 'Documentation',
-    edit: 'Edit',
-    empty_comment: 'Empty comment',
-    end_date: 'End date',
-    files_selected: 'files selected',
-    for: 'For',
-    go_productions: 'Go to productions',
-    history: 'history',
-    info: 'Information',
-    or: 'or',
-    no: 'No',
-    loading: 'Loading...',
-    loading_data: 'Loading data',
-    loading_error: 'An error occured while loading data.',
+    add: 'добавить', // add
+    all: 'Все', // All
+    all_assets: 'Все ассеты', // All assets
+    admin: 'Администратор', // Admin
+    cancel: 'Отмена', // Cancel
+    clear_selection: 'Очистить выбранное', // Clear current selection
+    close: 'Закрыть', // Close
+    confirmation: 'Подтвердить', // Confirm
+    confirmation_and_stay: 'Подтвердить и остаться', // Confirm and stay
+    date: 'Дата', // Date
+    dark_theme: 'Тёмная Тема', // Dark Theme
+    days_spent: 'день потрачен | дней потрачено', // day spent | days spent
+    days_estimated: 'день ожидается | дней ожидается', // day estimated | days estimated
+    delete: 'Удалить', // Delete
+    delete_all: 'Удалить все', // Delete all
+    delete_text: 'Уверены, что хотите удалить {name} из своей базы данных?', // Are you sure you want to remove {name} from your database?
+    documentation: 'Документация', // Documentation
+    edit: 'Редактировать', // Edit
+    empty_comment: 'Пустой комментарий', // Empty comment
+    end_date: 'Дата окончания', // End date
+    files_selected: 'выбранные файлы', // files selected
+    for: 'Для', // For
+    go_productions: 'Перейти к проектам', // Go to productions
+    history: 'история', // history
+    info: 'Информация', // Information
+    or: 'или', // or
+    no: 'Нет', // No
+    loading: 'Загрузка...', // Loading...
+    loading_data: 'Загрузка данных', // Loading data
+    loading_error: 'Ошибка при загрузке данных', // An error occured while loading data.
     logout: 'Logout',
     modify: 'Modify',
-    minimize: 'Minimize',
+    minimize: 'Минимизировать', // Minimize
     main_pack: 'Main Pack',
-    maximize: 'Maximize',
+    maximize: 'Максимизировать', // Maximize
     nb_frames: 'frame | frames',
     person: 'Person',
-    profile: 'Profile',
-    production: 'Production',
+    profile: 'Профиль', // Profile
+    production: 'Проэкт', // Production
     remove: 'Remove',
-    save: 'Save',
-    sort_by: 'Sort by',
-    sorted_by: 'Sorted by',
-    start_date: 'Start date',
-    studio: 'Studio',
-    tutorials: 'Tutorials',
-    user: 'User',
-    white_theme: 'White Theme',
-    yes: 'Yes',
+    save: 'Схранить', // Save
+    sort_by: 'Сортировать', // Sort by
+    sorted_by: 'Отсортировано', // Sorted by
+    start_date: 'Дата начала', // Start date
+    studio: 'Студия', // Studio
+    tutorials: 'Руководства', // Tutorials
+    user: 'Пользователь', // User
+    white_theme: 'Белая Тема', // White Theme
+    yes: 'Да', // Yes
     csv: {
-      choose: 'Choose',
-      error_upload: 'An error occured while uploading your CSV.',
-      export_file: 'Export',
-      import_file: 'Import',
-      import_title: 'Import data from a CSV',
-      legend: 'Legend',
-      legend_ok: 'Recognized data',
-      legend_ignored: 'Ignored data',
-      legend_missing: 'Missing data',
-      legend_disabled: 'Data that will no be updated or created',
-      legend_overwrite: 'Data that will be updated',
-      paste: 'Paste',
-      paste_code: 'Please paste here your CSV data:',
-      preview: 'Preview',
-      preview_episode_name: 'Episode name',
-      preview_title: 'Preview of your imported data',
+      choose: 'Выбрать', // Choose
+      error_upload: 'Ошибка при загрузке вашего CSV.', // An error occured while uploading your CSV.
+      export_file: 'Экспортировать', // Export
+      import_file: 'Импортировать', // Import
+      import_title: 'импортировать данные с CSV', // Import data from a CSV
+      legend: 'Легенда', // Legend
+      legend_ok: 'Опознанные данные', // Recognized data
+      legend_ignored: 'Пропущенные данные', // Ignored data
+      legend_missing: 'Недостающие данные', // Missing data
+      legend_disabled: 'Данные не подлежащие обновлению или созданию', // Data that will no be updated or created
+      legend_overwrite: 'Данные подлежащие обновлению', // Data that will be updated
+      paste: 'Вставить', // Paste
+      paste_code: 'Вставьте сюда данные вашего CSV:', // Please paste here your CSV data:
+      preview: 'Превью', // Preview
+      preview_episode_name: 'Название эпизода', // Episode name
+      preview_title: 'Превью импортированных данных', // Preview of your imported data
       preview_description: 'Upload a .csv file to populate your board with posts.',
       preview_required: 'NB: Headers must be included as first row.',
       preview_reupload: 'Reupload .CSV file',
-      required_fields: 'Your CSV requires the following columns',
-      select_file: 'Please select a file from one of your folder:',
-      tab_select_file: 'Upload a CSV file',
-      tab_paste_code: 'Paste a CSV data',
-      unknown: 'Unknown column',
-      upload_file: 'Browse',
+      required_fields: 'Вашему CSV нужны следующие столбцы', // Your CSV requires the following columns
+      select_file: 'Выберите файл из одной из ваших папок:', // Please select a file from one of your folder:
+      tab_select_file: 'Загрузить файл CSV', // Upload a CSV file
+      tab_paste_code: 'Вставить данные CSV', // Paste a CSV data
+      unknown: 'Неизвестный столбец', // Unknown column
+      upload_file: 'Искать', // Browse
       options: {
-        title: 'Options',
-        update: 'Update existing data'
+        title: 'Опции', // Options
+        update: 'Обновить существующие данные' // Update existing data
       }
     }
   },
 
   menu: {
-    assign_tasks: 'Assign tasks',
-    change_priority: 'Change priority',
-    change_status: 'Change status',
-    create_tasks: 'Create tasks',
-    delete_tasks: 'Delete tasks',
-    generate_playlists: 'Generate playlists',
-    run_custom_action: 'Run custom action',
+    assign_tasks: 'Распределить задачи', // Assign tasks
+    change_priority: 'Изменить приоритет', // Change priority
+    change_status: 'Изменить статус', // Change status
+    create_tasks: 'Создать задачи', // Create tasks
+    delete_tasks: 'Удалить задачи', // Delete tasks
+    generate_playlists: 'Сгенерировать плейлист', // Generate playlists
+    run_custom_action: 'Запустить специальное действие', // Run custom action
     set_estimations: 'Set estimations'
   },
 
   news: {
-    all: 'All',
-    commented_on: 'commented on',
-    infos: 'Infos',
+    all: 'Все', // All
+    commented_on: 'прокомментировал(а)', // commented on
+    infos: 'Информация', // Infos
     no_news: 'There is no news for this production or for this filter.',
-    only_comments: 'Only comments',
-    only_previews: 'Only previews',
+    only_comments: 'Только комментарии', // Only comments
+    only_previews: 'Только превью', // Only previews
     set_preview_on: 'set preview on',
-    task_status: 'Task status',
-    task_type: 'Task type',
-    title: 'News Feed'
+    task_status: 'Статус задачи', // Task status
+    task_type: 'Тип задачи', // Task type
+    title: 'Лента новостей' // News Feed
   },
 
   not_found: {
-    text: 'There was something wrong with the link you clicked on, we encourage you to come back on the home page.',
-    title: 'Page not found... are your looking for something you deleted?'
+    text: 'Ссылка на которую вы кликнули ненадёжна, мы рекомендуем вам вернуться на главную страницу.', // There was something wrong with the link you clicked on, we encourage you to come back on the home page.
+    title: 'Страница не найдена...  вы ищете что-то, что уже удалили?' // Page not found... are your looking for something you deleted?
   },
 
   notifications: {
-    and_change_status: 'and changed status to',
-    assigned_you: 'assigned you to',
-    commented_on: 'commented on',
-    mention_you_on: 'mentioned you on',
-    no_notifications: 'There is currently no notification for you for your current projects.',
-    unread_notifications: 'unread notification | unread notifications',
-    title: 'Notifications',
-    with_preview: 'with a preview'
+    and_change_status: 'и изменил(а) статус на', // and changed status to
+    assigned_you: 'назначил(а) вас на', // assigned you to
+    commented_on: 'прокомментировал(а)', // commented on
+    mention_you_on: 'упомянул(а) вас в', // mentioned you on
+    no_notifications: 'сейчас для вас нет комментариев по вашим текущим проэктам', // There is currently no notification for you for your current projects.
+    unread_notifications: 'непрочитанное уведомление | непрочитанные уведомления', // unread notification | unread notifications
+    title: 'Уведомления', // Notifications
+    with_preview: 'с превью' // with a preview
   },
 
   people: {
-    active: 'Active',
+    active: 'Активный', // Active
     active_persons: 'active person | active persons',
-    add_member_to_team: 'Add a member to the team: ',
-    create_invite: 'Create and send invitation',
+    add_member_to_team: 'Добавить члена в команду', // Add a member to the team: 
+    create_invite: 'Создать и отослать приглашение', // Create and send invitation
     create_error: 'An  error occured while creating this person. Please contact our support team for more information.',
     delete_error: 'An error occured while deleting this person. There are probably data linked to it. Are you sure this person has no assignation or wrote no comment?',
     delete_text: 'Are you sure you want to remove {personName} from your database? Every related comments and previews will be deleted. Please confirm by typing the full person name below.',
@@ -351,147 +351,147 @@ export default {
     persons: 'person | persons',
     running_tasks: 'Running tasks',
     select_person: 'Select a person...',
-    team: 'Team',
+    team: 'Команда', // Team
     title: 'People',
-    unactive: 'Unactive',
+    unactive: 'Неактивный', // Unactive
     csv: {
-      import_file: 'Import a .csv file',
-      export_file: 'Download as a .csv file',
-      import_title: 'Import data from a CSV file',
-      required_fields: 'Your CSV file requires the following columns',
-      select_file: 'Please select a file from one of your folder:',
-      error_upload: 'An error occured while uploading your CSV file.'
+      import_file: 'Импортироать .csv файл', // Import a .csv file
+      export_file: 'Сохранить как .csv файл', // Download as a .csv file
+      import_title: 'Импортировать данные с файла CSV', // Import data from a CSV file
+      required_fields: 'Вашему файлу CSV нужны седующие столбцы', // Your CSV file requires the following columns
+      select_file: 'Выберите файл из одной из ваших папок:', // Please select a file from one of your folder:
+      error_upload: 'Ошибка при загрузке вашего файла CSV.', // An error occured while uploading your CSV file.
     },
     fields: {
-      first_name: 'First name',
-      last_name: 'Last name',
-      email: 'Email',
-      phone: 'Phone',
-      role: 'Role',
-      old_password: 'Current password',
-      password: 'New password',
-      password_2: 'New password (repeat)',
-      active: 'Active'
+      first_name: 'Имя', // First name
+      last_name: 'Фамилия', // Last name
+      email: 'Почта', // Email
+      phone: 'Телефон', // Phone
+      role: 'Роль', // Role
+      old_password: 'Текущий пароль', // Current password
+      password: 'Новый пароль', // New password
+      password_2: 'Новый пароль (повторно)', // New password (repeat)
+      active: 'Активный' // Active
     },
     list: {
-      name: 'Name',
-      email: 'Email',
-      phone: 'Phone',
-      role: 'Role',
-      active: 'Active'
+      name: 'Имя', // Name
+      email: 'Почта', // Email
+      phone: 'Телефон', // Phone
+      role: 'Роль', // Role
+      active: 'Активный' // Active
     },
     role: {
-      admin: 'Studio Manager',
-      client: 'Client',
-      manager: 'Supervisor',
-      user: 'Artist',
+      admin: 'Студийный Менеджер', // Studio Manager
+      client: 'Клиент', // Client
+      manager: 'Диспетчер', // Supervisor
+      user: 'Художник', // Artist
       undefined: '',
-      vendor: 'Vendor'
+      vendor: 'Подрядчик' // Vendor
     }
   },
 
   playlists: {
-    add_assets: 'Add assets',
+    add_assets: 'Добавить ассеты', // Add assets
     add_selection: 'Add selection',
-    add_shots: 'Add shots',
+    add_shots: 'Добавить шоты', // Add shots
     add_sequence: 'Add whole sequence',
-    add_episode: 'Add whole episode',
-    add_movie: 'Add whole movie',
+    add_episode: 'Добавить целый эпизод', // Add whole episode
+    add_movie: 'Добавить целый фильм', // Add whole movie
     apply_task_type_change: 'This will set the last revison for given task type on all shots.',
-    available_build: 'Available builds',
+    available_build: 'Доступные сборки', // Available builds
     build_daily: 'Daily pending',
     build_weekly: 'All Pending',
     build_mp4: 'Build .mp4 (beta)',
     building: 'Building...',
-    client_playlist: 'Client Playlist',
+    client_playlist: 'Клиентский Плейлист', // Client Playlist
     create_for_selection: 'Generate a playlist for shot selection',
     create_title: 'Create playlist',
-    created_at: 'Created at:',
-    delete_text: 'Are you sure you want to remove {name} from your database?',
-    delete_error: 'An error occured while deleting this playlist.',
-    edit_error: 'An error occured while saving this playlist.',
-    download_zip: 'Download .zip',
+    created_at: 'Создан в:', // Created at:
+    delete_text: 'Уверены, что хотите удалить {name} из своей базы данных?', // Are you sure you want to remove {name} from your database?
+    delete_error: 'ошибка при удалении плейлиста.', // An error occured while deleting this playlist.
+    edit_error: 'Ошибка при сохранении плейлиста.', // An error occured while saving this playlist.
+    download_zip: 'Скачать .zip', // Download .zip
     failed: 'Failed',
-    for_client: 'The client',
-    for_studio: 'The Studio',
-    edit_title: 'Edit playlist',
+    for_client: 'Клиент', // The client
+    for_studio: 'Студия', // The Studio
+    edit_title: 'Редактировать плейлист', // Edit playlist
     last_creation: 'Last creations',
-    last_modification: 'Last modifications',
+    last_modification: 'Последние модификации', // Last modifications
     loading_error: 'A server error occured. Playlists cannot be loaded.',
-    new_playlist: 'Add a playlist',
-    no_build: 'No build',
-    no_playlist: 'There is currently no playlist for this project or episode.',
-    no_preview: 'No preview',
-    no_selection: 'Please select a playlist on the left.',
+    new_playlist: 'Добавить плейлист', // Add a playlist
+    no_build: 'Нет сборки', // No build
+    no_playlist: 'В настоящий момент нет плейлиста для этого проекта или эпизода', // There is currently no playlist for this project or episode.
+    no_preview: 'Нет превью', // No preview
+    no_selection: 'Выберите один из плейлистов слева.', // Please select a playlist on the left.
     no_sequence_for_episode: 'There is no sequence for this episode',
-    no_shot_for_production: 'There is no shot for this production',
-    select_shot: 'Please select a shot in the right column',
-    select_playlist: 'Please select a playlist in the left column',
-    select_task_type: 'Change task type for all shots',
-    title: 'Playlists',
+    no_shot_for_production: 'нет шота для этого проекта', // There is no shot for this production
+    select_shot: 'Веыберите шот из правого столбца', // Please select a shot in the right column
+    select_playlist: 'Выберите плейлист из левого столбца', // Please select a playlist in the left column
+    select_task_type: 'Изменить тип задачи для всех шотов', // Change task type for all shots
+    title: 'Плейлисты', // Playlists
     updated_at: 'Updated at:',
-    remove: 'remove',
+    remove: 'удалить', // remove
     fields: {
-      name: 'Name',
-      created_at: 'Creation date',
-      updated_at: 'Update date',
-      for_entity: 'Select entity to display',
+      name: 'Назв.', // Name
+      created_at: 'Дата создания', // Creation date
+      updated_at: 'Дата апдейта', // Update date
+      for_entity: 'Выбрать объект для отображения', // Select entity to display
       for_client: 'To be shared with'
     },
     actions: {
-      annotation: 'Annotation',
-      annotation_text: 'Double click on the preview to add some text',
-      annotation_delete: 'Delete annotation',
-      annotation_redo: 'Redo annotation',
-      annotation_undo: 'Undo annotation',
-      annotation_big: 'Big',
-      annotation_medium: 'Medium',
-      annotation_small: 'Small',
-      change_task_type: 'Change task type',
-      comments: 'Show/Hide comments',
-      delete: 'Delete playlist',
-      download: 'Download…',
-      edit: 'Edit playlist',
-      entity_list: 'Show/Hide entity list',
-      fullscreen: 'Fullscreen',
+      annotation: 'Аннотация', // Annotation
+      annotation_text: 'Дважды кликните по превью, чтобы добавить текст', // Double click on the preview to add some text
+      annotation_delete: 'Удалить аннотацию', // Delete annotation
+      annotation_redo: 'Повторить аннотацию', // Redo annotation
+      annotation_undo: 'Отменить аннотацию', // Undo annotation
+      annotation_big: 'Большой', // Big
+      annotation_medium: 'Средний', // Medium
+      annotation_small: 'Маленький', // Small
+      change_task_type: 'Изменить тип задачи', // Change task type
+      comments: 'Показать/Скрыть комментарии', // Show/Hide comments
+      delete: 'Удалить плейлист', // Delete playlist
+      download: 'Скачать...', // Download…
+      edit: 'Редактировать плейлист', // Edit playlist
+      entity_list: 'Показать/Скрыть список объектов', // Show/Hide entity list
+      fullscreen: 'Полный экран', // Fullscreen
       next_frame: 'Next frame',
-      next_shot: 'Next shot',
-      pause: 'Pause',
-      play: 'Play',
+      next_shot: 'Следующий шот', // Next shot
+      pause: 'Пауза', // Pause
+      play: 'Пуск', // Play
       previous_frame: 'Previous frame',
-      previous_shot: 'Previous shot',
-      save_playlist: 'Save playlist',
-      speed: 'Change speed',
-      split_screen: 'Split screen'
+      previous_shot: 'предыдущий шот', // Previous shot
+      save_playlist: 'Сохранить плейлист', // Save playlist
+      speed: 'Изменить скорость', // Change speed
+      split_screen: 'Двойной экран' // Split screen
     }
   },
 
   productions: {
-    current: 'Selected production',
+    current: 'Выбраный проект', // Selected production
     delete_text: 'Are you sure you want to remove {name} from your database? Please, confirm by typing the name of the project you want to delete in the text field.',
     delete_error: 'An error occured while deleting this production. There are probably data linked to it. Are you sure this production has no task, shot or asset linked to it? Kitsu doesn\'t allow production deletion. If you don\'t want to see the production anymore, you can close it instead.',
     edit_error: 'An error occured while editing production. Please contact our support team.',
-    edit_title: 'Edit production',
-    new_production: 'Add a production',
-    number: 'production | productions',
-    open_productions: 'My productions',
-    picture: 'Change picture',
-    title: 'Productions',
+    edit_title: 'Редактировать проект', // Edit production
+    new_production: 'Добавить проект', // Add a production
+    number: 'проект | проекты', // production | productions
+    open_productions: 'Мои проекты', // My productions
+    picture: 'Изменить изображение', // Change picture
+    title: 'Проекты', // Productions
     home: {
-      create_new: 'Create a new production',
-      empty: 'You don\'t have any production open. What about creating a new one?',
-      no_task: 'You have no task assigned. See your supervisor to see what you can do!',
+      create_new: 'Создать новый проект', // Create a new production
+      empty: 'У вас нет открытых проектов. Не хотите ли создать новый?', // You don't have any production open. What about creating a new one?
+      no_task: 'У вас не распределены задачи. Обратитесь к вашему диспетчеру за помощью', // You have no task assigned. See your supervisor to see what you can do!
       no_prod_for_client: 'You don\'t have access to any production. Contact your contractor to obtain an access.',
       title: 'Running Productions',
-      welcome: 'Welcome to Kitsu'
+      welcome: 'Добро пожаловать в Kitsu' // Welcome to Kitsu
     },
     fields: {
       fps: 'FPS',
-      name: 'Name',
+      name: 'Назв.', // Name
       ratio: 'Ratio',
-      resolution: 'Resolution',
-      status: 'Status',
-      type: 'Type'
+      resolution: 'Разрешение', // Resolution
+      status: 'Статус', // Status
+      type: 'Тип' // Type
     },
     metadata: {
       add_explaination: 'Add specific data required by this project.',
@@ -507,64 +507,64 @@ export default {
     },
 
     status: {
-      closed: 'Closed',
-      open: 'Open',
-      active: 'Open',
-      archived: 'Closed'
+      closed: 'Закрыт', // Closed
+      open: 'Открыт', // Open
+      active: 'Открыт', // Open
+      archived: 'Закрыт' // Closed
     },
 
     type: {
-      short: 'Short',
+      short: 'Короткий', // Short
       featurefilm: 'Feature Film',
-      tvshow: 'TV Show'
+      tvshow: 'ТВ шоу' // TV Show
     }
   },
 
   profile: {
-    change_avatar: 'Change avatar',
-    info_title: 'Information',
-    language: 'Language',
-    notifications_enabled: 'Email notifications enabled',
+    change_avatar: 'Изменить аватар', // Change avatar
+    info_title: 'Информация', // Information
+    language: 'Язык', // Language
+    notifications_enabled: 'Уведомления на почту включены', // Email notifications enabled
     notifications_slack_enabled: 'Slack notifications enabled',
     notifications_slack_user: 'Slack username',
-    password_title: 'Change password',
-    timezone: 'Timezone',
-    title: 'Your Profile',
+    password_title: 'Изменить пароль', // Change password
+    timezone: 'Временная зона', // Timezone
+    title: 'Ваш Профиль', // Your Profile
     avatar: {
-      title: 'Change avatar',
-      error_upload: 'There was an error while uploading picture.'
+      title: 'Изменить аватар', // Change avatar
+      error_upload: 'Ошибка при загрузке изображения' // There was an error while uploading picture.
     },
     change_password: {
-      button: 'Change password',
-      error: 'An error occured while changing password. Please verify your current password.',
-      success: 'Your password was successfully changed!',
+      button: 'Изменить пароль', // Change password
+      error: 'Ошибка при смене пароля. Подтвердите ваш текущий пароль.', // An error occured while changing password. Please verify your current password.
+      success: 'Ваш пароль успешно изменён!', // Your password was successfully changed!
       unvalid: 'Your new password confirmation doesn\'t match or your password is too short (7 chars, at least, is expected).'
     },
     save: {
-      button: 'Save changes',
-      error: 'An error occured while saving changes'
+      button: 'Сохранить изменения', // Save changes
+      error: 'Ошибка при сохраниении изменений' // An error occured while saving changes
     }
   },
 
   settings: {
-    change_logo: 'Change logo',
-    integrations: 'Integrations',
-    logo: 'Studio logo',
-    no_logo: 'There is no logo set.',
-    set_logo: 'Set studio logo',
-    title: 'Settings',
+    change_logo: 'Изменить логотип', // Change logo
+    integrations: 'Интеграции', // Integrations
+    logo: 'Логотип студии', // Studio logo
+    no_logo: 'Логотип не установлен', // There is no logo set.
+    set_logo: 'Установить логотип студии', // Set studio logo
+    title: 'Настройки', // Settings
     fields: {
-      name: 'Studio name',
-      hours_by_day: 'Hours by day',
-      slack_token: 'Slack Token (Optional)',
+      name: 'Название студии', // Studio name
+      hours_by_day: 'Часов в день', // Hours by day
+      slack_token: 'Slack Token (Опционально)', // Slack Token (Optional)
       use_original_name: 'Use original file name for downloads'
     },
     production: {
       empty_list: 'The list is currently empty. It means that all data from the main settings are available to users. Add some entries to limit choices for this production.'
     },
     save: {
-      button: 'Save settings',
-      error: 'A server error occured while saving settings'
+      button: 'Сохранить настройки', // Save settings
+      error: 'Ошибка сервера при сохранении настроек' // A server error occured while saving settings
     }
   },
 
@@ -575,7 +575,7 @@ export default {
     edit_title: 'Edit task status',
     number: 'task status | task status',
     new_task_status: 'Add a task status',
-    title: 'Task Status',
+    title: '', 
     fields: {
       color: 'Color',
       is_artist_allowed: 'Is artist allowed',

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -494,16 +494,16 @@ export default {
       type: 'Тип'
     },
     metadata: {
-      add_explaination: 'Add specific data required by this project.',
-      add_failed: 'An error occured while adding metadata to your project.',
-      add_new_values: 'There is currently no available values.',
-      available_values: 'Available values',
-      choices: 'List of values',
-      delete_text: 'Are you sure you want to delete this column and related data for all assets of this production?',
-      delete_error: 'An error occured while deleting this metadata column.',
-      error: 'An error occured while adding the metadata column. Make sure there is no column with similar name and that all fields are filled. If the problem is persists, please contact the support team.',
-      free: 'Free value',
-      title: 'Add metadata column'
+      add_explaination: 'Добавить данные спецификации этого проекта.', // Add specific data required by this project.
+      add_failed: 'Ошибка при добавлении метаданных в ваш проект.', // An error occured while adding metadata to your project.
+      add_new_values: 'В настоящий момент нет доступных значений.', // There is currently no available values.
+      available_values: 'Доступные значения', // Available values
+      choices: 'Доступные значения', // List of values
+      delete_text: 'Уверены, что хотите удалить этот столбец и связанные данные для всех ассетов этого проекта?', // Are you sure you want to delete this column and related data for all assets of this production?
+      delete_error: 'Ошибка при удалении этого столбца метаданных.', // An error occured while deleting this metadata column.
+      error: 'Ошибка при добавлении столбца метаданных. Убедитесь, нет ли уже столбца с таким названием и что все строки заполнены. Если проблема осталась, обратитесь в поддержку.', // An error occured while adding the metadata column. Make sure there is no column with similar name and that all fields are filled. If the problem is persists, please contact the support team.
+      free: 'Свободные значения', // Free value
+      title: 'Добавить столбец метаданных' // Add metadata column
     },
 
     status: {
@@ -560,7 +560,7 @@ export default {
       use_original_name: 'Использовать оригинальное название файла при скачивании'
     },
     production: {
-      empty_list: 'The list is currently empty. It means that all data from the main settings are available to users. Add some entries to limit choices for this production.'
+      empty_list: 'Список пуст. Это значит, что все данные основных настроек доступны пользователям. Внесите изменения, чтобы ограничить доступ к этому проекту.' // The list is currently empty. It means that all data from the main settings are available to users. Add some entries to limit choices for this production.
     },
     save: {
       button: 'Сохранить настройки',
@@ -592,7 +592,7 @@ export default {
     delete_text: 'Уверены, что хотите удалить {name} из базы данных?',
     delete_error: 'Ошибка при удалении этого типа задач. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот статус не связан с какой-либо задачей?',
     edit_title: 'Редактировать тип задачи',
-    create_error: 'An error occured while creating the task type. Please, check that there is no task type with similar name.', // 'An error occured while creating the task type. Please, check that there is no task type with similar name.'
+    create_error: 'Ошибка при создании типа задач. Убедитесь, нет ли уже типа задач с таким названием.', // 'An error occured while creating the task type. Please, check that there is no task type with similar name.'
     new_task_type: 'Добавить тип задачи',
     number: 'тпип задачи | типы задач',
     title: 'типы Задач',
@@ -627,7 +627,7 @@ export default {
     title_main: 'Основной график',
     overall_man_days: 'Человеко-дни',
     md: 'ч/д',
-    zoom_level: 'Zoom',
+    zoom_level: 'Зум', // Zoom
     milestone: {
       add_milestone: 'Добавить этапы для',
       edit_milestone: 'Редактировать этапы для',
@@ -656,14 +656,14 @@ export default {
 
   shots: {
     casting: 'Использование шота',
-    creation_explaination: 'To add shots you need first to create an episode and a sequence. Type an episode name in the bottom of the left column then click on add to create a new episode. Select this episode and repeat the same operation for sequence. Finally select a sequence and type a shot name in the field in the bottom of the right column. Click on the add button below. Your first shot was created. You can now add many more! If it\'s not a TV Show, you have to directly create a sequence.', // 'To add shots you need first to create an episode and a sequence. Type an episode name in the bottom of the left column then click on add to create a new episode. Select this episode and repeat the same operation for sequence. Finally select a sequence and type a shot name in the field in the bottom of the right column. Click on the add button below. Your first shot was created. You can now add many more! If it\'s not a TV Show, you have to directly create a sequence.'
+    creation_explaination: 'Чтобы добавить шоты вам необходиме сначала создать эпизод и секвенции. Впишите имя эпизода внизу левого столбца и нажмите "добавить", чтобы создать новый эпизод. Выберите этот эпизод и повторите то же самое для секвенции. В конце выдерите секвенцию и в поле внизу правого столбца впишите имя шота. Нажмите "добавить" внизу. Вы создали ваш первый шот. Вы можете создать ещё! Если это не ТВ шоу, вам необходимо создать дополнительную секвенцию.', // 'To add shots you need first to create an episode and a sequence. Type an episode name in the bottom of the left column then click on add to create a new episode. Select this episode and repeat the same operation for sequence. Finally select a sequence and type a shot name in the field in the bottom of the right column. Click on the add button below. Your first shot was created. You can now add many more! If it's not a TV Show, you have to directly create a sequence.'
     delete_text: 'Уверены, что хотите удалить {name} из базы данных?',
     delete_error: 'Ошибка при удалении шота. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот шот не связан с какой-либо задачей?',
     edit_success: 'Шот {name} отредактирован.',
-    edit_fail: 'Creation or edition failed, an error occured. Make sure that you are not renaming the shot with a name already listed for given sequence.', // 'Creation or edition failed, an error occured. Make sure that you are not renaming the shot with a name already listed for given sequence.'
+    edit_fail: 'Ошибка: не удалось создать или редактировать. Убедитесь, что вы не переименовываете шот именем, которое уже в списке данной секвенции.', // 'Creation or edition failed, an error occured. Make sure that you are not renaming the shot with a name already listed for given sequence.'
     edit_title: 'Редактировать шот',
-    empty_list: 'There is no shot in the production. What about creating some?', // 'There is no shot in the production. What about creating some?'
-    empty_list_client: 'There is no shot in this production.', // 'There is no shot in this production.'
+    empty_list: 'В проекте нет ни одного шота. Создать?', // 'There is no shot in the production. What about creating some?'
+    empty_list_client: 'В этом проекте нет ни одного шота.', // 'There is no shot in this production.'
     episodes: 'Эпизоды',
     history: 'История шота',
     new_shot: 'Добавить шот',
@@ -673,7 +673,7 @@ export default {
     no_casting: 'Шот нигде не используется',
     number: 'шот | шоты',
     manage: 'Создать шоты',
-    new_success: 'Shot {name} successfully created.', // 'Shot {name} successfully created.'
+    new_success: 'Шот {name} успешно изменён.', // 'Shot {name} successfully created.'
     padding: 'Shot Padding', // 'Shot Padding'
     restore_text: 'Вы уверены, что хотите восстановить {name} в базе данных?',
     restore_error: 'Ошибка при восстановлении шота',
@@ -684,8 +684,8 @@ export default {
       description: 'Описание',
       nb_frames: 'Кадры',
       episode: 'Эпизод',
-      frame_in: 'In',
-      frame_out: 'Out',
+      frame_in: 'In', // НЕ ЗНАЮ
+      frame_out: 'Out', // КАКОЙ ТАМ КОНТЕКСТ
       fps: 'FPS',
       name: 'Название',
       production: 'Проект',
@@ -695,8 +695,8 @@ export default {
   },
 
   server_down: {
-    text: 'Please contact your vendor support, your system administrator or your IT department to understand what is going wrong.', // 'Please contact your vendor support, your system administrator or your IT department to understand what is going wrong.',
-    title: 'Kitsu encountered an error while reaching its data API.' // 'Kitsu encountered an error while reaching its data API.'
+    text: 'Обратитесь к вашему вендору, системному администратору или отделу ИТ, чтобы определить причину проблем.', // 'Please contact your vendor support, your system administrator or your IT department to understand what is going wrong.',
+    title: 'Ошибка получения API данных в Kitsu.' // 'Kitsu encountered an error while reaching its data API.'
   },
 
   statistics: {
@@ -710,8 +710,8 @@ export default {
 
   tasks: {
     add_preview: 'Добавить превью',
-    add_preview_error: 'An error occured while adding preview.', // 'An error occured while adding preview.'
-    assign: 'Assign one task to: | Assign {nbSelectedTasks} tasks to:', // 'Assign one task to: | Assign {nbSelectedTasks} tasks to:'
+    add_preview_error: 'Ошибка при добавлении превью.', // 'An error occured while adding preview.'
+    assign: 'Назначить задачу: | Назначить {nbSelectedTasks} задач:', // 'Assign one task to: | Assign {nbSelectedTasks} tasks to:'
     back_to_list: 'Назад к списку',
     bigger: 'Расширить панель задач',
     change_status_to: 'Изменить статус задачи на:',
@@ -722,15 +722,15 @@ export default {
     create_for_selection: 'Create task for each empty cell:', // 'Create task for each empty cell:'
     create_tasks: 'Добавить задачи',
     create_tasks_shot: 'Добавть задачи для текущих шотов',
-    create_tasks_shot_explaination: 'You are going to create a new task for each shot of current project for the given task type. Do you want to continue?', // 'You are going to create a new task for each shot of current project for the given task type. Do you want to continue?'
-    create_tasks_shot_failed: 'A server error occured while proceeding creations.', // 'A server error occured while proceeding creations.'
+    create_tasks_shot_explaination: 'Вы хотите создать новые задачи данного типа для каждого шота текущего проекта. Продолжить?', // 'You are going to create a new task for each shot of current project for the given task type. Do you want to continue?'
+    create_tasks_shot_failed: 'Ошибка сервера при обработке созданных объектов.', // 'A server error occured while proceeding creations.'
     create_tasks_asset: 'Добавить задачи для текущих ассетов',
-    create_tasks_asset_explaination: 'You are going to create a new task for each asset of current project for the given task type. Do you want to continue?', // 'You are going to create a new task for each asset of current project for the given task type. Do you want to continue?'
-    create_tasks_asset_failed: 'A server error occured while proceeding creations.', // 'A server error occured while proceeding creations.'
+    create_tasks_asset_explaination: 'Вы хотите создать новые задачи данного типа для каждого ассета текущего проекта. Продолжить?', // 'You are going to create a new task for each asset of current project for the given task type. Do you want to continue?'
+    create_tasks_asset_failed: 'Ошибка сервера при обработке созданных объектов.', // 'A server error occured while proceeding creations.'
     current: 'Задача на выполнение',
     current_status: 'Текущий статус:',
-    delete_all_text: 'Are you sure you want to delete all tasks for given {name}? Please, confirm by typing the task type name of the tasks you want to delete in the text field.', // 'Are you sure you want to delete all tasks for given {name}? Please, confirm by typing the task type name of the tasks you want to delete in the text field.'
-    delete_all_error: 'Deleting all tasks for given task type failed.', // 'Deleting all tasks for given task type failed.'
+    delete_all_text: 'Уверены, что хотите удалить все задачи типа {name}? Для подтверждения введите названия типа задач, которые хотите удалить, в окне ниже', // 'Are you sure you want to delete all tasks for given {name}? Please, confirm by typing the task type name of the tasks you want to delete in the text field.'
+    delete_all_error: 'Не удалось удалить все задачи данного типа.', // 'Deleting all tasks for given task type failed.'
     delete_error: 'Ошибка при удалении задачи',
     delete_comment: 'Уверены, что хотите удалить последний комментарий?',
     delete_comment_error: 'Ошибка при удалении комментария.',

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -1,0 +1,824 @@
+export default {
+
+  assets: {
+    cast_in: 'Используется в', // Cast in
+    delete_error: 'Ошибка при удалении ассета. Вероятнее всего к нему привязаны какие-то данные. Вы уверены что этот ассет не связан с текущей задачей?', // An error occured while deleting this asset. There are probably data linked to it. Are you sure this asset type has no task linked to it?
+    delete_text: 'Are you sure you want to remove {name} from your database?',
+    edit_fail: 'Saving failed, it may be due to the fact that an asset with a similar name already exists.',
+    edit_success: 'Asset {name} successfully edited.',
+    edit_title: 'Edit asset',
+    empty_list: 'There is no asset in the production. What about creating some?',
+    empty_list_client: 'There is no asset in this production.',
+    new_asset: 'Create an asset',
+    new_assets: 'Add assets',
+    new_success: 'Asset {name} successfully created.',
+    no_cast_in: 'This asset is not cast in any shot.',
+    number: 'asset | assets',
+    restore_text: 'Are you sure you want to restore {name} into your database?',
+    restore_error: 'An error occured while restoring this asset.',
+    tasks: 'Asset tasks',
+    title: 'Assets',
+    fields: {
+      description: 'Description',
+      episode: 'Ep.',
+      name: 'Name',
+      production: 'Prod',
+      time_spent: 'Time',
+      type: 'Type',
+      hidden_from_client: 'Displayed to client'
+    }
+  },
+
+  asset_types: {
+    all_asset_types: 'All asset types',
+    create_error: 'An error occured while saving this asset type. Are you sure there is no asset type with similar name?',
+    delete_text: 'Are you sure you want to remove {name} from your database?',
+    delete_error: 'An error occured while deleting this asset type. There are probably data linked to it. Are you sure this asset type has no asset linked to it?',
+    edit_title: 'Edit asset type',
+    new_asset_type: 'Add an asset type',
+    number: 'asset type | asset types',
+    title: 'Asset Types',
+    production_title: 'Asset Types Stats',
+    fields: {
+      name: 'Name'
+    }
+  },
+
+  breakdown: {
+    all_assets: 'All available assets',
+    edit_label: 'Change the asset\'s label',
+    empty: 'Empty casting',
+    label: 'Label',
+    picture_mode: 'Switch to picture mode',
+    text_mode: 'Switch to text mode',
+    title: 'Breakdown',
+    options: {
+      fixed: 'fixed',
+      animate: 'animate'
+    }
+  },
+
+  comments: {
+    add_attachment: 'Add attachment',
+    add_checklist: 'Add checklist',
+    add_comment: 'Add a comment...',
+    add_preview: 'Attach preview',
+    change_preview: 'Change preview',
+    comment_from_client: 'Comment from client',
+    edit_title: 'Edit comment',
+    empty_text: 'This comment is empty',
+    edit_error: 'An error occured while editing comment. Please contact our support team.',
+    error: 'An error occured while posting comment',
+    no_file_attached: 'No file attached',
+    pin: 'Pin',
+    pinned: 'Pinned',
+    post_status: 'Post comment',
+    retake: 'Retake',
+    revision: 'revision',
+    set_status_to: 'Set status to',
+    task_placeholder: 'New item...',
+    text: 'Text',
+    unpin: 'Unpin',
+    validated: 'Validated!',
+    validation_required: 'Validation Required',
+    fields: {
+      text: 'text'
+    }
+  },
+
+  custom_actions: {
+    create_error: 'An error occured while saving this custom custom action. Are you sure that there is no other action with the same name?',
+    delete_text: 'Are you sure you want to remove custom action {name} from your database?',
+    delete_error: 'An error occured while deleting this custom custom action.',
+    edit_title: 'Edit a custom action',
+    new_custom_action: 'Add a custom action',
+    number: 'custom action | custom actions',
+    run_for_selection: 'Run custom action for selected tasks:',
+    title: 'Custom Actions',
+    fields: {
+      name: 'Name',
+      url: 'URL',
+      entity_type: 'Entity Type',
+      is_ajax: 'Use AJAX'
+    },
+    entity_types: {
+      all: 'All',
+      shot: 'Shot',
+      asset: 'Asset'
+    }
+  },
+
+  entities: {
+    build_filter: {
+      asset_type: 'Asset type',
+      all_types: 'All asset types',
+      assignation: 'Assignation',
+      assignation_exists_for: 'Assignations exists for',
+      assigned_to: 'Assigned to',
+      descriptor: 'Metadata',
+      equal: 'Equal',
+      in: 'In',
+      no_assignation_for: 'No assignation exists for',
+      no_filter: 'No filter',
+      not_equal: 'Not equal',
+      not_assigned_to: 'Not assigned to',
+      status: 'Task status',
+      thumbnail: 'Thumbnail presence',
+      title: 'Filter on...',
+      union_and: 'Match all the following filters',
+      union_or: 'Match one of the following filters',
+      with_thumbnail: 'With thumbnail',
+      without_thumbnail: 'Without thumbnail'
+    },
+
+    thumbnails: {
+      error: 'An error occured while uploading thumbnails',
+      explaination: 'Adding a thumbnail requires to set a new preview. In order to set several thumbnails at the same time, you must chose first a task type that will be used to create the new previews. The thumbnails will be set from this new preview.',
+      explaination_two: 'Then you have to select the files you want to upload. To find the right entities, the file names must match the following pattern:',
+      shots_pattern: '"SequenceName ShotName" eg. SQ01_SH01.',
+      assets_pattern: '"AssetType AssetName" eg. Environment_Forest.',
+      select_files: 'Select Files',
+      selected_files: 'Selected Files',
+      select_task_type: 'Select Task Type',
+      title: 'Add Thumbnails',
+      undefined: 'Undefined',
+      undefined_pattern: 'Undefined',
+      upload: 'Add Thumbnails'
+    }
+  },
+
+  estimation: {
+    title: 'Estimation'
+  },
+
+  episodes: {
+    all_episodes: 'All episodes',
+    edit_error: 'An error occured while saving this episode. Are you sure there is no episode with similar name?',
+    delete_error: 'An error occured while deleting this episode. There are probably data linked to it. Are you sure this episode has no sequence linked to it?',
+    delete_text: 'Are you sure you want to remove {name} from your database? Every related shots and previews will be deleted. Pleas confirm by typing the episode name below.',
+    edit_title: 'Edit episode',
+    empty_list: 'There is no episode in the production. What about creating some?',
+    empty_list_client: 'There is no episode in this production.',
+    new_episode: 'New episode',
+    number: 'episode | episodes',
+    title: 'Episode Stats',
+    fields: {
+      name: 'name',
+      description: 'description'
+    }
+  },
+
+  keyboard: {
+    altdown: 'Move task selection down',
+    altj: 'Select previous preview',
+    altk: 'Select next preview',
+    altleft: 'Move task selection left',
+    altright: 'Move task selection right',
+    altup: 'Move task selection up',
+    annotations: 'Annotations',
+    draw: 'Set draw mode on',
+    navigation: 'Navigation',
+    redo: 'Redo',
+    undo: 'Undo',
+    playlist_navigation: 'Playlist navigation',
+    remove_annotation: 'Remove annotation',
+    shortcuts: 'Shortcuts'
+  },
+
+  login: {
+    back_to_login: 'Go back to login page',
+    forgot_password: 'Forgot password?',
+    login: 'Log in',
+    login_failed: 'Log in failed, please verify your credentials',
+    login_page: 'Cancel',
+    redirecting: 'Redirecting in {secondsLeft} seconds...',
+    reset_change_password: 'Change password',
+    reset_change_password_form_failed: 'There is a problem with the password you gave. Please, verify that it is at least 7 chars long and that both passwords match.',
+    reset_change_password_failed: 'Changing password failed. Please, restart the whole procedure again.',
+    reset_change_password_succeed: 'Your password was changed successfully. Please, go back to the login page to use it.',
+    reset_change_password_title: 'Enter a new password',
+    reset_password: 'Reset Password',
+    reset_password_failed: 'Resetting you password failed. Please verify your email.',
+    reset_password_succeed: 'Resetting your password succeeded. Please check your inbox.',
+    reset_password_title: 'Enter your email to reset your password',
+    title: 'Log in to Kitsu',
+    fields: {
+      email: 'Email',
+      password: 'Password',
+      password2: 'Password again'
+    }
+  },
+
+  main: {
+    about: 'About',
+    add: 'add',
+    all: 'All',
+    all_assets: 'All assets',
+    admin: 'Admin',
+    cancel: 'Cancel',
+    clear_selection: 'Clear current selection',
+    close: 'Close',
+    confirmation: 'Confirm',
+    confirmation_and_stay: 'Confirm and stay',
+    date: 'Date',
+    dark_theme: 'Dark Theme',
+    days_spent: 'day spent | days spent',
+    days_estimated: 'day estimated | days estimated',
+    delete: 'Delete',
+    delete_all: 'Delete all',
+    delete_text: 'Are you sure you want to remove {name} from your database?',
+    documentation: 'Documentation',
+    edit: 'Edit',
+    empty_comment: 'Empty comment',
+    end_date: 'End date',
+    files_selected: 'files selected',
+    for: 'For',
+    go_productions: 'Go to productions',
+    history: 'history',
+    info: 'Information',
+    or: 'or',
+    no: 'No',
+    loading: 'Loading...',
+    loading_data: 'Loading data',
+    loading_error: 'An error occured while loading data.',
+    logout: 'Logout',
+    modify: 'Modify',
+    minimize: 'Minimize',
+    main_pack: 'Main Pack',
+    maximize: 'Maximize',
+    nb_frames: 'frame | frames',
+    person: 'Person',
+    profile: 'Profile',
+    production: 'Production',
+    remove: 'Remove',
+    save: 'Save',
+    sort_by: 'Sort by',
+    sorted_by: 'Sorted by',
+    start_date: 'Start date',
+    studio: 'Studio',
+    tutorials: 'Tutorials',
+    user: 'User',
+    white_theme: 'White Theme',
+    yes: 'Yes',
+    csv: {
+      choose: 'Choose',
+      error_upload: 'An error occured while uploading your CSV.',
+      export_file: 'Export',
+      import_file: 'Import',
+      import_title: 'Import data from a CSV',
+      legend: 'Legend',
+      legend_ok: 'Recognized data',
+      legend_ignored: 'Ignored data',
+      legend_missing: 'Missing data',
+      legend_disabled: 'Data that will no be updated or created',
+      legend_overwrite: 'Data that will be updated',
+      paste: 'Paste',
+      paste_code: 'Please paste here your CSV data:',
+      preview: 'Preview',
+      preview_episode_name: 'Episode name',
+      preview_title: 'Preview of your imported data',
+      preview_description: 'Upload a .csv file to populate your board with posts.',
+      preview_required: 'NB: Headers must be included as first row.',
+      preview_reupload: 'Reupload .CSV file',
+      required_fields: 'Your CSV requires the following columns',
+      select_file: 'Please select a file from one of your folder:',
+      tab_select_file: 'Upload a CSV file',
+      tab_paste_code: 'Paste a CSV data',
+      unknown: 'Unknown column',
+      upload_file: 'Browse',
+      options: {
+        title: 'Options',
+        update: 'Update existing data'
+      }
+    }
+  },
+
+  menu: {
+    assign_tasks: 'Assign tasks',
+    change_priority: 'Change priority',
+    change_status: 'Change status',
+    create_tasks: 'Create tasks',
+    delete_tasks: 'Delete tasks',
+    generate_playlists: 'Generate playlists',
+    run_custom_action: 'Run custom action',
+    set_estimations: 'Set estimations'
+  },
+
+  news: {
+    all: 'All',
+    commented_on: 'commented on',
+    infos: 'Infos',
+    no_news: 'There is no news for this production or for this filter.',
+    only_comments: 'Only comments',
+    only_previews: 'Only previews',
+    set_preview_on: 'set preview on',
+    task_status: 'Task status',
+    task_type: 'Task type',
+    title: 'News Feed'
+  },
+
+  not_found: {
+    text: 'There was something wrong with the link you clicked on, we encourage you to come back on the home page.',
+    title: 'Page not found... are your looking for something you deleted?'
+  },
+
+  notifications: {
+    and_change_status: 'and changed status to',
+    assigned_you: 'assigned you to',
+    commented_on: 'commented on',
+    mention_you_on: 'mentioned you on',
+    no_notifications: 'There is currently no notification for you for your current projects.',
+    unread_notifications: 'unread notification | unread notifications',
+    title: 'Notifications',
+    with_preview: 'with a preview'
+  },
+
+  people: {
+    active: 'Active',
+    active_persons: 'active person | active persons',
+    add_member_to_team: 'Add a member to the team: ',
+    create_invite: 'Create and send invitation',
+    create_error: 'An  error occured while creating this person. Please contact our support team for more information.',
+    delete_error: 'An error occured while deleting this person. There are probably data linked to it. Are you sure this person has no assignation or wrote no comment?',
+    delete_text: 'Are you sure you want to remove {personName} from your database? Every related comments and previews will be deleted. Please confirm by typing the full person name below.',
+    edit_title: 'Edit person',
+    empty_team: 'There is no one listed in the project team.',
+    invite: 'Send an invitation',
+    invite_error: 'An error occured while sending the invitation',
+    invite_success: 'Invitation was successfully sent',
+    new_person: 'Add a new employee',
+    no_task_assigned: 'There are no running tasks assigned to you',
+    persons: 'person | persons',
+    running_tasks: 'Running tasks',
+    select_person: 'Select a person...',
+    team: 'Team',
+    title: 'People',
+    unactive: 'Unactive',
+    csv: {
+      import_file: 'Import a .csv file',
+      export_file: 'Download as a .csv file',
+      import_title: 'Import data from a CSV file',
+      required_fields: 'Your CSV file requires the following columns',
+      select_file: 'Please select a file from one of your folder:',
+      error_upload: 'An error occured while uploading your CSV file.'
+    },
+    fields: {
+      first_name: 'First name',
+      last_name: 'Last name',
+      email: 'Email',
+      phone: 'Phone',
+      role: 'Role',
+      old_password: 'Current password',
+      password: 'New password',
+      password_2: 'New password (repeat)',
+      active: 'Active'
+    },
+    list: {
+      name: 'Name',
+      email: 'Email',
+      phone: 'Phone',
+      role: 'Role',
+      active: 'Active'
+    },
+    role: {
+      admin: 'Studio Manager',
+      client: 'Client',
+      manager: 'Supervisor',
+      user: 'Artist',
+      undefined: '',
+      vendor: 'Vendor'
+    }
+  },
+
+  playlists: {
+    add_assets: 'Add assets',
+    add_selection: 'Add selection',
+    add_shots: 'Add shots',
+    add_sequence: 'Add whole sequence',
+    add_episode: 'Add whole episode',
+    add_movie: 'Add whole movie',
+    apply_task_type_change: 'This will set the last revison for given task type on all shots.',
+    available_build: 'Available builds',
+    build_daily: 'Daily pending',
+    build_weekly: 'All Pending',
+    build_mp4: 'Build .mp4 (beta)',
+    building: 'Building...',
+    client_playlist: 'Client Playlist',
+    create_for_selection: 'Generate a playlist for shot selection',
+    create_title: 'Create playlist',
+    created_at: 'Created at:',
+    delete_text: 'Are you sure you want to remove {name} from your database?',
+    delete_error: 'An error occured while deleting this playlist.',
+    edit_error: 'An error occured while saving this playlist.',
+    download_zip: 'Download .zip',
+    failed: 'Failed',
+    for_client: 'The client',
+    for_studio: 'The Studio',
+    edit_title: 'Edit playlist',
+    last_creation: 'Last creations',
+    last_modification: 'Last modifications',
+    loading_error: 'A server error occured. Playlists cannot be loaded.',
+    new_playlist: 'Add a playlist',
+    no_build: 'No build',
+    no_playlist: 'There is currently no playlist for this project or episode.',
+    no_preview: 'No preview',
+    no_selection: 'Please select a playlist on the left.',
+    no_sequence_for_episode: 'There is no sequence for this episode',
+    no_shot_for_production: 'There is no shot for this production',
+    select_shot: 'Please select a shot in the right column',
+    select_playlist: 'Please select a playlist in the left column',
+    select_task_type: 'Change task type for all shots',
+    title: 'Playlists',
+    updated_at: 'Updated at:',
+    remove: 'remove',
+    fields: {
+      name: 'Name',
+      created_at: 'Creation date',
+      updated_at: 'Update date',
+      for_entity: 'Select entity to display',
+      for_client: 'To be shared with'
+    },
+    actions: {
+      annotation: 'Annotation',
+      annotation_text: 'Double click on the preview to add some text',
+      annotation_delete: 'Delete annotation',
+      annotation_redo: 'Redo annotation',
+      annotation_undo: 'Undo annotation',
+      annotation_big: 'Big',
+      annotation_medium: 'Medium',
+      annotation_small: 'Small',
+      change_task_type: 'Change task type',
+      comments: 'Show/Hide comments',
+      delete: 'Delete playlist',
+      download: 'Download…',
+      edit: 'Edit playlist',
+      entity_list: 'Show/Hide entity list',
+      fullscreen: 'Fullscreen',
+      next_frame: 'Next frame',
+      next_shot: 'Next shot',
+      pause: 'Pause',
+      play: 'Play',
+      previous_frame: 'Previous frame',
+      previous_shot: 'Previous shot',
+      save_playlist: 'Save playlist',
+      speed: 'Change speed',
+      split_screen: 'Split screen'
+    }
+  },
+
+  productions: {
+    current: 'Selected production',
+    delete_text: 'Are you sure you want to remove {name} from your database? Please, confirm by typing the name of the project you want to delete in the text field.',
+    delete_error: 'An error occured while deleting this production. There are probably data linked to it. Are you sure this production has no task, shot or asset linked to it? Kitsu doesn\'t allow production deletion. If you don\'t want to see the production anymore, you can close it instead.',
+    edit_error: 'An error occured while editing production. Please contact our support team.',
+    edit_title: 'Edit production',
+    new_production: 'Add a production',
+    number: 'production | productions',
+    open_productions: 'My productions',
+    picture: 'Change picture',
+    title: 'Productions',
+    home: {
+      create_new: 'Create a new production',
+      empty: 'You don\'t have any production open. What about creating a new one?',
+      no_task: 'You have no task assigned. See your supervisor to see what you can do!',
+      no_prod_for_client: 'You don\'t have access to any production. Contact your contractor to obtain an access.',
+      title: 'Running Productions',
+      welcome: 'Welcome to Kitsu'
+    },
+    fields: {
+      fps: 'FPS',
+      name: 'Name',
+      ratio: 'Ratio',
+      resolution: 'Resolution',
+      status: 'Status',
+      type: 'Type'
+    },
+    metadata: {
+      add_explaination: 'Add specific data required by this project.',
+      add_failed: 'An error occured while adding metadata to your project.',
+      add_new_values: 'There is currently no available values.',
+      available_values: 'Available values',
+      choices: 'List of values',
+      delete_text: 'Are you sure you want to delete this column and related data for all assets of this production?',
+      delete_error: 'An error occured while deleting this metadata column.',
+      error: 'An error occured while adding the metadata column. Make sure there is no column with similar name and that all fields are filled. If the problem is persists, please contact the support team.',
+      free: 'Free value',
+      title: 'Add metadata column'
+    },
+
+    status: {
+      closed: 'Closed',
+      open: 'Open',
+      active: 'Open',
+      archived: 'Closed'
+    },
+
+    type: {
+      short: 'Short',
+      featurefilm: 'Feature Film',
+      tvshow: 'TV Show'
+    }
+  },
+
+  profile: {
+    change_avatar: 'Change avatar',
+    info_title: 'Information',
+    language: 'Language',
+    notifications_enabled: 'Email notifications enabled',
+    notifications_slack_enabled: 'Slack notifications enabled',
+    notifications_slack_user: 'Slack username',
+    password_title: 'Change password',
+    timezone: 'Timezone',
+    title: 'Your Profile',
+    avatar: {
+      title: 'Change avatar',
+      error_upload: 'There was an error while uploading picture.'
+    },
+    change_password: {
+      button: 'Change password',
+      error: 'An error occured while changing password. Please verify your current password.',
+      success: 'Your password was successfully changed!',
+      unvalid: 'Your new password confirmation doesn\'t match or your password is too short (7 chars, at least, is expected).'
+    },
+    save: {
+      button: 'Save changes',
+      error: 'An error occured while saving changes'
+    }
+  },
+
+  settings: {
+    change_logo: 'Change logo',
+    integrations: 'Integrations',
+    logo: 'Studio logo',
+    no_logo: 'There is no logo set.',
+    set_logo: 'Set studio logo',
+    title: 'Settings',
+    fields: {
+      name: 'Studio name',
+      hours_by_day: 'Hours by day',
+      slack_token: 'Slack Token (Optional)',
+      use_original_name: 'Use original file name for downloads'
+    },
+    production: {
+      empty_list: 'The list is currently empty. It means that all data from the main settings are available to users. Add some entries to limit choices for this production.'
+    },
+    save: {
+      button: 'Save settings',
+      error: 'A server error occured while saving settings'
+    }
+  },
+
+  task_status: {
+    create_error: 'An error occured while saving this task status. Are you sure there is no task status with similar name?',
+    delete_text: 'Are you sure you want to remove {name} from your database?',
+    delete_error: 'An error occured while deleting this task status. There are probably data linked to it. Are you sure this task status has no task linked to it?',
+    edit_title: 'Edit task status',
+    number: 'task status | task status',
+    new_task_status: 'Add a task status',
+    title: 'Task Status',
+    fields: {
+      color: 'Color',
+      is_artist_allowed: 'Is artist allowed',
+      is_client_allowed: 'Is client allowed',
+      is_done: 'Is done',
+      is_reviewable: 'Is reviewable',
+      is_retake: 'Has retake value',
+      name: 'Name',
+      short_name: 'Short name'
+    }
+  },
+
+  task_types: {
+    delete_text: 'Are you sure you want to remove {name} from your database?',
+    delete_error: 'An error occured while deleting this task type. There are probably data linked to it. Are you sure this task type has no task linked to it?',
+    edit_title: 'Edit task type',
+    create_error: 'An error occured while creating the task type. Please, check that there is no task type with similar name.',
+    new_task_type: 'Add a task type',
+    number: 'task type | task types',
+    title: 'Task Types',
+    fields: {
+      dedicated_to: 'For',
+      color: 'Color',
+      name: 'Name',
+      allow_timelog: 'Timelog',
+      priority: 'Priority'
+    }
+  },
+
+  sequences: {
+    all_sequences: 'All sequences',
+    edit_error: 'An error occured while saving this sequence. Are you sure there is no sequence with similar name?',
+    delete_text: 'Are you sure you want to remove {name} from your database? Every related shots and previews will be deleted. Please confirm by typing the sequence name below.',
+    delete_error: 'An error occured while deleting this sequence. There are probably data linked to it. Are you sure this sequence has no shot linked to it?',
+    edit_title: 'Edit sequence',
+    empty_list: 'There is no sequence in the production. What about creating some?',
+    empty_list_client: 'There is no sequence in this production.',
+    new_sequence: 'New sequence',
+    number: 'sequence | sequences',
+    title: 'Sequence Stats',
+    fields: {
+      name: 'name',
+      description: 'description'
+    }
+  },
+
+  schedule: {
+    title: 'Schedule',
+    title_main: 'Main Schedule',
+    overall_man_days: 'Man-days',
+    md: 'md',
+    zoom_level: 'Zoom level',
+    milestone: {
+      add_milestone: 'Add milestone for',
+      edit_milestone: 'Edit milestone for',
+      name: 'Name',
+      error: 'An error occured while adding or editing the milestone. Please try again.'
+    }
+  },
+
+  quota: {
+    average: 'Average',
+    count_label: 'Count mode',
+    detail_label: 'Detail level',
+    details_name: 'Name',
+    details_seconds: 'Seconds',
+    details_frames: 'Frames',
+    month_label: 'Month',
+    no_quota: 'There is no quota for this task type.',
+    name: 'Name',
+    quota_day: 'Quota per day',
+    quota_week: 'Quota per week',
+    quota_month: 'Quota per month',
+    year_label: 'Year',
+    title: 'Quota',
+    type_label: 'Type'
+  },
+
+  shots: {
+    casting: 'Shot casting',
+    creation_explaination: 'To add shots you need first to create an episode and a sequence. Type an episode name in the bottom of the left column then click on add to create a new episode. Select this episode and repeat the same operation for sequence. Finally select a sequence and type a shot name in the field in the bottom of the right column. Click on the add button below. Your first shot was created. You can now add many more! If it\'s not a TV Show, you have to directly create a sequence.',
+    delete_text: 'Are you sure you want to remove {name} from your database?',
+    delete_error: 'An error occured while deleting this shot. There are probably data linked to it. Are you sure this shot has no task linked to it?',
+    edit_success: 'Shot {name} successfully edited.',
+    edit_fail: 'Creation or edition failed, an error occured. Make sure that you are not renaming the shot with a name already listed for given sequence.',
+    edit_title: 'Edit shot',
+    empty_list: 'There is no shot in the production. What about creating some?',
+    empty_list_client: 'There is no shot in this production.',
+    episodes: 'Episodes',
+    history: 'Shot values history',
+    new_shot: 'Add a shot',
+    new_shots: 'Add shots',
+    new_sequences: 'Add sequences',
+    new_episodes: 'Add episodes',
+    no_casting: 'The shot casting is empty.',
+    number: 'shot | shots',
+    manage: 'Create shots',
+    new_success: 'Shot {name} successfully created.',
+    padding: 'Shot Padding',
+    restore_text: 'Are you sure you want to restore {name} into your database?',
+    restore_error: 'An error occured while restoring this shot.',
+    sequences: 'Sequences',
+    tasks: 'Shot Tasks',
+    title: 'Shots',
+    fields: {
+      description: 'Description',
+      nb_frames: 'Frames',
+      episode: 'Episode',
+      frame_in: 'In',
+      frame_out: 'Out',
+      fps: 'FPS',
+      name: 'Name',
+      production: 'Prod',
+      sequence: 'Sequence',
+      time_spent: 'Time'
+    }
+  },
+
+  server_down: {
+    text: 'Please contact your vendor support, your system administrator or your IT department to understand what is going wrong.',
+    title: 'Kitsu encountered an error while reaching its data API.'
+  },
+
+  statistics: {
+    count: 'Counts',
+    count_mode: 'Count mode',
+    display_mode: 'Display mode',
+    frames: 'Frames',
+    pie: 'Pie charts',
+    shots: 'Shots'
+  },
+
+  tasks: {
+    add_preview: 'Add preview',
+    add_preview_error: 'An error occured while adding preview.',
+    assign: 'Assign one task to: | Assign {nbSelectedTasks} tasks to:',
+    back_to_list: 'back to list',
+    bigger: 'Widen task panel',
+    change_status_to: 'Change task status to:',
+    change_preview: 'Change preview',
+    change_priority: 'Change priority to:',
+    clear_assignations: 'clear assignations',
+    comment_image: 'Attach an image to your comment',
+    create_for_selection: 'Create task for each empty cell:',
+    create_tasks: 'Add tasks',
+    create_tasks_shot: 'Add tasks for current shots',
+    create_tasks_shot_explaination: 'You are going to create a new task for each shot of current project for the given task type. Do you want to continue?',
+    create_tasks_shot_failed: 'A server error occured while proceeding creations.',
+    create_tasks_asset: 'Add tasks for current assets',
+    create_tasks_asset_explaination: 'You are going to create a new task for each asset of current project for the given task type. Do you want to continue?',
+    create_tasks_asset_failed: 'A server error occured while proceeding creations.',
+    current: 'Task to do',
+    current_status: 'Current status :',
+    delete_all_text: 'Are you sure you want to delete all tasks for given {name}? Please, confirm by typing the task type name of the tasks you want to delete in the text field.',
+    delete_all_error: 'Deleting all tasks for given task type failed.',
+    delete_error: 'An error occured while deleting task.',
+    delete_comment: 'Are you sure you want to delete last comment?',
+    delete_comment_error: 'An error occured while deleting comment.',
+    delete_for_selection: 'Delete selected tasks:',
+    delete_preview: 'Are you sure you want to delete this preview?',
+    delete_preview_error: 'An error occured while deleting preview.',
+    edit_comment: 'Edit comment',
+    done: 'Done',
+    download_pdf_file: 'Download .{extension} file',
+    feedback: 'feedback',
+    full_screen: 'Display in full screen',
+    hide_assignations: 'Hide assignations',
+    hide_infos: 'Hide additional information',
+    my_tasks: 'My tasks',
+    next: 'next task',
+    no_assignation_right: 'You are not allowed to manage assignations',
+    no_comment: 'There is currently no comment for this task.',
+    no_preview: 'There is currently no preview for this task.',
+    no_task_selected: 'No task selected',
+    number: 'task | tasks',
+    preview: 'Previews',
+    previous: 'previous task',
+    unsubscribe_notifications: 'Unsubscribe from notifications',
+    set_estimations: 'Set estimations for selected tasks:',
+    set_preview: 'Set this preview as thumbnail',
+    set_preview_error: 'An error occured while setting preview as thumbnail',
+    set_preview_done: 'This preview is used as thumbnail for the current entity.',
+    select_preview_file: 'Please select a picture from your hard drive to be used as a preview for the current task:',
+    show_assignations: 'Show assignations',
+    show_infos: 'Show additional information',
+    subscribe_notifications: 'Subscribe to notifications',
+    select_image_file: 'Please select the picture from your hard drive you want to attach to your comment:',
+    tasks: 'Tasks',
+    validation: 'Validation',
+    with_comment: 'With a comment...',
+    fields: {
+      asset_type: 'Asset type',
+      assignees: 'Assignees',
+      count: 'Count',
+      due_date: 'Due date',
+      duration: 'Duration',
+      end_date: 'Validation date',
+      entity: 'Entity',
+      entity_name: 'Name',
+      estimated_quota: 'Avg. Quota',
+      estimation: 'Estimation',
+      frames: 'Fram.',
+      last_comment: 'Last comment',
+      last_comment_date: 'Last comment',
+      priority: 'Priority',
+      production: 'Prod',
+      real_end_date: 'Validation date',
+      real_start_date: 'WIP date',
+      retake_count: 'Retakes',
+      seconds: 'Seconds',
+      sequence: 'Sequence',
+      start_date: 'Start date',
+      task_status: 'Status',
+      task_status_short_name: 'Status',
+      task_type: 'Type'
+    },
+    colors: {
+      title: 'Coloring',
+      neutral: 'Neutral',
+      status: 'Status color',
+      late: 'Late in red'
+    },
+    priority: {
+      emergency: 'Emergency',
+      normal: 'Normal',
+      high: 'High',
+      very_high: 'Very High'
+    }
+  },
+
+  timesheets: {
+    detail_level: 'Detail level',
+    done_tasks: 'Done tasks',
+    export_timesheet: 'Export Timesheet',
+    hours: 'hours',
+    month: 'Month',
+    time_spents: 'Time Spent (hours)',
+    title: 'Timesheets',
+    year: 'Year'
+  },
+
+  wrong_browser: {
+    title: 'Your browser is not supported by Kitsu',
+    text: 'Kitsu can only be used with Firefox and Chrome browsers.'
+  }
+}

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -494,16 +494,16 @@ export default {
       type: 'Тип'
     },
     metadata: {
-      add_explaination: 'Добавить данные спецификации этого проекта.', // Add specific data required by this project.
-      add_failed: 'Ошибка при добавлении метаданных в ваш проект.', // An error occured while adding metadata to your project.
-      add_new_values: 'В настоящий момент нет доступных значений.', // There is currently no available values.
-      available_values: 'Доступные значения', // Available values
-      choices: 'Доступные значения', // List of values
-      delete_text: 'Уверены, что хотите удалить этот столбец и связанные данные для всех ассетов этого проекта?', // Are you sure you want to delete this column and related data for all assets of this production?
-      delete_error: 'Ошибка при удалении этого столбца метаданных.', // An error occured while deleting this metadata column.
-      error: 'Ошибка при добавлении столбца метаданных. Убедитесь, нет ли уже столбца с таким названием и что все строки заполнены. Если проблема осталась, обратитесь в поддержку.', // An error occured while adding the metadata column. Make sure there is no column with similar name and that all fields are filled. If the problem is persists, please contact the support team.
-      free: 'Свободные значения', // Free value
-      title: 'Добавить столбец метаданных' // Add metadata column
+      add_explaination: 'Добавить данные специально для этого проекта.',
+      add_failed: 'Ошибка при добавлении метаданных в ваш проект.',
+      add_new_values: 'В настоящий момент нет доступных значений.',
+      available_values: 'Доступные значения',
+      choices: 'Доступные значения',
+      delete_text: 'Уверены, что хотите удалить этот столбец и связанные данные для всех ассетов этого проекта?',
+      delete_error: 'Ошибка при удалении этого столбца метаданных.',
+      error: 'Ошибка при добавлении столбца метаданных. Убедитесь, нет ли уже столбца с таким названием и что все строки заполнены. Если проблема осталась, обратитесь в поддержку.',
+      free: 'Свободные значения',
+      title: 'Добавить столбец метаданных'
     },
 
     status: {
@@ -560,7 +560,7 @@ export default {
       use_original_name: 'Использовать оригинальное название файла при скачивании'
     },
     production: {
-      empty_list: 'Список пуст. Это значит, что все данные основных настроек доступны пользователям. Внесите изменения, чтобы ограничить доступ к этому проекту.' // The list is currently empty. It means that all data from the main settings are available to users. Add some entries to limit choices for this production.
+      empty_list: 'Список пуст. Это значит, что все данные основных настроек доступны пользователям. Внесите изменения, чтобы ограничить доступ к этому проекту.'
     },
     save: {
       button: 'Сохранить настройки',
@@ -592,7 +592,7 @@ export default {
     delete_text: 'Уверены, что хотите удалить {name} из базы данных?',
     delete_error: 'Ошибка при удалении этого типа задач. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот статус не связан с какой-либо задачей?',
     edit_title: 'Редактировать тип задачи',
-    create_error: 'Ошибка при создании типа задач. Убедитесь, нет ли уже типа задач с таким названием.', // 'An error occured while creating the task type. Please, check that there is no task type with similar name.'
+    create_error: 'Ошибка при создании типа задач. Убедитесь, нет ли уже типа задач с таким же названием.',
     new_task_type: 'Добавить тип задачи',
     number: 'тпип задачи | типы задач',
     title: 'типы Задач',
@@ -627,7 +627,7 @@ export default {
     title_main: 'Основной график',
     overall_man_days: 'Человеко-дни',
     md: 'ч/д',
-    zoom_level: 'Зум', // Zoom
+    zoom_level: 'Зум',
     milestone: {
       add_milestone: 'Добавить этапы для',
       edit_milestone: 'Редактировать этапы для',
@@ -660,10 +660,10 @@ export default {
     delete_text: 'Уверены, что хотите удалить {name} из базы данных?',
     delete_error: 'Ошибка при удалении шота. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот шот не связан с какой-либо задачей?',
     edit_success: 'Шот {name} отредактирован.',
-    edit_fail: 'Ошибка: не удалось создать или редактировать. Убедитесь, что вы не переименовываете шот именем, которое уже в списке данной секвенции.', // 'Creation or edition failed, an error occured. Make sure that you are not renaming the shot with a name already listed for given sequence.'
+    edit_fail: 'Ошибка: не удалось создать или отредактировать. Убедитесь, что вы не называете шот именем, которое уже в списке данной секвенции.',
     edit_title: 'Редактировать шот',
-    empty_list: 'В проекте нет ни одного шота. Создать?', // 'There is no shot in the production. What about creating some?'
-    empty_list_client: 'В этом проекте нет ни одного шота.', // 'There is no shot in this production.'
+    empty_list: 'В проекте нет ни одного шота. Создать?',
+    empty_list_client: 'В этом проекте нет ни одного шота.',
     episodes: 'Эпизоды',
     history: 'История шота',
     new_shot: 'Добавить шот',
@@ -673,7 +673,7 @@ export default {
     no_casting: 'Шот нигде не используется',
     number: 'шот | шоты',
     manage: 'Создать шоты',
-    new_success: 'Шот {name} успешно изменён.', // 'Shot {name} successfully created.'
+    new_success: 'Шот {name} успешно создан.',
     padding: 'Shot Padding', // 'Shot Padding'
     restore_text: 'Вы уверены, что хотите восстановить {name} в базе данных?',
     restore_error: 'Ошибка при восстановлении шота',
@@ -684,8 +684,8 @@ export default {
       description: 'Описание',
       nb_frames: 'Кадры',
       episode: 'Эпизод',
-      frame_in: 'In', // НЕ ЗНАЮ
-      frame_out: 'Out', // КАКОЙ ТАМ КОНТЕКСТ
+      frame_in: 'In',
+      frame_out: 'Out',
       fps: 'FPS',
       name: 'Название',
       production: 'Проект',
@@ -695,8 +695,8 @@ export default {
   },
 
   server_down: {
-    text: 'Обратитесь к вашему вендору, системному администратору или отделу ИТ, чтобы определить причину проблем.', // 'Please contact your vendor support, your system administrator or your IT department to understand what is going wrong.',
-    title: 'Ошибка получения API данных в Kitsu.' // 'Kitsu encountered an error while reaching its data API.'
+    text: 'Обратитесь к вашему вендору, системному администратору или отделу ИТ, чтобы определить причину проблем.',
+    title: 'Ошибка при получении данных из Kitsu.'
   },
 
   statistics: {
@@ -710,8 +710,8 @@ export default {
 
   tasks: {
     add_preview: 'Добавить превью',
-    add_preview_error: 'Ошибка при добавлении превью.', // 'An error occured while adding preview.'
-    assign: 'Назначить задачу: | Назначить {nbSelectedTasks} задач:', // 'Assign one task to: | Assign {nbSelectedTasks} tasks to:'
+    add_preview_error: 'Ошибка при добавлении превью.',
+    assign: 'Назначить задачу: | Назначить {nbSelectedTasks} задач:',
     back_to_list: 'Назад к списку',
     bigger: 'Расширить панель задач',
     change_status_to: 'Изменить статус задачи на:',
@@ -719,18 +719,18 @@ export default {
     change_priority: 'Изменить приоритет на:',
     clear_assignations: 'Очистить назначения',
     comment_image: 'Прикрепить изображение к комментарию',
-    create_for_selection: 'Create task for each empty cell:', // 'Create task for each empty cell:'
+    create_for_selection: 'Создать задачу для пустых ячеек:',
     create_tasks: 'Добавить задачи',
     create_tasks_shot: 'Добавть задачи для текущих шотов',
-    create_tasks_shot_explaination: 'Вы хотите создать новые задачи данного типа для каждого шота текущего проекта. Продолжить?', // 'You are going to create a new task for each shot of current project for the given task type. Do you want to continue?'
-    create_tasks_shot_failed: 'Ошибка сервера при обработке созданных объектов.', // 'A server error occured while proceeding creations.'
+    create_tasks_shot_explaination: 'Вы хотите создать новые задачи данного типа для каждого шота текущего проекта. Продолжить?',
+    create_tasks_shot_failed: 'Ошибка сервера при создании задач для шотов.',
     create_tasks_asset: 'Добавить задачи для текущих ассетов',
-    create_tasks_asset_explaination: 'Вы хотите создать новые задачи данного типа для каждого ассета текущего проекта. Продолжить?', // 'You are going to create a new task for each asset of current project for the given task type. Do you want to continue?'
-    create_tasks_asset_failed: 'Ошибка сервера при обработке созданных объектов.', // 'A server error occured while proceeding creations.'
-    current: 'Задача на выполнение',
+    create_tasks_asset_explaination: 'Вы создадите новые задачи данного типа для каждого ассета текущего проекта. Продолжить?',
+    create_tasks_asset_failed: 'Ошибка сервера при создании задач для ассетов.',
+    current: 'Текущая задача',
     current_status: 'Текущий статус:',
-    delete_all_text: 'Уверены, что хотите удалить все задачи типа {name}? Для подтверждения введите названия типа задач, которые хотите удалить, в окне ниже', // 'Are you sure you want to delete all tasks for given {name}? Please, confirm by typing the task type name of the tasks you want to delete in the text field.'
-    delete_all_error: 'Не удалось удалить все задачи данного типа.', // 'Deleting all tasks for given task type failed.'
+    delete_all_text: 'Уверены, что хотите удалить все задачи типа {name}? Для подтверждения введите названия типа задач, которые хотите удалить.',
+    delete_all_error: 'Не удалось удалить все задачи данного типа.',
     delete_error: 'Ошибка при удалении задачи',
     delete_comment: 'Уверены, что хотите удалить последний комментарий?',
     delete_comment_error: 'Ошибка при удалении комментария.',

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -1,497 +1,497 @@
 export default {
 
   assets: {
-    cast_in: 'Используется в', // Cast in
-    delete_error: 'Ошибка при удалении ассета. Вероятнее всего к нему привязаны какие-то данные. Вы уверены что этот ассет не связан с текущей задачей?', // An error occured while deleting this asset. There are probably data linked to it. Are you sure this asset type has no task linked to it?
-    delete_text: 'Уверены, что хотите удалить {name} из своей базы данных?', // Are you sure you want to remove {name} from your database?
-    edit_fail: 'Не удалось сохранить. Возможно, что файл с таким же названием уже существует.', // Saving failed, it may be due to the fact that an asset with a similar name already exists.
-    edit_success: 'Ассет {name} успешно изменён.', // Asset {name} successfully edited.
-    edit_title: 'Редактировать ассет', // Edit asset
-    empty_list: 'В проекте нет ни одного ассета. Не хотите ли создать?', // There is no asset in the production. What about creating some?
-    empty_list_client: 'В этом проекте нет ни одного ассета.', // There is no asset in this production.
-    new_asset: 'Создать ассет', // Create an asset
-    new_assets: 'Добавить ассеты', // Add assets
-    new_success: 'Ассет {name} успешно создан.', // Asset {name} successfully created.
-    no_cast_in: 'Этот ассет не задействован ни в одном шоте.', // This asset is not cast in any shot.
-    number: 'ассет | ассеты', // asset | assets
-    restore_text: 'Вы уверены, что хотите восстановить {name} в вашей базе данных?', // Are you sure you want to restore {name} into your database?
-    restore_error: 'Ошибка при восстановлении ассета.', // An error occured while restoring this asset.
-    tasks: 'Задачи ассета', // Asset tasks
-    title: 'Ассеты', // Assets
+    cast_in: 'Используется в',
+    delete_error: 'Ошибка при удалении ассета. Скорее всего к нему привязаны какие-то данные. Вы уверены что этот ассет не связан с существующей задачей?',
+    delete_text: 'Уверены, что хотите удалить {name} из базы данных?',
+    edit_fail: 'Не удалось сохранить. Возможно, что ассет с таким же именем уже существует.',
+    edit_success: 'Ассет {name} успешно изменён.',
+    edit_title: 'Редактировать ассет',
+    empty_list: 'В проекте нет ни одного ассета. Создать?',
+    empty_list_client: 'В этом проекте нет ни одного ассета.',
+    new_asset: 'Создать ассет',
+    new_assets: 'Добавить ассеты',
+    new_success: 'Ассет {name} успешно создан.',
+    no_cast_in: 'Этот ассет не используется ни в одном шоте.',
+    number: 'ассет | ассеты',
+    restore_text: 'Вы уверены, что хотите восстановить {name} в базу данных?',
+    restore_error: 'Ошибка при восстановлении ассета.',
+    tasks: 'Задачи по ассету',
+    title: 'Ассеты',
     fields: {
-      description: 'Описание', // Description
-      episode: 'Эп.', // Ep.
-      name: 'Назв.', // Name
-      production: 'Проект', // Prod
-      time_spent: 'Время', // Time
-      type: 'Тип', // Type
-      hidden_from_client: 'Отображено клиенту' // Displayed to client
+      description: 'Описание',
+      episode: 'Эпизод',
+      name: 'Название',
+      production: 'Проект',
+      time_spent: 'Время',
+      type: 'Тип',
+      hidden_from_client: 'Отображается клиенту'
     }
   },
 
   asset_types: {
-    all_asset_types: 'Все типы ассетов', // All asset types
-    create_error: 'Ошибка при сохранении этого типа ассетов. Вы уверены, что нет типа ассетов с таким же названием?', // An error occured while saving this asset type. Are you sure there is no asset type with similar name?
-    delete_text: 'Вы уверены, что хотите удалить {name} из своей базы данных?', // Are you sure you want to remove {name} from your database?
-    delete_error: 'Ошибка при удалении этого типа ассетов. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот тип ассетов не связан с каким-либо ассетом?', // An error occured while deleting this asset type. There are probably data linked to it. Are you sure this asset type has no asset linked to it?
-    edit_title: 'Редактировать тип ассетов', // Edit asset type
-    new_asset_type: 'Добавить тип ассетов', // Add an asset type
-    number: 'тип ассетов | типы ассетов', // asset type | asset types
-    title: 'Типы Ассетов', // Asset Types
-    production_title: 'Стат. Типов Ассетов', // Asset Types Stats
+    all_asset_types: 'Все типы ассетов',
+    create_error: 'Ошибка при сохранении этого типа ассетов. Вы уверены, что нет типа ассетов с таким же названием?',
+    delete_text: 'Вы уверены, что хотите удалить {name} из базы данных?',
+    delete_error: 'Ошибка при удалении этого типа ассетов. Скорее всего к нему привязаны какие-то данные. Вы уверены, что к этому типу не привязан какой-либо ассет?',
+    edit_title: 'Редактировать тип ассетов',
+    new_asset_type: 'Добавить тип ассетов',
+    number: 'тип ассетов | типов ассетов',
+    title: 'Типы Ассетов',
+    production_title: 'Статистика по Типам Ассетов',
     fields: {
-      name: 'Назв.' // Name
+      name: 'Название'
     }
   },
 
   breakdown: {
-    all_assets: 'Все доступные ассеты', // All available assets
-    edit_label: 'Изменить метку ассета', // Change the asset\'s label
-    empty: 'Empty casting',
-    label: 'Метка', // Label
-    picture_mode: 'Перепключиться в режим изображения', // Switch to picture mode
-    text_mode: 'Перепключиться в режим текста', // Switch to text mode
-    title: 'Breakdown',
+    all_assets: 'Доступные ассеты',
+    edit_label: 'Изменить лейбл ассета',
+    empty: 'Не используется',
+    label: 'Лейбл',
+    picture_mode: 'Перепключиться в режим картинок',
+    text_mode: 'Перепключиться в текстовый режим',
+    title: 'Брейкдаун',
     options: {
-      fixed: 'fixed',
-      animate: 'анимировать' // animate
+      fixed: 'зафиксирован',
+      animate: 'анимировать'
     }
   },
 
   comments: {
-    add_attachment: 'Добавить вложение', // Add attachment
-    add_checklist: 'Добавить чеклист', // Add checklist
-    add_comment: 'Оставить комментарий...', // Add a comment...
-    add_preview: 'Добавить превью', // Attach preview
-    change_preview: 'Изменить превью', // Change preview
-    comment_from_client: 'Комментарий клиента', // Comment from client
-    edit_title: 'Редактировать комментарий', // Edit comment
-    empty_text: 'Этот комментарий пустой', // This comment is empty
-    edit_error: 'Ошибка при редактировании комментария. Пожалуйста, обратитесь в поддержку.', // An error occured while editing comment. Please contact our support team.
-    error: 'Ошибка при размещении комментария', // An error occured while posting comment
-    no_file_attached: 'Файл не прикреплён', // No file attached
-    pin: 'Закрепить', // Pin
-    pinned: 'Закреплено', // Pinned
-    post_status: 'Опубликовать комментарий', // Post comment
-    retake: 'Retake',
-    revision: 'ревизия', // revision
-    set_status_to: 'Установить статус', // Set status to
-    task_placeholder: 'New item...',
-    text: 'Текст', // Text
-    unpin: 'Открепить', // Unpin
-    validated: 'Проверено!', // Validated!
-    validation_required: 'Необходима Проверка', // Validation Required
+    add_attachment: 'Прикрепить вложение',
+    add_checklist: 'Добавить чеклист',
+    add_comment: 'Оставить комментарий...',
+    add_preview: 'Добавить превью',
+    change_preview: 'Изменить превью',
+    comment_from_client: 'Комментарий клиента',
+    edit_title: 'Редактировать комментарий',
+    empty_text: 'Пустой комментарий',
+    edit_error: 'Ошибка при редактировании комментария. Пожалуйста, обратитесь в поддержку.',
+    error: 'Ошибка при создании комментария',
+    no_file_attached: 'Файл не прикреплён',
+    pin: 'Закрепить',
+    pinned: 'Закреплён',
+    post_status: 'Опубликовать комментарий',
+    retake: 'Переделать',
+    revision: 'Версия',
+    set_status_to: 'Установить статус',
+    task_placeholder: 'Новый объект...',
+    text: 'Текст',
+    unpin: 'Открепить',
+    validated: 'Проверено!',
+    validation_required: 'Необходима Проверка',
     fields: {
-      text: 'текст' // text
+      text: 'текст'
     }
   },
 
   custom_actions: {
-    create_error: 'Ошибка при сохранении этого специального действия. Вы уверены, что нет действия с таким же названием?', // An error occured while saving this custom custom action. Are you sure that there is no other action with the same name?
-    delete_text: 'Уверены, что хотите удалить специальное действие {name} из своей базы данных?', // Are you sure you want to remove custom action {name} from your database?
-    delete_error: 'Ошибка при удалении этого специального действия', // An error occured while deleting this custom custom action.
-    edit_title: 'Редактировать специальное действие', // Edit a custom action
-    new_custom_action: 'Добавить специальное действие', // Add a custom action
-    number: 'специальное действие | специальные действия', // custom action | custom actions
-    run_for_selection: 'Выполнить специальное действие для следующих задач:', // Run custom action for selected tasks:
-    title: 'Специальные Действия', // Custom Actions
+    create_error: 'Ошибка при сохранении специального действия. Вы уверены, что нет действия с таким же названием?',
+    delete_text: 'Уверены, что хотите удалить специальное действие {name} из базы данных?',
+    delete_error: 'Ошибка при удалении этого специального действия',
+    edit_title: 'Редактировать специальное действие',
+    new_custom_action: 'Добавить специальное действие',
+    number: 'специальное действие | специальные действия',
+    run_for_selection: 'Выполнять специальное действие для следующих задач:',
+    title: 'Специальные Действия',
     fields: {
-      name: 'Назв.', // Name
+      name: 'Название',
       url: 'URL',
-      entity_type: 'Тип Объекта', // Entity Type
-      is_ajax: 'Исп. AJAX' // Use AJAX
+      entity_type: 'Тип Объекта',
+      is_ajax: 'Использовать AJAX'
     },
     entity_types: {
-      all: 'Все', // All
-      shot: 'Шот', // Shot
-      asset: 'Ассет' // Asset
+      all: 'Все',
+      shot: 'Шот',
+      asset: 'Ассет'
     }
   },
 
   entities: {
     build_filter: {
-      asset_type: 'Тип ассетов', // Asset type
-      all_types: 'Все типы ассетов', // All asset types
-      assignation: 'Назначение', // Assignation
-      assignation_exists_for: 'Assignations exists for',
-      assigned_to: 'Assigned to',
-      descriptor: 'Metadata',
-      equal: 'Equal',
+      asset_type: 'Тип ассетов',
+      all_types: 'Все типы ассетов',
+      assignation: 'Назначение',
+      assignation_exists_for: 'Назначения для',
+      assigned_to: 'Назначен',
+      descriptor: 'Метаданные',
+      equal: 'Равно',
       in: 'В', // In
-      no_assignation_for: 'No assignation exists for',
-      no_filter: 'Нет фильтра', // No filter
-      not_equal: 'Not equal',
-      not_assigned_to: 'Not assigned to',
-      status: 'Статус задачи', // Task status
-      thumbnail: 'Thumbnail presence',
-      title: 'Filter on...',
-      union_and: 'Match all the following filters',
-      union_or: 'Match one of the following filters',
-      with_thumbnail: 'С ярлыком', // With thumbnail
-      without_thumbnail: 'Без ярлыка' // Without thumbnail
+      no_assignation_for: 'Нет назначений для',
+      no_filter: 'Нет фильтра',
+      not_equal: 'Не равно',
+      not_assigned_to: 'Не назначен',
+      status: 'Статус задачи',
+      thumbnail: 'Есть ярлык',
+      title: 'Фильтр...',
+      union_and: 'Применить все указанные фильтры',
+      union_or: 'Применить один из указанных фильтров',
+      with_thumbnail: 'С ярлыком',
+      without_thumbnail: 'Без ярлыка'
     },
 
     thumbnails: {
       error: 'An error occured while uploading thumbnails',
-      explaination: 'Для добавления ярлыка нужно новое превью. Чтобы сделать сразу несколько ярлыков, необходимо сначала выбрать тип задачи для создания новых превью. Ярлыки будут сделаны на основании этого нового превью.', // Adding a thumbnail requires to set a new preview. In order to set several thumbnails at the same time, you must chose first a task type that will be used to create the new previews. The thumbnails will be set from this new preview.
-      explaination_two: 'Далее выберите файлы для использования. Чтобы найти правильные объекты, имена файлов должны соответсвовать шаблону:', // Then you have to select the files you want to upload. To find the right entities, the file names must match the following pattern:
-      shots_pattern: '"SequenceName ShotName" пр. SQ01_SH01.', // "SequenceName ShotName" eg. SQ01_SH01.
-      assets_pattern: '"AssetType AssetName" пр. Окружение_Лес.', // "AssetType AssetName" eg. Environment_Forest.
-      select_files: 'Выбрать Файлы', // Select Files
-      selected_files: 'Выбранные Файлы', // Selected Files
-      select_task_type: 'Выбрать Тип Задачи', // Select Task Type
-      title: 'Добавить Ярлыки', // Add Thumbnails
-      undefined: 'Неопределён', // Undefined
-      undefined_pattern: 'Неопределён', // Undefined
-      upload: 'Добавить Ярлыки' // Add Thumbnails
+      explaination: 'Для добавления ярлыка нужно новое превью. Чтобы сделать сразу несколько ярлыков, необходимо сначала выбрать тип задачи для создания новых превью. Ярлыки будут сделаны на основании этого нового превью.',
+      explaination_two: 'Далее выберите файлы для загрузки. Чтобы найти правильные объекты, имена файлов должны соответсвовать маске:',
+      shots_pattern: '"SequenceName_ShotName" пр. SQ01_SH01.',
+      assets_pattern: '"AssetType_AssetName" пр. Окружение_Лес.',
+      select_files: 'Выбрать Файлы',
+      selected_files: 'Выбранные Файлы',
+      select_task_type: 'Выбрать Тип Задачи',
+      title: 'Добавить Ярлыки',
+      undefined: 'Неопределён',
+      undefined_pattern: 'Неопределён',
+      upload: 'Добавить Ярлыки'
     }
   },
 
   estimation: {
-    title: 'Вычисление' // Estimation
+    title: 'Оценка'
   },
 
   episodes: {
-    all_episodes: 'Все эпизоды', // All episodes
-    edit_error: 'Ошибка при сохранении этого эпизода. Вы уверены, что нет эпизода с таким же названием?', // An error occured while saving this episode. Are you sure there is no episode with similar name?
-    delete_error: 'Ошибка при удалении этого эпизода. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот тип ассетов не связан с какой-либо секвенция?', // An error occured while deleting this episode. There are probably data linked to it. Are you sure this episode has no sequence linked to it?
-    delete_text: 'Are you sure you want to remove {name} from your database? Every related shots and previews will be deleted. Pleas confirm by typing the episode name below.', // Are you sure you want to remove {name} from your database? Every related shots and previews will be deleted. Pleas confirm by typing the episode name below.
-    edit_title: 'Редактировать эпизод', // Edit episode
-    empty_list: 'В проекте нет ни одного эпизода. Не хотите ли создать?', // There is no episode in the production. What about creating some?
-    empty_list_client: 'В этом проекте нет ни одного эпизода.', // There is no episode in this production.
-    new_episode: 'Новый эпизод', // New episode
-    number: 'эпизод | эпизоды', // episode | episodes
-    title: 'Статистика эпизода', // Episode Stats
+    all_episodes: 'Все эпизоды',
+    edit_error: 'Ошибка при сохранении этого эпизода. Вы уверены, что нет эпизода с таким же названием?',
+    delete_error: 'Ошибка при удалении этого эпизода. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот тип ассетов не связан с какой-либо секвенция?',
+    delete_text: 'Уверены, что хотите удалить {name} из своей базы данных? Каждый связаный шот и превью будет удален. Пожалуйста, введите название эпизода для подтверждения.',
+    edit_title: 'Редактировать эпизод',
+    empty_list: 'В проекте нет ни одного эпизода. Создать?',
+    empty_list_client: 'В этом проекте нет ни одного эпизода.',
+    new_episode: 'Новый эпизод',
+    number: 'эпизод | эпизоды',
+    title: 'Статистика эпизодов',
     fields: {
-      name: 'назв.', // name
-      description: 'описание' // description
+      name: 'Название',
+      description: 'Описание'
     }
   },
 
   keyboard: {
-    altdown: 'Move task selection down',
-    altj: 'Выбрать предыдущее превью ', // Select previous preview
-    altk: 'Выбрать следующее превью', // Select next preview
-    altleft: 'Move task selection left',
-    altright: 'Move task selection right',
-    altup: 'Move task selection up',
-    annotations: 'Аннотации', // Annotations
-    draw: 'Set draw mode on',
-    navigation: '', // Navigation
-    redo: 'Повторить', // Redo
-    undo: 'Отменить', // Undo
-    playlist_navigation: 'Навигация по плейлисту', // Playlist navigation
-    remove_annotation: 'Убрать аннотацию', // Remove annotation
-    shortcuts: 'Ссылки' // Shortcuts
+    altdown: 'Подвинуть выбранные задачи вниз',
+    altj: 'Выбрать предыдущее превью ',
+    altk: 'Выбрать следующее превью',
+    altleft: 'Подвинуть выбранные задачи влево',
+    altright: 'Подвинуть выбранные задачи вправо',
+    altup: 'Подвинуть выбранные задачи вверх',
+    annotations: 'Аннотации',
+    draw: 'Включить режим рисования',
+    navigation: 'Навигация',
+    redo: 'Повторить',
+    undo: 'Отменить',
+    playlist_navigation: 'Навигация по плейлисту',
+    remove_annotation: 'Убрать аннотацию',
+    shortcuts: 'Хоткеи'
   },
 
   login: {
-    back_to_login: 'Вернуться к регистрации', // Go back to login page
-    forgot_password: 'Забыли пароль?', // Forgot password?
-    login: 'Войти', // Log in
-    login_failed: 'Ошибка входа. Пожалуйста, подтвердите ваши полномочия', // Log in failed, please verify your credentials
-    login_page: 'Отмена', // Cancel
-    redirecting: 'Перенаправление через {secondsLeft} секунд...', // Redirecting in {secondsLeft} seconds...
-    reset_change_password: 'Сменить пароль', // Change password
-    reset_change_password_form_failed: 'С паролем, который вы дали, возникла проблема. Убедитесь в том, что он состоит как минимум из 7 знаков и что оба пароля совпадают', // There is a problem with the password you gave. Please, verify that it is at least 7 chars long and that both passwords match.
-    reset_change_password_failed: 'Не удалось изменить пароль. Пожалуйста, пройдите процедуру ещё раз.', // Changing password failed. Please, restart the whole procedure again.
-    reset_change_password_succeed: 'Ваш пароль успешно изменён. Пожалуйста вернитесь к регистрации, чтобы использовать его.', // Your password was changed successfully. Please, go back to the login page to use it.
-    reset_change_password_title: 'Введите новый пароль', // Enter a new password
-    reset_password: 'Сбросить Пароль', // Reset Password
-    reset_password_failed: 'Resetting you password failed. Please verify your email.',
-    reset_password_succeed: 'Пароль успешно сброшен. Пожалуйста, проверьте вашу почту.', // Resetting your password succeeded. Please check your inbox.
-    reset_password_title: 'Введите вашу почту, чтобы сбросить пароль', // Enter your email to reset your password
-    title: 'Войти в Kitsu', // Log in to Kitsu
+    back_to_login: 'Вернуться к странице логина',
+    forgot_password: 'Забыли пароль?',
+    login: 'Войти',
+    login_failed: 'Ошибка входа. Пожалуйста, проверьте ваши имя пользователя и пароль',
+    login_page: 'Отмена',
+    redirecting: 'Перенаправление через {secondsLeft} секунд...',
+    reset_change_password: 'Сменить пароль',
+    reset_change_password_form_failed: 'С паролем, который вы дали, возникла проблема. Убедитесь в том, что он состоит как минимум из 7 знаков и что оба пароля совпадают',
+    reset_change_password_failed: 'Не удалось изменить пароль. Пожалуйста, пройдите процедуру ещё раз.',
+    reset_change_password_succeed: 'Ваш пароль успешно изменён. Пожалуйста вернитесь на страницу логина, чтобы использовать его.',
+    reset_change_password_title: 'Введите новый пароль',
+    reset_password: 'Сбросить Пароль',
+    reset_password_failed: 'Ошибка при сбросе пароля. Проверьте правильность указанной почты.',
+    reset_password_succeed: 'Пароль успешно сброшен. Пожалуйста, проверьте вашу почту.',
+    reset_password_title: 'Введите вашу почту, чтобы сбросить пароль',
+    title: 'Войти в Kitsu',
     fields: {
-      email: 'Почта', // Email
-      password: 'Пароль', // Password
-      password2: 'Пароль повторно' // Password again
+      email: 'Почта',
+      password: 'Пароль',
+      password2: 'Пароль повторно'
     }
   },
 
   main: {
-    about: 'About',
-    add: 'добавить', // add
-    all: 'Все', // All
-    all_assets: 'Все ассеты', // All assets
-    admin: 'Администратор', // Admin
-    cancel: 'Отмена', // Cancel
-    clear_selection: 'Очистить выбранное', // Clear current selection
-    close: 'Закрыть', // Close
-    confirmation: 'Подтвердить', // Confirm
-    confirmation_and_stay: 'Подтвердить и остаться', // Confirm and stay
-    date: 'Дата', // Date
-    dark_theme: 'Тёмная Тема', // Dark Theme
-    days_spent: 'день потрачен | дней потрачено', // day spent | days spent
-    days_estimated: 'день ожидается | дней ожидается', // day estimated | days estimated
-    delete: 'Удалить', // Delete
-    delete_all: 'Удалить все', // Delete all
-    delete_text: 'Уверены, что хотите удалить {name} из своей базы данных?', // Are you sure you want to remove {name} from your database?
-    documentation: 'Документация', // Documentation
-    edit: 'Редактировать', // Edit
-    empty_comment: 'Пустой комментарий', // Empty comment
-    end_date: 'Дата окончания', // End date
+    about: 'О системе',
+    add: 'Добавить',
+    all: 'Все',
+    all_assets: 'Все ассеты',
+    admin: 'Администратор',
+    cancel: 'Отмена',
+    clear_selection: 'Очистить выбранное',
+    close: 'Закрыть',
+    confirmation: 'Подтвердить',
+    confirmation_and_stay: 'Подтвердить и прододжить',
+    date: 'Дата',
+    dark_theme: 'Тёмная Тема',
+    days_spent: 'день затрачен | дней затрачено',
+    days_estimated: 'день ожидается | дней ожидается',
+    delete: 'Удалить',
+    delete_all: 'Удалить все',
+    delete_text: 'Уверены, что хотите удалить {name} из базы данных?',
+    documentation: 'Документация',
+    edit: 'Редактировать',
+    empty_comment: 'Пустой комментарий',
+    end_date: 'Дата окончания',
     files_selected: 'выбранные файлы', // files selected
-    for: 'Для', // For
-    go_productions: 'Перейти к проектам', // Go to productions
-    history: 'история', // history
-    info: 'Информация', // Information
-    or: 'или', // or
-    no: 'Нет', // No
-    loading: 'Загрузка...', // Loading...
-    loading_data: 'Загрузка данных', // Loading data
-    loading_error: 'Ошибка при загрузке данных', // An error occured while loading data.
-    logout: 'Logout',
-    modify: 'Modify',
-    minimize: 'Минимизировать', // Minimize
-    main_pack: 'Main Pack',
-    maximize: 'Максимизировать', // Maximize
-    nb_frames: 'frame | frames',
-    person: 'Person',
-    profile: 'Профиль', // Profile
-    production: 'Проэкт', // Production
-    remove: 'Remove',
-    save: 'Схранить', // Save
-    sort_by: 'Сортировать', // Sort by
-    sorted_by: 'Отсортировано', // Sorted by
-    start_date: 'Дата начала', // Start date
-    studio: 'Студия', // Studio
-    tutorials: 'Руководства', // Tutorials
-    user: 'Пользователь', // User
-    white_theme: 'Белая Тема', // White Theme
-    yes: 'Да', // Yes
+    for: 'Для',
+    go_productions: 'Перейти к проектам',
+    history: 'История',
+    info: 'Информация',
+    or: 'или',
+    no: 'Нет',
+    loading: 'Загрузка...',
+    loading_data: 'Загрузка данных',
+    loading_error: 'Ошибка при загрузке данных',
+    logout: 'Выйти',
+    modify: 'Изменить',
+    minimize: 'Свернуть',
+    main_pack: 'Main Pack', // Main Pack
+    maximize: 'Развернуть',
+    nb_frames: 'Кадр | Кадры',
+    person: 'Человек',
+    profile: 'Профиль',
+    production: 'Проект',
+    remove: 'Удалить',
+    save: 'Схранить',
+    sort_by: 'Сортировать по',
+    sorted_by: 'Отсортировано по',
+    start_date: 'Дата начала',
+    studio: 'Студия',
+    tutorials: 'Туториалы',
+    user: 'Пользователь',
+    white_theme: 'Светлая Тема',
+    yes: 'Да',
     csv: {
-      choose: 'Выбрать', // Choose
-      error_upload: 'Ошибка при загрузке вашего CSV.', // An error occured while uploading your CSV.
-      export_file: 'Экспортировать', // Export
-      import_file: 'Импортировать', // Import
-      import_title: 'импортировать данные с CSV', // Import data from a CSV
-      legend: 'Легенда', // Legend
-      legend_ok: 'Опознанные данные', // Recognized data
-      legend_ignored: 'Пропущенные данные', // Ignored data
-      legend_missing: 'Недостающие данные', // Missing data
-      legend_disabled: 'Данные не подлежащие обновлению или созданию', // Data that will no be updated or created
-      legend_overwrite: 'Данные подлежащие обновлению', // Data that will be updated
-      paste: 'Вставить', // Paste
-      paste_code: 'Вставьте сюда данные вашего CSV:', // Please paste here your CSV data:
-      preview: 'Превью', // Preview
-      preview_episode_name: 'Название эпизода', // Episode name
-      preview_title: 'Превью импортированных данных', // Preview of your imported data
-      preview_description: 'Upload a .csv file to populate your board with posts.',
-      preview_required: 'NB: Headers must be included as first row.',
-      preview_reupload: 'Reupload .CSV file',
-      required_fields: 'Вашему CSV нужны следующие столбцы', // Your CSV requires the following columns
-      select_file: 'Выберите файл из одной из ваших папок:', // Please select a file from one of your folder:
-      tab_select_file: 'Загрузить файл CSV', // Upload a CSV file
-      tab_paste_code: 'Вставить данные CSV', // Paste a CSV data
-      unknown: 'Неизвестный столбец', // Unknown column
-      upload_file: 'Искать', // Browse
+      choose: 'Выбрать',
+      error_upload: 'Ошибка при загрузке CSV.',
+      export_file: 'Экспортировать',
+      import_file: 'Импортировать',
+      import_title: 'импортировать данные с CSV',
+      legend: 'Легенда',
+      legend_ok: 'Опознанные данные',
+      legend_ignored: 'Пропущенные данные',
+      legend_missing: 'Недостающие данные',
+      legend_disabled: 'Данные не получится создать или обновить',
+      legend_overwrite: 'Данные будут обновлены',
+      paste: 'Вставить',
+      paste_code: 'Вставьте сюда данные из CSV:',
+      preview: 'Превью',
+      preview_episode_name: 'Название эпизода',
+      preview_title: 'Посмотреть импортированные данные',
+      preview_description: 'Загрузить .csv файл чтобы наполнить доску записями.',
+      preview_required: 'NB: Заголовки должны быть на первой строчке.',
+      preview_reupload: 'Загрузить .CSV файл заново',
+      required_fields: 'Вашему CSV нужны следующие столбцы',
+      select_file: 'Выберите файл:',
+      tab_select_file: 'Загрузить файл CSV',
+      tab_paste_code: 'Вставить данные CSV',
+      unknown: 'Неизвестный столбец',
+      upload_file: 'Найти',
       options: {
-        title: 'Опции', // Options
-        update: 'Обновить существующие данные' // Update existing data
+        title: 'Опции',
+        update: 'Обновить существующие данные'
       }
     }
   },
 
   menu: {
-    assign_tasks: 'Распределить задачи', // Assign tasks
-    change_priority: 'Изменить приоритет', // Change priority
-    change_status: 'Изменить статус', // Change status
-    create_tasks: 'Создать задачи', // Create tasks
-    delete_tasks: 'Удалить задачи', // Delete tasks
-    generate_playlists: 'Сгенерировать плейлист', // Generate playlists
-    run_custom_action: 'Запустить специальное действие', // Run custom action
-    set_estimations: 'Set estimations'
+    assign_tasks: 'Назначить задачи',
+    change_priority: 'Изменить приоритет',
+    change_status: 'Изменить статус',
+    create_tasks: 'Создать задачи',
+    delete_tasks: 'Удалить задачи',
+    generate_playlists: 'Создать плейлист',
+    run_custom_action: 'Выполнить специальное действие',
+    set_estimations: 'Оценить задачу'
   },
 
   news: {
-    all: 'Все', // All
-    commented_on: 'прокомментировал(а)', // commented on
-    infos: 'Информация', // Infos
-    no_news: 'There is no news for this production or for this filter.',
-    only_comments: 'Только комментарии', // Only comments
-    only_previews: 'Только превью', // Only previews
-    set_preview_on: 'set preview on',
-    task_status: 'Статус задачи', // Task status
-    task_type: 'Тип задачи', // Task type
-    title: 'Лента новостей' // News Feed
+    all: 'Все',
+    commented_on: 'прокомментировал(а)',
+    infos: 'Информация',
+    no_news: 'Для этого проекта или для этого фильтра нет новостей.',
+    only_comments: 'Только комментарии',
+    only_previews: 'Только превью',
+    set_preview_on: 'Включить превью',
+    task_status: 'Статус задачи',
+    task_type: 'Тип задачи',
+    title: 'Лента новостей'
   },
 
   not_found: {
-    text: 'Ссылка на которую вы кликнули ненадёжна, мы рекомендуем вам вернуться на главную страницу.', // There was something wrong with the link you clicked on, we encourage you to come back on the home page.
-    title: 'Страница не найдена...  вы ищете что-то, что уже удалили?' // Page not found... are your looking for something you deleted?
+    text: 'Что-то не так с этой ссылкой. Рекомендуем вернуться на главную страницу.',
+    title: 'Страница не найдена...  вы ищете что-то, что уже удалили?'
   },
 
   notifications: {
-    and_change_status: 'и изменил(а) статус на', // and changed status to
-    assigned_you: 'назначил(а) вас на', // assigned you to
-    commented_on: 'прокомментировал(а)', // commented on
-    mention_you_on: 'упомянул(а) вас в', // mentioned you on
-    no_notifications: 'сейчас для вас нет комментариев по вашим текущим проэктам', // There is currently no notification for you for your current projects.
-    unread_notifications: 'непрочитанное уведомление | непрочитанные уведомления', // unread notification | unread notifications
-    title: 'Уведомления', // Notifications
-    with_preview: 'с превью' // with a preview
+    and_change_status: 'и изменил(а) статус на',
+    assigned_you: 'назначил(а) вас на',
+    commented_on: 'прокомментировал(а)',
+    mention_you_on: 'упомянул(а) вас в',
+    no_notifications: 'Сейчас нет комментариев по вашим текущим проэктам',
+    unread_notifications: 'непрочитанное уведомление | непрочитанные уведомления',
+    title: 'Уведомления',
+    with_preview: 'с превью'
   },
 
   people: {
-    active: 'Активный', // Active
-    active_persons: 'active person | active persons',
-    add_member_to_team: 'Добавить члена в команду', // Add a member to the team: 
-    create_invite: 'Создать и отослать приглашение', // Create and send invitation
-    create_error: 'An  error occured while creating this person. Please contact our support team for more information.',
-    delete_error: 'An error occured while deleting this person. There are probably data linked to it. Are you sure this person has no assignation or wrote no comment?',
-    delete_text: 'Are you sure you want to remove {personName} from your database? Every related comments and previews will be deleted. Please confirm by typing the full person name below.',
-    edit_title: 'Edit person',
-    empty_team: 'There is no one listed in the project team.',
-    invite: 'Send an invitation',
-    invite_error: 'An error occured while sending the invitation',
-    invite_success: 'Invitation was successfully sent',
-    new_person: 'Add a new employee',
-    no_task_assigned: 'There are no running tasks assigned to you',
-    persons: 'person | persons',
-    running_tasks: 'Running tasks',
-    select_person: 'Select a person...',
-    team: 'Команда', // Team
-    title: 'People',
-    unactive: 'Неактивный', // Unactive
+    active: 'Активный',
+    active_persons: 'активный пользователь | активные пользователи',
+    add_member_to_team: 'Добавить человека в команду',
+    create_invite: 'Создать и отправить приглашение',
+    create_error: 'Произошла ошибка при создании этого пользователя. Свяжитесь с поддержкой.',
+    delete_error: 'Произошла ошибка при удалении этого пользователя. Скорее всего с ним связаны какие-то данные. Вы уверены что этого пользователь не участвует в задачах или не оставлял комментариев?',
+    delete_text: 'Вы уверены что хотите удалить {personName} из базы данных? Каждый связанный комментарий и превью будет удален. Пожалуйста, для подтверждения введите полное имя пользователя.',
+    edit_title: 'Редактировать пользователя',
+    empty_team: 'В команде проекта никто не указан.',
+    invite: 'Отправить приглашение',
+    invite_error: 'Произошла ошибка при отправке приглашения',
+    invite_success: 'Приглашение успешно отправлено',
+    new_person: 'Добавить нового сотрудника',
+    no_task_assigned: 'Для вас не назначено текущих задач',
+    persons: 'пользователь | пользователи',
+    running_tasks: 'Текущие задачи',
+    select_person: 'Выберите пользователя...',
+    team: 'Команда',
+    title: 'Команда',
+    unactive: 'Неактивный',
     csv: {
-      import_file: 'Импортироать .csv файл', // Import a .csv file
-      export_file: 'Сохранить как .csv файл', // Download as a .csv file
-      import_title: 'Импортировать данные с файла CSV', // Import data from a CSV file
-      required_fields: 'Вашему файлу CSV нужны седующие столбцы', // Your CSV file requires the following columns
-      select_file: 'Выберите файл из одной из ваших папок:', // Please select a file from one of your folder:
-      error_upload: 'Ошибка при загрузке вашего файла CSV.', // An error occured while uploading your CSV file.
+      import_file: 'Импортироать .csv файл',
+      export_file: 'Сохранить как .csv файл',
+      import_title: 'Импортировать данные из CSV',
+      required_fields: 'Вашему файлу CSV нужны седующие столбцы',
+      select_file: 'Выберите файл:',
+      error_upload: 'При загрузке CSV произошла ошибка.'
     },
     fields: {
-      first_name: 'Имя', // First name
-      last_name: 'Фамилия', // Last name
-      email: 'Почта', // Email
-      phone: 'Телефон', // Phone
-      role: 'Роль', // Role
-      old_password: 'Текущий пароль', // Current password
-      password: 'Новый пароль', // New password
-      password_2: 'Новый пароль (повторно)', // New password (repeat)
-      active: 'Активный' // Active
+      first_name: 'Имя',
+      last_name: 'Фамилия',
+      email: 'Почта',
+      phone: 'Телефон',
+      role: 'Роль',
+      old_password: 'Текущий пароль',
+      password: 'Новый пароль',
+      password_2: 'Новый пароль (повторно)',
+      active: 'Активный'
     },
     list: {
-      name: 'Имя', // Name
-      email: 'Почта', // Email
-      phone: 'Телефон', // Phone
-      role: 'Роль', // Role
-      active: 'Активный' // Active
+      name: 'Имя',
+      email: 'Почта',
+      phone: 'Телефон',
+      role: 'Роль',
+      active: 'Активный'
     },
     role: {
-      admin: 'Студийный Менеджер', // Studio Manager
-      client: 'Клиент', // Client
-      manager: 'Диспетчер', // Supervisor
-      user: 'Художник', // Artist
-      undefined: '',
-      vendor: 'Подрядчик' // Vendor
+      admin: 'Администратор',
+      client: 'Клиент',
+      manager: 'Супервайзер',
+      user: 'Художник',
+      undefined: 'Не определён',
+      vendor: 'Вендор'
     }
   },
 
   playlists: {
-    add_assets: 'Добавить ассеты', // Add assets
-    add_selection: 'Add selection',
-    add_shots: 'Добавить шоты', // Add shots
-    add_sequence: 'Add whole sequence',
-    add_episode: 'Добавить целый эпизод', // Add whole episode
-    add_movie: 'Добавить целый фильм', // Add whole movie
-    apply_task_type_change: 'This will set the last revison for given task type on all shots.',
-    available_build: 'Доступные сборки', // Available builds
-    build_daily: 'Daily pending',
-    build_weekly: 'All Pending',
-    build_mp4: 'Build .mp4 (beta)',
-    building: 'Building...',
-    client_playlist: 'Клиентский Плейлист', // Client Playlist
-    create_for_selection: 'Generate a playlist for shot selection',
-    create_title: 'Create playlist',
-    created_at: 'Создан в:', // Created at:
-    delete_text: 'Уверены, что хотите удалить {name} из своей базы данных?', // Are you sure you want to remove {name} from your database?
-    delete_error: 'ошибка при удалении плейлиста.', // An error occured while deleting this playlist.
-    edit_error: 'Ошибка при сохранении плейлиста.', // An error occured while saving this playlist.
-    download_zip: 'Скачать .zip', // Download .zip
-    failed: 'Failed',
-    for_client: 'Клиент', // The client
-    for_studio: 'Студия', // The Studio
-    edit_title: 'Редактировать плейлист', // Edit playlist
-    last_creation: 'Last creations',
-    last_modification: 'Последние модификации', // Last modifications
-    loading_error: 'A server error occured. Playlists cannot be loaded.',
-    new_playlist: 'Добавить плейлист', // Add a playlist
-    no_build: 'Нет сборки', // No build
-    no_playlist: 'В настоящий момент нет плейлиста для этого проекта или эпизода', // There is currently no playlist for this project or episode.
-    no_preview: 'Нет превью', // No preview
-    no_selection: 'Выберите один из плейлистов слева.', // Please select a playlist on the left.
-    no_sequence_for_episode: 'There is no sequence for this episode',
-    no_shot_for_production: 'нет шота для этого проекта', // There is no shot for this production
-    select_shot: 'Веыберите шот из правого столбца', // Please select a shot in the right column
-    select_playlist: 'Выберите плейлист из левого столбца', // Please select a playlist in the left column
-    select_task_type: 'Изменить тип задачи для всех шотов', // Change task type for all shots
-    title: 'Плейлисты', // Playlists
-    updated_at: 'Updated at:',
-    remove: 'удалить', // remove
+    add_assets: 'Добавить ассеты',
+    add_selection: 'Добавить selection',
+    add_shots: 'Добавить шоты',
+    add_sequence: 'Добавить секвенцию',
+    add_episode: 'Добавить эпизод',
+    add_movie: 'Добавить фильм',
+    apply_task_type_change: 'Выбрать последнюю версию для типа задачи на всех шотах.',
+    available_build: 'Доступные сборки',
+    build_daily: 'Дейли собирается',
+    build_weekly: 'Все собираются',
+    build_mp4: 'Собрать .mp4 (beta)',
+    building: 'Собираю...',
+    client_playlist: 'Клиентский Плейлист',
+    create_for_selection: 'Создать плейлист для выбранных шотов',
+    create_title: 'Создать плейлист',
+    created_at: 'Создан в:',
+    delete_text: 'Уверены, что хотите удалить {name} из базы данных?',
+    delete_error: 'Ошибка при удалении плейлиста.',
+    edit_error: 'Ошибка при сохранении плейлиста.',
+    download_zip: 'Скачать .zip',
+    failed: 'Облом',
+    for_client: 'Клиент',
+    for_studio: 'Студия',
+    edit_title: 'Редактировать плейлист',
+    last_creation: 'Последнее создание',
+    last_modification: 'Последняя модификация',
+    loading_error: 'На сервере произошла ошибка. Не получилось загрузить плейлисты.',
+    new_playlist: 'Добавить плейлист',
+    no_build: 'Нет сборки',
+    no_playlist: 'Для этого проекта или эпизода сейчас нет плейлиста',
+    no_preview: 'Нет превью',
+    no_selection: 'Выберите плейлист слева.',
+    no_sequence_for_episode: 'Для этого эпизода нет секвенций',
+    no_shot_for_production: 'Для этого проекта нет шотов',
+    select_shot: 'Веыберите шот из правого столбца',
+    select_playlist: 'Выберите плейлист из левого столбца',
+    select_task_type: 'Изменить тип задачи для всех шотов',
+    title: 'Плейлисты',
+    updated_at: 'Обновлен:',
+    remove: 'удалить',
     fields: {
-      name: 'Назв.', // Name
-      created_at: 'Дата создания', // Creation date
-      updated_at: 'Дата апдейта', // Update date
-      for_entity: 'Выбрать объект для отображения', // Select entity to display
-      for_client: 'To be shared with'
+      name: 'Название',
+      created_at: 'Дата создания',
+      updated_at: 'Дата обновления',
+      for_entity: 'Выбрать объект для отображения',
+      for_client: 'Поделиться с'
     },
     actions: {
-      annotation: 'Аннотация', // Annotation
-      annotation_text: 'Дважды кликните по превью, чтобы добавить текст', // Double click on the preview to add some text
-      annotation_delete: 'Удалить аннотацию', // Delete annotation
-      annotation_redo: 'Повторить аннотацию', // Redo annotation
-      annotation_undo: 'Отменить аннотацию', // Undo annotation
-      annotation_big: 'Большой', // Big
-      annotation_medium: 'Средний', // Medium
-      annotation_small: 'Маленький', // Small
-      change_task_type: 'Изменить тип задачи', // Change task type
-      comments: 'Показать/Скрыть комментарии', // Show/Hide comments
-      delete: 'Удалить плейлист', // Delete playlist
-      download: 'Скачать...', // Download…
-      edit: 'Редактировать плейлист', // Edit playlist
-      entity_list: 'Показать/Скрыть список объектов', // Show/Hide entity list
-      fullscreen: 'Полный экран', // Fullscreen
-      next_frame: 'Next frame',
-      next_shot: 'Следующий шот', // Next shot
-      pause: 'Пауза', // Pause
-      play: 'Пуск', // Play
-      previous_frame: 'Previous frame',
-      previous_shot: 'предыдущий шот', // Previous shot
-      save_playlist: 'Сохранить плейлист', // Save playlist
-      speed: 'Изменить скорость', // Change speed
-      split_screen: 'Двойной экран' // Split screen
+      annotation: 'Аннотация',
+      annotation_text: 'Чтобы добавить текст сделайте двойной клик по превью',
+      annotation_delete: 'Удалить аннотацию',
+      annotation_redo: 'Повторить аннотацию',
+      annotation_undo: 'Отменить аннотацию',
+      annotation_big: 'Большой',
+      annotation_medium: 'Средний',
+      annotation_small: 'Маленький',
+      change_task_type: 'Изменить тип задачи',
+      comments: 'Показать/Скрыть комментарии',
+      delete: 'Удалить плейлист',
+      download: 'Скачать...',
+      edit: 'Редактировать плейлист',
+      entity_list: 'Показать/Скрыть список объектов',
+      fullscreen: 'Полный экран',
+      next_frame: 'Следующий кадр',
+      next_shot: 'Следующий шот',
+      pause: 'Пауза',
+      play: 'Пуск',
+      previous_frame: 'Предыдущий кадр',
+      previous_shot: 'Предыдущий шот',
+      save_playlist: 'Сохранить плейлист',
+      speed: 'Изменить скорость',
+      split_screen: 'Двойной экран'
     }
   },
 
   productions: {
-    current: 'Выбраный проект', // Selected production
-    delete_text: 'Are you sure you want to remove {name} from your database? Please, confirm by typing the name of the project you want to delete in the text field.',
-    delete_error: 'An error occured while deleting this production. There are probably data linked to it. Are you sure this production has no task, shot or asset linked to it? Kitsu doesn\'t allow production deletion. If you don\'t want to see the production anymore, you can close it instead.',
-    edit_error: 'An error occured while editing production. Please contact our support team.',
-    edit_title: 'Редактировать проект', // Edit production
-    new_production: 'Добавить проект', // Add a production
-    number: 'проект | проекты', // production | productions
-    open_productions: 'Мои проекты', // My productions
-    picture: 'Изменить изображение', // Change picture
-    title: 'Проекты', // Productions
+    current: 'Выбраный проект',
+    delete_text: 'Вы уверены что хотите удалить {name} из базы данных? Пожалуйста, для подтверждения введите название проекта в текстовом поле.',
+    delete_error: 'Возникла ошибка при удалении проекта. Скорее всего к нему привязаны какие-то данные. Вы уведомления что к этому проекту не привязаны задачи, шоты или ассеты? Kitsu не позволяет удалять не пустые проекты. Если вы больше не хотите видеть это проект, можете закрыть его вместо удаления.',
+    edit_error: 'Возникла ошибка при редактировании проекта. Обратитесь в поддержку.',
+    edit_title: 'Редактировать проект',
+    new_production: 'Добавить проект',
+    number: 'проект | проекты',
+    open_productions: 'Мои проекты',
+    picture: 'Изменить картинку',
+    title: 'Проекты',
     home: {
-      create_new: 'Создать новый проект', // Create a new production
-      empty: 'У вас нет открытых проектов. Не хотите ли создать новый?', // You don't have any production open. What about creating a new one?
-      no_task: 'У вас не распределены задачи. Обратитесь к вашему диспетчеру за помощью', // You have no task assigned. See your supervisor to see what you can do!
-      no_prod_for_client: 'You don\'t have access to any production. Contact your contractor to obtain an access.',
-      title: 'Running Productions',
-      welcome: 'Добро пожаловать в Kitsu' // Welcome to Kitsu
+      create_new: 'Создать новый проект',
+      empty: 'У вас нет проектов в работе. Создать?',
+      no_task: 'Вам не назначено задач. Попросите задачу у супервайзера',
+      no_prod_for_client: 'У вас нет доступа к проектам. Обратитесь к заказчику для получения доступа.',
+      title: 'Проекты в работе',
+      welcome: 'Добро пожаловать в Kitsu'
     },
     fields: {
       fps: 'FPS',
-      name: 'Назв.', // Name
-      ratio: 'Ratio',
-      resolution: 'Разрешение', // Resolution
-      status: 'Статус', // Status
-      type: 'Тип' // Type
+      name: 'Название',
+      ratio: 'Соотношение сторон',
+      resolution: 'Разрешение',
+      status: 'Статус',
+      type: 'Тип'
     },
     metadata: {
       add_explaination: 'Add specific data required by this project.',
@@ -507,64 +507,64 @@ export default {
     },
 
     status: {
-      closed: 'Закрыт', // Closed
-      open: 'Открыт', // Open
-      active: 'Открыт', // Open
-      archived: 'Закрыт' // Closed
+      closed: 'Закрыт',
+      open: 'Открыт',
+      active: 'Открыт',
+      archived: 'Закрыт'
     },
 
     type: {
-      short: 'Короткий', // Short
-      featurefilm: 'Feature Film',
-      tvshow: 'ТВ шоу' // TV Show
+      short: 'Видео',
+      featurefilm: 'Фильм',
+      tvshow: 'ТВ шоу'
     }
   },
 
   profile: {
-    change_avatar: 'Изменить аватар', // Change avatar
-    info_title: 'Информация', // Information
-    language: 'Язык', // Language
-    notifications_enabled: 'Уведомления на почту включены', // Email notifications enabled
-    notifications_slack_enabled: 'Slack notifications enabled',
-    notifications_slack_user: 'Slack username',
-    password_title: 'Изменить пароль', // Change password
-    timezone: 'Временная зона', // Timezone
-    title: 'Ваш Профиль', // Your Profile
+    change_avatar: 'Изменить аватар',
+    info_title: 'Информация',
+    language: 'Язык',
+    notifications_enabled: 'Отправлять уведомления на почту?',
+    notifications_slack_enabled: 'Отправлять уведомления в Slack?',
+    notifications_slack_user: 'Имя пользователя в Slack',
+    password_title: 'Изменить пароль',
+    timezone: 'Часовой пояс',
+    title: 'Профиль',
     avatar: {
-      title: 'Изменить аватар', // Change avatar
-      error_upload: 'Ошибка при загрузке изображения' // There was an error while uploading picture.
+      title: 'Изменить аватар',
+      error_upload: 'Ошибка при загрузке изображения'
     },
     change_password: {
-      button: 'Изменить пароль', // Change password
-      error: 'Ошибка при смене пароля. Подтвердите ваш текущий пароль.', // An error occured while changing password. Please verify your current password.
-      success: 'Ваш пароль успешно изменён!', // Your password was successfully changed!
-      unvalid: 'Your new password confirmation doesn\'t match or your password is too short (7 chars, at least, is expected).'
+      button: 'Изменить пароль',
+      error: 'Ошибка при смене пароля. Подтвердите ваш текущий пароль.',
+      success: 'Ваш пароль успешно изменён!',
+      unvalid: 'Введенные пароли не совпадают или пароль слишком короткий (нужно не менее 7-ми символов).'
     },
     save: {
-      button: 'Сохранить изменения', // Save changes
-      error: 'Ошибка при сохраниении изменений' // An error occured while saving changes
+      button: 'Сохранить изменения',
+      error: 'Ошибка при сохраниении изменений'
     }
   },
 
   settings: {
-    change_logo: 'Изменить логотип', // Change logo
-    integrations: 'Интеграции', // Integrations
-    logo: 'Логотип студии', // Studio logo
-    no_logo: 'Логотип не установлен', // There is no logo set.
-    set_logo: 'Установить логотип студии', // Set studio logo
-    title: 'Настройки', // Settings
+    change_logo: 'Изменить логотип',
+    integrations: 'Интеграции',
+    logo: 'Логотип студии',
+    no_logo: 'Нет логотипа',
+    set_logo: 'Добавить логотип студии',
+    title: 'Настройки',
     fields: {
-      name: 'Название студии', // Studio name
-      hours_by_day: 'Часов в день', // Hours by day
-      slack_token: 'Slack Token (Опционально)', // Slack Token (Optional)
-      use_original_name: 'Use original file name for downloads'
+      name: 'Название студии',
+      hours_by_day: 'Часов в день',
+      slack_token: 'Токен Slack (Опционально)',
+      use_original_name: 'Использовать оригинальное название файла при скачивании'
     },
     production: {
       empty_list: 'The list is currently empty. It means that all data from the main settings are available to users. Add some entries to limit choices for this production.'
     },
     save: {
-      button: 'Сохранить настройки', // Save settings
-      error: 'Ошибка сервера при сохранении настроек' // A server error occured while saving settings
+      button: 'Сохранить настройки',
+      error: 'При сохранении настроек на сервере произошна ошибка'
     }
   },
 
@@ -575,7 +575,7 @@ export default {
     edit_title: 'Edit task status',
     number: 'task status | task status',
     new_task_status: 'Add a task status',
-    title: '', 
+    title: 'Статусы задач',
     fields: {
       color: 'Color',
       is_artist_allowed: 'Is artist allowed',

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -155,7 +155,7 @@ export default {
     all_episodes: 'Все эпизоды',
     edit_error: 'Ошибка при сохранении этого эпизода. Вы уверены, что нет эпизода с таким же названием?',
     delete_error: 'Ошибка при удалении этого эпизода. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот тип ассетов не связан с какой-либо секвенция?',
-    delete_text: 'Уверены, что хотите удалить {name} из своей базы данных? Каждый связаный шот и превью будет удален. Пожалуйста, введите название эпизода для подтверждения.',
+    delete_text: 'Уверены, что хотите удалить {name} из базы данных? Каждый связаный шот и превью будет удален. Пожалуйста, введите название эпизода для подтверждения.',
     edit_title: 'Редактировать эпизод',
     empty_list: 'В проекте нет ни одного эпизода. Создать?',
     empty_list_client: 'В этом проекте нет ни одного эпизода.',
@@ -327,7 +327,7 @@ export default {
     assigned_you: 'назначил(а) вас на',
     commented_on: 'прокомментировал(а)',
     mention_you_on: 'упомянул(а) вас в',
-    no_notifications: 'Сейчас нет комментариев по вашим текущим проэктам',
+    no_notifications: 'Сейчас нет комментариев по вашим текущим проектам',
     unread_notifications: 'непрочитанное уведомление | непрочитанные уведомления',
     title: 'Уведомления',
     with_preview: 'с превью'
@@ -564,261 +564,261 @@ export default {
     },
     save: {
       button: 'Сохранить настройки',
-      error: 'При сохранении настроек на сервере произошна ошибка'
+      error: 'При сохранении настроек на сервере произошла ошибка'
     }
   },
 
   task_status: {
-    create_error: 'Ошибка при сохранении этого статуса задачи. Вы уверены, что нет статуса задачи с таким же названием?', // An error occured while saving this task status. Are you sure there is no task status with similar name?
-    delete_text: 'Уверены, что хотите удалить {name} из своей базы данных?', // Are you sure you want to remove {name} from your database?
-    delete_error: 'Ошибка при удалении статуса задачи. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот статус задачи не связан с какой-либо задачей?', // An error occured while deleting this task status. There are probably data linked to it. Are you sure this task status has no task linked to it?
-    edit_title: 'Редактировать статус задачи', // Edit task status
-    number: 'статус задачи | статус задачи', // task status | task status
-    new_task_status: 'Добавить статус задаци', // Add a task status
-    title: 'Статус Задачи', // Task Status
+    create_error: 'Ошибка при сохранении этого статуса задачи. Вы уверены, что нет статуса с таким же названием?',
+    delete_text: 'Уверены, что хотите удалить {name} из базы данных?',
+    delete_error: 'Ошибка при удалении статуса задачи. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот статус не связан с какой-либо задачей?',
+    edit_title: 'Редактировать статус задачи',
+    number: 'статус задачи | статус задачи',
+    new_task_status: 'Добавить статус задачи',
+    title: 'Статус Задачи',
     fields: {
-      color: 'Цвет', // Color
-      is_artist_allowed: 'Is artist allowed',
-      is_client_allowed: 'Is client allowed',
-      is_done: 'Завершена', // Is done
-      is_reviewable: 'Is reviewable',
-      is_retake: 'Has retake value',
-      name: 'Назв.', // Name
-      short_name: 'Сокр. назв.' // Short name
+      color: 'Цвет',
+      is_artist_allowed: 'Видна художнику',
+      is_client_allowed: 'Видна клиенту',
+      is_done: 'Готово',
+      is_reviewable: 'Можно проверить',
+      is_retake: 'Отправлялся на доработку',
+      name: 'Название',
+      short_name: 'Краткое название'
     }
   },
 
   task_types: {
-    delete_text: 'Уверены, что хотите удалить {name} из своей базы данных?', // Are you sure you want to remove {name} from your database?
-    delete_error: 'Ошибка при удалении этого типа задачи. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот статус задачи не связан с какой-либо задачей?', // An error occured while deleting this task type. There are probably data linked to it. Are you sure this task type has no task linked to it?
-    edit_title: 'Редактировать тип задачи', // Edit task type
-    create_error: 'An error occured while creating the task type. Please, check that there is no task type with similar name.',
-    new_task_type: 'Добавить тип задачи', // Add a task type
-    number: 'тпип задачи | типы задач', // task type | task types
-    title: 'типы Задач', // Task Types
+    delete_text: 'Уверены, что хотите удалить {name} из базы данных?',
+    delete_error: 'Ошибка при удалении этого типа задач. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот статус не связан с какой-либо задачей?',
+    edit_title: 'Редактировать тип задачи',
+    create_error: 'An error occured while creating the task type. Please, check that there is no task type with similar name.', // 'An error occured while creating the task type. Please, check that there is no task type with similar name.'
+    new_task_type: 'Добавить тип задачи',
+    number: 'тпип задачи | типы задач',
+    title: 'типы Задач',
     fields: {
-      dedicated_to: 'Для', // For
-      color: 'Цвет', // Color
-      name: 'Назв.', // Name
-      allow_timelog: 'Timelog',
-      priority: 'Приоритет' // Priority
+      dedicated_to: 'Для',
+      color: 'Цвет',
+      name: 'Название',
+      allow_timelog: 'Лог времени',
+      priority: 'Приоритет'
     }
   },
 
   sequences: {
-    all_sequences: 'Все секвенции', // All sequences
-    edit_error: 'Ошибка при сохранении этой секвенции. Вы уверены, что нет секвенции с таким же названием?', // An error occured while saving this sequence. Are you sure there is no sequence with similar name?
-    delete_text: 'Уверены, что хотите удалить {name} из своей базы данных? Все связанные шоты и превью будут удалены. Для подтверждения введите название секвенции внизу.', // Are you sure you want to remove {name} from your database? Every related shots and previews will be deleted. Please confirm by typing the sequence name below.
-    delete_error: 'Ошибка при удалении секвенции. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот тип ассетов не связан с каким-либо шотом?', // An error occured while deleting this sequence. There are probably data linked to it. Are you sure this sequence has no shot linked to it?
-    edit_title: 'Редактировать секвенцию', // Edit sequence
-    empty_list: 'В проекте нет ни одной секвенции. Не хотите ли создать?', // There is no sequence in the production. What about creating some?
-    empty_list_client: 'В этом проекте нет ни одной секвенции.', // There is no sequence in this production.
-    new_sequence: 'Новая секвенция', // New sequence
-    number: 'секвенция | секвенции', // sequence | sequences
-    title: 'Статистика Севенции', // Sequence Stats
+    all_sequences: 'Все секвенции',
+    edit_error: 'Ошибка при сохранении этой секвенции. Вы уверены, что нет секвенции с таким же названием?',
+    delete_text: 'Уверены, что хотите удалить {name} из базы данных? Все связанные шоты и превью будут удалены. Для подтверждения введите название секвенции.',
+    delete_error: 'Ошибка при удалении секвенции. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что эта секвенция не связана с каким-либо шотом?',
+    edit_title: 'Редактировать секвенцию',
+    empty_list: 'В проекте нет ни одной секвенции. Создать?',
+    empty_list_client: 'В этом проекте нет ни одной секвенции.',
+    new_sequence: 'Новая секвенция',
+    number: 'секвенция | секвенции',
+    title: 'Статистика Севенции',
     fields: {
-      name: 'назв.', // name
-      description: 'описание' // description
+      name: 'назв.',
+      description: 'описание'
     }
   },
 
   schedule: {
-    title: 'График', // Schedule
-    title_main: 'Основной график', // Main Schedule
-    overall_man_days: 'Man-days',
-    md: 'md',
-    zoom_level: 'Zoom level',
+    title: 'График',
+    title_main: 'Основной график',
+    overall_man_days: 'Человеко-дни',
+    md: 'ч/д',
+    zoom_level: 'Zoom',
     milestone: {
-      add_milestone: 'Добавить этапы для', // Add milestone for
-      edit_milestone: 'Редактировать этапы для', // Edit milestone for
-      name: 'Назв', // Name
-      error: 'Ошибка при добавлении или редактировании этапа. Повторите попытку.' // An error occured while adding or editing the milestone. Please try again.
+      add_milestone: 'Добавить этапы для',
+      edit_milestone: 'Редактировать этапы для',
+      name: 'Назв',
+      error: 'Ошибка при добавлении или редактировании этапа. Повторите попытку.'
     }
   },
 
   quota: {
-    average: 'Средний', // Average
-    count_label: 'Count mode',
-    detail_label: 'Detail level',
-    details_name: 'Назв.', // Name
-    details_seconds: 'Секунды', // Seconds
-    details_frames: 'Кадры', // Frames
-    month_label: 'Месяц', // Month
-    no_quota: 'Нет квоты для этого типа задачи', // There is no quota for this task type.
-    name: 'Назв.', // Name
-    quota_day: 'Ежедневная квота', // Quota per day
-    quota_week: 'Еженедельная квота', // Quota per week
-    quota_month: 'Ежемесечная квота', // Quota per month
-    year_label: 'Год', // Year
-    title: 'Квота', // Quota
-    type_label: 'Тип' // Type
+    average: 'Средний',
+    count_label: 'Счет',
+    detail_label: 'Уровень детализации',
+    details_name: 'Название',
+    details_seconds: 'Секунд',
+    details_frames: 'Кадры',
+    month_label: 'Месяц',
+    no_quota: 'Нет оценки трудозатрат для этого типа задачи',
+    name: 'Название',
+    quota_day: 'Трудозатраты в день',
+    quota_week: 'Трудозатраты в неделю',
+    quota_month: 'Трудозатраты в месяц',
+    year_label: 'Год',
+    title: 'Трудозатраны',
+    type_label: 'Тип'
   },
 
   shots: {
-    casting: 'Задействование шота', // Shot casting
-    creation_explaination: 'To add shots you need first to create an episode and a sequence. Type an episode name in the bottom of the left column then click on add to create a new episode. Select this episode and repeat the same operation for sequence. Finally select a sequence and type a shot name in the field in the bottom of the right column. Click on the add button below. Your first shot was created. You can now add many more! If it\'s not a TV Show, you have to directly create a sequence.',
-    delete_text: 'Уверены, что хотите удалить {name} из своей базы данных?', // Are you sure you want to remove {name} from your database?
-    delete_error: 'Ошибка при удалении шота. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот тип ассетов не связан с какой-либо задачей?', // An error occured while deleting this shot. There are probably data linked to it. Are you sure this shot has no task linked to it?
-    edit_success: 'Шот {name} успешно изменён.', // Shot {name} successfully edited.
-    edit_fail: 'Creation or edition failed, an error occured. Make sure that you are not renaming the shot with a name already listed for given sequence.',
-    edit_title: 'Редактировать шот', // Edit shot
-    empty_list: 'There is no shot in the production. What about creating some?',
-    empty_list_client: 'There is no shot in this production.',
-    episodes: 'Эпизоды', // Episodes
-    history: 'История значений шота', // Shot values history
-    new_shot: 'Добавить шот', // Add a shot
-    new_shots: 'Добавить шоты', // Add shots
-    new_sequences: 'добавить секвенции', // Add sequences
-    new_episodes: 'Добавить эпизоды', // Add episodes
-    no_casting: 'Пустое задействование шота', // The shot casting is empty.
-    number: 'шот | шоты', // shot | shots
-    manage: 'Создать шоты', // Create shots
-    new_success: 'Shot {name} successfully created.',
-    padding: 'Shot Padding',
-    restore_text: 'Вы уверены, что хотите восстановить {name} в вашей базе данных?', // Are you sure you want to restore {name} into your database?
-    restore_error: 'Ошибка при восстановлении шота', // An error occured while restoring this shot.
-    sequences: 'Секвенции', // Sequences
-    tasks: 'Задачи Шотов', // Shot Tasks
-    title: 'Шоты', // Shots
+    casting: 'Использование шота',
+    creation_explaination: 'To add shots you need first to create an episode and a sequence. Type an episode name in the bottom of the left column then click on add to create a new episode. Select this episode and repeat the same operation for sequence. Finally select a sequence and type a shot name in the field in the bottom of the right column. Click on the add button below. Your first shot was created. You can now add many more! If it\'s not a TV Show, you have to directly create a sequence.', // 'To add shots you need first to create an episode and a sequence. Type an episode name in the bottom of the left column then click on add to create a new episode. Select this episode and repeat the same operation for sequence. Finally select a sequence and type a shot name in the field in the bottom of the right column. Click on the add button below. Your first shot was created. You can now add many more! If it\'s not a TV Show, you have to directly create a sequence.'
+    delete_text: 'Уверены, что хотите удалить {name} из базы данных?',
+    delete_error: 'Ошибка при удалении шота. Вероятнее всего к нему привязаны какие-то данные. Вы уверены, что этот шот не связан с какой-либо задачей?',
+    edit_success: 'Шот {name} отредактирован.',
+    edit_fail: 'Creation or edition failed, an error occured. Make sure that you are not renaming the shot with a name already listed for given sequence.', // 'Creation or edition failed, an error occured. Make sure that you are not renaming the shot with a name already listed for given sequence.'
+    edit_title: 'Редактировать шот',
+    empty_list: 'There is no shot in the production. What about creating some?', // 'There is no shot in the production. What about creating some?'
+    empty_list_client: 'There is no shot in this production.', // 'There is no shot in this production.'
+    episodes: 'Эпизоды',
+    history: 'История шота',
+    new_shot: 'Добавить шот',
+    new_shots: 'Добавить шоты',
+    new_sequences: 'Добавить секвенции',
+    new_episodes: 'Добавить эпизоды',
+    no_casting: 'Шот нигде не используется',
+    number: 'шот | шоты',
+    manage: 'Создать шоты',
+    new_success: 'Shot {name} successfully created.', // 'Shot {name} successfully created.'
+    padding: 'Shot Padding', // 'Shot Padding'
+    restore_text: 'Вы уверены, что хотите восстановить {name} в базе данных?',
+    restore_error: 'Ошибка при восстановлении шота',
+    sequences: 'Секвенции',
+    tasks: 'Задачи по Шотам',
+    title: 'Шоты',
     fields: {
-      description: 'Описание', // Description
-      nb_frames: 'Кадры', // Frames
-      episode: 'Эпизод', // Episode
+      description: 'Описание',
+      nb_frames: 'Кадры',
+      episode: 'Эпизод',
       frame_in: 'In',
       frame_out: 'Out',
       fps: 'FPS',
-      name: 'Назв.', // Name
-      production: 'Проект', // Prod
-      sequence: 'Секвенция', // Sequence
-      time_spent: 'Время' // Time
+      name: 'Название',
+      production: 'Проект',
+      sequence: 'Секвенция',
+      time_spent: 'Время'
     }
   },
 
   server_down: {
-    text: 'Please contact your vendor support, your system administrator or your IT department to understand what is going wrong.',
-    title: 'Kitsu encountered an error while reaching its data API.'
+    text: 'Please contact your vendor support, your system administrator or your IT department to understand what is going wrong.', // 'Please contact your vendor support, your system administrator or your IT department to understand what is going wrong.',
+    title: 'Kitsu encountered an error while reaching its data API.' // 'Kitsu encountered an error while reaching its data API.'
   },
 
   statistics: {
-    count: 'Counts',
-    count_mode: 'Count mode',
-    display_mode: 'Display mode',
-    frames: 'Кадры', // Frames
-    pie: 'Круговые диаграммы', // Pie charts
-    shots: 'Шоты' // Shots
+    count: 'Счет',
+    count_mode: 'Тип счета',
+    display_mode: 'Тип отображения',
+    frames: 'Кадры',
+    pie: 'Круговые диаграммы',
+    shots: 'Шоты'
   },
 
   tasks: {
-    add_preview: 'Добавить превью', // Add preview
-    add_preview_error: 'An error occured while adding preview.',
-    assign: 'Assign one task to: | Assign {nbSelectedTasks} tasks to:',
-    back_to_list: 'назад к списку', // back to list
-    bigger: 'расширить панель задач', // Widen task panel
-    change_status_to: 'Изменить статус задачи на:', // Change task status to:
-    change_preview: 'Изменить превью', // Change preview
-    change_priority: 'Изменить приоритет на:', // Change priority to:
-    clear_assignations: 'очистить назначения', // clear assignations
-    comment_image: 'Прикрепить изображение к комментарию', // Attach an image to your comment
-    create_for_selection: 'Create task for each empty cell:',
-    create_tasks: 'Добавить задачи', // Add tasks
-    create_tasks_shot: 'Добавть задачи для текущих шотов', // Add tasks for current shots
-    create_tasks_shot_explaination: 'You are going to create a new task for each shot of current project for the given task type. Do you want to continue?',
-    create_tasks_shot_failed: 'A server error occured while proceeding creations.',
-    create_tasks_asset: 'Добавить задачи для текущих ассетов', // Add tasks for current assets
-    create_tasks_asset_explaination: 'You are going to create a new task for each asset of current project for the given task type. Do you want to continue?',
-    create_tasks_asset_failed: 'A server error occured while proceeding creations.',
-    current: 'Задача на выполнение', // Task to do
-    current_status: 'Текущий статус:', // Current status :
-    delete_all_text: 'Are you sure you want to delete all tasks for given {name}? Please, confirm by typing the task type name of the tasks you want to delete in the text field.',
-    delete_all_error: 'Deleting all tasks for given task type failed.',
-    delete_error: 'Ошибка при удалении задачи', // An error occured while deleting task.
-    delete_comment: 'Уверены, что хотите удалить последний комментарий?', // Are you sure you want to delete last comment?
-    delete_comment_error: 'Ошибка при удалении комментария.', // An error occured while deleting comment.
-    delete_for_selection: 'Удалить выбранные задачи:', // Delete selected tasks:
-    delete_preview: 'Уверены, что хотите удалить этот превью? ', // Are you sure you want to delete this preview?
-    delete_preview_error: 'ошибка при удвлении превью.', // An error occured while deleting preview.
-    edit_comment: 'Редактировать комментарий', // Edit comment
-    done: 'Завершено', // Done
-    download_pdf_file: 'Скачать .{extension} файл', // Download .{extension} file
-    feedback: 'обратная связь', // feedback
-    full_screen: 'Открыть на полный экран', // Display in full screen
-    hide_assignations: 'Скрыть назначения', // Hide assignations
-    hide_infos: 'Скрыть дополнительную информацию', // Hide additional information
-    my_tasks: 'Мои задачи', // My tasks
-    next: 'следующая задача', // next task
-    no_assignation_right: 'You are not allowed to manage assignations',
-    no_comment: 'В настоящий момент у этогй задачи нет комментариев.', // There is currently no comment for this task.
-    no_preview: 'В настоящий момент у этогй задачи нет превью.', // There is currently no preview for this task.
-    no_task_selected: 'Задачи не выбраны', // No task selected
-    number: 'задача | задачи', // task | tasks
-    preview: 'Превью', // Previews
-    previous: 'предыдущая задача', // previous task
-    unsubscribe_notifications: 'Отписаться от уведомлений', // Unsubscribe from notifications
-    set_estimations: 'Выставить ожидания для выбранных задач:', // Set estimations for selected tasks:
-    set_preview: 'Установить это превью как ярлык', // Set this preview as thumbnail
-    set_preview_error: 'Ошибка при установлении превью как ярлыка', // An error occured while setting preview as thumbnail
-    set_preview_done: 'Это превью используется как ярлык для текущего объекта', // This preview is used as thumbnail for the current entity.
-    select_preview_file: 'Выберите изображение с диска для использования в качестве превью для текущей задачи', // Please select a picture from your hard drive to be used as a preview for the current task:
-    show_assignations: 'Показать назначения', // Show assignations
-    show_infos: 'Показать дополнитеьную информацию', // Show additional information
-    subscribe_notifications: 'Подписаться на уведомления', // Subscribe to notifications
-    select_image_file: 'Выберите изображение с диска, которе вы хотите прикрепить к комментарию.', // Please select the picture from your hard drive you want to attach to your comment:
-    tasks: 'Задачи', // Tasks
-    validation: 'Валидация', // Validation
-    with_comment: 'С комменарием...', // With a comment...
+    add_preview: 'Добавить превью',
+    add_preview_error: 'An error occured while adding preview.', // 'An error occured while adding preview.'
+    assign: 'Assign one task to: | Assign {nbSelectedTasks} tasks to:', // 'Assign one task to: | Assign {nbSelectedTasks} tasks to:'
+    back_to_list: 'Назад к списку',
+    bigger: 'Расширить панель задач',
+    change_status_to: 'Изменить статус задачи на:',
+    change_preview: 'Изменить превью',
+    change_priority: 'Изменить приоритет на:',
+    clear_assignations: 'Очистить назначения',
+    comment_image: 'Прикрепить изображение к комментарию',
+    create_for_selection: 'Create task for each empty cell:', // 'Create task for each empty cell:'
+    create_tasks: 'Добавить задачи',
+    create_tasks_shot: 'Добавть задачи для текущих шотов',
+    create_tasks_shot_explaination: 'You are going to create a new task for each shot of current project for the given task type. Do you want to continue?', // 'You are going to create a new task for each shot of current project for the given task type. Do you want to continue?'
+    create_tasks_shot_failed: 'A server error occured while proceeding creations.', // 'A server error occured while proceeding creations.'
+    create_tasks_asset: 'Добавить задачи для текущих ассетов',
+    create_tasks_asset_explaination: 'You are going to create a new task for each asset of current project for the given task type. Do you want to continue?', // 'You are going to create a new task for each asset of current project for the given task type. Do you want to continue?'
+    create_tasks_asset_failed: 'A server error occured while proceeding creations.', // 'A server error occured while proceeding creations.'
+    current: 'Задача на выполнение',
+    current_status: 'Текущий статус:',
+    delete_all_text: 'Are you sure you want to delete all tasks for given {name}? Please, confirm by typing the task type name of the tasks you want to delete in the text field.', // 'Are you sure you want to delete all tasks for given {name}? Please, confirm by typing the task type name of the tasks you want to delete in the text field.'
+    delete_all_error: 'Deleting all tasks for given task type failed.', // 'Deleting all tasks for given task type failed.'
+    delete_error: 'Ошибка при удалении задачи',
+    delete_comment: 'Уверены, что хотите удалить последний комментарий?',
+    delete_comment_error: 'Ошибка при удалении комментария.',
+    delete_for_selection: 'Удалить выбранные задачи:',
+    delete_preview: 'Уверены, что хотите удалить это превью? ',
+    delete_preview_error: 'Ошибка при удалении превью.',
+    edit_comment: 'Редактировать комментарий',
+    done: 'Готово',
+    download_pdf_file: 'Скачать .{extension} файл',
+    feedback: 'обратная связь',
+    full_screen: 'Открыть на весь экран',
+    hide_assignations: 'Скрыть назначения',
+    hide_infos: 'Скрыть дополнительную информацию',
+    my_tasks: 'Мои задачи',
+    next: 'Следующая задача',
+    no_assignation_right: 'Вы не можете управлять назначениями',
+    no_comment: 'В настоящий момент у этой задачи нет комментариев.',
+    no_preview: 'В настоящий момент у этой задачи нет превью.',
+    no_task_selected: 'Задачи не выбраны',
+    number: 'задача | задачи',
+    preview: 'Превью',
+    previous: 'Предыдущая задача',
+    unsubscribe_notifications: 'Отписаться от уведомлений',
+    set_estimations: 'Оценить выбранные задачи:',
+    set_preview: 'Установить это превью как ярлык',
+    set_preview_error: 'Ошибка при установлении превью как ярлыка',
+    set_preview_done: 'Это превью используется как ярлык для текущего объекта',
+    select_preview_file: 'Выберите изображение с диска для использования в качестве превью текущей задачи',
+    show_assignations: 'Показать назначения',
+    show_infos: 'Показать дополнитеьную информацию',
+    subscribe_notifications: 'Подписаться на уведомления',
+    select_image_file: 'Выберите изображение с диска, которе вы хотите прикрепить к комментарию.',
+    tasks: 'Задачи',
+    validation: 'Валидация',
+    with_comment: 'С комменарием...',
     fields: {
-      asset_type: 'Тип ассетов', // Asset type
-      assignees: 'Назначенные', // Assignees
-      count: 'Count',
-      due_date: 'До даты', // Due date
-      duration: 'Длительность', // Duration
-      end_date: 'Дата валидации', // Validation date
-      entity: 'Объект', // Entity
-      entity_name: 'Назв', // Name
-      estimated_quota: 'Средн. Квота', // Avg. Quota
-      estimation: 'Вычисление', // Estimation
-      frames: 'Кадр.', // Fram.
-      last_comment: 'Последний комментарий', // Last comment
-      last_comment_date: 'Последний комментарий', // Last comment
-      priority: 'Приоритет', // Priority
-      production: 'Проект', // Prod
-      real_end_date: 'Дата валидации', // Validation date
-      real_start_date: 'WIP дата', // WIP date
-      retake_count: 'Повторы', // Retakes
-      seconds: 'Секунды', // Seconds
-      sequence: 'Секвенция', // Sequence
-      start_date: 'Дата начала', // Start date
-      task_status: 'Статус', // Status
-      task_status_short_name: 'Статус', // Status
-      task_type: 'Тип' // Type
+      asset_type: 'Тип ассета',
+      assignees: 'Назначенные',
+      count: 'Кол-во',
+      due_date: 'Крайний срок',
+      duration: 'Длительность',
+      end_date: 'Дата валидации',
+      entity: 'Объект',
+      entity_name: 'Название',
+      estimated_quota: 'Оценка трудозатрат',
+      estimation: 'Оценка',
+      frames: 'Кадр',
+      last_comment: 'Последний комментарий',
+      last_comment_date: 'Последний комментарий',
+      priority: 'Приоритет',
+      production: 'Проект',
+      real_end_date: 'Дата валидации',
+      real_start_date: 'WIP дата',
+      retake_count: 'Повторы',
+      seconds: 'Секунды',
+      sequence: 'Секвенция',
+      start_date: 'Дата начала',
+      task_status: 'Статус',
+      task_status_short_name: 'Статус',
+      task_type: 'Тип'
     },
     colors: {
-      title: 'Окрас', // Coloring
-      neutral: 'Нейтральный', // Neutral
-      status: 'Цвет стауса', // Status color
-      late: 'Late in red'
+      title: 'Цвет',
+      neutral: 'Нейтральный',
+      status: 'Цвет стауса',
+      late: 'КРАСНЫЙ!'
     },
     priority: {
-      emergency: 'Черезвычайная ситуация', // Emergency
-      normal: 'Нормальный', // Normal
-      high: 'высокий', // High
-      very_high: 'Очень высокий' // Very High
+      emergency: 'СРОЧНО!',
+      normal: 'Нормальный',
+      high: 'Высокий',
+      very_high: 'Очень высокий'
     }
   },
 
   timesheets: {
-    detail_level: 'Detail level',
-    done_tasks: 'Выполненные задачи', // Done tasks
-    export_timesheet: 'Export Timesheet',
-    hours: 'часы', // hours
-    month: 'Месяц', // Month
-    time_spents: 'Затраченное время (часы)', // Time Spent (hours)
-    title: 'Timesheets',
-    year: 'Год' // Year
+    detail_level: 'Уровень детализации',
+    done_tasks: 'Выполненные задачи',
+    export_timesheet: 'Экспортировать План',
+    hours: 'часы',
+    month: 'Месяц',
+    time_spents: 'Затраченное время (часы)',
+    title: 'План',
+    year: 'Год'
   },
 
   wrong_browser: {
-    title: 'Kitsu не поддерживает ваш браузер', // Your browser is not supported by Kitsu
-    text: 'Kitsu поддерживает только Firefox и Chrome' // Kitsu can only be used with Firefox and Chrome browsers.
+    title: 'Kitsu не поддерживает ваш браузер',
+    text: 'Kitsu поддерживает только Firefox и Chrome'
   }
 }


### PR DESCRIPTION
**Problem**
Russian language was not supported in Kitsu.

**Solution**
Added Russian localisation. In this implementation for most of the terms the professional slang is used. 
For example:
- the word "asset" is translated as "ассет" (pronounced as asset) because everyone calls assets this way.
- same goes for the word "shot". It is translated as "шот" (pronounced as shot) because this is how everyone calls shots.

There might be a more old-school way of calling production terms from the soviet cinematographic legacy, but there's nobody I know who uses such terminology.
