### PR TITLE
Revision comparison inside a playlist

### DIFF
--- a/src/variables.scss
+++ b/src/variables.scss
@@ -29,7 +29,6 @@ $dark-red: #DA002C;
 $pink-light: #FFC9D0;
 $pink: #FF69C0;
 $pink-strong: #FF49A0;
-$purple: #D1C4E9;
 $light-purple: #F1E4FF;
 $purple: #CFD1FF;
 $purple-strong: #8F91EB;


### PR DESCRIPTION
**Problem**

It's not possible to compare revisions inside a playlist.

**Solution**

Allow to compare revisions for a single entity. Moving to the next entity will set back to the latest revision (it's too complex to handle several revision numbers for each entity)
