### PR TITLE
Add dates and episodes spacing for task types (Production settings)

### DIFF
--- a/src/components/pages/ProductionSettings.vue
+++ b/src/components/pages/ProductionSettings.vue
@@ -81,46 +81,7 @@
     </div>
 
     <div class="tab" v-show="isActiveTab('taskTypes')">
-      <div class="flexrow mt1 mb1 add-task-type">
-        <combobox-task-type
-          class="flexrow-item selector"
-          :task-type-list="remainingTaskTypes"
-          v-model="taskTypeId"
-        />
-        <button
-          class="button flexrow-item"
-          @click="addTaskType"
-        >
-          {{ $t('main.add') }}
-        </button>
-      </div>
-      <div
-        class="box"
-        v-if="isEmpty(currentProduction.task_types)"
-      >
-        {{ $t('settings.production.empty_list') }}
-      </div>
-      <table class="datatable list" v-else>
-        <tbody class="datatable-body">
-          <tr
-            class="datatable-row"
-            :key="taskType.id"
-            v-for="taskType in productionTaskTypes"
-          >
-            <task-type-cell
-              :task-type="taskType"
-            />
-            <td>
-              <button
-                class="button"
-                @click="removeTaskType(taskType.id)"
-              >
-                {{ $t('main.remove') }}
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <production-task-types />
     </div>
 
     <div class="tab" v-show="isActiveTab('taskStatus')">
@@ -197,14 +158,11 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 
-import { sortByName } from '@/lib/sorting'
-
 import Combobox from '@/components/widgets/Combobox'
 import ComboboxStatus from '@/components/widgets/ComboboxStatus'
-import ComboboxTaskType from '@/components/widgets/ComboboxTaskType'
 import ProductionBrief from '@/components/pages/production/ProductionBrief'
 import ProductionParameters from '@/components/pages/production/ProductionParameters'
