### PR TITLE
Various fixes

### DIFF
--- a/src/components/mixins/dom.js
+++ b/src/components/mixins/dom.js
@@ -16,6 +16,10 @@ export const domMixin = {
   },
 
   methods: {
+    isFocusTextArea () {
+      return document.activeElement.nodeName === 'TEXTAREA'
+    },
+
     clearFocus () {
       document.activeElement.blur()
     },

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -694,8 +694,13 @@ export default {
 
     deleteText () {
       const asset = this.assetToDelete
-      if (asset) {
+      if (
+        asset &&
+        (asset.canceled || !asset.tasks || asset.tasks.length === 0)
+      ) {
         return this.$t('assets.delete_text', { name: asset.name })
+      } else if (asset) {
+        return this.$t('assets.cancel_text', { name: asset.name })
       } else {
         return ''
       }

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -730,8 +730,13 @@ export default {
 
     deleteText () {
       const shot = this.shotToDelete
-      if (shot) {
+      if (
+        shot &&
+        (shot.canceled || !shot.tasks || shot.tasks.length === 0)
+      ) {
         return this.$t('shots.delete_text', { name: shot.name })
+      } else if (shot) {
+        return this.$t('shots.cancel_text', { name: shot.name })
       } else {
         return ''
       }

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1526,7 +1526,9 @@ export default {
     },
 
     onVideoRepeated () {
-      this.clearFocus()
+      if (!this.isCommentsHidden || this.isFocusTextarea()) {
+        this.clearFocus()
+      }
       if (this.rawPlayerComparison) {
         this.rawPlayerComparison.setCurrentTime(0)
       }

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -62,9 +62,10 @@
           position: isComparisonOverlay ? 'absolute': 'static'
         }"
         :entities="entityListToCompare"
+        :full-screen="fullScreen"
+        :is-hd="isHd"
         :is-repeating="isRepeating"
         :muted="true"
-        :full-screen="fullScreen"
         name="comparison"
         v-show="isComparing && isCurrentPreviewMovie &&
                 isMovieComparison && !isLoading"
@@ -109,9 +110,10 @@
           opacity: overlayOpacity
         }"
         :entities="entityList"
+        :full-screen="fullScreen"
+        :is-hd="isHd"
         :is-repeating="isRepeating"
         :muted="isMuted"
-        :full-screen="fullScreen"
         @repeat="onVideoRepeated"
         @metadata-loaded="onMetadataLoaded"
         @entity-change="onPlayerEntityChange"
@@ -556,6 +558,13 @@
       @click="onFilmClicked"
       icon="film"
     />
+    <button-simple
+      class="playlist-button flexrow-item"
+      :title="$t('playlists.actions.switch_hd')"
+      :text="isHd ? 'HD' : 'LD'"
+      @click="isHd = !isHd"
+      v-if="isCurrentPreviewMovie"
+    />
 
     <div
       class="flexrow-item playlist-button"
@@ -792,11 +801,12 @@ export default {
       entityListToCompare: [],
       fabricCanvas: null,
       fullScreen: false,
-      isDlButtonsHidden: true,
       isCommentsHidden: true,
       isComparing: false,
+      isDlButtonsHidden: true,
       isDrawing: false,
       isEntitiesHidden: false,
+      isHd: false,
       isMuted: false,
       isPlaying: false,
       isRepeating: false,

--- a/src/components/pages/playlists/RawVideoPlayer.vue
+++ b/src/components/pages/playlists/RawVideoPlayer.vue
@@ -39,6 +39,10 @@ export default {
       type: Boolean,
       default: false
     },
+    isHd: {
+      type: Boolean,
+      default: false
+    },
     isRepeating: {
       type: Boolean,
       default: false
@@ -113,7 +117,7 @@ export default {
     getMoviePath (entity) {
       if (entity.preview_file_extension === 'mp4') {
         const previewId = entity.preview_file_id
-        if (this.fullScreen) {
+        if (this.isHd) {
           return `/api/movies/originals/preview-files/${previewId}.mp4`
         } else {
           return `/api/movies/low/preview-files/${previewId}.mp4`
@@ -389,9 +393,9 @@ export default {
   },
 
   watch: {
-    fullScreen () {
+    isHd () {
       if (this.currentPlayer) {
-        this.loadEntity(this.currentIndex, this.currentPlayer.currentTime)
+        this.reloadCurrentEntity()
         if (this.isPlaying) this.play()
       }
     },

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1321,8 +1321,11 @@ export default {
     },
 
     setCurrentTime (time) {
-      this.previewViewer.setCurrentTime(time)
-      if (this.comparisonViewer) this.comparisonViewer.setCurrentTime(time)
+      const currentTime = roundToFrame(this.currentTimeRaw, this.fps)
+      if (time !== currentTime) {
+        this.previewViewer.setCurrentTime(time)
+        if (this.comparisonViewer) this.comparisonViewer.setCurrentTime(time)
+      }
     },
 
     updateProgressBar (currentTime) {

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -22,9 +22,10 @@
       :big="big"
       :default-height="defaultHeight"
       :full-screen="fullScreen"
-      :is-ordering="isOrdering"
+      :is-hd="isHd"
       :is-comparing="isComparing"
       :is-muted="isMuted"
+      :is-ordering="isOrdering"
       :is-repeating="isRepeating"
       :light="light"
       :preview="currentPreview"
@@ -314,6 +315,14 @@
         >
         </div>
 
+        <button-simple
+          class="flexrow-item"
+          :title="$t('playlists.actions.switch_hd')"
+          :text="isHd ? 'HD' : 'LD'"
+          @click="isHd = !isHd"
+          v-if="fullScreen && isMovie"
+        />
+
         <a
           class="button flexrow-item"
           :href="originalDlPath"
@@ -440,6 +449,7 @@ export default {
       currentTimeRaw: 0,
       isComparing: false,
       isDrawing: false,
+      isHd: false,
       isLoading: false,
       isMuted: false,
       isPlaying: false,

--- a/src/components/previews/PreviewViewer.vue
+++ b/src/components/previews/PreviewViewer.vue
@@ -25,6 +25,7 @@
       :big="big"
       :default-height="defaultHeight"
       :is-comparing="isComparing"
+      :is-hd="isHd"
       :is-muted="isMuted"
       :is-repeating="isRepeating"
       :light="light"
@@ -130,6 +131,10 @@ export default {
       default: 0
     },
     isComparing: {
+      type: Boolean,
+      default: false
+    },
+    isHd: {
       type: Boolean,
       default: false
     },

--- a/src/components/previews/VideoViewer.vue
+++ b/src/components/previews/VideoViewer.vue
@@ -50,6 +50,10 @@ export default {
       type: Boolean,
       default: false
     },
+    isHd: {
+      type: Boolean,
+      default: false
+    },
     isDrawing: {
       type: Boolean,
       default: false
@@ -171,7 +175,7 @@ export default {
     },
 
     moviePath () {
-      if (this.extension === 'mp4' && this.isAvailable && !this.fullScreen) {
+      if (this.extension === 'mp4' && this.isAvailable && !this.isHd) {
         return `/api/movies/low/preview-files/${this.preview.id}.mp4`
       } else if (this.extension === 'mp4' && this.isAvailable) {
         return `/api/movies/originals/preview-files/${this.preview.id}.mp4`

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -2,6 +2,7 @@ export default {
 
   assets: {
     cast_in: 'Cast in',
+    cancel_text: 'Are you sure you want to archive {name}?',
     delete_error: 'An error occurred while deleting this asset. There are probably data linked to it. Are you sure this asset type has no task linked to it?',
     delete_text: 'Are you sure you want to remove {name} from your database?',
     edit_fail: 'Saving failed, it may be due to the fact that an asset with a similar name already exists.',
@@ -15,7 +16,7 @@ export default {
     new_success: 'Asset {name} successfully created.',
     no_cast_in: 'This asset is not cast in any shot.',
     number: 'asset | assets',
-    restore_text: 'Are you sure you want to restore {name} into your database?',
+    restore_text: 'Are you sure you want to restore {name} from your archive?',
     restore_error: 'An error occurred while restoring this asset.',
     tasks: 'Asset tasks',
     title: 'Assets',
@@ -751,6 +752,7 @@ export default {
 
   shots: {
     casting: 'Shot casting',
+    cancel_text: 'Are you sure you want to archive {name}?',
     creation_explaination: 'To add shots you need first to create an episode and a sequence. Type an episode name in the bottom of the left column then click on add to create a new episode. Select this episode and repeat the same operation for sequence. Finally select a sequence and type a shot name in the field in the bottom of the right column. Click on the add button below. Your first shot was created. You can now add many more! If it\'s not a TV Show, you have to directly create a sequence.',
     delete_text: 'Are you sure you want to remove {name} from your database?',
     delete_error: 'An error occurred while deleting this shot. There are probably data linked to it. Are you sure this shot has no task linked to it?',
@@ -770,7 +772,7 @@ export default {
     manage: 'Create shots',
     new_success: 'Shot {name} successfully created.',
     padding: 'Shot Padding',
-    restore_text: 'Are you sure you want to restore {name} into your database?',
+    restore_text: 'Are you sure you want to restore {name} from your archive?',
     restore_error: 'An error occurred while restoring this shot.',
     sequences: 'Sequences',
     tasks: 'Shot Tasks',

--- a/tests/unit/pages/production-news-feed.spec.js
+++ b/tests/unit/pages/production-news-feed.spec.js
@@ -298,7 +298,7 @@ describe('ProductionNewsFeed', () => {
 
     test('onBodyScroll', () => {
       wrapper.vm.loading.more = false
-      wrapper.vm.onBodyScroll(null, { scrollTop: -100 })
+        wrapper.vm.onBodyScroll(null, { scrollTop: -800 })
       expect(newsStore.actions.loadMoreNews).not.toHaveBeenCalled()
       wrapper.vm.onBodyScroll(null, { scrollTop: 500 })
       expect(newsStore.actions.loadMoreNews).toHaveBeenCalled()


### PR DESCRIPTION
**Problem**

* The automatic switch between low def and high def videos when going full screen is disturbing.
* Sometimes the preview player is running an infinite loop which consumes a lot of resources.
* Canceling message for an entity says it deletes it which is confusing.
* We lose focus when looping on a shot in a playlist.

**Solution**

* Always put lowdef by default. Allow to switch to high def by clicking on a button
* Do not allow to run the setCurrentTime function if the time is the same
* Use the right message when the user asks for cancelation
* Do not clear focus (needed for shortcuts) when the user is writing in the comment text area.
