### PR TITLE
Add retake statistics for TV shows

### DIFF
--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -665,9 +665,11 @@ export default {
       if (duration) {
         this.maxDuration = this.formatTime(duration)
         this.videoDuration = duration
+        this.progress.setAttribute('max', this.videoDuration)
       } else {
         this.maxDuration = '00:00.000'
         this.videoDuration = 0
+        this.progress.setAttribute('max', 0)
       }
     },
 

--- a/src/components/previews/PreviewViewer.vue
+++ b/src/components/previews/PreviewViewer.vue
@@ -140,8 +140,6 @@ export default {
   },
 
   mounted () {
-    if (!this.container) return
-    if (this.isMovie) this.configureVideo()
   },
 
   beforeDestroy () {
@@ -294,22 +292,6 @@ export default {
       }
     },
 
-    onToggleSoundClicked () {
-      this.isMuted = !this.isMuted
-    },
-
-    configureVideo () {
-      this.isPlaying = false
-      this.isMuted = false
-      this.isRepeating = false
-      /*
-      this.container.addEventListener('keydown', (event) => {
-        this.pauseEvent(event)
-        return false
-      })
-      */
-    },
-
     // Sizing
 
     getDimensions () {
@@ -357,7 +339,6 @@ export default {
   watch: {
     preview () {
       if (this.isMovie) {
-        this.configureVideo()
         this.pause()
         this.maxDuration = '00:00.000'
       } else if (this.isPicture) {

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -159,9 +159,7 @@ const actions = {
   loadTask ({ commit, state }, { taskId }) {
     return tasksApi.getTask(taskId)
       .then(task => {
-        setTimeout(() => {
-          commit(LOAD_TASK_END, task)
-        }, 1000)
+        commit(LOAD_TASK_END, task)
         return Promise.resolve(task)
       })
   },


### PR DESCRIPTION
**Problem**

* There is no way to have the number of retakes by "take".
* Video progress bar is broken 
* Realtime task loading has a 1s delay.

**Solution**

* Add an option to statistics table to see only retake count and show the progress of retake count by "take".
* Set properly max value.
* Remove useless timeout on data refreshing.