### PR TITLE
Playlist improvements

### DIFF
--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -564,7 +564,7 @@ export default {
         this.$t('tasks.fields.last_comment_date')
       ]
       if (!this.isAssets) {
-        headers.splice(4, 0, 'otot')
+        headers.splice(4, 0, 'Frames')
       }
       const taskLines = [headers]
       this.tasks.forEach((task) => {

--- a/src/components/lists/TimesheetList.vue
+++ b/src/components/lists/TimesheetList.vue
@@ -265,8 +265,6 @@ export default {
       this.$refs['th-type'].offsetWidth +
       'px'
     const beginningOfTheWeek = moment().startOf('isoWeek').toDate()
-    console.log(this.organisation.timesheets_locked)
-    console.log(this.organisation.timesheets_locked && this.isCurrentUserArtist)
     this.disabledDates = {
       to: this.isCurrentUserArtist &&
           this.organisation.timesheets_locked === 'true'

--- a/src/components/modals/EditPlaylistModal.vue
+++ b/src/components/modals/EditPlaylistModal.vue
@@ -96,6 +96,10 @@ export default {
     typeDisabled: {
       type: Boolean,
       default: false
+    },
+    taskTypeId: {
+      type: String,
+      default: ''
     }
   },
 
@@ -111,7 +115,7 @@ export default {
         for_entity: this.playlistToEdit.for_entity || this.defaultForEntity,
         for_client: this.playlistToEdit.for_client,
         is_for_all: this.currentEpisode && this.currentEpisode.id === 'all',
-        task_type_id: null
+        task_type_id: this.taskTypeId
       }
     }
   },
@@ -147,11 +151,14 @@ export default {
     },
 
     taskTypeList () {
+      const forShots = this.form.for_entity !== 'asset'
+      const taskTypes = [...this.productionTaskTypes]
+        .filter(taskType => taskType.for_shots === forShots)
       return [{
         id: '',
         color: '#999',
         name: this.$t('news.all')
-      }].concat(sortByName([...this.productionTaskTypes]))
+      }].concat(sortByName([...taskTypes]))
     }
   },
 
@@ -174,7 +181,7 @@ export default {
           for_entity: this.playlistToEdit.for_entity || this.defaultForEntity,
           for_client: 'false',
           is_for_all: this.currentEpisode && this.currentEpisode.id === 'all',
-          task_type_id: null
+          task_type_id: this.taskTypeId
         }
       }
     }

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -9,27 +9,36 @@
           toggled: isListToggled
         }"
         v-scroll="onPlaylistListScroll"
-        v-if="playlists.length > 0"
       >
+
+        <div class="flexrow">
+          <combobox-task-type
+            class="flexrow-item selector mb1"
+            :task-type-list="taskTypeList"
+            :label="$t('playlists.filter_task_type')"
+            :thin="true"
+            v-model="taskTypeId"
+          />
+        </div>
 
         <div class="flexrow">
           <template v-if="!isListToggled">
             <combobox
-              class="flexrow-item"
+              class="flexrow-item mb2"
               :label="$t('main.sorted_by')"
               :options="sortOptions"
-              :thin="true"
               locale-key-prefix="playlists.fields."
               v-model="currentSort"
             />
             <span class="flexrow-item filler"></span>
           </template>
-          <button-simple
+          <!--button-simple
             class="flexrow-item"
             style="flex: 0;"
             @click="isListToggled = !isListToggled"
             :icon="isListToggled ? 'right' : 'left'"
-          />
+          /-->
+
         </div>
 
         <button
@@ -378,6 +387,7 @@
       :is-loading="loading.editPlaylist"
       :is-error="errors.editPlaylist"
       :playlist-to-edit="playlistToEdit"
+      :task-type-id="taskTypeId"
       @cancel="hideEditModal"
       @confirm="confirmEditPlaylist"
     />
@@ -407,6 +417,7 @@ import { sortShots } from '@/lib/sorting'
 import ButtonSimple from '@/components/widgets/ButtonSimple'
 import BuildFilterModal from '@/components/modals/BuildFilterModal'
 import Combobox from '@/components/widgets/Combobox'
+import ComboboxTaskType from '@/components/widgets/ComboboxTaskType'
 import EditPlaylistModal from '@/components/modals/EditPlaylistModal'
 import ErrorText from '@/components/widgets/ErrorText'
 import LightEntityThumbnail from '@/components/widgets/LightEntityThumbnail'
