### PR TITLE
Add brief for production

### DIFF
--- a/src/components/pages/ProductionSettings.vue
+++ b/src/components/pages/ProductionSettings.vue
@@ -3,6 +3,11 @@
     <div class="wrapper">
     <div class="tabs">
       <ul>
+        <li :class="{'is-active': isActiveTab('brief')}">
+          <a @click="activeTab = 'brief'">
+            {{ $t('brief.title')}}
+          </a>
+        </li>
         <li :class="{'is-active': isActiveTab('taskStatus')}">
           <a @click="activeTab = 'taskStatus'">
             {{ $t('task_status.title')}}
@@ -19,6 +24,10 @@
           </a>
         </li>
       </ul>
+    </div>
+
+    <div class="tab" v-show="isActiveTab('brief')">
+      <ProductionBrief />
     </div>
 
     <div class="tab" v-show="isActiveTab('assetTypes')">
@@ -162,12 +171,14 @@ import { sortByName } from '@/lib/sorting'
 import Combobox from '@/components/widgets/Combobox'
 import ComboboxStatus from '@/components/widgets/ComboboxStatus'
 import ComboboxTaskType from '@/components/widgets/ComboboxTaskType'
+import ProductionBrief from '@/components/pages/production/ProductionBrief'
 import TaskTypeCell from '@/components/cells/TaskTypeName'
 import ValidationTag from '@/components/widgets/ValidationTag'
 
 export default {
   name: 'production-settings',
   components: {
+    ProductionBrief,
     Combobox,
     ComboboxStatus,
     ComboboxTaskType,
@@ -177,7 +188,7 @@ export default {
 
   data () {
     return {
-      activeTab: 'taskStatus',
+      activeTab: 'brief',
       assetTypeId: '',
       taskStatusId: '',
       taskTypeId: ''

--- a/src/components/pages/production/ProductionBrief.vue
+++ b/src/components/pages/production/ProductionBrief.vue
@@ -1,0 +1,116 @@
+<template>
+    <div>
+      <div v-if="!isEditing" class="box" @dblclick="openEditing">
+        <div v-if="isEmpty(currentProduction.description)">
+          <p>{{$t('brief.empty')}}</p>
+        </div>
+        <div class="content" v-else v-html="compileMarkdown(currentProduction.description)">
+        </div>
+      </div>
+      <div v-else class="box has-text-right">
+        <TextareaField
+          v-model="brief"
+          inputClass="textarea"
+          editable
+        />
+
+        <p v-if="errors.editBrief" class="error mt1 has-text-right">
+          {{ $t('brief.edit.errorText') }}
+        </p>
+        <ButtonSimple
+          class="is-primary"
+          icon="save"
+          :class="{'is-loading': isLoading}"
+          :disabled="isLoading"
+          :text="$t('brief.save.button')"
+          @click="editBrief"
+        >
+        </ButtonSimple>
+
+      </div>
+    </div>
+</template>
+
+<script>
+import marked from 'marked'
+import { mapGetters, mapActions } from 'vuex'
+
+import TextareaField from '@/components/widgets/TextareaField'
+import ButtonSimple from '@/components/widgets/ButtonSimple'
+
+export default {
+  name: 'production-brief',
+  components: {
+    ButtonSimple,
+    TextareaField
+  },
+  data () {
+    return {
+      brief: '',
+      isEditing: false,
+      isLoading: false,
+      errors: {
+        editBrief: false
+      }
+    }
+  },
+  computed: {
+    ...mapGetters([
+      'currentProduction'
+    ])
+  },
+  mounted () {
+    if (this.currentProduction) {
+      this.brief = this.currentProduction.description
+    }
+  },
+  methods: {
+    ...mapActions([
+      'editProduction',
+      'setProduction'
+    ]),
+
+    isEmpty (str) {
+      return (!str || str.length === 0)
+    },
+
+    openEditing () {
+      this.isEditing = true
+    },
+
+    async editBrief () {
+      this.isLoading = true
+      try {
+        await this.editProduction(
+          {
+            ...this.currentProduction,
+            ...{ description: this.brief }
+          }
+        )
+      } catch {
+        this.errors.editBrief = true
+        this.isLoading = false
+        return
+      }
+      /*
+        editProduction action doesn't refresh properly the currentProduction
+        if the edited production is the currentProduction we set again the
+        production, this can be automaticly in action / mutation
+      */
+      await this.setProduction(this.currentProduction.id)
+      this.isEditing = false
+      this.isLoading = false
+    },
+
+    compileMarkdown (input) {
+      return marked(input || '')
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.box {
+  max-width: 400px;
+}
+</style>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -870,5 +870,14 @@ export default {
   wrong_browser: {
     title: 'Your browser is not supported by Kitsu',
     text: 'Kitsu can only be used with Firefox and Chrome browsers.'
+  },
+
+  brief: {
+    title: 'Brief',
+    empty: 'There is not brief yiet. What about creating some?',
+    create: 'Create a brief',
+    save: {
+      button: 'Save brief'
+    }
   }
 }

--- a/src/store/api/productions.js
+++ b/src/store/api/productions.js
@@ -29,6 +29,7 @@ export default {
   updateProduction (production) {
     const data = {
       name: production.name,
+      description: production.description,
       project_status_id: production.project_status_id,
       production_type: production.production_type,
       fps: production.fps,

--- a/tests/unit/pages/production/production-brief.spec.js
+++ b/tests/unit/pages/production/production-brief.spec.js
@@ -1,0 +1,109 @@
+import Vue from 'vue'
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+import vuescroll from 'vue-scroll'
+import Vuex from 'vuex'
+
+import i18n from '@/lib/i18n'
+
+import ProductionBrief from '@/components/pages/production/ProductionBrief'
+import productionStoreFixture from '../../fixtures/production-store.js'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+localVue.use(vuescroll)
+
+function initialiseStore (actions) {
+    const userStore = {
+      getters: {
+        user: () => ({ id: 'user-1', timezone: 'Europe/Paris' }),
+        isCurrentUserAdmin: () => true,
+        isCurrentUserManager: () => true
+      },
+    }
+
+    return new Vuex.Store({
+      strict: true,
+      modules: {
+        productions: {
+          ...productionStoreFixture,
+          state: {
+            currentProduction: {
+              id: 'production-1',
+              description: 'initial brief',
+              name: 'Caminandes',
+              team: ['person-2', 'person-3'],
+              task_statuses: []
+            }
+          },
+          mutations: {
+            setCurrentProduction(state, production) {
+              state.currentProduction = production
+            },
+          },
+          actions: {
+            setProduction () {
+              return new Promise((resolve, reject) => {
+                resolve()
+              })
+            },
+            ...actions
+          },
+          getters: {
+            currentProduction: (state) => state.currentProduction
+          }
+        },
+        user: userStore,
+      }
+    })
+}
+
+function initialiseWrapper(store, localVue, i18n) {
+    return shallowMount(ProductionBrief, {
+      store,
+      localVue,
+      i18n
+    })
+}
+
+describe('ProductionBrief', () => {
+  beforeEach(() => {
+  })
+
+  describe('Methods', () => {
+    test('editBrief', async() => {
+      const store = initialiseStore({
+        editProduction({commit}, production) {
+          return new Promise((resolve) => {
+            commit('setCurrentProduction', production)
+            resolve(production)
+          })
+        }
+      })
+      const wrapper = initialiseWrapper(store, localVue, i18n)
+      const brief = "BRIEF"
+      expect(wrapper.vm.brief).toBe('initial brief')
+      wrapper.setData({ brief, isLoading: true});
+      await wrapper.vm.editBrief()
+      await Vue.nextTick()
+      expect(wrapper.vm.isLoading).toBe(false)
+      expect(store.getters.currentProduction.description).toBe(brief)
+    }),
+
+    test('editBrief error', async() => {
+      const store = initialiseStore({
+         editProduction () {
+          return Promise.reject()
+        },
+      })
+      const wrapper = initialiseWrapper(store, localVue, i18n)
+      const brief = "BRIEF"
+      expect(wrapper.vm.brief).toBe('initial brief')
+      wrapper.setData({ brief, isLoading: true});
+      await wrapper.vm.editBrief()
+      await Vue.nextTick()
+      expect(wrapper.vm.isLoading).toBe(false)
+      expect(wrapper.vm.errors.editBrief).toBe(true)
+      expect(store.getters.currentProduction.description).toBe('initial brief')
+    })
+  })
+})


### PR DESCRIPTION
- Add a component ProductionBrief,
- Add ProductionBrief to tab on ProductionSettings,
- Add locales en
- Add description in method `editProduction`

**Problem**

The first refresh of `brief` is not working without a direct call to `setProduction`