-import TaskTypeCell from '@/components/cells/TaskTypeName'
+import ProductionTaskTypes from '@/components/pages/production/ProductionTaskTypes'
 import ValidationTag from '@/components/widgets/ValidationTag'
 
 export default {
@@ -212,10 +170,9 @@ export default {
   components: {
     ProductionBrief,
     ProductionParameters,
+    ProductionTaskTypes,
     Combobox,
     ComboboxStatus,
-    ComboboxTaskType,
-    TaskTypeCell,
     ValidationTag
   },
 
@@ -223,8 +180,7 @@ export default {
     return {
       activeTab: 'brief',
       assetTypeId: '',
-      taskStatusId: '',
-      taskTypeId: ''
+      taskStatusId: ''
     }
   },
 
@@ -234,9 +190,6 @@ export default {
     }
     if (this.remainingTaskStatuses.length > 0) {
       this.taskStatusId = this.remainingTaskStatuses[0].id
-    }
-    if (this.remainingTaskTypes.length > 0) {
-      this.taskTypeId = this.remainingTaskTypes[0].id
     }
   },
 
@@ -251,7 +204,8 @@ export default {
       'taskStatus',
       'taskStatusMap',
       'taskTypeMap',
-      'taskTypes'
+      'taskTypes',
+      'isTVShow'
     ]),
 
     remainingAssetTypes () {
@@ -263,13 +217,6 @@ export default {
     remainingTaskStatuses () {
       return this.taskStatus
         .filter(s => !this.currentProduction.task_statuses.includes(s.id))
-    },
-
-    remainingTaskTypes () {
-      return sortByName(
-        this.taskTypes
-          .filter(t => !this.currentProduction.task_types.includes(t.id))
-      )
     }
   },
 
@@ -277,10 +224,8 @@ export default {
     ...mapActions([
       'addAssetTypeToProduction',
       'addTaskStatusToProduction',
-      'addTaskTypeToProduction',
       'removeAssetTypeFromProduction',
-      'removeTaskStatusFromProduction',
-      'removeTaskTypeFromProduction'
+      'removeTaskStatusFromProduction'
     ]),
 
     isEmpty (list) {
@@ -321,16 +266,6 @@ export default {
       }
     },
 
-    addTaskType () {
-      this.addTaskTypeToProduction(this.taskTypeId)
-      if (this.remainingTaskTypes.length > 0) {
-        this.taskTypeId = this.remainingTaskTypes[0].id
-      }
-    },
-
-    removeTaskType (taskTypeId) {
-      this.removeTaskTypeFromProduction(taskTypeId)
-    },
     getBooleanTranslation (bool) {
       return bool ? this.$t('main.yes') : this.$t('main.no')
     }

--- a/src/components/pages/production/ProductionParameters.vue
+++ b/src/components/pages/production/ProductionParameters.vue
@@ -171,9 +171,12 @@ export default {
     this.resetForm()
   },
   watch: {
-    currentProduction () {
-      this.resetForm()
-      this.updateTvShowRelatedDatas(this.isTVShow)
+    currentProduction: {
+      handler () {
+        this.resetForm()
+        this.updateTvShowRelatedDatas(this.isTVShow)
+      },
+      deep: true
     },
     'form.production_type' (newProductionType) {
       this.updateTvShowRelatedDatas(newProductionType === 'tvshow')

--- a/src/components/pages/production/ProductionTaskTypes.vue
+++ b/src/components/pages/production/ProductionTaskTypes.vue
@@ -1,0 +1,353 @@
+<template>
+  <div class="columns">
+    <div class="column is-7">
+    <template v-if="remainingTaskTypes.length > 0">
+      <div class="flexrow mt1 mb1 add-task-type">
+        <combobox-task-type
+          class="flexrow-item selector"
+          :task-type-list="remainingTaskTypes"
+          v-model="taskTypeId"
+        />
+        <button
+          class="button flexrow-item"
+          :disabled="loading.scheduleTimeDelete"
+          @click="addTaskType"
+        >
+          {{ $t('main.add') }}
+        </button>
+      </div>
+    </template>
+    <p v-if="errors.delete || errors.scheduleTimeUpdate" class="error mt1">
+      {{ $t('productions.edit_error') }}
+    </p>
+    <div
+      class="box"
+      v-if="isEmpty(currentProduction.task_types)"
+    >
+      {{ $t('settings.production.empty_list') }}
+    </div>
+    <template v-for="(taskListObject, index) in [assetTableDatas, shotTableDatas]" v-else>
+      <table class="datatable list" v-if="taskListObject.list.length > 0" :key="index">
+        <thead>
+          <tr>
+            <th>
+              {{taskListObject.title}}
+            </th>
+            <th>
+              {{$t('productions.fields.start_date')}}
+            </th>
+            <th>
+              {{$t('productions.fields.end_date')}}
+            </th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody class="datatable-body">
+          <tr
+            class="datatable-row"
+            :key="taskTypeScheduleItemCouple.taskTypes.id"
+            v-for="taskTypeScheduleItemCouple in taskListObject.list"
+          >
+            <task-type-cell
+              :task-type="taskTypeScheduleItemCouple.taskTypes"
+            />
+            <td>
+             <date-field
+              :value="new Date(taskTypeScheduleItemCouple.scheduleItem.startDate)"
+              @input="(startDate) => { updateScheduleItem(taskTypeScheduleItemCouple.scheduleItem, {startDate})}"
+              v-if="taskTypeScheduleItemCouple.scheduleItem && !loading.scheduleTimeUpdate"
+             />
+             <spinner v-else />
+            </td>
+            <td>
+             <date-field
+               :value="new Date(taskTypeScheduleItemCouple.scheduleItem.endDate)"
+               @input="(endDate) => { updateScheduleItem(taskTypeScheduleItemCouple.scheduleItem, {endDate})}"
+               v-if="taskTypeScheduleItemCouple.scheduleItem && !loading.scheduleTimeUpdate"
+             />
+             <spinner v-else />
+            </td>
+            <td>
+              <button
+                class="button"
+                @click="removeTaskTypeScheduleItemCouple(taskTypeScheduleItemCouple)"
+              >
+                {{ $t('main.remove') }}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </template>
+    </div>
+    <div class="column is-2 episode-span-column">
+      <text-field
+        ref="episodesSpanField"
+        type="number"
+        :label="$t('productions.fields.episode_span')"
+        :value="currentProduction.episode_span"
+        :disabled="loading.episode_span"
+        @enter="editEpisodeSpan"
+        v-focus
+        v-model="episode_span"
+        v-if="currentProduction && currentProduction.id && isTVShow"
+      />
+      <p v-if="errors.episode_span" class="error mt1">
+        {{ $t('productions.edit_error') }}
+      </p>
+    </div>
+  </div>
+</template>
+<script>
+import moment from 'moment'
+import { mapGetters, mapActions } from 'vuex'
+import { sortByName } from '@/lib/sorting'
+
+import ComboboxTaskType from '@/components/widgets/ComboboxTaskType'
+import DateField from '@/components/widgets/DateField'
+import Spinner from '@/components/widgets/Spinner'
+import TaskTypeCell from '@/components/cells/TaskTypeName'
+import TextField from '@/components/widgets/TextField'
+
+export default {
+  name: 'production-task-types',
+  components: {
+    ComboboxTaskType,
+    DateField,
+    Spinner,
+    TaskTypeCell,
+    TextField
+  },
+  data () {
+    return {
+      taskTypeId: '',
+      loading: {
+        episode_span: false,
+        scheduleTimeUpdate: false,
+        scheduleTimeDelete: false
+      },
+      episode_span: 0,
+      errors: {
+        episode_span: false,
+        scheduleTimeUpdate: false,
+        delete: false
+      }
+    }
+  },
+  mounted () {
+    if (this.remainingTaskTypes.length > 0) {
+      this.taskTypeId = this.remainingTaskTypes[0].id
+    }
+    if (this.currentProduction) {
+      this.episode_span = this.currentProduction.episode_span
+      this.loadAllScheduleItems(this.currentProduction)
+    }
+  },
+  computed: {
+    ...mapGetters([
+      'currentProduction',
+      'currentScheduleItems',
+      'productionTaskTypes',
+      'taskStatusMap',
+      'taskTypes',
+      'isTVShow'
+    ]),
+
+    remainingTaskTypes () {
+      return sortByName(
+        this.taskTypes
+          .filter(t => !this.currentProduction.task_types.includes(t.id))
+      )
+    },
+    /*
+      Return an object with the following structure:
+      {
+        title: 'title of the first column of the tab (Assets or short)',
+        list:  [{taskTypes, scheduleItem}] // A list of objects that represente a couple of taskType and their linked scheduleItem
+      }
+    */
+    assetTableDatas () {
+      const list = []
+      const assetTaskTypes = sortByName(
+        this.taskTypes.filter(
+          t => !t.for_shots && this.currentProduction.task_types.includes(t.id)
+        )
+      )
+      assetTaskTypes.forEach(taskTypes => {
+        list.push(this.computeCoupleTaskTypeScheduleItem(taskTypes))
+      })
+      return {
+        title: this.$t('assets.title'),
+        list
+      }
+    },
+
+    /*
+      Return an object with the following structure:
+      {
+        title: 'title of the first column of the tab (Assets or short)',
+        list:  [{taskTypes, scheduleItem}] // A list of objects that represente a couple of taskType and their linked scheduleItem
+      }
+    */
+    shotTableDatas () {
+      const list = []
+      const assetTaskTypes = sortByName(
+        this.taskTypes.filter(
+          t => t.for_shots && this.currentProduction.task_types.includes(t.id)
+        )
+      )
+      assetTaskTypes.forEach(taskTypes => {
+        list.push(this.computeCoupleTaskTypeScheduleItem(taskTypes))
+      })
+      return {
+        title: this.$t('shots.title'),
+        list
+      }
+    }
+  },
+  watch: {
+    currentProduction: {
+      handler () {
+        this.episode_span = this.currentProduction.episode_span
+        this.loadAllScheduleItems(this.currentProduction)
+      },
+      deep: true
+    }
+  },
+  methods: {
+    ...mapActions([
+      'addTaskTypeToProduction',
+      'createScheduleItem',
+      'deleteScheduleItem',
+      'editProduction',
+      'loadAllScheduleItems',
+      'removeTaskTypeFromProduction',
+      'saveScheduleItem'
+    ]),
+
+    isEmpty (list) {
+      return !list || list.length === 0
+    },
+
+    computeCoupleTaskTypeScheduleItem (taskTypes) {
+      const index = this.currentScheduleItems.findIndex(
+        scheduleItem => scheduleItem.task_type_id === taskTypes.id
+      )
+      // We need to clone the value from the store
+      const scheduleItem = (index !== -1) ? { ...this.currentScheduleItems[index] } : null
+      if (scheduleItem) {
+        scheduleItem.startDate = scheduleItem.start_date
+        scheduleItem.endDate = scheduleItem.end_date
+        // clean data to avoir mix camelCase / snake_case
+        delete scheduleItem.start_date
+        delete scheduleItem.end_date
+      }
+      return { taskTypes, scheduleItem }
+    },
+
+    async addTaskType () {
+      await this.addTaskTypeToProduction(this.taskTypeId)
+      await this.createScheduleItem(
+        {
+          startDate: moment(),
+          endDate: moment(),
+          project_id: this.currentProduction.id,
+          task_type_id: this.taskTypeId
+        }
+      )
+      if (this.remainingTaskTypes.length > 0) {
+        this.taskTypeId = this.remainingTaskTypes[0].id
+      } else {
+        this.taskTypeId = ''
+      }
+    },
+
+    async updateScheduleItem (scheduleItem, updatedData) {
+      const data = {
+        ...scheduleItem,
+        ...updatedData
+      }
+      data.startDate = moment(data.startDate)
+      data.endDate = moment(data.endDate)
+      this.loading.scheduleTimeUpdate = true
+      this.errors.scheduleTimeUpdate = false
+      try {
+        await this.saveScheduleItem(data)
+      } catch {
+        this.loading.scheduleTimeUpdate = false
+        this.errors.scheduleTimeUpdate = true
+        return
+      }
+      this.loading.scheduleTimeUpdate = false
+    },
+
+    async removeTaskTypeScheduleItemCouple (taskTypeScheduleItemCouple) {
+      this.errors.delete = false
+      try {
+        await this.removeTaskTypeFromProduction(taskTypeScheduleItemCouple.taskTypes.id)
+        if (taskTypeScheduleItemCouple.scheduleItem !== null) {
+          this.loading.scheduleTimeDelete = true
+          await this.deleteScheduleItem(taskTypeScheduleItemCouple.scheduleItem)
+          this.loading.scheduleTimeDelete = false
+        }
+      } catch {
+        this.errors.delete = true
+        this.loading.scheduleTimeDelete = false
+        return
+      }
+      await this.$nextTick()
+      if (this.remainingTaskTypes.length > 0) {
+        this.taskTypeId = this.remainingTaskTypes[0].id
+      }
+    },
+
+    async editEpisodeSpan () {
+      this.loading.episode_span = true
+      this.errors.episode_span = false
+      try {
+        await this.editProduction(
+          {
+            id: this.currentProduction.id,
+            episode_span: this.episode_span
+          }
+        )
+      } catch {
+        this.loading.episode_span = false
+        this.errors.episode_span = true
+        return
+      }
+      this.loading.episode_span = false
+    }
+  }
+}
+</script>
+<style lang="scss" scoped>
+.column {
+  overflow-y: initial;
+}
+.datatable th {
+  color: var(--text);
+}
+table {
+  margin-bottom: 1.5em;
+}
+th {
+  padding-left: 10px;
+  padding-bottom: 5px;
+}
+td p {
+  color: var(--text);
+}
+td.name {
+  width: 200px;
+}
+td /deep/ p.control.flexrow {
+  width: 105px;
+}
+.episode-span-column {
+  margin-left: 5rem;
+}
+.field {
+  margin-bottom: 0;
+}
+</style>

--- a/src/components/widgets/DateField.vue
+++ b/src/components/widgets/DateField.vue
@@ -96,7 +96,9 @@ export default {
       this.localValue = this.value
     },
     localValue () {
-      this.$emit('input', this.localValue)
+      if (this.localValue !== this.value) {
+        this.$emit('input', this.localValue)
+      }
     }
   }
 }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -539,7 +539,7 @@ export default {
       start_date: 'Start date',
       end_date: 'End date',
       nb_episodes: 'Number of episodes',
-      episode_span: 'Span beetwen episodes'
+      episode_span: 'Episode spacing'
     },
     metadata: {
       add_explaination: 'Add specific data required by this project.',

--- a/src/store/api/productions.js
+++ b/src/store/api/productions.js
@@ -86,7 +86,7 @@ export default {
   removeTaskTypeFromProduction (productionId, taskTypeId) {
     const path =
       `/api/data/projects/${productionId}/settings/task-types/${taskTypeId}`
-    return client.pdel(path)
+    return client.pdel(path).catch(console.error)
   },
 
   addTaskStatusToProduction (productionId, taskStatusId) {

--- a/src/store/api/schedule.js
+++ b/src/store/api/schedule.js
@@ -67,6 +67,52 @@ export default {
     })
   },
 
+  getAllScheduleItems (production) {
+    return new Promise((resolve, reject) => {
+      client.get(
+        `/api/data/projects/${production.id}/schedule-items/`,
+        (err, scheduleItems) => {
+          if (err) reject(err)
+          else resolve(scheduleItems)
+        }
+      )
+    })
+  },
+
+  createScheduleItem (scheduleItem) {
+    return new Promise((resolve, reject) => {
+      if (!scheduleItem.endDate) {
+        scheduleItem.endDate = scheduleItem.startDate.add('days', 1).clone()
+      }
+      const manDays = scheduleItem.man_days
+      const data = {
+        start_date: scheduleItem.startDate.format('YYYY-MM-DD'),
+        end_date: scheduleItem.endDate.format('YYYY-MM-DD'),
+        project_id: scheduleItem.project_id,
+        task_type_id: scheduleItem.task_type_id
+      }
+      if (manDays) data.man_days = parseInt(manDays)
+      client.post(
+        '/api/data/schedule-items/',
+        data,
+        (err, scheduleItem) => {
+          if (err) reject(err)
+          else resolve(scheduleItem)
+        }
+      )
+    })
+  },
+
+  deleteScheduleItem (scheduleItem) {
+    return new Promise((resolve, reject) => {
+      const path = `/api/data/schedule-items/${scheduleItem.id}`
+      client.del(path, (err) => {
+        if (err) reject(err)
+        else resolve(scheduleItem)
+      })
+    })
+  },
+
   getAssetTypeScheduleItems (production, taskType) {
     return this.getEntitycheduleItems(production, taskType, 'asset-types')
   },

--- a/src/store/modules/schedule.js
+++ b/src/store/modules/schedule.js
@@ -15,12 +15,24 @@ const initialState = {
 const state = { ...initialState }
 
 const getters = {
-  milestones: (state) => state.milestones
+  milestones: (state) => state.milestones,
+  currentScheduleItems: (state) => state.currentScheduleItems
 }
 
 const actions = {
   loadScheduleItems ({ commit }, production) {
     return scheduleApi.getScheduleItems(production)
+      .then((scheduleItems) => {
+        commit(SET_CURRENT_SCHEDULE_ITEMS, scheduleItems)
+      })
+      .catch(console.error)
+  },
+
+  loadAllScheduleItems ({ commit }, production) {
+    return scheduleApi.getAllScheduleItems(production)
+      .then((scheduleItems) => {
+        commit(SET_CURRENT_SCHEDULE_ITEMS, scheduleItems)
+      })
       .catch(console.error)
   },
 
@@ -43,8 +55,39 @@ const actions = {
     }
   },
 
-  saveScheduleItem ({ commit }, scheduleItem) {
+  createScheduleItem ({ commit, state }, scheduleItem) {
+    return scheduleApi.createScheduleItem(scheduleItem)
+      .then((newScheduleItem) => {
+        const scheduleItems = state.currentScheduleItems.slice()
+        scheduleItems.push(newScheduleItem)
+        commit(SET_CURRENT_SCHEDULE_ITEMS, scheduleItems)
+      })
+      .catch(console.error)
+  },
+
+  deleteScheduleItem ({ commit, state }, scheduleItem) {
+    return scheduleApi.deleteScheduleItem(scheduleItem)
+      .then((deletedItem) => {
+        const scheduleItems = state.currentScheduleItems.slice()
+        const indexToRemove = scheduleItems.findIndex(item => item.id === deletedItem.id)
+        if (indexToRemove !== -1) {
+          scheduleItems.splice(indexToRemove, 1)
+          commit(SET_CURRENT_SCHEDULE_ITEMS, scheduleItems)
+        }
+      })
+      .catch(console.error)
+  },
+
+  saveScheduleItem ({ commit, state }, scheduleItem) {
     return scheduleApi.updateScheduleItem(scheduleItem)
+      .then((updatedItem) => {
+        const scheduleItems = state.currentScheduleItems.slice()
+        const indexUpdate = scheduleItems.findIndex(item => item.id === updatedItem.id)
+        if (indexUpdate !== -1) {
+          scheduleItems[indexUpdate] = updatedItem
+          commit(SET_CURRENT_SCHEDULE_ITEMS, scheduleItems)
+        }
+      })
       .catch(console.error)
   },
 
@@ -99,7 +142,7 @@ const mutations = {
   },
 
   [SET_CURRENT_SCHEDULE_ITEMS] (state, items) {
-    this.currentScheduleItems = items
+    state.currentScheduleItems = items
   },
 
   [RESET_ALL] (state) {


### PR DESCRIPTION
**Problem**
We can't specify date for task types, the task types are not group by "assets" / "shots"

**Solution**
- Move Production task types to another components and add the dates and group them by assets / shots
- Small fix on ProductionParameters to take account update on current production (refresh)
