### PR TITLE
add metadata column selector for assets/shots lists

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -23,6 +23,13 @@
       @sort-by-clicked="onSortByMetadataClicked()"
     />
 
+    <table-metadata-selector-menu
+      ref="headerMetadataSelectorMenu"
+      :metadataDisplayHeaders.sync="metadataDisplayHeaders"
+      :descriptors="assetMetadataDescriptors"
+      namespace="assets"
+    />
+
     <table class="datatable">
       <thead
         class="datatable-head"
@@ -70,7 +77,7 @@
             scope="col"
             class="metadata-descriptor"
             :key="descriptor.id"
-            v-for="descriptor in assetMetadataDescriptors"
+            v-for="descriptor in visibleMetadataDescriptors"
             v-if="isShowInfos"
           >
             <div class="flexrow">
@@ -139,7 +146,7 @@
               />
             </div>
           </th>
-          <th scope="col" class="actions">
+          <th scope="col" class="actions" ref="actionsSection">
             <button-simple
               :class="{
                 'is-small': true,
@@ -149,6 +156,12 @@
               :text="$t('tasks.create_tasks')"
               @click="$emit('create-tasks')"
               v-if="isCurrentUserManager && displayedAssets.length > 0 && !isLoading"
+            />
+            <button-simple
+              class="is-small is-pulled-right"
+              icon="down"
+              @click="showMetadataSelectorMenu"
+              v-if="assetMetadataDescriptors.length > 0"
             />
           </th>
         </tr>
@@ -208,7 +221,7 @@
             class="metadata-descriptor"
             :key="asset.id + '-' + descriptor.id"
             :title="asset.data ? asset.data[descriptor.field_name] : ''"
-            v-for="(descriptor, j) in assetMetadataDescriptors"
+            v-for="(descriptor, j) in visibleMetadataDescriptors"
             v-if="isShowInfos"
           >
             <input
@@ -356,6 +369,7 @@ import TableHeaderMenu from '@/components/widgets/TableHeaderMenu'
 import TableInfo from '@/components/widgets/TableInfo'
 import TableMetadataHeaderMenu from
   '@/components/widgets/TableMetadataHeaderMenu'
+import TableMetadataSelectorMenu from '@/components/widgets/TableMetadataSelectorMenu'
 import ValidationCell from '@/components/cells/ValidationCell'
 
 export default {
@@ -376,6 +390,7 @@ export default {
     TableInfo,
     TableHeaderMenu,
     TableMetadataHeaderMenu,
+    TableMetadataSelectorMenu,
     ValidationCell
   },
 
@@ -402,7 +417,8 @@ export default {
     return {
       lastSelection: null,
       hiddenColumns: {},
-      lastHeaderMenuDisplayed: null
+      lastHeaderMenuDisplayed: null,
+      metadataDisplayHeaders: {}
     }
   },
 
@@ -462,6 +478,12 @@ export default {
       )
     },
 
