### PR TITLE
[shots] allow to cancel restoration

### DIFF
--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -143,7 +143,7 @@
     :is-error="errors.restore"
     :text="restoreText()"
     :error-text="$t('shots.restore_error')"
-    @cancel="modals.isDeleteDisplayed = false"
+    @cancel="modals.isRestoreDisplayed = false"
     @confirm="confirmRestoreShot"
   />
 


### PR DESCRIPTION
**Problem**
Shots: the `cancel` button of the `restore` popup was ineffective.

**Solution**
Hide the right popup.
