### PR TITLE
people: wait for departments to be ready before showing them

### DIFF
--- a/src/components/lists/PeopleList.vue
+++ b/src/components/lists/PeopleList.vue
@@ -45,6 +45,7 @@
             <span class="departments-element" v-for="departmentId in entry.departments" :key="departmentId">
               <department-name
                 :department="departmentMap[departmentId]"
+                v-if="departmentMap[departmentId]"
               />
             </span>
           </td>
@@ -77,6 +78,7 @@
             <span class="departments-element" v-for="departmentId in entry.departments" :key="departmentId">
               <department-name
                 :department="departmentMap[departmentId]"
+                v-if="departmentMap[departmentId]"
               />
             </span>
           </td>


### PR DESCRIPTION
**Problem**

the list of people was showing before the departments were loaded, which wasn't working because we try to show the department in a people row in the table

**Solution**

check if the department is present in memory before trying to display it