+    visibleMetadataDescriptors () {
+      return this.assetMetadataDescriptors.filter(
+        descriptor => this.metadataDisplayHeaders[descriptor.field_name] === undefined || this.metadataDisplayHeaders[descriptor.field_name]
+      )
+    },
+
     visibleColumns () {
       let count = 1
       count += this.isTVShow ? 1 : 0
@@ -470,7 +492,7 @@ export default {
         this.isAssetDescription
         ? 1
         : 0
-      count += this.assetMetadataDescriptors.length
+      count += this.visibleMetadataDescriptors.length
       count += !this.isCurrentUserClient &&
         this.isShowInfos &&
         this.isAssetTime
@@ -563,7 +585,7 @@ export default {
     },
 
     onInputKeyUp (event, i, j) {
-      const listWidth = this.assetMetadataDescriptors.length
+      const listWidth = this.visibleMetadataDescriptors.length
       const listHeight = this.displayedAssetsLength
       this.keyMetadataNavigation(listWidth, listHeight, i, j, event.key)
     }

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -23,6 +23,13 @@
       @sort-by-clicked="onSortByMetadataClicked()"
     />
 
+    <table-metadata-selector-menu
+      ref="headerMetadataSelectorMenu"
+      :metadataDisplayHeaders.sync="metadataDisplayHeaders"
+      :descriptors="shotMetadataDescriptors"
+      namespace="shots"
+    />
+
     <table class="datatable">
       <thead
         class="datatable-head"
@@ -59,7 +66,7 @@
             scope="col"
             class="metadata-descriptor"
             :key="descriptor.id"
-            v-for="descriptor in shotMetadataDescriptors"
+            v-for="descriptor in visibleMetadataDescriptors"
             v-if="isShowInfos"
           >
             <div class="flexrow">
@@ -143,7 +150,7 @@
               />
             </div>
           </th>
-          <th scope="col" class="actions">
+          <th scope="col" class="actions" ref="actionsSection">
             <button-simple
               :class="{
                 'is-small': true,
@@ -153,6 +160,12 @@
               :text="$t('tasks.create_tasks')"
               @click="$emit('create-tasks')"
               v-if="isCurrentUserManager"
+            />
+            <button-simple
+              class="is-small is-pulled-right"
+              icon="down"
+              @click="showMetadataSelectorMenu"
+              v-if="shotMetadataDescriptors.length > 0"
             />
           </th>
         </tr>
@@ -211,7 +224,7 @@
           <td
             class="metadata-descriptor"
             :key="shot.id + '-' + descriptor.id"
-            v-for="(descriptor, j) in shotMetadataDescriptors"
+            v-for="(descriptor, j) in visibleMetadataDescriptors"
             v-if="isShowInfos"
           >
             <input
@@ -427,6 +440,7 @@ import ButtonSimple from '@/components/widgets/ButtonSimple'
 import DescriptionCell from '@/components/cells/DescriptionCell'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail'
 import TableMetadataHeaderMenu from '@/components/widgets/TableMetadataHeaderMenu'
+import TableMetadataSelectorMenu from '@/components/widgets/TableMetadataSelectorMenu'
 import RowActionsCell from '@/components/cells/RowActionsCell'
 import TableHeaderMenu from '@/components/widgets/TableHeaderMenu'
 import TableInfo from '@/components/widgets/TableInfo'
@@ -465,7 +479,8 @@ export default {
     return {
       lastSelection: null,
       hiddenColumns: {},
-      lastHeaderMenuDisplayed: null
+      lastHeaderMenuDisplayed: null,
+      metadataDisplayHeaders: {}
     }
   },
 
@@ -477,6 +492,7 @@ export default {
     RowActionsCell,
     TableHeaderMenu,
     TableMetadataHeaderMenu,
+    TableMetadataSelectorMenu,
     TableInfo,
     ValidationCell
   },
@@ -538,6 +554,12 @@ export default {
       )
     },
 
+    visibleMetadataDescriptors () {
+      return this.shotMetadataDescriptors.filter(
+        descriptor => this.metadataDisplayHeaders[descriptor.field_name] === undefined || this.metadataDisplayHeaders[descriptor.field_name]
+      )
+    },
+
     visibleColumns () {
       let count = 2
       count += !this.isCurrentUserClient &&
@@ -545,7 +567,7 @@ export default {
         this.isShotDescription
         ? 1
         : 0
-      count += this.shotMetadataDescriptors.length
+      count += this.visibleMetadataDescriptors.length
       count += !this.isCurrentUserClient &&
         this.isShowInfos &&
         this.isShotTime
@@ -638,7 +660,7 @@ export default {
     },
 
     onInputKeyUp (event, i, j) {
-      const listWidth = this.shotMetadataDescriptors.length + 4
+      const listWidth = this.visibleMetadataDescriptors.length + 4
       const listHeight = this.displayedShotsLength
       this.keyMetadataNavigation(listWidth, listHeight, i, j, event.key)
       return this.pauseEvent(event)

--- a/src/components/mixins/descriptors.js
+++ b/src/components/mixins/descriptors.js
@@ -72,6 +72,23 @@ export const descriptorMixin = {
       this.lastMetadaDataHeaderMenuDisplayed = columnId
     },
 
+    showMetadataSelectorMenu () {
+      const headerMenuEl = this.$refs.headerMetadataSelectorMenu.$el
+      if (headerMenuEl.className === 'header-menu') {
+        headerMenuEl.className = 'header-menu hidden'
+      } else {
+        headerMenuEl.className = 'header-menu'
+        const headerElement = this.$refs.actionsSection
+        const headerBox = headerElement.getBoundingClientRect()
+        const left = headerBox.left
+        const top = headerBox.bottom
+        const width = Math.max(100, headerBox.width - 1)
+        headerMenuEl.style.left = left + 'px'
+        headerMenuEl.style.top = top + 'px'
+        headerMenuEl.style.width = width + 'px'
+      }
+    },
+
     getDescriptorChoicesOptions (descriptor) {
       const values = descriptor.choices.map(c => ({ label: c, value: c }))
       return [{ label: '', value: '' }, ...values]

--- a/src/components/widgets/ButtonSimple.vue
+++ b/src/components/widgets/ButtonSimple.vue
@@ -82,6 +82,10 @@
     :class="iconClass"
     v-if="icon === 'forward'"
   />
+  <chevron-down-icon
+    :class="iconClass"
+    v-if="icon === 'down'"
+  />
   <chevron-left-icon
     :class="iconClass"
     v-if="icon === 'left'"
@@ -149,6 +153,7 @@
 
 <script>
 import {
+  ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   CornerLeftDownIcon,
@@ -185,6 +190,7 @@ import {
 export default {
   name: 'button-simple',
   components: {
+    ChevronDownIcon,
     ChevronLeftIcon,
     ChevronRightIcon,
     CornerLeftDownIcon,

--- a/src/components/widgets/TableMetadataSelectorMenu.vue
+++ b/src/components/widgets/TableMetadataSelectorMenu.vue
@@ -1,0 +1,114 @@
+<template>
+  <div class="header-menu hidden">
+    <div
+      class="field is-marginless"
+      v-for="metadataDescriptor in descriptors"
+      :key="metadataDescriptor.field_name"
+    >
+      <label
+        class="checkbox"
+        :for="metadataDescriptor.field_name"
+      >
+        <input
+          type="checkbox"
+          :id="metadataDescriptor.field_name"
+          :checked="metadataDisplayHeaders[metadataDescriptor.field_name]"
+          @change="setMetadataDisplayValue(metadataDescriptor.field_name, $event.target.checked)"
+        >
+        {{ metadataDescriptor.name }}
+      </label>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+
+export default {
+  name: 'table-metadata-selector-menu',
+
+  props: {
+    metadataDisplayHeaders: {
+      type: Object,
+      required: true
+    },
+    descriptors: {
+      type: Array,
+      required: true
+    },
+    namespace: {
+      type: String,
+      required: true
+    }
+  },
+
+  data () {
+    return {
+    }
+  },
+
+  computed: {
+    ...mapGetters([
+    ]),
+    localStorageKey () {
+      return `metadataDisplayHeaders.${this.namespace}`
+    }
+  },
+
+  methods: {
+    ...mapActions([
+    ]),
+    shallowCopy (object) {
+      const newObject = {}
+      for (const key in object) {
+        newObject[key] = object[key]
+      }
+      return newObject
+    },
+    setMetadataDisplayValue (metadataName, isSelected) {
+      const localMetadataDisplayHeaders = this.shallowCopy(this.metadataDisplayHeaders)
+      localMetadataDisplayHeaders[metadataName] = isSelected
+      localStorage.setItem(this.localStorageKey, JSON.stringify(localMetadataDisplayHeaders))
+      this.$emit('update:metadataDisplayHeaders', localMetadataDisplayHeaders)
+    }
+  },
+
+  created () {
+    const metadataDisplayHeadersString = localStorage.getItem(this.localStorageKey)
+    let localMetadataDisplayHeaders = {}
+    if (metadataDisplayHeadersString) {
+      localMetadataDisplayHeaders = JSON.parse(metadataDisplayHeadersString)
+    }
+    for (const descriptor of this.descriptors) {
+      if (localMetadataDisplayHeaders[descriptor.field_name] === undefined) {
+        localMetadataDisplayHeaders[descriptor.field_name] = true
+      }
+    }
+    this.$emit('update:metadataDisplayHeaders', localMetadataDisplayHeaders)
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.dark .header-menu {
+  background-color: $dark-grey-light;
+  box-shadow: 0 2px 6px $dark-grey-light;
+}
+
+.header-menu {
+  position: absolute;
+  background: white;
+  width: 118px;
+  box-shadow: 0 2px 6px $light-grey;
+  top: 90px;
+  z-index: 100;
+}
+
+.header-menu div {
+  padding: 0.5em;
+}
+
+label.checkbox {
+  width: 100%;
+}
+</style>

--- a/tests/unit/widgets/tablemetadataselectormenu.spec.js
+++ b/tests/unit/widgets/tablemetadataselectormenu.spec.js
@@ -1,0 +1,53 @@
+import i18n from '../../../src/lib/i18n'
+import { mount, createLocalVue } from '@vue/test-utils'
+import TableMetadataSelectorMenu from '../../../src/components/widgets/TableMetadataSelectorMenu'
+
+const localVue = createLocalVue()
+
+// Allow access to i18n object from vue instance.
+localVue.prototype.$locale = {
+  change (locale) {
+    i18n.locale = locale
+  },
+  current () {
+    return i18n.locale
+  }
+}
+
+describe('TableMetadataSelectorMenu', () => {
+  describe('Mount', () => {
+    it('emits the preferences saved in localStorage', () => {
+      localStorage.setItem('metadataDisplayHeaders.shots', JSON.stringify({ key: true }))
+      const component = mount(TableMetadataSelectorMenu, {
+        propsData: {
+          metadataDisplayHeaders: {},
+          descriptors: [],
+          namespace: 'shots'
+        },
+        localVue,
+        i18n
+      })
+      const emitted = component.emitted()['update:metadataDisplayHeaders']
+      expect(emitted).toHaveLength(1)
+      expect(emitted[0]).toEqual([{ key: true }])
+    })
+    it('emits changes the preferences in localStorage', () => {
+      localStorage.setItem('metadataDisplayHeaders.shots', JSON.stringify({ key: true }))
+      const component = mount(TableMetadataSelectorMenu, {
+        propsData: {
+          metadataDisplayHeaders: { key: true },
+          descriptors: [],
+          namespace: 'shots'
+        },
+        localVue,
+        i18n
+      })
+      component.vm.setMetadataDisplayValue('newKey', true)
+      const emitted = component.emitted()['update:metadataDisplayHeaders']
+      expect(emitted).toHaveLength(2)
+      expect(emitted[1]).toEqual([{ key: true, newKey: true }])
+      const stored = JSON.parse(localStorage.getItem('metadataDisplayHeaders.shots'))
+      expect(stored).toEqual({ key: true, newKey: true })
+    })
+  })
+})


### PR DESCRIPTION
**Problem**

There are too many columns in some assets/shots lists

**Solution**

It's now possible to hide some columns in the assets/shots lists. This preference is stored locally on the computer of the user (in localStorage)

![image](https://user-images.githubusercontent.com/9109308/112033002-43b2f680-8b3d-11eb-9741-e5a3b4c02992.png)
