### PR TITLE
Add support to Opera (browser) > 22

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -60,7 +60,8 @@ export const routes = [
       const isValidBrowser = browser.satisfies({
         chrome: '>20.1.1432',
         firefox: '>31',
-        vivaldi: '>2.8'
+        vivaldi: '>2.8',
+        opera: '>22'
       })
       if (!isValidBrowser) {
         return next({ name: 'wrong-browser' })


### PR DESCRIPTION
**Problem**
Browser validation in routes.js does not include Opera. Opera is a popular browser based on chromium, with all the basic features to work with Kitsu.

**Solution**
Add support from version 22 on the isValidBrowser configuration object inside routes file.
