### PR TITLE
Attempt to improve entity lists performances

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -125,13 +125,13 @@ export default {
   socket: {
     events: {
       'project:new' (eventData) {
-        if (!this.productionMap[eventData.project_id]) {
+        if (!this.productionMap.get(eventData.project_id)) {
           this.loadProduction(eventData.project_id)
         }
       },
 
       'project:update' (eventData) {
-        if (this.productionMap[eventData.project_id]) {
+        if (this.productionMap.get(eventData.project_id)) {
           this.loadProduction(eventData.project_id)
         } else {
           this.loadOpenProductions()
@@ -139,14 +139,14 @@ export default {
       },
 
       'project:delete' (eventData) {
-        if (this.productionMap[eventData.project_id]) {
+        if (this.productionMap.get(eventData.project_id)) {
           this.$store.commit('REMOVE_PRODUCTION', { id: eventData.project_id })
         }
       },
 
       'sequence:new' (eventData) {
         if (
-          !this.sequenceMap[eventData.sequence_id] &&
+          !this.sequenceMap.get(eventData.sequence_id) &&
           this.currentProduction &&
           this.currentProduction.id === eventData.project_id
         ) {
@@ -155,20 +155,20 @@ export default {
       },
 
       'sequence:update' (eventData) {
-        if (this.sequenceMap[eventData.sequence_id]) {
+        if (this.sequenceMap.get(eventData.sequence_id)) {
           this.loadSequence(eventData.sequence_id)
         }
       },
 
       'sequence:delete' (eventData) {
-        if (this.sequenceMap[eventData.sequence_id]) {
+        if (this.sequenceMap.get(eventData.sequence_id)) {
           this.$store.commit('REMOVE_SEQUENCE', { id: eventData.sequence_id })
         }
       },
 
       'episode:new' (eventData) {
         if (
-          !this.episodeMap[eventData.episode_id] &&
+          !this.episodeMap.get(eventData.episode_id) &&
           this.currentProduction &&
           this.currentProduction.id === eventData.project_id
         ) {
@@ -177,20 +177,20 @@ export default {
       },
 
       'episode:update' (eventData) {
-        if (this.episodeMap[eventData.episode_id]) {
+        if (this.episodeMap.get(eventData.episode_id)) {
           this.loadEpisode(eventData.episode_id)
         }
       },
 
       'episode:delete' (eventData) {
-        if (this.episodeMap[eventData.episode_id]) {
+        if (this.episodeMap.get(eventData.episode_id)) {
           this.$store.commit('REMOVE_EPISODE', { id: eventData.episode_id })
         }
       },
 
       'shot:new' (eventData) {
         if (
-          !this.shotMap[eventData.shot_id] &&
+          !this.shotMap.get(eventData.shot_id) &&
           this.currentProduction &&
           this.currentProduction.id === eventData.project_id &&
           (
@@ -205,20 +205,20 @@ export default {
       },
 
       'shot:update' (eventData) {
-        if (this.shotMap[eventData.shot_id]) {
+        if (this.shotMap.get(eventData.shot_id)) {
           this.loadShot(eventData.shot_id)
         }
       },
 
       'shot:delete' (eventData) {
-        if (this.shotMap[eventData.shot_id]) {
+        if (this.shotMap.get(eventData.shot_id)) {
           this.$store.commit('REMOVE_SHOT', { id: eventData.shot_id })
         }
       },
 
       'asset:new' (eventData) {
         if (
-          !this.assetMap[eventData.asset_id] &&
+          !this.assetMap.get(eventData.asset_id) &&
           this.currentProduction &&
           this.currentProduction.id === eventData.project_id
         ) {
@@ -229,26 +229,26 @@ export default {
       },
 
       'asset:update' (eventData) {
-        if (this.assetMap[eventData.asset_id]) {
+        if (this.assetMap.get(eventData.asset_id)) {
           this.loadAsset(eventData.asset_id)
         }
       },
 
       'asset:delete' (eventData) {
-        if (this.assetMap[eventData.asset_id]) {
+        if (this.assetMap.get(eventData.asset_id)) {
           this.$store.commit('REMOVE_ASSET', { id: eventData.asset_id })
         }
       },
 
       'task:delete' (eventData) {
-        const task = this.taskMap[eventData.task_id]
+        const task = this.taskMap.get(eventData.task_id)
         if (task) {
           this.$store.commit('DELETE_TASK_END', task)
         }
       },
 
       'task-type:new' (eventData) {
-        if (!this.taskTypeMap[eventData.task_type_id]) {
+        if (!this.taskTypeMap.get(eventData.task_type_id)) {
           this.loadTaskType(eventData.task_type_id)
         }
       },
@@ -258,7 +258,7 @@ export default {
       },
 
       'task-type:delete' (eventData) {
-        if (this.taskTypeMap[eventData.task_type_id]) {
+        if (this.taskTypeMap.get(eventData.task_type_id)) {
           this.$store.commit(
             'DELETE_TASK_TYPE_END',
             { id: eventData.task_type_id }
@@ -267,19 +267,19 @@ export default {
       },
 
       'task-status:new' (eventData) {
-        if (!this.taskStatusMap[eventData.task_status_id]) {
+        if (!this.taskStatusMap.get(eventData.task_status_id)) {
           this.loadTaskStatus(eventData.task_status_id)
         }
       },
 
       'task-status:update' (eventData) {
-        if (this.taskStatusMap[eventData.task_status_id]) {
+        if (this.taskStatusMap.get(eventData.task_status_id)) {
           this.loadTaskStatus(eventData.task_status_id)
         }
       },
 
       'task-status:delete' (eventData) {
-        if (this.taskStatusMap[eventData.task_status_id]) {
+        if (this.taskStatusMap.get(eventData.task_status_id)) {
           this.$store.commit(
             'DELETE_TASK_STATUS_END',
             { id: eventData.task_status_id }
@@ -288,19 +288,19 @@ export default {
       },
 
       'asset-type:new' (eventData) {
-        if (!this.assetTypeMap[eventData.asset_type_id]) {
+        if (!this.assetTypeMap.get(eventData.asset_type_id)) {
           this.loadAssetType(eventData.asset_type_id)
         }
       },
 
       'asset-type:update' (eventData) {
-        if (this.assetTypeMap[eventData.asset_type_id]) {
+        if (this.assetTypeMap.get(eventData.asset_type_id)) {
           this.loadAssetType(eventData.asset_type_id)
         }
       },
 
       'asset-type:delete' (eventData) {
-        if (this.assetTypeMap[eventData.asset_type_id]) {
+        if (this.assetTypeMap.get(eventData.asset_type_id)) {
           this.$store.commit(
             'DELETE_ASSET_TYPE_END',
             { id: eventData.asset_type_id }
@@ -309,19 +309,19 @@ export default {
       },
 
       'person:new' (eventData) {
-        if (!this.personMap[eventData.person_id]) {
+        if (!this.personMap.get(eventData.person_id)) {
           this.loadPerson(eventData.person_id)
         }
       },
 
       'person:update' (eventData) {
-        if (this.personMap[eventData.person_id]) {
+        if (this.personMap.get(eventData.person_id)) {
           this.loadPerson(eventData.person_id)
         }
       },
 
       'person:delete' (eventData) {
-        const person = this.personMap[eventData.person_id]
+        const person = this.personMap.get(eventData.person_id)
         if (person) {
           this.$store.commit('DELETE_PEOPLE_START', person)
           this.$store.commit('DELETE_PEOPLE_END', person)
@@ -337,15 +337,17 @@ export default {
       },
 
       'comment:new' (eventData) {
+        console.log(eventData)
         const commentId = eventData.comment_id
-        if (!this.isSavingCommentPreview) {
+        if (!this.isSavingCommentPreview &&
+            this.taskMap.get(eventData.task_id)) {
           this.loadComment({ commentId })
             .catch(console.error)
         }
       },
 
       'task:update' (eventData) {
-        if (this.taskMap[eventData.task_id]) {
+        if (this.taskMap.get(eventData.task_id)) {
           this.$nextTick(() => {
             this.loadTask({ taskId: eventData.task_id })
           })

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -36,9 +36,9 @@
     </span>
     <span
       class="avatar has-text-centered"
-      :title="personMap[personId].full_name"
+      :title="personMap.get(personId).full_name"
       :style="{
-        background: personMap[personId].color,
+        background: personMap.get(personId).color,
         width: '20px',
         height: '20px',
         'font-size': '10px'
@@ -52,10 +52,10 @@
         :key="avatarKey(personId)"
         width="20"
         height="20"
-        v-if="personMap[personId].has_avatar"
+        v-if="personMap.get(personId).has_avatar"
       />
       <span v-else>
-        {{ personMap[personId].initials }}
+        {{ personMap.get(personId).initials }}
       </span>
     </span>
   </div>
@@ -147,7 +147,7 @@ export default {
     if (this.taskTest) {
       this.task = this.taskTest
     } else if (this.entity && this.column) {
-      this.task = this.taskMap[this.entity.validations[this.column.id]]
+      this.task = this.taskMap.get(this.entity.validations.get(this.column.id))
     }
     this.changeStyleBasedOnSelected()
   },
@@ -211,7 +211,7 @@ export default {
     taskStatus () {
       if (this.task) {
         const taskStatusId = this.task.task_status_id
-        return this.taskStatusMap ? this.taskStatusMap[taskStatusId] : {}
+        return this.taskStatusMap ? this.taskStatusMap.get(taskStatusId) : {}
       } else {
         return {}
       }
@@ -289,7 +289,7 @@ export default {
     },
 
     avatarPath (personId) {
-      const person = this.personMap[personId]
+      const person = this.personMap.get(personId)
       if (person) {
         return person.avatarPath + '?unique=' + person.uniqueHash
       } else {
@@ -298,7 +298,7 @@ export default {
     },
 
     avatarKey (personId) {
-      const person = this.personMap[personId]
+      const person = this.personMap.get(personId)
       if (person) {
         return person.id + '-' + person.uniqueHash
       } else {
@@ -328,7 +328,8 @@ export default {
       if (this.taskTest) {
         this.task = this.taskTest
       } else if (this.entity) {
-        this.task = this.taskMap[this.entity.validations[this.column.id]]
+        this.task =
+          this.taskMap.get(this.entity.validations.get(this.column.id))
       }
     }
   }

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -127,7 +127,7 @@
                 v-if="!isCurrentUserClient"
               >
                 {{ !hiddenColumns[columnId]
-                   ? taskTypeMap[columnId].name
+                   ? taskTypeMap.get(columnId).name
                    : '' }}
               </router-link>
               <span
@@ -136,7 +136,7 @@
                 v-else
               >
                 {{ !hiddenColumns[columnId]
-                  ? taskTypeMap[columnId].name
+                  ? taskTypeMap.get(columnId).name
                   : '' }}
               </span>
 
@@ -205,7 +205,11 @@
           v-for="(asset, i) in group"
         >
           <td class="episode" v-if="isTVShow">
-            {{ episodeMap[asset.episode_id] ? episodeMap[asset.episode_id].name : 'MP' }}
+            {{
+              episodeMap.get(asset.episode_id)
+              ? episodeMap.get(asset.episode_id).name
+              : 'MP'
+            }}
           </td>
           <th
             :class="{
@@ -301,9 +305,9 @@
             }"
             :key="columnId + '-' + asset.id"
             :ref="'validation-' + getIndex(i, k) + '-' + j"
-            :column="taskTypeMap[columnId]"
+            :column="taskTypeMap.get(columnId)"
             :entity="asset"
-            :task-test="taskMap[asset.validations[columnId]]"
+            :task-test="taskMap.get(asset.validations.get(columnId))"
             :selected="assetSelectionGrid[getIndex(i, k)][j]"
             :rowX="getIndex(i, k)"
             :columnY="j"

--- a/src/components/lists/EntityTaskList.vue
+++ b/src/components/lists/EntityTaskList.vue
@@ -64,7 +64,7 @@
                 <people-avatar
                   class="person-avatar flexrow-item"
                   :key="taskId + '-' + personId"
-                  :person="personMap[personId]"
+                  :person="personMap.get(personId)"
                   :size="30"
                   :font-size="15"
                 />
@@ -133,8 +133,10 @@ export default {
       return [...this.entries].sort((taskIdA, taskIdB) => {
         const taskA = this.getTask(taskIdA)
         const taskB = this.getTask(taskIdB)
-        const taskTypeA = this.getTask(this.taskTypeMap[taskA.task_type_id])
-        const taskTypeB = this.getTask(this.taskTypeMap[taskB.task_type_id])
+        const taskTypeA =
+          this.getTask(this.taskTypeMap.get(taskA.task_type_id))
+        const taskTypeB =
+          this.getTask(this.taskTypeMap.get(taskB.task_type_id))
         if (taskTypeA.priority === taskTypeB.priority) {
           return this.taskTypeA.localeCompare(this.taskTypeB.name)
         } else {
@@ -154,7 +156,7 @@ export default {
 
     getTask (task) {
       if (typeof (task) === 'string') {
-        return this.taskMap[task]
+        return this.taskMap.get(task)
       } else {
         return task
       }
@@ -162,7 +164,7 @@ export default {
 
     getTaskType (entry) {
       const task = this.getTask(entry)
-      return task ? this.taskTypeMap[task.task_type_id] : null
+      return task ? this.taskTypeMap.get(task.task_type_id) : null
     },
 
     getAssignees (entry) {

--- a/src/components/lists/EpisodeList.vue
+++ b/src/components/lists/EpisodeList.vue
@@ -20,7 +20,7 @@
           <th
             scope="col"
             class="validation validation-cell"
-            :key="taskTypeMap[columnId].id"
+            :key="taskTypeMap.get(columnId).id"
             v-for="columnId in validationColumns">
             <div
               class="flexrow validation-content"
@@ -31,13 +31,13 @@
                 :to="taskTypePath(columnId)"
                 v-if="!isCurrentUserClient"
               >
-                {{ taskTypeMap[columnId].name }}
+                {{ taskTypeMap.get(columnId).name }}
               </router-link>
               <span
                 class="flexrow-item"
                 v-else
               >
-                {{ taskTypeMap[columnId].name }}
+                {{ taskTypeMap.get(columnId).name }}
               </span>
             </div>
           </th>

--- a/src/components/lists/PeopleList.vue
+++ b/src/components/lists/PeopleList.vue
@@ -44,8 +44,8 @@
           <td class="departments">
             <span class="departments-element" v-for="departmentId in entry.departments" :key="departmentId">
               <department-name
-                :department="departmentMap[departmentId]"
-                v-if="departmentMap[departmentId]"
+                :department="departmentMap.get(departmentId)"
+                v-if="departmentMap.get(departmentId)"
               />
             </span>
           </td>
@@ -77,8 +77,8 @@
           <td class="departments">
             <span class="departments-element" v-for="departmentId in entry.departments" :key="departmentId">
               <department-name
-                :department="departmentMap[departmentId]"
-                v-if="departmentMap[departmentId]"
+                :department="departmentMap.get(departmentId)"
+                v-if="departmentMap.get(departmentId)"
               />
             </span>
           </td>
@@ -133,20 +133,12 @@ export default {
 
   computed: {
     ...mapGetters([
-      'departments',
+      'departmentMap',
       'isCurrentUserAdmin'
     ]),
 
     activePeople () {
       return this.entries.filter(person => person.active)
-    },
-
-    departmentMap () {
-      const departmentMap = {}
-      this.departments.forEach(department => {
-        departmentMap[department.id] = department
-      })
-      return departmentMap
     },
 
     unactivePeople () {

--- a/src/components/lists/ProductionAssetTypeList.vue
+++ b/src/components/lists/ProductionAssetTypeList.vue
@@ -31,13 +31,13 @@
                 :to="taskTypePath(columnId)"
                 v-if="!isCurrentUserClient"
               >
-                {{ taskTypeMap[columnId].name }}
+                {{ taskTypeMap.get(columnId).name }}
               </router-link>
               <span
                 class="flexrow-item"
                 v-else
               >
-                {{ taskTypeMap[columnId].name }}
+                {{ taskTypeMap.get(columnId).name }}
               </span>
             </div>
           </th>

--- a/src/components/lists/SequenceList.vue
+++ b/src/components/lists/SequenceList.vue
@@ -29,13 +29,13 @@
                 :to="taskTypePath(columnId)"
                 v-if="!isCurrentUserClient"
               >
-                {{ taskTypeMap[columnId].name }}
+                {{ taskTypeMap.get(columnId).name }}
               </router-link>
               <span
                 class="flexrow-item"
                 v-else
               >
-                {{ taskTypeMap[columnId].name }}
+                {{ taskTypeMap.get(columnId).name }}
               </span>
             </div>
           </th>

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -126,7 +126,7 @@
                 v-if="!isCurrentUserClient"
               >
                 {{ !hiddenColumns[columnId]
-                   ? taskTypeMap[columnId].name
+                   ? taskTypeMap.get(columnId).name
                    : '' }}
               </router-link>
               <span
@@ -135,7 +135,7 @@
                 v-else
               >
                 {{ !hiddenColumns[columnId]
-                  ? taskTypeMap[columnId].name
+                  ? taskTypeMap.get(columnId).name
                   : '' }}
               </span>
               <chevron-down-icon
@@ -364,9 +364,12 @@
             }"
             :key="`${columnId}-${shot.id}`"
             :ref="`validation-${getIndex(i, k)}-${j}`"
-            :column="taskTypeMap[columnId]"
+            :column="taskTypeMap.get(columnId)"
             :entity="shot"
-            :task-test="taskMap[shot.validations[columnId]]"
+            :task-test="taskMap.get(shot.validations
+                        ? shot.validations.get(columnId)
+                        : null
+            )"
             :minimized="hiddenColumns[columnId]"
             :selected="shotSelectionGrid[getIndex(i, k)][j]"
             :rowX="getIndex(i, k)"

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -100,7 +100,7 @@
               <people-avatar
                 class="flexrow-item"
                 :key="task.id + '-' + personId"
-                :person="personMap[personId]"
+                :person="personMap.get(personId)"
                 :size="30"
                 :font-size="17"
                 v-for="personId in task.assignees"
@@ -301,7 +301,7 @@ export default {
     nbFrames () {
       let total = 0
       this.tasks.forEach(task => {
-        const entity = this.shotMap[task.entity.id]
+        const entity = this.shotMap.get(task.entity.id)
         if (entity && entity.nb_frames) total += entity.nb_frames
       })
       return total
@@ -350,7 +350,7 @@ export default {
           start_date: null,
           due_date: null
         }
-        const task = this.taskMap[taskId]
+        const task = this.taskMap.get(taskId)
         const dueDate = task.due_date ? moment(task.due_date) : null
         if (date) {
           const startDate = moment(date)
@@ -382,7 +382,7 @@ export default {
           start_date: null,
           due_date: null
         }
-        const task = this.taskMap[taskId]
+        const task = this.taskMap.get(taskId)
         const startDate = task.start_date ? moment(task.start_date) : null
         if (date) {
           const dueDate = moment(date)
@@ -410,7 +410,7 @@ export default {
 
     updateTasksEstimation ({ estimation }) {
       Object.keys(this.selectionGrid).forEach(taskId => {
-        const task = this.taskMap[taskId]
+        const task = this.taskMap.get(taskId)
         let data = { estimation }
         if (task.start_date) {
           const startDate = moment(task.start_date)
@@ -451,9 +451,9 @@ export default {
 
     getEntity (entityId) {
       if (this.isAssets) {
-        return this.assetMap[entityId]
+        return this.assetMap.get(entityId)
       } else {
-        return this.shotMap[entityId]
+        return this.shotMap.get(entityId)
       }
     },
 
@@ -569,7 +569,7 @@ export default {
       const taskLines = [headers]
       this.tasks.forEach((task) => {
         const assignees = task.assignees.map(personId => {
-          const person = this.personMap[personId]
+          const person = this.personMap.get(personId)
           if (person) return person.name
           else return ''
         }).join(', ')

--- a/src/components/lists/TimeSpentTaskList.vue
+++ b/src/components/lists/TimeSpentTaskList.vue
@@ -24,7 +24,7 @@
         class="by-task-type-id"
         v-for="taskTypeId in Object.keys(projects[projectId])"
       >
-        <task-type-name :task-type="taskTypeMap[taskTypeId]" />
+        <task-type-name :task-type="taskTypeMap.get(taskTypeId)" />
 
         <div class="table-body">
           <table class="datatable">

--- a/src/components/lists/TimesheetList.vue
+++ b/src/components/lists/TimesheetList.vue
@@ -74,14 +74,14 @@
             scope="row"
           >
             <production-name-cell
-              :entry="productionMap[task.project_id]"
+              :entry="productionMap.get(task.project_id)"
               :only-avatar="true"
             />
           </th>
           <task-type-cell
             class="type datatable-row-header datatable-row-header--nobd"
             :production-id="task.project_id"
-            :task-type="taskTypeMap[task.task_type_id]"
+            :task-type="taskTypeMap.get(task.task_type_id)"
             :style="{left: colTypePosX}"
           />
 
@@ -129,7 +129,7 @@
             scope="row"
           >
            <production-name-cell
-             :entry="productionMap[task.project_id]"
+             :entry="productionMap.get(task.project_id)"
              :only-avatar="true"
            />
           </th>
@@ -150,7 +150,7 @@
            </router-link>
           </th>
           <time-slider-cell
-            :duration="timeSpentMap[task.id] ? timeSpentMap[task.id].duration / 60 : 0"
+            :duration="timeSpentMap.get(task.id) ? timeSpentMap.get(task.id).duration / 60 : 0"
             class="time-spent"
             :task-id="task.id"
             @change="onSliderChange"

--- a/src/components/lists/TodosList.vue
+++ b/src/components/lists/TodosList.vue
@@ -72,7 +72,7 @@
           >
             <production-name-cell
               :is-tooltip="true"
-              :entry="productionMap[entry.project_id]"
+              :entry="productionMap.get(entry.project_id)"
               :only-avatar="true"
             />
           </td>
@@ -312,8 +312,8 @@ export default {
     },
 
     getTaskType (entry) {
-      const taskType = this.taskTypeMap[entry.task_type_id]
-      const production = this.productionMap[entry.project_id]
+      const taskType = this.taskTypeMap.get(entry.task_type_id)
+      const production = this.productionMap.get(entry.project_id)
       taskType.episode_id = entry.episode_id
       if (production && production.production_type === 'tvshow' && !entry.episode_id) {
         taskType.episode_id = production.first_episode_id
@@ -336,7 +336,7 @@ export default {
         route.params.shot_id = entity.entity_id
       }
 
-      const production = this.productionMap[entity.project_id]
+      const production = this.productionMap.get(entity.project_id)
       let episodeId = entity.episode_id
       if (production && production.production_type === 'tvshow' && !episodeId) {
         if (entityType === 'shot') {

--- a/src/components/mixins/entity_list.js
+++ b/src/components/mixins/entity_list.js
@@ -76,7 +76,7 @@ export const entityListMixin = {
     },
 
     getValidationStyle (columnId) {
-      const taskType = this.taskTypeMap[columnId]
+      const taskType = this.taskTypeMap.get(columnId)
       return {
         'border-left': `1px solid ${taskType.color}`,
         background: this.getBackground(taskType.color)
@@ -191,7 +191,7 @@ export const entityListMixin = {
       this.$emit('change-sort', {
         type: 'status',
         column: taskTypeId,
-        name: this.taskTypeMap[taskTypeId].name
+        name: this.taskTypeMap.get(taskTypeId).name
       })
       this.showHeaderMenu()
     },
@@ -204,8 +204,10 @@ export const entityListMixin = {
       entities.forEach((entity, i) => {
         selection.push({
           entity: entity,
-          column: this.taskTypeMap[this.lastHeaderMenuDisplayed],
-          task: this.taskMap[entity.validations[this.lastHeaderMenuDisplayed]],
+          column: this.taskTypeMap.get(this.lastHeaderMenuDisplayed),
+          task: this.taskMap.get(
+            entity.validations[this.lastHeaderMenuDisplayed]
+          ),
           x: i,
           y: this.lastHeaderMenuDisplayedIndexInGrid
         })

--- a/src/components/modals/AddThumbnailsModal.vue
+++ b/src/components/modals/AddThumbnailsModal.vue
@@ -156,10 +156,10 @@ export default {
     taskTypeList () {
       if (this.isAssets) {
         return this.assetValidationColumns
-          .map((taskTypeId) => this.taskTypeMap[taskTypeId])
+          .map((taskTypeId) => this.taskTypeMap.get(taskTypeId))
       } else {
         return this.shotValidationColumns
-          .map((taskTypeId) => this.taskTypeMap[taskTypeId])
+          .map((taskTypeId) => this.taskTypeMap.get(taskTypeId))
       }
     },
 
@@ -204,7 +204,7 @@ export default {
     addTaskInformation (form) {
       const filename = this.slugifyFilename(form)
       const entity = this.entityMap[filename]
-      const task = this.taskMap[entity.validations[this.taskTypeId]]
+      const task = this.taskMap.get(entity.validations.get(this.taskTypeId))
       form.task = task
       return form
     },
@@ -226,7 +226,7 @@ export default {
         .filter((form) => {
           const filename = this.slugifyFilename(form)
           const asset = this.entityMap[filename]
-          return asset && asset.validations[this.taskTypeId]
+          return asset && asset.validations.get(this.taskTypeId)
         })
     },
 

--- a/src/components/modals/BuildFilterModal.vue
+++ b/src/components/modals/BuildFilterModal.vue
@@ -335,15 +335,15 @@ export default {
     taskTypeList () {
       if (this.isAssets) {
         return this.assetValidationColumns
-          .map((taskTypeId) => this.taskTypeMap[taskTypeId])
+          .map((taskTypeId) => this.taskTypeMap.get(taskTypeId))
       } else {
         return this.shotValidationColumns
-          .map((taskTypeId) => this.taskTypeMap[taskTypeId])
+          .map((taskTypeId) => this.taskTypeMap.get(taskTypeId))
       }
     },
 
     team () {
-      return this.currentProduction.team.map(pId => this.personMap[pId])
+      return this.currentProduction.team.map(pId => this.personMap.get(pId))
     },
 
     descriptorOptions () {
@@ -387,7 +387,7 @@ export default {
       if (value && value !== '-') {
         let operator = '=['
         if (this.assetTypeFilters.operator === '=-') operator = '=[-'
-        const assetType = this.assetTypeMap[value]
+        const assetType = this.assetTypeMap.get(value)
         query += ` type${operator}${assetType.name}]`
       }
       return query
@@ -399,7 +399,7 @@ export default {
         if (taskTypeFilter.operator === '=-') operator = '=[-'
         const taskType = this.getTaskType(taskTypeFilter.id)
         const value = taskTypeFilter.values.map(statusId => {
-          return this.taskStatusMap[statusId].short_name
+          return this.taskStatusMap.get(statusId).short_name
         }).join(',')
         query += ` [${taskType.name}]${operator}${value}]`
       })
@@ -424,7 +424,7 @@ export default {
           if (this.assignation.value === '-assignedto') value = `-${value}`
           query += ` assignedto=[${value}]`
         } else if (this.assignation.taskTypeId) {
-          const taskType = this.taskTypeMap[this.assignation.taskTypeId]
+          const taskType = this.taskTypeMap.get(this.assignation.taskTypeId)
           const value =
             this.assignation.value === 'assigned' ? 'assigned' : 'unassigned'
           query += ` [${taskType.name}]=${value}`
@@ -473,7 +473,7 @@ export default {
     },
 
     getTaskType (taskTypeId) {
-      return this.taskTypeMap[taskTypeId]
+      return this.taskTypeMap.get(taskTypeId)
     },
 
     // Descriptors

--- a/src/components/modals/EditPersonDepartmentsModal.vue
+++ b/src/components/modals/EditPersonDepartmentsModal.vue
@@ -19,7 +19,7 @@
           <div class="department-element" :key="departmentId"
             v-for="departmentId in form.departments" @click="removeDepartment(departmentId)">
             <department-name
-              :department="departmentMap[departmentId]"
+              :department="departmentMap.get(departmentId)"
             />
           </div>
           <div class="field">
@@ -108,12 +108,15 @@ export default {
 
   computed: {
     ...mapGetters([
-      'departments',
+      'departmentMap',
+      'departments'
     ]),
 
     selectableDepartments () {
       return this.departments.filter(departement => {
-        return this.form.departments.findIndex(selectedDepartment => selectedDepartment === departement.id) === -1
+        return this.form.departments.findIndex(
+          selectedDepartment => selectedDepartment === departement.id
+        ) === -1
       })
     },
 
@@ -123,14 +126,6 @@ export default {
       } else {
         return ''
       }
-    },
-
-    departmentMap () {
-      const departmentMap = {}
-      this.departments.forEach(department => {
-        departmentMap[department.id] = department
-      })
-      return departmentMap
     }
   },
 
@@ -156,7 +151,9 @@ export default {
     resetForm () {
       if (this.personToEdit) {
         this.form = {
-          departments: (this.personToEdit.departments) ? this.personToEdit.departments : []
+          departments: (this.personToEdit.departments)
+            ? this.personToEdit.departments
+            : []
         }
       } else {
         this.form = {

--- a/src/components/modals/EditPersonModal.vue
+++ b/src/components/modals/EditPersonModal.vue
@@ -53,7 +53,7 @@
             v-for="departmentId in form.departments"
           >
             <department-name
-              :department="departmentMap[departmentId]"
+              :department="departmentMap.get(departmentId)"
               v-if="departmentId"
             />
           </div>
@@ -224,15 +224,16 @@ export default {
   computed: {
     ...mapGetters([
       'departments',
+      'departmentMap',
       'isLdap',
       'isCurrentUserAdmin',
       'people'
     ]),
 
     selectableDepartments () {
-      return this.departments.filter(departement => {
+      return this.departments.filter(department => {
         return this.form.departments.findIndex(
-          selectedDepartment => selectedDepartment === departement.id
+          selectedDepartment => selectedDepartment === department.id
         ) === -1
       })
     },
@@ -247,14 +248,6 @@ export default {
       } else {
         return ''
       }
-    },
-
-    departmentMap () {
-      const departmentMap = {}
-      this.departments.forEach(department => {
-        departmentMap[department.id] = department
-      })
-      return departmentMap
     }
   },
 

--- a/src/components/modals/ManageShotsModal.vue
+++ b/src/components/modals/ManageShotsModal.vue
@@ -306,7 +306,7 @@ export default {
 
     selectSequence (sequenceId) {
       this.selectedSequenceId = sequenceId
-      this.displayedShots = Object.values(this.shotMap).filter((shot) => {
+      this.displayedShots = Array.from(this.shotMap.values()).filter((shot) => {
         return shot.sequence_id === sequenceId
       })
     },

--- a/src/components/modals/ShotHistoryModal.vue
+++ b/src/components/modals/ShotHistoryModal.vue
@@ -126,7 +126,7 @@ export default {
     },
 
     getPersonFullName (personId) {
-      const person = this.personMap[personId]
+      const person = this.personMap.get(personId)
       return person ? person.full_name : ''
     },
 

--- a/src/components/modals/ViewPlaylistModal.vue
+++ b/src/components/modals/ViewPlaylistModal.vue
@@ -90,7 +90,6 @@ export default {
       'currentProduction',
       'isTVShow',
       'selectedTasks',
-      'shotMap',
       'taskMap'
     ]),
 
@@ -99,7 +98,7 @@ export default {
     },
 
     taskIds () {
-      return Object.keys(this.selectedTasks)
+      return Array.from(this.selectedTasks.keys())
     },
 
     playlistPlayer () {

--- a/src/components/pages/Asset.vue
+++ b/src/components/pages/Asset.vue
@@ -261,7 +261,6 @@ export default {
     ...mapGetters([
       'assetMap',
       'assetMetadataDescriptors',
-      'assetsPath',
       'currentEpisode',
       'currentProduction',
       'isTVShow',
@@ -288,6 +287,23 @@ export default {
       return this.currentAsset &&
         this.currentAsset.preview_file_id &&
         this.currentAsset.preview_file_id.length > 0
+    },
+
+    assetsPath () {
+      const route = {
+        name: 'assets',
+        params: {
+          production_id: this.currentProduction.id
+        },
+        query: {
+          search: ''
+        }
+      }
+      if (this.currentEpisode) {
+        route.name = 'episode-assets'
+        route.params.episode_id = this.currentEpisode.id
+      }
+      return route
     }
   },
 
@@ -307,7 +323,7 @@ export default {
     },
 
     getCurrentAsset () {
-      return this.assetMap[this.route.params.asset_id] || null
+      return this.assetMap.get(this.route.params.asset_id) || null
     },
 
     onEditClicked () {

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -103,7 +103,7 @@
     v-if="nbSelectedTasks === 1"
   >
     <task-info
-      :task="Object.values(selectedTasks)[0]"
+      :task="selectedTasks.values().next().value"
     />
   </div>
 
@@ -386,7 +386,7 @@ export default {
       Object.keys(this.assetMap).length < 2 ||
       (
         this.assetValidationColumns.length > 0 &&
-        !this.assetMap[Object.keys(this.assetMap)[0]].validations
+        !this.assetMap.get(this.assetMap.keys()[0]).validations
       )
     ) {
       setTimeout(() => {
@@ -451,7 +451,7 @@ export default {
         type.forEach(item => {
           let assetKey = ''
           if (this.isTVShow && item.episode_id) {
-            assetKey += this.episodeMap[item.episode_id].name
+            assetKey += this.episodeMap.get(item.episode_id).name
           }
           assetKey += `${item.asset_type_name}${item.name}`
           assets[assetKey] = true
@@ -817,7 +817,7 @@ export default {
     },
 
     onDeleteAllTasksClicked (taskTypeId) {
-      const taskType = this.taskTypeMap[taskTypeId]
+      const taskType = this.taskTypeMap.get(taskTypeId)
       this.deleteAllTasksLockText = taskType.name
       this.modals.isDeleteAllTasksDisplayed = true
     },
@@ -916,7 +916,7 @@ export default {
           }
           this.assetValidationColumns
             .forEach((taskTypeId) => {
-              headers.push(this.taskTypeMap[taskTypeId].name)
+              headers.push(this.taskTypeMap.get(taskTypeId).name)
             })
           csv.buildCsvFile(name, [headers].concat(assetLines))
         })

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -782,7 +782,7 @@ export default {
         const sequenceId = this.$route.params.sequence_id
         if (
           sequenceId &&
-          this.sequenceMap[sequenceId]
+          this.sequenceMap.get(sequenceId)
         ) {
           this.sequenceId = sequenceId
         } else if (this.castingSequenceOptions.length > 0) {
@@ -829,14 +829,14 @@ export default {
   socket: {
     events: {
       'shot:casting-update' (eventData) {
-        const shot = this.shotMap[eventData.shot_id]
+        const shot = this.shotMap.get(eventData.shot_id)
         if (shot.sequence_id === this.sequenceId) {
           this.loadShotCasting(shot)
         }
       },
 
       'asset:casting-update' (eventData) {
-        const asset = this.assetMap[eventData.asset_id]
+        const asset = this.assetMap.get(eventData.asset_id)
         if (asset.asset_type_id === this.assetTypeId) {
           this.loadAssetCasting(asset)
         }

--- a/src/components/pages/Logs.vue
+++ b/src/components/pages/Logs.vue
@@ -51,12 +51,12 @@
             <people-avatar
               class="flexrow-item"
               :size="20"
-              :person="personMap[event.user_id]"
+              :person="personMap.get(event.user_id)"
               v-if="event.user_id"
             />
             <people-name
               class="flexrow-item"
-              :person="personMap[event.user_id]"
+              :person="personMap.get(event.user_id)"
               v-if="event.user_id"
             />
           </li>

--- a/src/components/pages/MainSchedule.vue
+++ b/src/components/pages/MainSchedule.vue
@@ -173,7 +173,7 @@ export default {
       return scheduleItems.map((item) => {
         const startDate = getStartDateFromString(item.start_date)
         const endDate = getEndDateFromString(startDate, item.end_date)
-        const taskType = this.taskTypeMap[item.task_type_id]
+        const taskType = this.taskTypeMap.get(item.task_type_id)
 
         return {
           ...item,

--- a/src/components/pages/Notifications.vue
+++ b/src/components/pages/Notifications.vue
@@ -67,9 +67,9 @@
         <div class="notification-info flexrow">
         <people-avatar
           class="flexrow-item"
-          :person="personMap[notification.author_id]"
+          :person="personMap.get(notification.author_id)"
           :size="30"
-          v-if="personMap[notification.author_id]"
+          v-if="personMap.get(notification.author_id)"
         />
 
           <router-link
@@ -269,7 +269,7 @@ export default {
     },
 
     entityPath (notification) {
-      const taskType = this.taskTypeMap[notification.task_type_id]
+      const taskType = this.taskTypeMap.get(notification.task_type_id)
       const type = taskType.for_shots ? 'shot' : 'asset'
 
       const route = {
@@ -299,7 +299,7 @@ export default {
     },
 
     personName (notification) {
-      const person = this.personMap[notification.author_id]
+      const person = this.personMap.get(notification.author_id)
       return person ? person.full_name : ''
     },
 
@@ -314,7 +314,7 @@ export default {
 
     buildTaskTypeFromNotification (notification) {
       return {
-        ...this.taskTypeMap[notification.task_type_id],
+        ...this.taskTypeMap.get(notification.task_type_id),
         episode_id: notification.episode_id
       }
     },

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -137,7 +137,7 @@
     v-if="nbSelectedTasks === 1"
   >
     <task-info
-      :task="Object.values(selectedTasks)[0]"
+      :task="selectedTasks.values().next().value"
     />
   </div>
 </div>
@@ -227,14 +227,14 @@ export default {
     loggablePersonTasks () {
       return this.displayedPersonTasks
         .filter((task) => {
-          return this.taskTypeMap[task.task_type_id].allow_timelog
+          return this.taskTypeMap.get(task.task_type_id).allow_timelog
         })
     },
 
     loggableDoneTasks () {
       return this.displayedPersonDoneTasks
         .filter((task) => {
-          return this.taskTypeMap[task.task_type_id].allow_timelog
+          return this.taskTypeMap.get(task.task_type_id).allow_timelog
         })
     },
 
@@ -300,7 +300,7 @@ export default {
     },
 
     loadPerson (personId) {
-      this.person = this.personMap[personId]
+      this.person = this.personMap.get(personId)
       this.isTasksLoading = true
       this.loadPersonTasks({
         personId: this.person.id,

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -709,9 +709,9 @@ export default {
     convertEntityToPlaylistFormat (entityInfo) {
       let entity
       if (this.isAssetPlaylist) {
-        entity = this.assetMap[entityInfo.id]
+        entity = this.assetMap.get(entityInfo.id)
       } else {
-        entity = this.shotMap[entityInfo.id]
+        entity = this.shotMap.get(entityInfo.id)
       }
       if (entity) {
         const playlistEntity = {
@@ -744,7 +744,7 @@ export default {
 
     setCurrentPlaylist (callback) {
       const playlistId = this.$route.params.playlist_id
-      const playlist = this.playlistMap[playlistId]
+      const playlist = this.playlistMap.get(playlistId)
       if (playlist) {
         this.loading.playlist = true
         this.loadPlaylist({
@@ -832,7 +832,7 @@ export default {
     addSequence (sequenceShots) {
       if (sequenceShots.length > 0) {
         const sequenceId = sequenceShots[0].sequence_id
-        const shots = Object.values(this.shotMap)
+        const shots = this.shotMap.values()
           .filter(s => s.sequence_id === sequenceId)
           .sort(firstBy('name'))
           .reverse()
@@ -880,7 +880,7 @@ export default {
     addMovie () {
       this.loading.addMovie = true
       this.$options.silent = true
-      const shots = Object.values(this.shotMap)
+      const shots = this.shotMap.values()
       this.addEntities(shots.reverse(), () => {
         this.loading.addMovie = false
         this.$options.silent = false
@@ -1176,7 +1176,7 @@ export default {
   socket: {
     events: {
       'playlist:new' (eventData) {
-        if (!this.playlistMap[eventData.playlist_id]) {
+        if (!this.playlistMap.get(eventData.playlist_id)) {
           this.refreshPlaylist(eventData.playlist_id)
         }
       },

--- a/src/components/pages/ProductionNewsFeed.vue
+++ b/src/components/pages/ProductionNewsFeed.vue
@@ -176,11 +176,11 @@
                       <div class="news-info flexrow">
                         <people-avatar
                           class="flexrow-item"
-                          :person="personMap[news.author_id]"
+                          :person="personMap.get(news.author_id)"
                           :size="30"
                           :font-size="14"
                           :is-link="false"
-                          v-if="personMap[news.author_id]"
+                          v-if="personMap.get(news.author_id)"
                         />
                         <span
                           class="explaination flexrow-item"
@@ -245,10 +245,10 @@
                       <div class="news-info flexrow">
                         <people-avatar
                           class="flexrow-item"
-                          :person="personMap[news.author_id]"
+                          :person="personMap.get(news.author_id)"
                           :size="30"
                           :no-link="true"
-                          v-if="personMap[news.author_id]"
+                          v-if="personMap.get(news.author_id)"
                         />
                         <span
                           class="explaination flexrow-item"
@@ -468,7 +468,7 @@ export default {
 
     team () {
       return this.currentProduction.team
-        .map(pId => this.personMap[pId])
+        .map(pId => this.personMap.get(pId))
         .sort((a, b) => a.full_name.localeCompare(b.full_name))
     },
 
@@ -486,9 +486,9 @@ export default {
           .keys(this.newsStats)
           .map(taskStatusId => {
             const name =
-              this.taskStatusMap[taskStatusId].short_name.toUpperCase()
+              this.taskStatusMap.get(taskStatusId).short_name.toUpperCase()
             const color =
-              this.taskStatusMap[taskStatusId].color
+              this.taskStatusMap.get(taskStatusId).color
             return {
               name,
               color,
@@ -547,7 +547,7 @@ export default {
     },
 
     personName (news) {
-      const person = this.personMap[news.author_id]
+      const person = this.personMap.get(news.author_id)
       return person ? person.full_name : ''
     },
 
@@ -562,7 +562,7 @@ export default {
 
     buildTaskTypeFromNews (news) {
       return {
-        ...this.taskTypeMap[news.task_type_id],
+        ...this.taskTypeMap.get(news.task_type_id),
         episode_id: news.episode_id
       }
     },
@@ -656,12 +656,12 @@ export default {
     },
 
     hasRetakeValue (news) {
-      const taskStatus = this.taskStatusMap[news.task_status_id]
+      const taskStatus = this.taskStatusMap.get(news.task_status_id)
       return taskStatus ? news.change && taskStatus.is_retake : false
     },
 
     hasDoneValue (news) {
-      const taskStatus = this.taskStatusMap[news.task_status_id]
+      const taskStatus = this.taskStatusMap.get(news.task_status_id)
       return taskStatus ? news.change && taskStatus.is_done : false
     },
 

--- a/src/components/pages/ProductionQuota.vue
+++ b/src/components/pages/ProductionQuota.vue
@@ -180,7 +180,7 @@ export default {
     getCurrentPerson () {
       const personId = this.$route.params.person_id
       if (personId && this.personMap) {
-        return this.personMap[personId]
+        return this.personMap.get(personId)
       } else {
         return {}
       }

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -172,7 +172,7 @@ export default {
       this.loadScheduleItems(this.currentProduction)
         .then(scheduleItems => {
           scheduleItems = scheduleItems.map((item) => {
-            const taskType = this.taskTypeMap[item.task_type_id]
+            const taskType = this.taskTypeMap.get(item.task_type_id)
             let startDate, endDate
             if (item.start_date) {
               startDate = parseDate(item.start_date)
@@ -273,7 +273,7 @@ export default {
     expandTaskTypeElement (taskTypeElement) {
       const parameters = {
         production: this.currentProduction,
-        taskType: this.taskTypeMap[taskTypeElement.task_type_id]
+        taskType: this.taskTypeMap.get(taskTypeElement.task_type_id)
       }
 
       taskTypeElement.expanded = !taskTypeElement.expanded

--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -259,7 +259,6 @@ export default {
       'isCurrentUserManager',
       'isTVShow',
       'route',
-      'taskMap',
       'shotMap',
       'shotMetadataDescriptors',
       'shotsPath'
@@ -305,6 +304,10 @@ export default {
           search: ''
         }
       }
+      if (this.currentEpisode) {
+        route.name = 'episode-shots'
+        route.params.episode_id = this.currentEpisode.id
+      }
       return route
     }
   },
@@ -323,7 +326,7 @@ export default {
     },
 
     getCurrentShot () {
-      return this.shotMap[this.route.params.shot_id] || null
+      return this.shotMap.get(this.route.params.shot_id) || null
     },
 
     onEditClicked () {
@@ -389,7 +392,7 @@ export default {
     },
 
     currentEpisode () {
-      if (this.isTVShow && Object.keys(this.shotMap).length === 0) {
+      if (this.isTVShow && this.shotMap.size === 0) {
         this.resetData()
       }
     }

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -108,7 +108,7 @@
     v-if="nbSelectedTasks === 1"
   >
     <task-info
-      :task="Object.values(selectedTasks)[0]"
+      :task="selectedTasks.values().next().value"
     />
   </div>
 
@@ -463,10 +463,13 @@ export default {
     }
 
     if (
-      Object.keys(this.shotMap).length < 2 ||
+      this.shotMap.size < 2 ||
       (
         this.shotValidationColumns.length > 0 &&
-        !this.shotMap[Object.keys(this.shotMap)[0]].validations
+        (
+          !this.shotMap.get(this.shotMap.keys()[0]) ||
+          !this.shotMap.get(this.shotMap.keys()[0]).validations
+        )
       )
     ) {
       setTimeout(() => {
@@ -813,7 +816,7 @@ export default {
     },
 
     onDeleteAllTasksClicked (taskTypeId) {
-      const taskType = this.taskTypeMap[taskTypeId]
+      const taskType = this.taskTypeMap.get(taskTypeId)
       this.taskTypeForTaskDeletion = taskType
       this.deleteAllTasksLockText = taskType.name
       this.modals.isDeleteAllTasksDisplayed = true
@@ -933,7 +936,7 @@ export default {
           }
           this.shotValidationColumns
             .forEach((taskTypeId) => {
-              headers.push(this.taskTypeMap[taskTypeId].name)
+              headers.push(this.taskTypeMap.get(taskTypeId).name)
               headers.push('Assignations')
             })
           csv.buildCsvFile(name, [headers].concat(shotLines))

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -51,7 +51,7 @@
           <people-avatar
             class="flexrow-item"
             :key="personId"
-            :person="personMap[personId]"
+            :person="personMap.get(personId)"
             :size="30"
             :font-size="16"
           />
@@ -499,7 +499,7 @@ export default {
           if (this.entityList[previousEntityIndex]) {
             const entity = this.entityList[previousEntityIndex]
             taskId = entity.tasks.find((ctaskId) => {
-              const task = this.taskMap[ctaskId]
+              const task = this.taskMap.get(taskId)
               if (task) {
                 return task.task_type_id === taskTypeId
               } else {
@@ -548,7 +548,7 @@ export default {
           if (this.entityList[nextEntityIndex]) {
             const entity = this.entityList[nextEntityIndex]
             taskId = entity.tasks.find((ctaskId) => {
-              const task = this.taskMap[ctaskId]
+              const task = this.taskMap.get(taskId)
               if (task) {
                 return task.task_type_id === taskTypeId
               } else {
@@ -612,7 +612,7 @@ export default {
 
     deleteText () {
       if (this.currentTask) {
-        const taskType = this.taskTypeMap[this.currentTask.task_type_id]
+        const taskType = this.taskTypeMap.get(this.currentTask.task_type_id)
         return this.$t('main.delete_text', {
           name: `${this.currentTask.entity_name} / ${taskType.name}`
         })
@@ -633,14 +633,14 @@ export default {
 
     currentTaskType () {
       if (this.currentTask) {
-        return this.taskTypeMap[this.currentTask.task_type_id]
+        return this.taskTypeMap.get(this.currentTask.task_type_id)
       } else {
         return null
       }
     },
 
     currentTeam () {
-      return this.currentProduction.team.map(id => this.personMap[id])
+      return this.currentProduction.team.map(id => this.personMap.get(id))
     },
 
     pinnedCount () {
@@ -763,7 +763,7 @@ export default {
     },
 
     getCurrentTask () {
-      return this.taskMap[this.route.params.task_id]
+      return this.taskMap.get(this.route.params.task_id)
     },
 
     getCurrentComment () {
@@ -1103,7 +1103,7 @@ export default {
         const comment = this.currentTaskComments.find(
           c => c.id === eventData.comment_id
         )
-        const user = this.personMap[eventData.person_id]
+        const user = this.personMap.get(eventData.person_id)
         if (comment && user) {
           if (this.user.id === user.id) {
             if (
@@ -1177,7 +1177,8 @@ export default {
   metaInfo () {
     let title = 'Loading task... - Kitsu'
     if (this.currentTask) {
-      const taskTypeName = this.taskTypeMap[this.currentTask.task_type_id].name
+      const taskTypeName =
+        this.taskTypeMap.get(this.currentTask.task_type_id).name
       title = `${this.title} / ${taskTypeName} - Kitsu`
     }
     return { title }

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -183,7 +183,7 @@
     v-if="nbSelectedTasks === 1"
   >
     <task-info
-      :task="Object.values(selectedTasks)[0]"
+      :task="selectedTasks.values().next().value"
     />
   </div>
 </div>
@@ -368,11 +368,11 @@ export default {
     // Meta
 
     assetTasks () {
-      return this.getTasks(Object.values(this.assetMap))
+      return this.getTasks(Array.from(this.assetMap.values()))
     },
 
     shotTasks () {
-      return this.getTasks(Object.values(this.shotMap))
+      return this.getTasks(Array.from(this.shotMap.values()))
     },
 
     title () {
@@ -453,7 +453,7 @@ export default {
 
     scheduleTeam () {
       const scheduleTeam = this.currentProduction.team.map((personId) => {
-        return this.personMap[personId]
+        return this.personMap.get(personId)
       })
       return sortPeople(scheduleTeam)
     },
@@ -485,7 +485,9 @@ export default {
     initData (force) {
       this.resetTasks()
       this.focusSearchField()
+      console.log('init')
       if (this.tasks.length === 0) {
+        console.log('no tasks')
         this.loading.entities = true
         this.errors.entities = false
         this.initTaskType(force)
@@ -665,7 +667,7 @@ export default {
         tasks = this.shotTasks
       }
       tasks = tasks.filter((task) => {
-        const entity = this.entityMap[task.entity_id]
+        const entity = this.entityMap.get(task.entity_id)
         return !entity.canceled
       })
       this.tasks = this.sortTasks(tasks)
@@ -684,7 +686,7 @@ export default {
       const tasks = []
       entities.forEach(entity => {
         entity.tasks.forEach(taskId => {
-          const task = this.taskMap[taskId]
+          const task = this.taskMap.get(taskId)
           if (task) {
             // Hack to allow filtering on linked entity metadata.
             task.data = entity.data
@@ -729,7 +731,7 @@ export default {
 
     updateEstimation ({ taskId, days, item }) {
       const estimation = daysToMinutes(this.organisation, days)
-      const task = this.taskMap[taskId]
+      const task = this.taskMap.get(taskId)
       let data = { estimation }
       if (!task.start_date) task.start_date = formatSimpleDate(moment())
       const startDate = parseDate(task.start_date)
@@ -896,12 +898,12 @@ export default {
 
     getTaskElementColor (task, endDate) {
       if (this.schedule.currentColor === 'status') {
-        let color = this.taskStatusMap[task.task_status_id].color
+        let color = this.taskStatusMap.get(task.task_status_id).color
         if (color === '#f5f5f5') color = '#999'
         return color
       } else if (this.schedule.currentColor === 'late') {
         const isLate = (
-          !this.taskStatusMap[task.task_status_id].is_done &&
+          !this.taskStatusMap.get(task.task_status_id).is_done &&
           endDate.isBefore(moment())
         )
         return isLate ? '#FF3860' : '#999'
@@ -1035,7 +1037,7 @@ export default {
   socket: {
     events: {
       'task:update' (eventData) {
-        if (this.taskMap[eventData.task_id]) {
+        if (this.taskMap.get(eventData.task_id)) {
           setTimeout(this.resetTaskIndex, 1000)
         }
       }

--- a/src/components/pages/Team.vue
+++ b/src/components/pages/Team.vue
@@ -62,7 +62,7 @@ export default {
 
     teamPersons () {
       return sortPeople(this.currentProduction.team
-        .map((personId) => this.personMap[personId]))
+        .map(personId => this.personMap.get(personId)))
     },
 
     unlistedPeople () {

--- a/src/components/pages/Timesheets.vue
+++ b/src/components/pages/Timesheets.vue
@@ -375,7 +375,7 @@ export default {
     getCurrentPerson () {
       const personId = this.$route.params.person_id
       if (personId && this.personMap) {
-        return this.personMap[personId]
+        return this.personMap.get(personId)
       } else {
         return {}
       }

--- a/src/components/pages/Todos.vue
+++ b/src/components/pages/Todos.vue
@@ -119,7 +119,7 @@
     v-if="nbSelectedTasks === 1"
   >
     <task-info
-      :task="Object.values(selectedTasks)[0]"
+      :task="selectedTasks.values().next().value"
     />
   </div>
 </div>
@@ -202,7 +202,6 @@ export default {
       'isTodosLoadingError',
       'nbSelectedTasks',
       'selectedTasks',
-      'taskMap',
       'taskTypeMap',
       'todosSearchText',
       'timeSpentMap',
@@ -216,14 +215,14 @@ export default {
     loggableTodos () {
       return this.sortedTasks
         .filter((task) => {
-          return this.taskTypeMap[task.task_type_id].allow_timelog
+          return this.taskTypeMap.get(task.task_type_id).allow_timelog
         })
     },
 
     loggableDoneTasks () {
       return this.displayedDoneTasks
         .filter((task) => {
-          return this.taskTypeMap[task.task_type_id].allow_timelog
+          return this.taskTypeMap.get(task.task_type_id).allow_timelog
         })
     },
 

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -131,6 +131,7 @@
           class="button"
           ref="preview-file"
           :href="currentPreviewDlPath"
+          v-if="extension && extension.length > 0"
         >
           <download-icon class="icon" />
           <span class="text">
@@ -1302,7 +1303,7 @@ export default {
     updateTaskPanel () {
       if (this.entityList.length > 0) {
         const entity = this.entityList[this.playingEntityIndex]
-        if (entity) this.task = this.taskMap[entity.preview_file_task_id]
+        if (entity) this.task = this.taskMap.get(entity.preview_file_task_id)
         else this.task = null
       } else {
         this.task = null
@@ -1924,15 +1925,15 @@ export default {
       const entities = Object.values(this.entities)
       if (entities.length > 0) {
         let taskTypeIds = Object.keys(entities[0].preview_files)
-        entities.forEach((entity) => {
+        entities.forEach(entity => {
           taskTypeIds = taskTypeIds.filter(
             taskTypeId => entity.preview_files[taskTypeId]
           )
         })
         this.taskTypeOptions = taskTypeIds.map((taskTypeId) => {
           return {
-            label: this.taskTypeMap[taskTypeId].name,
-            value: this.taskTypeMap[taskTypeId].id
+            label: this.taskTypeMap.get(taskTypeId).name,
+            value: this.taskTypeMap.get(taskTypeId).id
           }
         }).sort((a, b) => a.label.localeCompare(b.label))
         if (this.taskTypeOptions.length > 0) {

--- a/src/components/pages/playlists/PlaylistedEntity.vue
+++ b/src/components/pages/playlists/PlaylistedEntity.vue
@@ -120,7 +120,7 @@ export default {
       return this.entity.preview_files
         ? Object
             .keys(this.entity.preview_files)
-            .map(id => this.taskTypeMap[id])
+            .map(id => this.taskTypeMap.get(id))
             .sort(firstBy('priority', 1).thenBy('name'))
             .map((taskType) => {
               return {

--- a/src/components/pages/quota/Quota.vue
+++ b/src/components/pages/quota/Quota.vue
@@ -59,8 +59,8 @@
         >
           <th scope="row" class="name datatable-row-header">
             <div class="flexrow">
-              <people-avatar :size="30" :person="personMap[key]"/>
-              {{ personMap[key].full_name }}
+              <people-avatar :size="30" :person="personMap.get(key)"/>
+              {{ personMap.get(key).full_name }}
             </div>
           </th>
           <td
@@ -255,7 +255,7 @@ export default {
   },
 
   mounted () {
-    if (Object.keys(this.shotMap).length < 2) {
+    if (this.shotMap.size < 2) {
       setTimeout(() => {
         this.loadShots((err) => {
           setTimeout(() => {
@@ -300,8 +300,8 @@ export default {
     personIds () {
       const personIds = Object.keys(this.quotaMap)
       return personIds.sort((a, b) => {
-        const personAName = this.personMap[a].full_name
-        const personBName = this.personMap[b].full_name
+        const personAName = this.personMap.get(a).full_name
+        const personBName = this.personMap.get(b).full_name
         return personAName.localeCompare(personBName)
       })
     }
@@ -445,10 +445,6 @@ export default {
     },
 
     countMode () {
-      this.loadData()
-    },
-
-    shotMap () {
       this.loadData()
     },
 

--- a/src/components/pages/tasktype/EstimationHelper.vue
+++ b/src/components/pages/tasktype/EstimationHelper.vue
@@ -52,7 +52,7 @@
             <td class="assignees flexrow">
               <people-avatar
                 class="flexrow-item"
-                :person="personMap[personId]"
+                :person="personMap.get(personId)"
                 :size="30"
                 :font-size="17"
                 v-for="personId in task.assignees"
@@ -67,13 +67,13 @@
               >
                 <people-avatar
                   class="flexrow-item"
-                  :person="personMap[personId]"
+                  :person="personMap.get(personId)"
                   :size="30"
                   :font-size="17"
                 />
                 <people-name
                   class="flexrow-item"
-                  :person="personMap[personId]"
+                  :person="personMap.get(personId)"
                 />
               </span>
             </td>
@@ -290,7 +290,7 @@ export default {
         })
       })
       assigneeSet.forEach(
-        (val, personId) => assignees.push(this.personMap[personId])
+        (val, personId) => assignees.push(this.personMap.get(personId))
       )
       return assignees
         .sort(firstBy('name'))
@@ -326,16 +326,16 @@ export default {
 
     getEntity (entityId) {
       if (this.isAssets) {
-        return this.assetMap[entityId]
+        return this.assetMap.get(entityId)
       } else {
-        return this.shotMap[entityId]
+        return this.shotMap.get(entityId)
       }
     },
 
     compareFirstAssignees (a, b) {
       if (a.assignees.length > 0 && b.assignees.length > 0) {
-        const personA = this.personMap[a.assignees[0]]
-        const personB = this.personMap[b.assignees[0]]
+        const personA = this.personMap.get(a.assignees[0])
+        const personB = this.personMap.get(b.assignees[0])
         return personA.name.localeCompare(personB.name)
       } else if (a.assignees.length > 0) {
         return -1

--- a/src/components/pages/tasktype/TaskTypeEntityBlock.vue
+++ b/src/components/pages/tasktype/TaskTypeEntityBlock.vue
@@ -73,8 +73,8 @@ export default {
     ]),
 
     task () {
-      if (this.entity.validations[this.taskType.id]) {
-        return this.taskMap[this.entity.validations[this.taskType.id]]
+      if (this.entity.validations.get(this.taskType.id)) {
+        return this.taskMap.get(this.entity.validations.get(this.taskType.id))
       } else {
         return null
       }

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -434,7 +434,7 @@ export default {
       default: () => []
     },
     taskTypeMap: {
-      type: Object,
+      type: Map,
       default: () => {}
     }
   },
@@ -620,10 +620,10 @@ export default {
         .filter((taskTypeId) => {
           const previewFiles = this.entityPreviewFiles[taskTypeId]
             .filter(p => ['mp4', 'png'].includes(p.extension))
-          return previewFiles.length > 0 && this.taskTypeMap[taskTypeId]
+          return previewFiles.length > 0 && this.taskTypeMap.get(taskTypeId)
         })
         .map(taskTypeId => {
-          const taskType = this.taskTypeMap[taskTypeId]
+          const taskType = this.taskTypeMap.get(taskTypeId)
           return {
             label: taskType.name,
             value: taskType.id

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -361,8 +361,8 @@ export default {
     ]),
 
     currentTeam () {
-      const production = this.productionMap[this.task.project_id]
-      return production.team.map(id => this.personMap[id])
+      const production = this.productionMap.get(this.task.project_id)
+      return production.team.map(id => this.personMap.get(id))
     },
 
     title () {
@@ -404,7 +404,7 @@ export default {
     },
 
     currentTaskType () {
-      return this.task ? this.taskTypeMap[this.task.task_type_id] : null
+      return this.task ? this.taskTypeMap.get(this.task.task_type_id) : null
     },
 
     currentPreview () {
@@ -879,7 +879,7 @@ export default {
     onRemoteAcknowledge (eventData, type) {
       if (this.task) {
         const comment = this.getTaskComment(this.task.id, eventData.comment_id)
-        const user = this.personMap[eventData.person_id]
+        const user = this.personMap.get(eventData.person_id)
         if (comment && user) {
           if (this.user.id === user.id) {
             if (

--- a/src/components/tops/ActionTopbar.vue
+++ b/src/components/tops/ActionTopbar.vue
@@ -691,7 +691,7 @@ export default {
       if (this.people.length > 10 && this.currentProduction) {
         this.currentTeam = sortPeople(
           this.currentProduction.team.map((personId) => {
-            return this.personMap[personId]
+            return this.personMap.get(personId)
           })
         )
       } else {
@@ -750,21 +750,20 @@ export default {
     },
 
     nbSelectedTasks () {
-      this.selectedTaskIds = Object.keys(this.selectedTasks)
+      this.selectedTaskIds = Array.from(this.selectedTasks.keys())
 
       if (this.nbSelectedTasks > 0) {
         let isShotSelected = false
         let isAssetSelected = false
 
-        for (const taskId of Object.keys(this.selectedTasks)) {
-          const task = this.selectedTasks[taskId]
+        this.selectedTaskIds.forEach(taskId => {
+          const task = this.selectedTasks.get(taskId)
           if (task.sequence_name) {
             isShotSelected = true
           } else {
             isAssetSelected = true
           }
-        }
-
+        })
         if (isShotSelected && isAssetSelected) {
           this.customActions = this.allCustomActions
         } else if (isShotSelected) {
@@ -808,7 +807,7 @@ export default {
     },
 
     $route () {
-      this.selectedTaskIds = Object.keys(this.selectedTasks)
+      this.selectedTaskIds = Array.from(this.selectedTasks.keys())
       if (this.nbSelectedTasks > 0) {
         this.clearSelectedTasks()
       }

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -300,7 +300,7 @@ export default {
     },
 
     lastProduction () {
-      let production = this.productionMap[this.lastProductionViewed]
+      let production = this.productionMap.get(this.lastProductionViewed)
       if (!production) {
         production = this.currentProduction
       }
@@ -562,7 +562,7 @@ export default {
 
     pushContextRoute (section) {
       const isAssetSection = this.assetSections.includes(section)
-      const production = this.productionMap[this.currentProductionId]
+      const production = this.productionMap.get(this.currentProductionId)
       const isTVShow = production.production_type === 'tvshow'
       let episodeId = this.currentEpisodeId
       if (!episodeId && isTVShow) {
@@ -615,7 +615,7 @@ export default {
       const isAssetSection = this.assetSections.includes(section)
       const isAssetEpisode =
         ['all', 'main'].includes(this.currentEpisodeId)
-      const production = this.productionMap[this.currentProductionId]
+      const production = this.productionMap.get(this.currentProductionId)
       if (!production) return
       const isTVShow = production.production_type === 'tvshow'
 

--- a/src/components/widgets/ComboboxDepartment.vue
+++ b/src/components/widgets/ComboboxDepartment.vue
@@ -85,6 +85,7 @@ export default {
 
   computed: {
     ...mapGetters([
+      'departmentMap',
       'departments'
     ]),
 
@@ -97,17 +98,9 @@ export default {
       return [{ name: '---', id: null, color: '#000000' }, ...this.departmentsToTakeAccount]
     },
 
-    departmentMap () {
-      const departmentMap = {}
-      this.departmentList.forEach(department => {
-        departmentMap[department.id] = department
-      })
-      return departmentMap
-    },
-
     currentDepartment () {
       if (this.value) {
-        return this.departmentMap[this.value]
+        return this.departmentMap.get(this.value)
       } else {
         return this.departmentList[0]
       }

--- a/src/components/widgets/ComboboxModel.vue
+++ b/src/components/widgets/ComboboxModel.vue
@@ -59,7 +59,7 @@ export default {
   methods: {
     emitValue (value) {
       this.currentModelId = value
-      const model = this.modelMap[this.currentModelId]
+      const model = this.modelMap.get(this.currentModelId)
       this.$emit('input', model)
     },
 

--- a/src/components/widgets/ComboboxProduction.vue
+++ b/src/components/widgets/ComboboxProduction.vue
@@ -97,7 +97,7 @@ export default {
 
     currentProduction () {
       if (this.value) {
-        return this.productionMap[this.value]
+        return this.productionMap.get(this.value)
       } else {
         return this.productionList[0]
       }

--- a/src/components/widgets/ComboboxStatus.vue
+++ b/src/components/widgets/ComboboxStatus.vue
@@ -112,7 +112,7 @@ export default {
 
     currentStatus () {
       if (this.value) {
-        return this.taskStatusMap[this.value]
+        return this.taskStatusMap.get(this.value)
       } else {
         return this.taskStatusList[0]
       }

--- a/src/components/widgets/ComboboxTaskType.vue
+++ b/src/components/widgets/ComboboxTaskType.vue
@@ -92,7 +92,7 @@ export default {
 
     currentTaskType () {
       if (this.value) {
-        return this.taskTypeMap[this.value]
+        return this.taskTypeMap.get(this.value)
       } else {
         return this.taskTypeList[0]
       }

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -57,7 +57,7 @@
         <div class="content">
           <p
             class="client-comment"
-            v-if="personMap[comment.person_id].role === 'client'"
+            v-if="personMap.get(comment.person_id).role === 'client'"
           >
             <span>
               {{ $t('comments.comment_from_client') }}
@@ -294,7 +294,6 @@ export default {
       'isDarkTheme',
       'user',
       'personMap',
-      'taskMap',
       'taskTypeMap',
       'taskStatusMap'
     ]),
@@ -337,7 +336,7 @@ export default {
         route.name = `episode-${route.name}`
         route.params.episode_id = this.task.entity.episode_id
       }
-      const taskType = this.taskTypeMap[this.task.task_type_id]
+      const taskType = this.taskTypeMap.get(this.task.task_type_id)
       route.params.type = taskType.for_shots ? 'shots' : 'assets'
       return route
     },
@@ -355,7 +354,7 @@ export default {
     },
 
     taskStatus () {
-      const status = this.taskStatusMap[this.comment.task_status.id]
+      const status = this.taskStatusMap.get(this.comment.task_status.id)
       return status || this.comment.task_status
     },
 
@@ -372,7 +371,7 @@ export default {
 
     isLikedBy () {
       const personList = this.comment.acknowledgements.map(
-        personId => this.personMap[personId]
+        personId => this.personMap.get(personId)
       )
       return sortByName(personList)
         .map(p => p.name)

--- a/src/components/widgets/ValidationTag.vue
+++ b/src/components/widgets/ValidationTag.vue
@@ -80,7 +80,6 @@ export default {
       'currentProduction',
       'isDarkTheme',
       'isTVShow',
-      'taskMap',
       'taskStatusMap',
       'taskTypeMap',
       'isCurrentUserClient'
@@ -93,7 +92,7 @@ export default {
     taskStatus () {
       if (this.task) {
         const taskStatusId = this.task.task_status_id
-        return this.taskStatusMap ? this.taskStatusMap[taskStatusId] : {}
+        return this.taskStatusMap ? this.taskStatusMap.get(taskStatusId) : {}
       } else {
         return {}
       }
@@ -175,7 +174,7 @@ export default {
         route.params.episode_id = task.episode_id || this.currentEpisode.id
       }
 
-      const taskType = this.taskTypeMap[task.task_type_id]
+      const taskType = this.taskTypeMap.get(task.task_type_id)
       route.params.type = taskType.for_shots ? 'shots' : 'assets'
 
       return route

--- a/src/lib/csv.js
+++ b/src/lib/csv.js
@@ -127,7 +127,7 @@ const csv = {
     const initialHeaders = ['Name', '', 'All', '']
     return taskTypeIds.reduce((acc, taskTypeId) => {
       if (taskTypeId !== 'all') {
-        const taskTypeName = taskTypeMap[taskTypeId].name
+        const taskTypeName = taskTypeMap.get(taskTypeId).name
         return acc.concat([taskTypeName, ''])
       } else {
         return acc
@@ -321,7 +321,7 @@ const getStatsTaskTypeIds = (mainStats, taskTypeMap) => {
     .sort((a, b) => {
       if (a === 'all') return 1
       if (b === 'all') return -1
-      return taskTypeMap[a].priority - taskTypeMap[b].priority
+      return taskTypeMap.get(a).priority - taskTypeMap.get(b).priority
     })
 }
 
@@ -330,7 +330,7 @@ const getStatsEntryIds = (mainStats, entryMap) => {
     .sort((a, b) => {
       if (a === 'all') return -1
       if (b === 'all') return 1
-      return entryMap[a].name.localeCompare(entryMap[b].name)
+      return entryMap.get(a).name.localeCompare(entryMap.get(b).name)
     })
 }
 
@@ -375,10 +375,10 @@ const buildTotalLines = (
   total
 ) => {
   const lineMap = {}
-  taskStatusIds.forEach((taskStatusId) => {
-    const taskStatus = taskStatusMap[taskStatusId]
+  taskStatusIds.forEach(taskStatusId => {
+    const taskStatus = taskStatusMap.get(taskStatusId)
     const taskStatusName = taskStatus ? taskStatus.name : taskStatusId
-    const entry = entryMap[entryId]
+    const entry = entryMap.get(entryId)
     const name = entry ? entry.name : 'All'
     const taskStatusStats = mainStats[entryId].all[taskStatusId]
     const count = taskStatusStats[countMode]

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -40,7 +40,7 @@ const applyFiltersFunctions = {
   },
 
   assignation (entry, filter, taskMap) {
-    const task = taskMap[entry.validations[filter.taskType.id]]
+    const task = taskMap.get(entry.validations[filter.taskType.id])
     if (filter.assigned) {
       return task && task.assignees && task.assignees.length > 0
     } else {
@@ -52,8 +52,8 @@ const applyFiltersFunctions = {
   assignedto (entry, filter, taskMap) {
     let isOk = false
     if (entry.tasks) {
-      entry.tasks.forEach((taskId) => {
-        const task = taskMap[taskId]
+      entry.tasks.forEach(taskId => {
+        const task = taskMap.get(taskId)
         isOk = isOk || task.assignees.includes(filter.personId)
       })
     }
@@ -85,7 +85,7 @@ const applyFiltersFunctions = {
   },
 
   status (entry, filter, taskMap) {
-    const task = taskMap[entry.validations[filter.taskType.id]]
+    const task = taskMap.get(entry.validations[filter.taskType.id])
     let isOk = true
     isOk = task && filter.taskStatuses.includes(task.task_status_id)
     if (filter.excluding) isOk = !isOk

--- a/src/lib/indexing.js
+++ b/src/lib/indexing.js
@@ -82,7 +82,7 @@ export const buildSupervisorTaskIndex = (tasks, personMap) => {
       task.task_status_short_name
     ])
     task.assignees.forEach((personId) => {
-      const person = personMap[personId]
+      const person = personMap.get(personId)
       if (person) words.push(person.first_name, person.last_name)
     })
     indexWords(index, taskIndex, task, words)

--- a/src/lib/models.js
+++ b/src/lib/models.js
@@ -48,13 +48,16 @@ export const getFilledColumns = (entries) => {
   const filledColumns = {}
   entries.forEach((entry) => {
     if (entry.validations) {
+      Array.from(entry.validations.keys()).forEach(taskTypeId => {
+        filledColumns[taskTypeId] = true
+      })
       Object.assign(
         filledColumns,
         entry.validations
       )
     } else {
       entry.tasks.forEach((task) => {
-        filledColumns[task.task_type_id] = task.id
+        filledColumns[task.task_type_id] = true
       })
     }
   })

--- a/src/lib/path.js
+++ b/src/lib/path.js
@@ -18,7 +18,7 @@ export const getTaskPath = (
     route.name = 'episode-task'
     route.params.episode_id = task.episode_id || episode.id
   }
-  const taskType = taskTypeMap[task.task_type_id]
+  const taskType = taskTypeMap.get(task.task_type_id)
   route.params.type = taskType.for_shots ? 'shots' : 'assets'
   return route
 }

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -11,8 +11,8 @@ export const getTaskTypeStyle = (task) => {
 export const renderComment = (input, mentions, personMap) => {
   let compiled = marked(input || '')
   if (mentions) {
-    mentions.forEach((personId) => {
-      const person = personMap[personId]
+    mentions.forEach(personId => {
+      const person = personMap.get(personId)
       compiled = compiled.replace(
         `@${person.full_name}`,
         `<a class="mention" href="/people/${person.id}">@${person.full_name}</a>`

--- a/src/lib/sorting.js
+++ b/src/lib/sorting.js
@@ -52,8 +52,8 @@ export const sortTasks = (tasks, taskTypeMap) => {
         }
       })
       .thenBy((a, b) => {
-        const taskTypeA = taskTypeMap[a.task_type_id]
-        const taskTypeB = taskTypeMap[b.task_type_id]
+        const taskTypeA = taskTypeMap.get(a.task_type_id)
+        const taskTypeB = taskTypeMap.get(b.task_type_id)
         return taskTypeA.name.localeCompare(taskTypeB.name)
       })
       .thenBy((a, b) => {
@@ -113,8 +113,8 @@ export const sortByDate = (entries) => {
 
 export const sortValidationColumns = (columns, taskTypeMap) => {
   return columns.sort((a, b) => {
-    const taskTypeA = taskTypeMap[a]
-    const taskTypeB = taskTypeMap[b]
+    const taskTypeA = taskTypeMap.get(a)
+    const taskTypeB = taskTypeMap.get(b)
     if (taskTypeA.priority === taskTypeB.priority) {
       return taskTypeA.name.localeCompare(taskTypeB.name)
     } else if (taskTypeA.priority > taskTypeB.priority) {
@@ -194,8 +194,8 @@ const sortByTaskType = (taskMap, sortInfo) => (a, b) => {
   const taskB = b.validations[sortInfo.column]
   if (!taskA) return -1
   if (!taskB) return 1
-  const taskStatusA = taskMap[taskA].task_status_short_name
-  const taskStatusB = taskMap[taskB].task_status_short_name
+  const taskStatusA = taskMap.get(taskA).task_status_short_name
+  const taskStatusB = taskMap.get(taskB).task_status_short_name
   return taskStatusA.localeCompare(taskStatusB)
 }
 

--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -95,7 +95,7 @@ export const computeStats = (entities, idField, taskStatusMap, taskMap) => {
       }
 
       entity.tasks.forEach((taskId) => {
-        const task = taskMap[taskId]
+        const task = taskMap.get(taskId)
         computeTaskResult(
           taskStatusMap,
           results,
@@ -123,7 +123,7 @@ const computeTaskResult = (
 ) => {
   if (task) {
     const taskTypeId = task.task_type_id
-    const taskStatus = taskStatusMap[task.task_status_id]
+    const taskStatus = taskStatusMap.get(task.task_status_id)
 
     if (taskStatus) {
       const taskStatusId = taskStatus.id

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -101,16 +101,16 @@ const helpers = {
     return productionsStore.getters.currentProduction(productionsStore.state)
   },
   getTaskStatus (taskStatusId) {
-    return tasksStore.state.taskStatusMap[taskStatusId]
+    return tasksStore.state.taskStatusMap.get(taskStatusId)
   },
   getTaskType (taskTypeId) {
-    return taskTypesStore.state.taskTypeMap[taskTypeId]
+    return taskTypesStore.state.taskTypeMap.get(taskTypeId)
   },
   getTask (taskId) {
-    return tasksStore.state.taskMap[taskId]
+    return tasksStore.state.taskMap.get(taskId)
   },
   getPerson (personId) {
-    return peopleStore.state.personMap[personId]
+    return peopleStore.state.personMap.get(personId)
   },
 
   setListStats (state, assets) {
@@ -162,14 +162,14 @@ const helpers = {
     validationColumns,
     asset
   ) {
-    const validations = {}
+    const validations = new Map()
     let timeSpent = 0
     let estimation = 0
-    if (!assetTypeMap[asset.asset_type]) {
-      assetTypeMap[asset.asset_type_id] = {
+    if (!assetTypeMap.get(asset.asset_type)) {
+      assetTypeMap.set(asset.asset_type_id, {
         id: asset.asset_type_id,
         name: asset.asset_type_name
-      }
+      })
     }
     asset.production_id = production.id
     asset.project_name = production.name
@@ -182,11 +182,11 @@ const helpers = {
 
       if (task.assignees.length > 1) {
         task.assignees = task.assignees.sort((a, b) => {
-          return personMap[a].name.localeCompare(personMap[b].name)
+          return personMap.get(a).name.localeCompare(personMap.get(b).name)
         })
       }
 
-      const taskType = taskTypeMap[task.task_type_id]
+      const taskType = taskTypeMap.get(task.task_type_id)
       if (!validationColumns[taskType.name]) {
         validationColumns[taskType.name] = task.task_type_id
       }
@@ -194,8 +194,8 @@ const helpers = {
       timeSpent += task.duration
       estimation += task.estimation
       taskIds.push(task.id)
-      validations[task.task_type_id] = task.id
-      taskMap[task.id] = task
+      validations.set(task.task_type_id, task.id)
+      taskMap.set(task.id, task)
     })
 
     asset.tasks = taskIds
@@ -219,11 +219,8 @@ const helpers = {
     persons,
     taskMap
   }) {
-    const taskTypes = Object.values(taskTypeMap)
-    const taskStatuses = Object.keys(taskStatusMap).map((id) => {
-      return taskStatusMap[id]
-    })
-
+    const taskTypes = Array.from(taskTypeMap.values())
+    const taskStatuses = Array.from(taskStatusMap.values())
     const query = assetSearch
     const keywords = getKeyWords(query) || []
     const filters = getFilters({
@@ -265,7 +262,7 @@ const cache = {
 }
 
 const initialState = {
-  assetMap: {},
+  assetMap: new Map(),
   assetValidationColumns: [],
   nbValidationColumns: 0,
 
@@ -392,7 +389,7 @@ const actions = {
    * occurs.
    */
   loadAsset ({ commit, state, rootGetters }, assetId) {
-    const asset = state.assetMap[assetId]
+    const asset = state.assetMap.get(assetId)
     if (asset && asset.lock) return
 
     const personMap = rootGetters.personMap
@@ -401,7 +398,7 @@ const actions = {
     const taskTypeMap = rootGetters.taskTypeMap
     return assetsApi.getAsset(assetId)
       .then((asset) => {
-        if (state.assetMap[asset.id]) {
+        if (state.assetMap.get(asset.id)) {
           commit(UPDATE_ASSET, asset)
         } else {
           commit(ADD_ASSET, {
@@ -462,7 +459,7 @@ const actions = {
   deleteAsset ({ commit, state }, asset) {
     return assetsApi.deleteAsset(asset)
       .then(() => {
-        const previousAsset = state.assetMap[asset.id]
+        const previousAsset = state.assetMap.get(asset.id)
         if (
           previousAsset &&
           previousAsset.tasks.length > 0 &&
@@ -595,7 +592,7 @@ const actions = {
       let assetLine = []
       if (rootGetters.isTVShow) {
         assetLine.push(
-          asset.episode_id ? episodeMap[asset.episode_id].name : 'MP'
+          asset.episode_id ? episodeMap.get(asset.episode_id).name : 'MP'
         )
       }
       assetLine = assetLine.concat([
@@ -617,7 +614,8 @@ const actions = {
       }
       state.assetValidationColumns
         .forEach(validationColumn => {
-          const task = rootGetters.taskMap[asset.validations[validationColumn]]
+          const task =
+            rootGetters.taskMap.get(asset.validations.get(validationColumn))
           if (task) {
             assetLine.push(task.task_status_short_name)
           } else {
@@ -647,8 +645,8 @@ const actions = {
     let taskIds = []
     if (selectionOnly) {
       taskIds = cache.result
-        .filter(a => a.validations[taskTypeId])
-        .map(a => a.validations[taskTypeId])
+        .filter(a => a.validations.get(taskTypeId))
+        .map(a => a.validations.get(taskTypeId))
     }
     return dispatch('deleteAllTasks', { projectId, taskTypeId, taskIds })
   }
@@ -657,7 +655,7 @@ const actions = {
 const mutations = {
   [CLEAR_ASSETS] (state) {
     cache.assets = []
-    state.assetMap = {}
+    state.assetMap = new Map()
     cache.result = []
     state.assetValidationColumns = []
 
@@ -671,7 +669,7 @@ const mutations = {
   [LOAD_ASSETS_START] (state) {
     cache.assets = []
     cache.result = []
-    state.assetMap = {}
+    state.assetMap = new Map()
     state.isAssetsLoading = true
     state.isAssetsLoadingError = false
     state.assetValidationColumns = []
@@ -697,7 +695,7 @@ const mutations = {
     taskTypeMap
   }) {
     const validationColumns = {}
-    const assetTypeMap = {}
+    const assetTypeMap = new Map()
     let isTime = false
     let isEstimation = false
     let isDescription = false
@@ -705,7 +703,7 @@ const mutations = {
     cache.assets = assets
     cache.result = assets
     cache.assetIndex = buildAssetIndex(assets)
-    state.assetMap = {}
+    state.assetMap = new Map()
 
     assets.forEach(asset => {
       helpers.populateAndRegisterAsset(
@@ -717,13 +715,13 @@ const mutations = {
         validationColumns,
         asset
       )
-      state.assetMap[asset.id] = asset
+      state.assetMap.set(asset.id, asset)
       if (!isTime && asset.timeSpent > 0) isTime = true
       if (!isEstimation && asset.estimation > 0) isEstimation = true
       if (!isDescription && asset.description) isDescription = true
     })
 
-    const assetTypes = Object.values(assetTypeMap)
+    const assetTypes = Array.from(assetTypeMap.values())
     cache.assetTypeIndex = buildNameIndex(assetTypes)
     const displayedAssets = cache.assets.slice(0, PAGE_SIZE)
     const filledColumns = getFilledColumns(displayedAssets)
@@ -769,7 +767,7 @@ const mutations = {
     asset
   }) {
     asset.tasks = sortTasks(asset.tasks, taskTypeMap)
-    asset.validations = {}
+    asset.validations = new Map()
     asset.production_id = asset.project_id
     asset.episode_id = asset.source_id
     helpers.populateAndRegisterAsset(
@@ -783,7 +781,7 @@ const mutations = {
     )
     cache.assets.push(asset)
     cache.assets = sortAssets(cache.assets)
-    state.assetMap[asset.id] = asset
+    state.assetMap.set(asset.id, asset)
 
     state.displayedAssets.push(asset)
     state.displayedAssets = sortAssets(state.displayedAssets)
@@ -793,19 +791,19 @@ const mutations = {
     const maxX = state.displayedAssets.length
     const maxY = state.nbValidationColumns
     state.assetSelectionGrid = buildSelectionGrid(maxX, maxY)
-    state.assetMap[asset.id] = asset
+    state.assetMap.set(asset.id, asset)
 
     cache.assetIndex = buildAssetIndex(cache.assets)
   },
 
   [UPDATE_ASSET] (state, asset) {
-    Object.assign(state.assetMap[asset.id], asset)
+    Object.assign(state.assetMap.get(asset.id), asset)
     cache.assetIndex = buildAssetIndex(cache.assets)
   },
 
   [REMOVE_ASSET] (state, assetToDelete) {
-    if (state.assetMap[assetToDelete.id]) {
-      delete state.assetMap[assetToDelete.id]
+    if (state.assetMap.get(assetToDelete.id)) {
+      delete state.assetMap.get(assetToDelete.id)
       cache.assets = removeModelFromList(cache.assets, assetToDelete)
       state.displayedAssets =
         removeModelFromList(state.displayedAssets, assetToDelete)
@@ -831,8 +829,8 @@ const mutations = {
 
   [EDIT_ASSET_END] (state, { newAsset, assetTypeMap }) {
     state.assetCreated = newAsset.name
-    const asset = state.assetMap[newAsset.id]
-    const assetType = assetTypeMap[newAsset.entity_type_id]
+    const asset = state.assetMap.get(newAsset.id)
+    const assetType = assetTypeMap.get(newAsset.entity_type_id)
     if (assetType) {
       newAsset.asset_type_name = assetType.name
       newAsset.asset_type_id = assetType.id
@@ -844,7 +842,7 @@ const mutations = {
       Object.assign(asset, newAsset)
       state.displayedAssets = sortAssets(state.displayedAssets)
     } else {
-      newAsset.validations = {}
+      newAsset.validations = new Map()
       newAsset.production_id = newAsset.project_id
       newAsset.episode_id = newAsset.source_id
       cache.assets.push(newAsset)
@@ -857,7 +855,7 @@ const mutations = {
       const maxX = state.displayedAssets.length
       const maxY = state.nbValidationColumns
       state.assetSelectionGrid = buildSelectionGrid(maxX, maxY)
-      state.assetMap[newAsset.id] = newAsset
+      state.assetMap.set(newAsset.id, newAsset)
     }
     if (newAsset.description && !state.isAssetDescription) {
       state.isAssetDescription = true
@@ -870,7 +868,7 @@ const mutations = {
   },
 
   [RESTORE_ASSET_END] (state, assetToRestore) {
-    const asset = state.assetMap[assetToRestore.id]
+    const asset = state.assetMap.get(assetToRestore.id)
     asset.canceled = false
     cache.assetIndex = buildAssetIndex(cache.assets)
   },
@@ -880,7 +878,7 @@ const mutations = {
       (asset) => asset.id === task.entity_id
     )
     if (asset) {
-      const validations = JSON.parse(JSON.stringify(asset.validations))
+      const validations = new Map(asset.validations)
       delete asset.validations
       Vue.set(asset, 'validations', validations)
 
@@ -948,11 +946,11 @@ const mutations = {
   },
 
   [SET_PREVIEW] (state, { entityId, taskId, previewId, taskMap }) {
-    const asset = state.assetMap[entityId]
+    const asset = state.assetMap.get(entityId)
     if (asset) {
       asset.preview_file_id = previewId
-      asset.tasks.forEach((taskId) => {
-        const task = taskMap[taskId]
+      asset.tasks.forEach(taskId => {
+        const task = taskMap.get(taskId)
         if (task) task.entity.preview_file_id = previewId
       })
     }
@@ -1002,24 +1000,22 @@ const mutations = {
   },
 
   [NEW_TASK_END] (state, task) {
-    const asset = state.assetMap[task.entity_id]
+    const asset = state.assetMap.get(task.entity_id)
     if (asset && task) {
       task = helpers.populateTask(task, asset)
       asset.tasks.push(task.id)
-      if (!asset.validations) asset.validations = {}
-      Vue.set(asset.validations, task.task_type_id, task.id)
+      if (!asset.validations) asset.validations = new Map()
+      asset.validations.set(task.task_type_id, task.id)
+      Vue.set(asset, 'validations', new Map(asset.validations))
     }
   },
 
   [CREATE_TASKS_END] (state, tasks) {
     tasks.forEach((task) => {
       if (task) {
-        const asset = state.assetMap[task.entity_id]
+        const asset = state.assetMap.get(task.entity_id)
         if (asset) {
-          const validations = { ...asset.validations }
-          Vue.set(validations, task.task_type_id, task.id)
-          delete asset.validations
-          Vue.set(asset, 'validations', validations)
+          asset.validations.set(task.task_type_id, task.id)
         }
       }
     })
@@ -1072,12 +1068,12 @@ const mutations = {
   },
 
   [LOCK_ASSET] (state, asset) {
-    asset = state.assetMap[asset.id]
+    asset = state.assetMap.get(asset.id)
     asset.lock = true
   },
 
   [UNLOCK_ASSET] (state, asset) {
-    asset = state.assetMap[asset.id]
+    asset = state.assetMap.get(asset.id)
     asset.lock = false
   },
 

--- a/src/store/modules/assettypes.js
+++ b/src/store/modules/assettypes.js
@@ -13,7 +13,7 @@ import { sortByName } from '../../lib/sorting'
 
 const initialState = {
   assetTypes: [],
-  assetTypeMap: {}
+  assetTypeMap: new Map()
 }
 
 const state = { ...initialState }
@@ -92,9 +92,9 @@ const mutations = {
     state.isAssetTypesLoadingError = false
     state.assetTypes = assetTypes
     state.assetTypes = sortByName(state.assetTypes)
-    state.assetTypeMap = {}
+    state.assetTypeMap = new Map()
     state.assetTypes.forEach((assetType) => {
-      state.assetTypeMap[assetType.id] = assetType
+      state.assetTypeMap.set(assetType.id, assetType)
     })
   },
 
@@ -105,7 +105,7 @@ const mutations = {
       Object.assign(assetType, newAssetType)
     } else {
       state.assetTypes.push(newAssetType)
-      state.assetTypeMap[newAssetType.id] = newAssetType
+      state.assetTypeMap.set(newAssetType.id, newAssetType)
     }
     state.assetTypes = sortByName(state.assetTypes)
   },
@@ -117,7 +117,7 @@ const mutations = {
     if (assetTypeToDeleteIndex >= 0) {
       state.assetTypes.splice(assetTypeToDeleteIndex, 1)
     }
-    delete state.assetTypeMap[assetTypeToDelete.id]
+    state.assetTypeMap.delete(assetTypeToDelete.id)
   },
 
   [RESET_ALL] (state) {

--- a/src/store/modules/breakdown.js
+++ b/src/store/modules/breakdown.js
@@ -63,8 +63,8 @@ const actions = {
     const production = rootState.productions.currentProduction
     const assetMap = rootState.assets.assetMap
     const shots =
-      Object.values(rootState.shots.shotMap)
-        .filter((shot) => shot.sequence_id === sequenceId)
+     Array.from(rootState.shots.shotMap.values())
+       .filter((shot) => shot.sequence_id === sequenceId)
     commit(CASTING_SET_SEQUENCE, sequenceId)
     commit(CASTING_SET_SHOTS, shots)
     return breakdownApi.getSequenceCasting(production.id, sequenceId)
@@ -80,7 +80,7 @@ const actions = {
     const production = rootState.productions.currentProduction
     const assetMap = rootState.assets.assetMap
     const assets =
-      Object.values(rootState.assets.assetMap)
+      Array.from(rootState.assets.assetMap.values())
         .filter((asset) => asset.asset_type_id === assetTypeId)
     commit(CASTING_SET_ASSET_TYPE, assetTypeId)
     commit(CASTING_SET_ASSETS, assets)
@@ -105,7 +105,7 @@ const actions = {
     { commit, rootState },
     { entityId, assetId, nbOccurences }
   ) {
-    const asset = rootState.assets.assetMap[assetId]
+    const asset = rootState.assets.assetMap.get(assetId)
     commit(CASTING_ADD_TO_CASTING, { entityId, asset, nbOccurences })
   },
 
@@ -113,7 +113,7 @@ const actions = {
     { commit, rootState },
     { entityId, assetId, nbOccurences }
   ) {
-    const asset = rootState.assets.assetMap[assetId]
+    const asset = rootState.assets.assetMap.get(assetId)
     commit(CASTING_REMOVE_FROM_CASTING, { entityId, asset, nbOccurences })
   },
 
@@ -264,7 +264,7 @@ const mutations = {
   [CASTING_SET_CASTING] (state, { casting, assetMap }) {
     const entityCastingByType = {}
     const entityCastingKeys = Object.keys(casting)
-    entityCastingKeys.forEach((entityId) => {
+    entityCastingKeys.forEach(entityId => {
       const entityCasting = casting[entityId]
       entityCastingByType[entityId] =
         groupEntitiesByParents(entityCasting, 'asset_type_name')

--- a/src/store/modules/playlists.js
+++ b/src/store/modules/playlists.js
@@ -37,7 +37,7 @@ import {
 
 const initialState = {
   playlists: [],
-  playlistMap: {}
+  playlistMap: new Map()
 }
 
 const state = { ...initialState }
@@ -222,10 +222,10 @@ const actions = {
 const mutations = {
   [LOAD_PLAYLISTS_END] (state, playlists) {
     state.playlists = playlists
-    state.playlistMap = {}
+    state.playlistMap = new Map()
     playlists.forEach(playlist => {
       if (!playlist.entities) playlist.entities = []
-      state.playlistMap[playlist.id] = playlist
+      state.playlistMap.set(playlist.id, playlist)
     })
   },
 
@@ -236,7 +236,7 @@ const mutations = {
   },
 
   [LOAD_PLAYLIST_END] (state, playlist) {
-    state.playlistMap[playlist.id].build_jobs = playlist.build_jobs
+    state.playlistMap.get(playlist.id).build_jobs = playlist.build_jobs
   },
 
   [EDIT_PLAYLIST_START] (state, data) {
@@ -246,12 +246,12 @@ const mutations = {
   },
 
   [EDIT_PLAYLIST_END] (state, newPlaylist) {
-    const playlist = state.playlistMap[newPlaylist.id]
+    const playlist = state.playlistMap.get(newPlaylist.id)
     if (playlist && playlist.id) {
       Object.assign(playlist, newPlaylist)
     } else {
       state.playlists = [newPlaylist].concat(state.playlists)
-      state.playlistMap[newPlaylist.id] = newPlaylist
+      state.playlistMap.set(newPlaylist.id, newPlaylist)
     }
   },
 
@@ -261,7 +261,7 @@ const mutations = {
   },
   [DELETE_PLAYLIST_END] (state, playlistToDelete) {
     state.playlists = removeModelFromList(state.playlists, playlistToDelete)
-    delete state.playlistMap[playlistToDelete.id]
+    state.playlistMap.delete(playlistToDelete.id)
   },
 
   [LOAD_ENTITY_PREVIEW_FILES_END] (state, { playlist, entity, previewFiles }) {
@@ -330,7 +330,7 @@ const mutations = {
   },
 
   [ADD_NEW_JOB] (state, job) {
-    const playlist = state.playlistMap[job.playlist_id]
+    const playlist = state.playlistMap.get(job.playlist_id)
     playlist.build_jobs = [{
       id: job.build_job_id,
       created_at: job.created_at,
@@ -340,7 +340,7 @@ const mutations = {
   },
 
   [MARK_JOB_AS_DONE] (state, job) {
-    const playlist = state.playlistMap[job.playlist_id]
+    const playlist = state.playlistMap.get(job.playlist_id)
     updateModelFromList(playlist.build_jobs, {
       id: job.build_job_id,
       status: 'succeeded'
@@ -348,7 +348,7 @@ const mutations = {
   },
 
   [REMOVE_BUILD_JOB] (state, job) {
-    const playlist = state.playlistMap[job.playlist_id]
+    const playlist = state.playlistMap.get(job.playlist_id)
     Vue.set(
       playlist, 'build_jobs', removeModelFromList(playlist.build_jobs, job)
     )
@@ -374,7 +374,7 @@ const mutations = {
     state.playlists = state.playlists.concat(playlists)
     playlists.forEach(playlist => {
       if (!playlist.entities) playlist.entities = []
-      state.playlistMap[playlist.id] = playlist
+      state.playlistMap.set(playlist.id, playlist)
     })
   },
 

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -138,16 +138,16 @@ const cache = {
 
 const helpers = {
   getTask (taskId) {
-    return tasksStore.state.taskMap[taskId]
+    return tasksStore.state.taskMap.get(taskId)
   },
   getTaskStatus (taskStatusId) {
-    return tasksStore.state.taskStatusMap[taskStatusId]
+    return tasksStore.state.taskStatusMap.get(taskStatusId)
   },
   getTaskType (taskTypeId) {
-    return taskTypesStore.state.taskTypeMap[taskTypeId]
+    return taskTypesStore.state.taskTypeMap.get(taskTypeId)
   },
   getPerson (personId) {
-    return peopleStore.state.personMap[personId]
+    return peopleStore.state.personMap.get(personId)
   },
 
   getShotName (shot) {
@@ -320,7 +320,7 @@ const helpers = {
 }
 
 const initialState = {
-  shotMap: {},
+  shotMap: new Map(),
   sequences: [],
   episodes: [],
   shotSearchText: '',
@@ -356,8 +356,8 @@ const initialState = {
   sequenceIndex: {},
   shotFilledColumns: {},
 
-  sequenceMap: {},
-  episodeMap: {},
+  sequenceMap: new Map(),
+  episodeMap: new Map(),
   shotCreated: '',
   shotSelectionGrid: {},
   sequenceSelectionGrid: {},
@@ -428,7 +428,7 @@ const getters = {
   isShotsLoadingError: state => state.isShotsLoadingError,
   shotCreated: state => state.shotCreated,
 
-  isLongShotList: state => Object.keys(state.shotMap).length > 500,
+  isLongShotList: state => state.shotMap.size > 500,
   shotsCsvFormData: state => state.shotsCsvFormData,
   shotListScrollPosition: state => state.shotListScrollPosition,
   sequenceListScrollPosition: state => state.sequenceListScrollPosition,
@@ -441,7 +441,7 @@ const getters = {
     let sequenceShots = []
     let previousShot = null
 
-    for (const shot of Object.values(state.shotMap)) {
+    for (const shot of state.shotMap.values()) {
       if (previousShot && shot.sequence_name !== previousShot.sequence_name) {
         shotsBySequence.push(sequenceShots.slice(0))
         sequenceShots = []
@@ -479,7 +479,7 @@ const actions = {
       cache.shots.forEach((shot) => {
         let isPending = false
         shot.tasks.forEach((taskId) => {
-          const task = tasksStore.state.taskMap[taskId]
+          const task = tasksStore.state.taskMap.get(taskId)
           if (!isPending) {
             if (daily) {
               if (task.last_comment_date) {
@@ -575,7 +575,7 @@ const actions = {
   loadEpisode ({ commit, state }, episodeId) {
     return shotsApi.getEpisode(episodeId)
       .then((episode) => {
-        if (state.episodeMap[episode.id]) {
+        if (state.episodeMap.get(episode.id)) {
           commit(UPDATE_EPISODE, episode)
         } else {
           commit(ADD_EPISODE, episode)
@@ -587,7 +587,7 @@ const actions = {
   loadSequence ({ commit, state }, sequenceId) {
     return shotsApi.getSequence(sequenceId)
       .then((sequence) => {
-        if (state.sequenceMap[sequence.id]) {
+        if (state.sequenceMap.get(sequence.id)) {
           commit(UPDATE_SEQUENCE, sequence)
         } else {
           commit(ADD_SEQUENCE, sequence)
@@ -601,7 +601,7 @@ const actions = {
    * event. If the shot was updated a few times ago, it is not reloaded.
    */
   loadShot ({ commit, state, rootGetters }, shotId) {
-    const shot = rootGetters.shotMap[shotId]
+    const shot = rootGetters.shotMap.get(shotId)
     if (shot && shot.lock) return
 
     const personMap = rootGetters.personMap
@@ -610,7 +610,7 @@ const actions = {
     const taskTypeMap = rootGetters.taskTypeMap
     return shotsApi.getShot(shotId)
       .then((shot) => {
-        if (state.shotMap[shot.id]) {
+        if (state.shotMap.get(shot.id)) {
           commit(UPDATE_SHOT, shot)
         } else {
           commit(ADD_SHOT, {
@@ -693,7 +693,7 @@ const actions = {
   deleteShot ({ commit, state }, shot) {
     return shotsApi.deleteShot(shot)
       .then(() => {
-        const previousShot = state.shotMap[shot.id]
+        const previousShot = state.shotMap.get(shot.id)
         if (
           previousShot &&
           previousShot.tasks.length > 0 &&
@@ -978,11 +978,13 @@ const actions = {
       if (state.isFps) shotLine.push(shot.data.fps)
       state.shotValidationColumns
         .forEach(validationColumn => {
-          const task = rootGetters.taskMap[shot.validations[validationColumn]]
+          const task = rootGetters.taskMap.get(
+            shot.validations.get(validationColumn)
+          )
           if (task) {
             shotLine.push(task.task_status_short_name)
             shotLine.push(
-              task.assignees.map(id => personMap[id].full_name).join(',')
+              task.assignees.map(id => personMap.get(id).full_name).join(',')
             )
           } else {
             shotLine.push('') // Status
@@ -1007,8 +1009,9 @@ const actions = {
     const quotas = {}
 
     cache.shots.forEach((shot) => {
-      const task = taskMap[shot.validations[taskTypeId]]
-      const isTaskFinished = task && taskStatusMap[task.task_status_id].is_done
+      const task = taskMap.get(shot.validations.get(taskTypeId))
+      const isTaskFinished =
+        task && taskStatusMap.get(task.task_status_id).is_done
       if (isTaskFinished) {
         const period = helpers.getPeriod(task, detailLevel)
         const endDateString = helpers.getTaskEndDate(task, detailLevel)
@@ -1050,9 +1053,9 @@ const actions = {
     })
 
     const shots = cache.shots.filter((shot) => {
-      const task = rootGetters.taskMap[shot.validations[taskTypeId]]
+      const task = rootGetters.taskMap.get(shot.validations.get(taskTypeId))
       if (task) {
-        const taskStatus = taskStatusMap[task.task_status_id]
+        const taskStatus = taskStatusMap.get(task.task_status_id)
         const endDateString = helpers.getTaskEndDate(task, detailLevel)
         return (
           task &&
@@ -1089,8 +1092,8 @@ const actions = {
     let taskIds = []
     if (selectionOnly) {
       taskIds = cache.result
-        .filter(a => a.validations[taskTypeId])
-        .map(a => a.validations[taskTypeId])
+        .filter(a => a.validations.get(taskTypeId))
+        .map(a => a.validations.get(taskTypeId))
     }
     return dispatch('deleteAllTasks', { projectId, taskTypeId, taskIds })
   }
@@ -1101,7 +1104,7 @@ const mutations = {
     cache.shots = []
     cache.result = []
     cache.shotIndex = {}
-    state.shotMap = {}
+    state.shotMap = new Map()
 
     state.sequences = []
     state.sequenceIndex = {}
@@ -1121,7 +1124,7 @@ const mutations = {
     cache.shots = []
     cache.result = []
     cache.shotIndex = {}
-    state.shotMap = {}
+    state.shotMap = new Map()
     state.shotValidationColumns = []
 
     state.sequences = []
@@ -1157,37 +1160,36 @@ const mutations = {
     let isDescription = false
     let isTime = false
     let isEstimation = false
-    shots = sortShots(shots)
-    cache.shots = shots
-    cache.result = shots
-    cache.shotIndex = buildShotIndex(shots)
-
-    state.shotMap = {}
-    shots.forEach((shot) => {
+    state.shotMap = new Map()
+    shots.forEach(shot => {
       const taskIds = []
-      const validations = {}
+      const validations = new Map()
       let timeSpent = 0
       let estimation = 0
+      const sequence = state.sequenceMap.get(shot.sequence_id)
+      const episode = state.episodeMap.get(sequence.parent_id)
+      shot.sequence_name = sequence.name
+      shot.episode_name = episode ? episode.name : ''
       shot.project_name = production.name
       shot.production_id = production.id
       shot.full_name = helpers.getShotName(shot)
-      shot.tasks.forEach((task) => {
+      shot.tasks.forEach(task => {
         helpers.populateTask(task, shot, production)
         timeSpent += task.duration
         estimation += task.estimation
         task.episode_id = shot.episode_id
 
-        taskMap[task.id] = task
-        validations[task.task_type_id] = task.id
+        taskMap.set(task.id, task)
+        validations.set(task.task_type_id, task.id)
         taskIds.push(task.id)
 
-        const taskType = taskTypeMap[task.task_type_id]
+        const taskType = taskTypeMap.get(task.task_type_id)
         if (!validationColumns[taskType.name]) {
           validationColumns[taskType.name] = taskType.id
         }
         if (task.assignees.length > 1) {
           task.assignees = task.assignees.sort((a, b) => {
-            return personMap[a].name.localeCompare(personMap[b])
+            return personMap.get(a).name.localeCompare(personMap.get(b))
           })
         }
       })
@@ -1204,8 +1206,13 @@ const mutations = {
       if (!isEstimation && shot.estimation > 0) isEstimation = true
       if (!isDescription && shot.description) isDescription = true
 
-      state.shotMap[shot.id] = shot
+      state.shotMap.set(shot.id, shot)
     })
+    shots = sortShots(shots)
+    cache.shots = shots
+    cache.result = shots
+    cache.shotIndex = buildShotIndex(shots)
+
     const displayedShots = shots.slice(0, PAGE_SIZE)
     const filledColumns = getFilledColumns(displayedShots)
 
@@ -1272,11 +1279,11 @@ const mutations = {
   },
 
   [LOAD_SEQUENCES_END] (state, sequences) {
-    const sequenceMap = {}
-    sequences.forEach((sequence) => {
-      sequenceMap[sequence.id] = sequence
+    const sequenceMap = new Map()
+    sequences.forEach(sequence => {
+      sequenceMap.set(sequence.id, sequence)
       if (sequence.parent_id) {
-        const episode = state.episodeMap[sequence.parent_id]
+        const episode = state.episodeMap.get(sequence.parent_id)
         if (episode) {
           Object.assign(sequence, {
             episode_id: episode.id,
@@ -1294,10 +1301,10 @@ const mutations = {
   },
 
   [LOAD_EPISODES_END] (state, { episodes, routeEpisodeId }) {
-    const episodeMap = {}
+    const episodeMap = new Map()
     if (!episodes) episodes = []
-    episodes.forEach((episode) => {
-      episodeMap[episode.id] = episode
+    episodes.forEach(episode => {
+      episodeMap.set(episode.id, episode)
     })
     state.episodeMap = episodeMap
     state.episodes = sortByName(episodes)
@@ -1312,7 +1319,7 @@ const mutations = {
       } else if (routeEpisodeId === 'main') {
         state.currentEpisode = { id: 'main' }
       } else if (routeEpisodeId) {
-        state.currentEpisode = state.episodeMap[routeEpisodeId]
+        state.currentEpisode = state.episodeMap.get(routeEpisodeId)
       } else {
         state.currentEpisode = state.episodes[0]
       }
@@ -1326,7 +1333,7 @@ const mutations = {
       helpers.populateTask(task, shot)
     })
     shot.tasks = sortTasks(shot.tasks, taskTypeMap)
-    state.shotMap[shot.id] = shot
+    state.shotMap.set(shot.id, shot)
   },
 
   [SHOT_CSV_FILE_SELECTED] (state, formData) {
@@ -1341,7 +1348,7 @@ const mutations = {
   },
 
   [EDIT_SHOT_END] (state, newShot) {
-    const shot = state.shotMap[newShot.id]
+    const shot = state.shotMap.get(newShot.id)
     const sequence = state.sequences.find(
       (sequence) => sequence.id === newShot.parent_id
     )
@@ -1352,7 +1359,7 @@ const mutations = {
     } else {
       cache.shots.push(newShot)
       cache.shots = sortShots(cache.shots)
-      state.shotMap[newShot.id] = newShot
+      state.shotMap.set(newShot.id, newShot)
 
       const maxX = state.displayedShots.length
       const maxY = state.nbValidationColumns
@@ -1382,7 +1389,7 @@ const mutations = {
   },
 
   [EDIT_SEQUENCE_END] (state, newSequence) {
-    const sequence = state.sequenceMap[newSequence.id]
+    const sequence = state.sequenceMap.get(newSequence.id)
     if (sequence) {
       Object.assign(sequence, newSequence)
     }
@@ -1390,7 +1397,7 @@ const mutations = {
   },
 
   [EDIT_EPISODE_END] (state, newEpisode) {
-    const episode = state.episodeMap[newEpisode.id]
+    const episode = state.episodeMap.get(newEpisode.id)
     if (episode) {
       Object.assign(episode, newEpisode)
     }
@@ -1398,7 +1405,7 @@ const mutations = {
   },
 
   [RESTORE_SHOT_END] (state, shotToRestore) {
-    const shot = state.shotMap[shotToRestore.id]
+    const shot = state.shotMap.get(shotToRestore.id)
     shot.canceled = false
     cache.shotIndex = buildShotIndex(cache.shots)
   },
@@ -1442,8 +1449,8 @@ const mutations = {
   },
 
   [NEW_SHOT_END] (state, shot) {
-    const sequence = state.sequenceMap[shot.parent_id]
-    const episode = state.episodeMap[sequence.parent_id]
+    const sequence = state.sequenceMap.get(shot.parent_id)
+    const episode = state.episodeMap.get(sequence.parent_id)
     shot.production_id = shot.project_id
     shot.sequence_name = sequence.name
     shot.sequence_id = sequence.id
@@ -1452,7 +1459,7 @@ const mutations = {
     shot.preview_file_id = ''
 
     shot.tasks = []
-    shot.validations = {}
+    shot.validations = new Map()
     shot.data = {}
 
     cache.shots.push(shot)
@@ -1460,7 +1467,7 @@ const mutations = {
     state.displayedShots = cache.shots.slice(0, PAGE_SIZE)
     helpers.setListStats(state, cache.shots)
     state.shotFilledColumns = getFilledColumns(state.displayedShots)
-    state.shotMap[shot.id] = shot
+    state.shotMap.set(shot.id, shot)
     cache.shotIndex = buildShotIndex(cache.shots)
 
     const maxX = state.displayedShots.length
@@ -1475,13 +1482,13 @@ const mutations = {
 
   [NEW_SEQUENCE_END] (state, sequence) {
     if (sequence.parent_id) {
-      const episode = state.episodeMap[sequence.parent_id]
+      const episode = state.episodeMap.get(sequence.parent_id)
       sequence.episode_id = episode.id
       sequence.episode_name = episode.name
     }
     state.sequences.push(sequence)
     state.sequences = sortSequences(state.sequences)
-    state.sequenceMap[sequence.id] = sequence
+    state.sequenceMap.set(sequence.id, sequence)
     state.sequenceIndex = buildSequenceIndex(state.sequences)
   },
 
@@ -1489,19 +1496,16 @@ const mutations = {
     state.episodes.push(episode)
     state.episodes = sortByName(state.episodes)
     state.displayedEpisodes = state.episodes
-    state.episodeMap[episode.id] = episode
+    state.episodeMap.set(episode.id, episode)
   },
 
   [CREATE_TASKS_END] (state, tasks) {
     tasks.forEach((task) => {
       if (task) {
-        const shot = state.shotMap[task.entity_id]
+        const shot = state.shotMap.get(task.entity_id)
         if (shot) {
           helpers.populateTask(task, shot)
-          const validations = { ...shot.validations }
-          Vue.set(validations, task.task_type_id, task.id)
-          delete shot.validations
-          Vue.set(shot, 'validations', validations)
+          shot.validations.set(task.task_type_id, task.id)
           shot.tasks.push(task.id)
         }
       }
@@ -1568,11 +1572,11 @@ const mutations = {
   },
 
   [SET_PREVIEW] (state, { entityId, taskId, previewId, taskMap }) {
-    const shot = state.shotMap[entityId]
+    const shot = state.shotMap.get(entityId)
     if (shot) {
       shot.preview_file_id = previewId
       shot.tasks.forEach((taskId) => {
-        const task = taskMap[taskId]
+        const task = taskMap.get(taskId)
         if (task) task.entity.preview_file_id = previewId
       })
     }
@@ -1610,7 +1614,7 @@ const mutations = {
   },
 
   [NEW_TASK_END] (state, task) {
-    const shot = state.shotMap[task.entity_id]
+    const shot = state.shotMap.get(task.entity_id)
     if (shot && task) {
       task = helpers.populateTask(task, shot)
 
@@ -1624,8 +1628,8 @@ const mutations = {
       (shot) => shot.id === task.entity_id
     )
     if (shot) {
-      const validations = JSON.parse(JSON.stringify(shot.validations))
-      delete validations[task.task_type_id]
+      const validations = new Map(shot.validations)
+      validations.remove(task.task_type_id)
       delete shot.validations
       Vue.set(shot, 'validations', validations)
 
@@ -1659,7 +1663,7 @@ const mutations = {
       } else if (episodeId === 'all') {
         state.currentEpisode = { id: 'all' }
       } else {
-        state.currentEpisode = state.episodeMap[episodeId]
+        state.currentEpisode = state.episodeMap.get(episodeId)
       }
     }
   },
@@ -1702,7 +1706,7 @@ const mutations = {
   [ADD_EPISODE] (state, episode) {
     state.episodes.push(episode)
     const sortedEpisodes = sortByName(state.episodes)
-    state.episodeMap[episode.id] = episode
+    state.episodeMap.set(episode.id, episode)
     state.episodes = sortedEpisodes
     state.displayedEpisodes.push(episode)
     state.displayedEpisodes = sortByName(state.displayedEpisodes)
@@ -1711,12 +1715,12 @@ const mutations = {
   },
 
   [UPDATE_EPISODE] (state, episode) {
-    Object.assign(state.episodeMap[episode.id], episode)
+    Object.assign(state.episodeMap.get(episode.id), episode)
     state.episodeIndex = buildSequenceIndex(state.episodes)
   },
 
   [REMOVE_EPISODE] (state, episode) {
-    delete state.episodeMap[episode.id]
+    delete state.episodeMap.get(episode.id)
     state.episodes = removeModelFromList(state.episodes, episode)
     state.displayedEpisodes =
       removeModelFromList(state.displayedEpisodes, episode)
@@ -1726,9 +1730,9 @@ const mutations = {
   [ADD_SEQUENCE] (state, sequence) {
     state.sequences.push(sequence)
     const sortedSequences = sortSequences(state.sequences)
-    state.sequenceMap[sequence.id] = sequence
+    state.sequenceMap.set(sequence.id, sequence)
     if (sequence.parent_id) {
-      const episode = state.episodeMap[sequence.parent_id]
+      const episode = state.episodeMap.get(sequence.parent_id)
       if (episode) {
         Object.assign(sequence, {
           episode_id: episode.id,
@@ -1744,12 +1748,12 @@ const mutations = {
   },
 
   [UPDATE_SEQUENCE] (state, sequence) {
-    Object.assign(state.sequenceMap[sequence.id], sequence)
+    Object.assign(state.sequenceMap.get(sequence.id), sequence)
     state.sequenceIndex = buildSequenceIndex(state.sequences)
   },
 
   [REMOVE_SEQUENCE] (state, sequence) {
-    delete state.sequenceMap[sequence.id]
+    delete state.sequenceMap.get(sequence.id)
     state.sequences = removeModelFromList(state.sequences, sequence)
     state.displayedSequences =
       removeModelFromList(state.displayedSequences, sequence)
@@ -1764,7 +1768,7 @@ const mutations = {
     shot
   }) {
     const taskIds = []
-    const validations = {}
+    const validations = new Map()
     let timeSpent = 0
     let estimation = 0
     shot.project_name = production.name
@@ -1775,13 +1779,13 @@ const mutations = {
       estimation += task.estimation
       task.episode_id = shot.episode_id
 
-      taskMap[task.id] = task
-      validations[task.task_type_id] = task.id
+      taskMap.set(task.id, task)
+      validations.set(task.task_type_id, task.id)
       taskIds.push(task.id)
 
       if (task.assignees.length > 1) {
         task.assignees = task.assignees.sort((a, b) => {
-          return personMap[a].name.localeCompare(personMap[b])
+          return personMap.get(a).name.localeCompare(personMap.get(b))
         })
       }
     })
@@ -1792,7 +1796,7 @@ const mutations = {
 
     cache.shots.push(shot)
     cache.shots = sortShots(cache.shots)
-    state.shotMap[shot.id] = shot
+    state.shotMap.set(shot.id, shot)
 
     state.displayedShots.push(shot)
     state.displayedShots = sortShots(state.displayedShots)
@@ -1802,16 +1806,16 @@ const mutations = {
     const maxX = state.displayedShots.length
     const maxY = state.nbValidationColumns
     state.shotSelectionGrid = buildSelectionGrid(maxX, maxY)
-    state.shotMap[shot.id] = shot
+    state.shotMap.set(shot.id, shot)
   },
 
   [UPDATE_SHOT] (state, shot) {
-    Object.assign(state.shotMap[shot.id], shot)
+    Object.assign(state.shotMap.get(shot.id), shot)
     cache.shotIndex = buildShotIndex(cache.shots)
   },
 
   [REMOVE_SHOT] (state, shotToDelete) {
-    delete state.shotMap[shotToDelete.id]
+    state.shotMap.delete(shotToDelete.id)
     cache.shots = removeModelFromList(cache.shots, shotToDelete)
     cache.result = removeModelFromList(cache.result, shotToDelete)
     cache.shotIndex = buildShotIndex(cache.shots)
@@ -1861,12 +1865,12 @@ const mutations = {
   },
 
   [LOCK_SHOT] (state, shot) {
-    shot = state.shotMap[shot.id]
+    shot = state.shotMap.get(shot.id)
     if (shot) shot.lock = true
   },
 
   [UNLOCK_SHOT] (state, shot) {
-    shot = state.shotMap[shot.id]
+    shot = state.shotMap.get(shot.id)
     if (shot) shot.lock = false
   },
 

--- a/src/store/modules/taskstatus.js
+++ b/src/store/modules/taskstatus.js
@@ -14,7 +14,7 @@ import {
 
 const initialState = {
   taskStatus: [],
-  taskStatusMap: {}
+  taskStatusMap: new Map()
 }
 
 const state = initialState
@@ -104,17 +104,17 @@ const actions = {
 const mutations = {
   [LOAD_TASK_STATUSES_START] (state) {
     state.taskStatus = []
-    state.taskStatusMap = {}
+    state.taskStatusMap = new Map()
   },
 
   [LOAD_TASK_STATUSES_ERROR] (state) {
     state.taskStatus = []
-    state.taskStatusMap = {}
+    state.taskStatusMap = new Map()
   },
 
   [LOAD_TASK_STATUSES_END] (state, taskStatus) {
     state.taskStatus = sortByName(taskStatus)
-    state.taskStatusMap = {}
+    state.taskStatusMap = new Map()
     taskStatus.forEach((taskStatus) => {
       if (taskStatus.is_artist_allowed === null) {
         taskStatus.is_artist_allowed = true
@@ -122,12 +122,12 @@ const mutations = {
       if (taskStatus.is_client_allowed === null) {
         taskStatus.is_client_allowed = false
       }
-      state.taskStatusMap[taskStatus.id] = taskStatus
+      state.taskStatusMap.set(taskStatus.id, taskStatus)
     })
   },
 
   [EDIT_TASK_STATUS_END] (state, newTaskStatus) {
-    const taskStatus = state.taskStatusMap[newTaskStatus.id]
+    const taskStatus = state.taskStatusMap.get(newTaskStatus.id)
 
     if (taskStatus && taskStatus.id) {
       Object.assign(taskStatus, newTaskStatus)
@@ -135,7 +135,7 @@ const mutations = {
       state.taskStatus.push(newTaskStatus)
       state.taskStatus = sortByName(state.taskStatus)
     }
-    state.taskStatusMap[newTaskStatus.id] = newTaskStatus
+    state.taskStatusMap.set(newTaskStatus.id, newTaskStatus)
   },
 
   [DELETE_TASK_STATUS_END] (state, taskStatusToDelete) {
@@ -145,7 +145,7 @@ const mutations = {
     if (taskStatusToDeleteIndex >= 0) {
       state.taskStatus.splice(taskStatusToDeleteIndex, 1)
     }
-    delete state.taskStatusMap[taskStatusToDelete.id]
+    delete state.taskStatusMap.get(taskStatusToDelete.id)
   },
 
   [RESET_ALL] (state) {

--- a/src/store/modules/tasktypes.js
+++ b/src/store/modules/tasktypes.js
@@ -23,7 +23,7 @@ import {
 
 const initialState = {
   taskTypes: [],
-  taskTypeMap: {},
+  taskTypeMap: new Map(),
   sequenceSubscriptions: {},
 
   editTaskType: {
@@ -50,7 +50,7 @@ const getters = {
   deleteTaskType: state => state.deleteTaskType,
 
   currentTaskType: (state, getters, rootState) => {
-    return state.taskTypeMap[rootState.route.params.task_type_id] || {}
+    return state.taskTypeMap.get(rootState.route.params.task_type_id) || {}
   },
 
   assetTaskTypes: (state, getters, rootState, rootGetters) => {
@@ -78,7 +78,7 @@ const getters = {
     ),
 
   getTaskType: (state, getters) => (id) => {
-    return state.taskTypeMap[id]
+    return state.taskTypeMap.get(id)
   }
 }
 
@@ -139,7 +139,7 @@ const actions = {
   initTaskType ({ commit, dispatch, state, rootState, rootGetters }, force) {
     return new Promise((resolve, reject) => {
       if (rootGetters.currentTaskType.for_shots) {
-        if (Object.keys(rootGetters.shotMap).length < 2 || force) {
+        if (rootGetters.shotMap.size < 2 || force) {
           if (rootGetters.episodes.length === 0 && rootGetters.isTVShow) {
             dispatch('loadEpisodes')
               .then(() => {
@@ -159,7 +159,7 @@ const actions = {
           resolve()
         }
       } else {
-        if (Object.keys(rootGetters.assetMap).length < 2 || force) {
+        if (rootGetters.assetMap.size < 2 || force) {
           dispatch('loadAssets')
             .then(resolve)
             .catch(reject)
@@ -177,14 +177,14 @@ const mutations = {
 
   [LOAD_TASK_TYPES_ERROR] (state) {
     state.taskTypes = []
-    state.taskTypeMap = {}
+    state.taskTypeMap = new Map()
   },
 
   [LOAD_TASK_TYPES_END] (state, taskTypes) {
     state.taskTypes = sortTaskTypes(taskTypes)
-    state.taskTypeMap = {}
-    taskTypes.forEach((taskType) => {
-      state.taskTypeMap[taskType.id] = taskType
+    state.taskTypeMap = new Map()
+    taskTypes.forEach(taskType => {
+      state.taskTypeMap.set(taskType.id, taskType)
     })
   },
 
@@ -199,13 +199,13 @@ const mutations = {
   },
 
   [EDIT_TASK_TYPE_END] (state, newTaskType) {
-    const taskType = state.taskTypeMap[newTaskType.id]
+    const taskType = state.taskTypeMap.get(newTaskType.id)
 
     if (taskType && taskType.id) {
       Object.assign(taskType, newTaskType)
     } else {
       state.taskTypes.push(newTaskType)
-      state.taskTypeMap[newTaskType.id] = newTaskType
+      state.taskTypeMap.set(newTaskType.id, newTaskType)
     }
     state.taskTypes = sortTaskTypes(state.taskTypes)
     state.editTaskType = {
@@ -233,7 +233,7 @@ const mutations = {
     if (taskTypeToDeleteIndex >= 0) {
       state.taskTypes.splice(taskTypeToDeleteIndex, 1)
     }
-    delete state.taskTypeMap[taskTypeToDelete.id]
+    state.taskTypeMap.delete(taskTypeToDelete.id)
 
     state.deleteTaskType = {
       isLoading: false,

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -73,7 +73,7 @@ import {
 
 const helpers = {
   getTaskStatus (taskStatusId) {
-    return taskStatusStore.state.taskStatusMap[taskStatusId]
+    return taskStatusStore.state.taskStatusMap.get(taskStatusId)
   }
 }
 

--- a/tests/unit/fixtures/person-store.js
+++ b/tests/unit/fixtures/person-store.js
@@ -6,11 +6,11 @@ export default {
        { id: 'person-2', name: 'James', active: true },
        { id: 'person-3', name: 'Ema', active: true }
      ],
-     personMap: () => ({
+     personMap: () => new Map(Object.entries({
        'person-1': { id: 'person-1', name: 'John', active: true },
        'person-2': { id: 'person-2', name: 'James', active: true },
        'person-3': { id: 'person-3', name: 'Ema', active: true }
-     })
+     }))
   },
   actions: {}
 }

--- a/tests/unit/lib/descriptor.spec.js
+++ b/tests/unit/lib/descriptor.spec.js
@@ -1,0 +1,16 @@
+import descriptors from '@/lib/descriptors'
+
+describe('descriptors', () => {
+  test('getChoiceOptions', () => {
+    const descriptor = {
+      field_name: 'difficulty',
+      choices: [ 'easy', 'medium', 'difficult']
+    }
+    expect(descriptors.getChoicesOptions(descriptor)).toEqual([
+      { label: '', value: '' },
+      { label: 'easy', value: 'easy' },
+      { label: 'medium', value: 'medium' },
+      { label: 'difficult', value: 'difficult' },
+    ])
+  })
+})

--- a/tests/unit/lib/filtering.spec.js
+++ b/tests/unit/lib/filtering.spec.js
@@ -490,7 +490,7 @@ describe('lib/filtering', () => {
         tasks: ['task-5', 'task-6']
       }
     ]
-    const taskMap = {
+    const taskMap = new Map(Object.entries({
       'task-1': {
         id: 'task-1',
         assignees: [],
@@ -526,11 +526,11 @@ describe('lib/filtering', () => {
         assignees: [],
         task_status_id: 'task-status-2'
       }
-    }
-    const taskStatusMap = {
+    }))
+    const taskStatusMap = new Map(Object.entries({
       'task-status-1': { id: 'task-status-1', short_name: 'wip' },
       'task-status-2': { id: 'task-status-2', short_name: 'done' }
-    }
+    }))
     const descriptors = [
       {
         id: 'descriptor-1',

--- a/tests/unit/lib/models.spec.js
+++ b/tests/unit/lib/models.spec.js
@@ -43,15 +43,15 @@ describe('lib/helpers', () => {
     const assets = [
       {
         id: 'asset-1',
-        validations: {
+        validations: new Map(Object.entries({
           'task-type-1': 'task-1'
-        }
+        }))
       },
       {
         id: 'asset-2',
-        validations: {
+        validations: new Map(Object.entries({
           'task-type-2': 'task-2'
-        }
+        }))
       },
       {
         id: 'asset-3',

--- a/tests/unit/lib/render.spec.js
+++ b/tests/unit/lib/render.spec.js
@@ -1,0 +1,23 @@
+import { getTaskTypeStyle, renderComment } from '@/lib/render'
+
+describe('render', () => {
+  test('getTaskTypeStyle', () => {
+    const task = { task_type_color: 'red' }
+    expect(getTaskTypeStyle(task)).toEqual({
+      'border-left': '4px solid red'
+    })
+    expect(getTaskTypeStyle(null)).toEqual({
+      'border-left': '4px solid transparent'
+    })
+  })
+
+  test('renderComment', () => {
+    const input = "Text @Jhon Doe"
+    const mentions = ['person-1']
+    const personMap = { 'person-1': { id: 'person-1', full_name: 'Jhon Doe' } }
+    const result = renderComment(input, mentions, personMap)
+    expect(result).toEqual(
+      '<p>Text <a class="mention" href="/people/person-1">@Jhon Doe</a></p>'
+    )
+  })
+})

--- a/tests/unit/lib/render.spec.js
+++ b/tests/unit/lib/render.spec.js
@@ -14,9 +14,11 @@ describe('render', () => {
   test('renderComment', () => {
     const input = "Text @Jhon Doe"
     const mentions = ['person-1']
-    const personMap = { 'person-1': { id: 'person-1', full_name: 'Jhon Doe' } }
+    const personMap = new Map(Object.entries(
+      { 'person-1': { id: 'person-1', full_name: 'Jhon Doe' } }
+    ))
     const result = renderComment(input, mentions, personMap)
-    expect(result).toEqual(
+    expect(result.trim()).toEqual(
       '<p>Text <a class="mention" href="/people/person-1">@Jhon Doe</a></p>'
     )
   })

--- a/tests/unit/lib/selection.spec.js
+++ b/tests/unit/lib/selection.spec.js
@@ -1,0 +1,49 @@
+import {
+  buildSelectionGrid,
+  appendSelectionGrid,
+  clearSelectionGrid
+} from '@/lib/selection'
+
+describe('selection', () => {
+  test('buildSelectionGrid', () => {
+    let result = buildSelectionGrid(2, 2)
+    expect(result).toEqual({
+      0: { 0: false, 1: false },
+      1: { 0: false, 1: false }
+    })
+    result = buildSelectionGrid(0, 0)
+    expect(result).toEqual({})
+    result = buildSelectionGrid(3, 2)
+    expect(result).toEqual({
+      0: { 0: false, 1: false },
+      1: { 0: false, 1: false },
+      2: { 0: false, 1: false }
+    })
+  })
+
+  test('appendSelectionGrid', () => {
+    const selectionGrid = {
+      0: { 0: true, 1: false },
+      1: { 0: false, 1: true }
+    }
+    const result = appendSelectionGrid(selectionGrid, 1, 4, 2)
+    expect(result).toEqual({
+      0: { 0: true, 1: false },
+      1: { 0: false, 1: false },
+      2: { 0: false, 1: false },
+      3: { 0: false, 1: false }
+    })
+  })
+
+  test('clearSelectionGrid', () => {
+    const selectionGrid = {
+      0: { 0: true, 1: false },
+      1: { 0: false, 1: true }
+    }
+    const result = clearSelectionGrid(selectionGrid)
+    expect(result).toEqual({
+      0: { 0: false, 1: false },
+      1: { 0: false, 1: false }
+    })
+  })
+})

--- a/tests/unit/lib/sorting.spec.js
+++ b/tests/unit/lib/sorting.spec.js
@@ -14,11 +14,11 @@ import {
 } from '../../../src/lib/sorting'
 
 
-const taskTypeMap = {
+const taskTypeMap = new Map(Object.entries({
   'task-type-1': {id: 'task-type-1', priority: 1, name: 'Modeling'},
   'task-type-2': {id: 'task-type-2', priority: 1, name: 'Setup'},
   'task-type-3': {id: 'task-type-3', priority: 2, name: 'Texture'}
-}
+}))
 
 describe('lib/sorting', () => {
 

--- a/tests/unit/lib/stats.spec.js
+++ b/tests/unit/lib/stats.spec.js
@@ -5,7 +5,7 @@ import {
 } from '../../../src/lib/stats'
 
 
-const taskMap = {
+const taskMap = new Map(Object.entries({
   'task-1': {
     id: 'task-1',
     entity_id: 'shot-1',
@@ -42,8 +42,8 @@ const taskMap = {
     task_status_id: 'task-status-2',
     task_type_id: 'task-type-2'
   }
-}
-const taskTypeMap = {
+}))
+const taskTypeMap = new Map(Object.entries({
   'task-type-1': {
     id: 'task-type-1',
     name: 'Layout'
@@ -52,8 +52,8 @@ const taskTypeMap = {
     id: 'task-type-2',
     name: 'Animation'
   }
-}
-const taskStatusMap = {
+}))
+const taskStatusMap = new Map(Object.entries({
   'task-status-1': {
     id: 'task-status-1',
     name: 'WIP',
@@ -78,7 +78,7 @@ const taskStatusMap = {
     is_retake: false,
     is_done: true
   }
-}
+}))
 const expectedStatResult = {
   all: {
     all: {
@@ -157,7 +157,7 @@ describe('lib/stats', () => {
 
   it('getChartData', () => {
     const sequence = { id: 'sequence-1' }
-    const taskType = taskTypeMap['task-type-1']
+    const taskType = taskTypeMap.get('task-type-1')
     let data = getChartData(expectedStatResult, sequence.id, taskType.id)
     expect(data).toEqual([ [ 'retake', 1, 'red' ], [ 'wip', 1, 'blue' ] ])
     data = getChartData(expectedStatResult, 'all', 'all')
@@ -166,7 +166,7 @@ describe('lib/stats', () => {
 
   it('getChartColors', () => {
     const sequence = { id: 'sequence-1' }
-    const taskType = taskTypeMap['task-type-1']
+    const taskType = taskTypeMap.get('task-type-1')
     let data = getChartColors(expectedStatResult, sequence.id, taskType.id)
     expect(data).toEqual([ 'red' , 'blue' ])
     data = getChartColors(expectedStatResult, 'all', 'all')

--- a/tests/unit/modals/buildfiltermodal.spec.js
+++ b/tests/unit/modals/buildfiltermodal.spec.js
@@ -31,11 +31,11 @@ describe('BuildFilterModal', () => {
         ],
         assetSearchText: (state) => state.assetSearchText,
         assetValidationColumns: () => ['task-type-1', 'task-type-2'],
-        assetTypeMap: () => ({
+        assetTypeMap: () => new Map(Object.entries({
           'asset-type-1': { id: 'asset-type-1', name: 'chars' },
           'asset-type-2': { id: 'asset-type-2', name: 'sets' },
           'asset-type-3': { id: 'asset-type-3', name: 'props' }
-        }),
+        })),
         assetTypes: () => [
           { id: 'asset-type-1', name: 'chars' },
           { id: 'asset-type-2', name: 'sets' },
@@ -70,11 +70,11 @@ describe('BuildFilterModal', () => {
           { id: 'person-2', name: 'James', active: true },
           { id: 'person-3', name: 'Ema', active: true }
         ],
-        personMap: () => ({
+        personMap: () => new Map(Object.entries({
           'person-1': { id: 'person-1', name: 'John', active: true },
           'person-2': { id: 'person-2', name: 'James', active: true },
           'person-3': { id: 'person-3', name: 'Ema', active: true }
-        })
+        }))
       },
       actions: {}
     }
@@ -91,17 +91,17 @@ describe('BuildFilterModal', () => {
           { id: 'task-status-2', short_name: 'WIP' },
           { id: 'task-status-3', short_name: 'Retake' }
         ],
-        taskTypeMap: () => ({
+        taskTypeMap: () => new Map(Object.entries({
           'task-type-1': { id: 'task-type-1', name: 'Modeling' },
           'task-type-2': { id: 'task-type-2', name: 'Rigging' },
           'task-type-3': { id: 'task-type-3', name: 'Layout' },
           'task-type-4': { id: 'task-type-4', name: 'Animation' }
-        }),
-        taskStatusMap: () => ({
+        })),
+        taskStatusMap: () => new Map(Object.entries({
           'task-status-1': { id: 'task-status-1', short_name: 'WFA' },
           'task-status-2': { id: 'task-status-2', short_name: 'WIP' },
           'task-status-3': { id: 'task-status-3', short_name: 'Retake' },
-        })
+        }))
       },
       actions: {}
     }

--- a/tests/unit/pages/production-news-feed.spec.js
+++ b/tests/unit/pages/production-news-feed.spec.js
@@ -34,12 +34,12 @@ describe('ProductionNewsFeed', () => {
     }
     taskStore = {
       getters: {
-        taskTypeMap: () => ({
+        taskTypeMap: () => new Map(Object.entries({
           'task-type-1': {
             name: 'Modeling'
           }
-        }),
-        taskStatusMap: () => ({
+        })),
+        taskStatusMap: () => new Map(Object.entries({
           'task-status-1': {
             name: 'WIP',
             is_retake: false,
@@ -55,7 +55,7 @@ describe('ProductionNewsFeed', () => {
             is_retake: false,
             is_done: true
           }
-        })
+        }))
       },
       actions: {
         loadTask: jest.fn()
@@ -83,7 +83,7 @@ describe('ProductionNewsFeed', () => {
     }
     personStore = {
       getters: {
-        personMap: () => ({
+        personMap: () => new Map(Object.entries({
           'person-1': {
             id: 'person-1',
             name: 'Jhon Doe'
@@ -92,7 +92,7 @@ describe('ProductionNewsFeed', () => {
             id: 'person-1',
             name: 'Emma Doe'
           }
-        })
+        }))
       },
       actions: {}
     }

--- a/tests/unit/pages/quota.spec.js
+++ b/tests/unit/pages/quota.spec.js
@@ -18,10 +18,10 @@ describe('Quota', () => {
       getters: {
         currentEpisode: () => ({}),
         isShotsLoading: () => false,
-        shotMap: () => ({
+        shotMap: () => new Map(Object.entries({
           '24ec56f9-0c00-43e5-9233-3dec2ee06a98': {},
           '32c5b3a2-eaa7-49b6-8f86-03f2b1c4b7bd': {}
-        })
+        }))
       },
       actions: {
         loadShots: jest.fn(),
@@ -43,11 +43,11 @@ describe('Quota', () => {
     }
     peopleStore = {
       getters: {
-        personMap: () => ({
+        personMap: () => new Map(Object.entries({
           'cd5f95f0-8293-4cf2-8220-6928b594ede7': {
             full_name: 'Alicia Cooper'
           }
-        })
+        }))
       },
       actions: {
       }

--- a/tests/unit/pages/schedule.spec.js
+++ b/tests/unit/pages/schedule.spec.js
@@ -28,12 +28,12 @@ describe('Schedule', () => {
   beforeEach(() => {
     taskStore = {
       getters: {
-        taskTypeMap: () => ({
+        taskTypeMap: () => new Map(Object.entries({
           'task-type-1': {
             name: 'Modeling'
           }
-        }),
-        taskStatusMap: () => ({
+        })),
+        taskStatusMap: () => new Map(Object.entries({
           'task-status-1': {
             name: 'WIP',
             is_retake: false,
@@ -49,7 +49,7 @@ describe('Schedule', () => {
             is_retake: false,
             is_done: true
           }
-        })
+        }))
       },
       actions: {
         loadTask: jest.fn()

--- a/tests/unit/pages/tasktype/estimationhelper.spec.js
+++ b/tests/unit/pages/tasktype/estimationhelper.spec.js
@@ -49,10 +49,10 @@ describe('EstimationHelper', () => {
         ],
         assetSearchText: (state) => state.assetSearchText,
         assetValidationColumns: () => ['task-type-1', 'task-type-2'],
-        assetMap: () => ({
+        assetMap: () => new Map(Object.entries({
           'asset-1': { id: 'asset-1', name: 'Lama'},
           'asset-2': { id: 'asset-2', name: 'Pingu'}
-        })
+        }))
       },
       mutations: {
         'CHANGE_SEARCH': (state, query) => state.assetSearchText = query
@@ -71,10 +71,10 @@ describe('EstimationHelper', () => {
         ],
         shotSearchText: () => '',
         shotValidationColumns: () => ['task-type-3', 'task-type-4'],
-        shotMap: () => ({
+        shotMap: () => new Map(Object.entries({
           'shot-1': { id: 'shot-1', name: 'SH01', nb_frames: 58 },
           'shot-2': { id: 'shot-2', name: 'SH02', nb_frames: 34 }
-        })
+        }))
       },
       actions: {}
     }
@@ -92,11 +92,11 @@ describe('EstimationHelper', () => {
           { id: 'person-2', name: 'James' },
           { id: 'person-3', name: 'Ema' }
         ],
-        personMap: () => ({
+        personMap: () => new Map(Object.entries({
           'person-1': { id: 'person-1', name: 'John' },
           'person-2': { id: 'person-2', name: 'James' },
           'person-3': { id: 'person-3', name: 'Ema' }
-        })
+        }))
       },
       actions: {}
     }
@@ -113,17 +113,17 @@ describe('EstimationHelper', () => {
           { id: 'task-status-2', short_name: 'WIP' },
           { id: 'task-status-3', short_name: 'Retake' }
         ],
-        taskTypeMap: () => ({
+        taskTypeMap: () => new Map(Object.entries({
           'task-type-1': { id: 'task-type-1', name: 'Modeling' },
           'task-type-2': { id: 'task-type-2', name: 'Rigging' },
           'task-type-3': { id: 'task-type-3', name: 'Layout' },
           'task-type-4': { id: 'task-type-4', name: 'Animation' }
-        }),
-        taskStatusMap: () => ({
+        })),
+        taskStatusMap: () => new Map(Object.entries({
           'task-status-1': { id: 'task-status-1', short_name: 'WFA' },
           'task-status-2': { id: 'task-status-2', short_name: 'WIP' },
           'task-status-3': { id: 'task-status-3', short_name: 'Retake' },
-        })
+        }))
       },
       actions: {}
     }

--- a/tests/unit/store/breakdown.spec.js
+++ b/tests/unit/store/breakdown.spec.js
@@ -56,7 +56,7 @@ describe('Breakdown store', () => {
         nb_occurences: 2
       }
     ]
-    assetMap = {
+    assetMap = new Map(Object.entries({
       'asset-1': assetCasting[0],
       'asset-2': assetCasting[1],
       'asset-3': {
@@ -67,7 +67,7 @@ describe('Breakdown store', () => {
         nb_occurences: 1,
         preview_file_id: undefined
       }
-    }
+    }))
     casting = {
       'shot-1': assetCasting,
       'shot-2': []
@@ -79,7 +79,7 @@ describe('Breakdown store', () => {
     const entityMapReducer = (acc, entity) => {
       acc[entity.id] = entity ; return acc
     }
-    shotMap = shots.reduce(entityMapReducer, {})
+    shotMap = new Map(Object.entries(shots.reduce(entityMapReducer, {})))
     expectedSequenceOptions = [{
       label: 'SE01',
       value: 'sequence-1',
@@ -249,7 +249,7 @@ describe('Breakdown store', () => {
         .toEqual(newAsset.id)
 
       store.mutations.CASTING_ADD_TO_CASTING(state,
-        { entityId: 'shot-1', asset: assetMap['asset-2'], nbOccurences: 3 }
+        { entityId: 'shot-1', asset: assetMap.get('asset-2'), nbOccurences: 3 }
       )
       expect(state.casting['shot-1'][1]['nb_occurences'])
         .toEqual(5)
@@ -261,14 +261,14 @@ describe('Breakdown store', () => {
       store.mutations.CASTING_SET_SHOTS(state, shots)
       store.mutations.CASTING_SET_CASTING(state, { casting, assetMap })
       store.mutations.CASTING_REMOVE_FROM_CASTING(state,
-        { entityId: 'shot-1', asset: assetMap['asset-2'], nbOccurences: 1 }
+        { entityId: 'shot-1', asset: assetMap.get('asset-2'), nbOccurences: 1 }
       )
       expect(state.casting['shot-1'][1]['nb_occurences'])
         .toEqual(1)
       expect(state.castingByType['shot-1'][1][0]['nb_occurences'])
         .toEqual(1)
       store.mutations.CASTING_REMOVE_FROM_CASTING(state,
-        { entityId: 'shot-1', asset: assetMap['asset-2'], nbOccurences: 1 }
+        { entityId: 'shot-1', asset: assetMap.get('asset-2'), nbOccurences: 1 }
       )
       expect(state.casting['shot-1'].length).toEqual(1)
       expect(state.castingByType['shot-1'].length).toEqual(1)

--- a/tests/unit/store/productions.spec.js
+++ b/tests/unit/store/productions.spec.js
@@ -13,11 +13,11 @@ describe('Productions store', () => {
             { id: 'asset-type-2', name: 'Asset type 2' },
             { id: 'asset-type-3', name: 'Asset type 3' }
           ],
-          assetTypeMap: {
+          assetTypeMap: new Map(Object.entries({
             'asset-type-1': { id: 'asset-type-1', name: 'Asset type 1' },
             'asset-type-2': { id: 'asset-type-2', name: 'Asset type 2' },
             'asset-type-3': { id: 'asset-type-3', name: 'Asset type 3' }
-          }
+          }))
         },
         taskStatus: {
           taskStatus: [
@@ -25,11 +25,11 @@ describe('Productions store', () => {
             { id: 'task-status-2', name: 'Task status 2' },
             { id: 'task-status-3', name: 'Task status 3' }
           ],
-          taskStatusMap: {
+          taskStatusMap: new Map(Object.entries({
             'task-status-1': { id: 'task-status-1', name: 'Task status 1' },
             'task-status-2': { id: 'task-status-2', name: 'Task status 2' },
             'task-status-3': { id: 'task-status-3', name: 'Task status 3' }
-          }
+          }))
         },
         taskTypes: {
           taskTypes: [
@@ -37,11 +37,11 @@ describe('Productions store', () => {
             { id: 'task-type-2', name: 'Task type 2' },
             { id: 'task-type-3', name: 'Task type 3' }
           ],
-          taskTypeMap: {
+          taskTypeMap: new Map(Object.entries({
             'task-type-1': { id: 'task-type-1', name: 'Task type 1' },
             'task-type-2': { id: 'task-type-2', name: 'Task type 2' },
             'task-type-3': { id: 'task-type-3', name: 'Task type 3' }
-          }
+          }))
         },
         productions: {
           currentProduction: {
@@ -49,13 +49,13 @@ describe('Productions store', () => {
             name: 'Caminandes',
             task_types: []
           },
-          productionMap: {
+          productionMap: new Map(Object.entries({
             'production-1': {
               id: 'production-1',
               name: 'Caminandes',
               task_statuses: ['task-status-3', 'task-status-1']
             }
-          }
+          }))
         }
       }
     })

--- a/tests/unit/widgets/combobox-task-type.spec.js
+++ b/tests/unit/widgets/combobox-task-type.spec.js
@@ -14,7 +14,7 @@ describe('ComboboxTaskType', () => {
   beforeEach(() => {
     taskTypeStore = {
       getters: {
-        taskTypeMap: () => ({
+        taskTypeMap: () => new Map(Object.entries({
           'task-type-1': {
             id: 'task-type-1',
             name: 'Modeling',
@@ -25,7 +25,7 @@ describe('ComboboxTaskType', () => {
             name: 'Compositing',
             color: 'red'
           }
-        })
+        }))
       },
       actions: {
       }


### PR DESCRIPTION
**Problem**

Entity lists become slow when there are too many columns and entities. It degrades the user experience. 

**Solution**

This PR is an attempt to limit this problem. It's mainly due to component and data reactivity which fires many functions when something changes even when it is not needed. The component reactivity problem should be fixed with Vue 3. 

For the data aspect, we mitigate the problem here by transforming the biggest maps from Javascript objects to Javascript Map. Vue doesn't support reactivity for Maps. So it should make things lighter because it won't fire an event for each entry anymore (every task, shots and assets are stored in maps). The reactivity is still ensured because the displayed components are registered in dedicated lists.