@@ -422,6 +433,7 @@ export default {
     BuildFilterModal,
     ButtonSimple,
     Combobox,
+    ComboboxTaskType,
     ErrorText,
     EditPlaylistModal,
     LightEntityThumbnail,
@@ -437,16 +449,17 @@ export default {
     return {
       currentPlaylist: { name: '' },
       currentSort: 'updated_at',
+      currentEntities: {},
+      isAddingEntity: false,
+      isListToggled: false,
+      page: 1,
+      taskTypeId: '',
+      sortedPlaylists: [],
       sortOptions: [
         'updated_at',
         'created_at',
         'name'
       ].map(name => ({ label: name, value: name })),
-      currentEntities: {},
-      isAddingEntity: false,
-      isListToggled: false,
-      page: 1,
-      sortedPlaylists: [],
       playlistToEdit: {
         name: `${moment().format('YYYY-MM-DD HH:mm:ss')}`,
         for_client: false
@@ -492,6 +505,7 @@ export default {
       'isCurrentUserManager',
       'isShotsLoading',
       'isTVShow',
+      'productionTaskTypes',
       'playlistMap',
       'playlists',
       'playlistsPath',
@@ -562,7 +576,16 @@ export default {
       const productionName =
         this.currentProduction ? this.currentProduction.name : ''
       return `${productionName} ${this.$t('playlists.title')} - Kitsu`
+    },
+
+    taskTypeList () {
+      return [{
+        id: '',
+        color: '#999',
+        name: this.$t('news.all')
+      }].concat([...this.productionTaskTypes])
     }
+
   },
 
   methods: {
@@ -660,7 +683,8 @@ export default {
       if (this.playlists.length === 0 || force) {
         return this.loadPlaylists({
           sortBy: this.currentSort,
-          page: this.page
+          page: this.page,
+          taskTypeId: this.taskTypeId
         })
           .then(() => {
             return setFirstPlaylist()
@@ -1143,6 +1167,10 @@ export default {
   watch: {
     $route () {
       this.setCurrentPlaylist()
+    },
+
+    taskTypeId () {
+      this.loadPlaylistsData(true)
     },
 
     currentPlaylist () {

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -904,7 +904,8 @@ export default {
     addEpisodePending () {
       this.loading.addEpisode = true
       this.$options.silent = true
-      const shots = [].concat(sortShots(...this.shotsByEpisode)).reverse()
+      let shots = [].concat(...this.shotsByEpisode)
+      shots = sortShots(shots).reverse()
       this.addEntities(shots, () => {
         this.loading.addEpisode = false
         this.$options.silent = false

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -673,7 +673,6 @@ export default {
     },
 
     resetTaskIndex () {
-      console.log(this.tasks)
       this.$options.taskIndex = buildSupervisorTaskIndex(
         this.tasks, this.personMap, this.taskStatusMap
       )

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -472,6 +472,7 @@ export default {
     download_csv: 'Download .csv',
     download_zip: 'Download .zip',
     failed: 'Failed',
+    filter_task_type: 'Filtered with task type',
     for_client: 'The Client',
     for_studio: 'The Studio',
     edit_title: 'Edit playlist',

--- a/src/store/api/playlists.js
+++ b/src/store/api/playlists.js
@@ -1,12 +1,18 @@
 import client from './client'
 
 export default {
-  getPlaylists (production, episode, sortBy, page) {
+  getPlaylists (production, episode, taskTypeId, sortBy, page) {
     let path = `/api/data/projects/${production.id}`
     if (episode) {
       path += `/episodes/${episode.id}/playlists`
+      if (taskTypeId && taskTypeId.length > 0) {
+        path += `?task_type_id=${taskTypeId}`
+      }
     } else {
       path += `/playlists?sort_by=${sortBy}&page=${page}`
+      if (taskTypeId && taskTypeId.length > 0) {
+        path += `&task_type_id=${taskTypeId}`
+      }
     }
     return client.pget(path)
   },

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -838,6 +838,7 @@ const mutations = {
     newAsset.tasks = []
     if (asset) {
       newAsset.episode_id = newAsset.source_id
+      delete newAsset.tasks
       Object.assign(asset, newAsset)
       state.displayedAssets = sortAssets(state.displayedAssets)
     } else {
@@ -988,7 +989,9 @@ const mutations = {
           state.nbValidationColumns
         )
       }
-      tmpGrid[validationInfo.x][validationInfo.y] = true
+      if (tmpGrid[validationInfo.x]) {
+        [validationInfo.y] = true
+      }
     })
     state.assetSelectionGrid = tmpGrid
   },

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -1650,7 +1650,9 @@ const mutations = {
           state.nbValidationColumns
         )
       }
-      tmpGrid[validationInfo.x][validationInfo.y] = true
+      if (tmpGrid[validationInfo.x]) {
+        tmpGrid[validationInfo.x][validationInfo.y] = true
+      }
     })
     state.shotSelectionGrid = tmpGrid
   },


### PR DESCRIPTION
**Problem**

* Users who create a lot of playlists would like to filter them by type.
* It's not possible to add a whole episode to a playlist anymore.

**Solution**

* Allow to filter playlists by task type.
* Fix the playlist addition following recent changes about shot loading (no more sorted for faster response from the server). Sort only the list of shot when it is properly created on the frontend side.