### PR TITLE
Change annotation saving behaviour

### DIFF
--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -9,6 +9,7 @@ export const annotationMixin = {
 
   data () {
     return {
+      notSave: false,
       isShowingPalette: false,
       isShowingPencilPalette: false
     }
@@ -150,6 +151,7 @@ export const annotationMixin = {
           this.annotations.splice(index, 1)
         }
       } else {
+        if (!this.annotations || !this.annotations.push) this.annotations = []
         this.annotations.push({
           time: currentTime,
           width: this.fabricCanvas.width,
@@ -196,6 +198,14 @@ export const annotationMixin = {
       const strokeWidth = converter[pencil]
       this.fabricCanvas.freeDrawingBrush.width = strokeWidth
       this.isShowingPalette = false
+    },
+
+    onWindowsClosed (event) {
+      if (this.notSaved) {
+        const confirmationMessage = 'Your annotations are not saved yet.'
+        event.returnValue = confirmationMessage
+        return confirmationMessage
+      }
     },
 
     // Undo / Redo
@@ -302,6 +312,25 @@ export const annotationMixin = {
     clearCanvas () {
       if (this.fabricCanvas) {
         this.fabricCanvas.clear()
+      }
+    },
+
+    // Saving
+
+    startAnnotationSaving (preview, annotations) {
+      this.notSaved = true
+      this.$options.changesToSave = { preview, annotations }
+      this.$options.annotationToSave = setTimeout(() => {
+        this.notSaved = false
+        this.$emit('annotation-changed', this.$options.changesToSave)
+      }, 3000)
+    },
+
+    endAnnotationSaving () {
+      if (this.notSaved) {
+        clearTimeout(this.$options.annotationToSave)
+        this.notSaved = false
+        this.$emit('annotation-changed', this.$options.changesToSave)
       }
     }
   }

--- a/src/components/pages/Logs.vue
+++ b/src/components/pages/Logs.vue
@@ -16,7 +16,7 @@
         icon="refresh"
         @click="loadDayEvents"
       />
-      <span class="flexrow-item">
+      <span class="flexrow-item nb-events">
         {{ events.length }} {{ $t('logs.events') }}
       </span>
     </div>
@@ -195,6 +195,17 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.dark {
+  .tag {
+    color: $white;
+    background: $dark-grey;
+  }
+
+  .nb-events {
+    color: $white;
+  }
+}
+
 .fixed-page {
   margin-top: 60px;
   padding: 2em;
@@ -247,7 +258,7 @@ export default {
   }
 
   .type[data-status="set"] {
-    background: $light-purple;
+    background: $purple;
   }
 
   ul {

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -201,7 +201,7 @@
           @playlist-deleted="$router.push(playlistsPath)"
           @remove-entity="removeEntity"
           @order-change="onOrderChange"
-          @annotationchanged="onAnnotationChanged"
+          @annotation-changed="onAnnotationChanged"
           @for-client-changed="onForClientChanged"
         />
 

--- a/src/components/widgets/SearchQueryList.vue
+++ b/src/components/widgets/SearchQueryList.vue
@@ -115,7 +115,14 @@ export default {
   }
 }
 </script>
-<style>
+<style lang="scss">
+.dark {
+  .search-queries .delete,
+  .search-queries .edit {
+    background: $dark-grey-light;
+    color: white;
+  }
+}
 .tag {
   cursor: pointer;
 }
@@ -137,22 +144,20 @@ export default {
   display: inline-block;
 }
 
+.search-queries .delete:hover,
 .search-queries .edit:hover {
-  background: #A4A4A4;
+  background: $dark-grey-lighter;
 }
 
 .search-queries .edit {
-  display: none;
-  background: #C4C4C4;
+  background: $light-grey;
   border-radius: 50%;
   color: white;
   cursor: pointer;
+  display: none;
   height: 14px;
   margin-right: 0;
   width: 14px;
   line-height: 8px;
-  .edit-icon {
-    padding-bottom: 20px;
-  }
 }
 </style>

--- a/src/store/api/tasks.js
+++ b/src/store/api/tasks.js
@@ -162,7 +162,7 @@ export default {
 
   updatePreviewAnnotation (preview, annotations) {
     return client.pput(
-      `/api/data/preview-files/${preview.id}`,
+      `/api/actions/preview-files/${preview.id}/update-annotations`,
       { annotations }
     )
   },

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -523,7 +523,7 @@ const actions = {
           preview,
           annotations
         })
-        return Promise.resolve(updatedPreview)
+        return Promise.resolve(preview)
       })
       .catch(console.error)
   },


### PR DESCRIPTION
**Problem**

When people are drawing fast, it generates too many annotation requests.

+ Unrelated: fix edit button color in the saved search query widget

**Solution**

* Save annotations every 3s
* Force annotation saving if there is a context change
* Display a warning if someone tries to close the window before the saving was done
