### PR TITLE
Various fixes

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -449,6 +449,7 @@ import { mapGetters, mapActions } from 'vuex'
 import { descriptorMixin } from '@/components/mixins/descriptors'
 import { entityListMixin } from '@/components/mixins/entity_list'
 import { formatListMixin } from '@/components/mixins/format'
+import { range } from '@/lib/time'
 import { selectionListMixin } from '@/components/mixins/selection'
 
 import DescriptionCell from '@/components/cells/DescriptionCell'
@@ -669,13 +670,9 @@ export default {
           [startAssetIndex, endAssetIndex] = [endAssetIndex, startAssetIndex]
         }
         if (startAssetIndex >= 0 && endAssetIndex >= 0) {
-          for (
-            let index = startAssetIndex + 1;
-            index < endAssetIndex;
-            index++
-          ) {
+          range(startAssetIndex, endAssetIndex).forEach(index => {
             assetsToSelect.push(assetsFlatten[index])
-          }
+          })
         }
       }
       if (selected) {

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -500,6 +500,7 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 
+import { range } from '@/lib/time'
 import { descriptorMixin } from '@/components/mixins/descriptors'
 import { domMixin } from '@/components/mixins/dom'
 import { entityListMixin } from '@/components/mixins/entity_list'
@@ -556,6 +557,7 @@ export default {
       lastHeaderMenuDisplayed: null,
       lastMetadaDataHeaderMenuDisplayed: null,
       lastHeaderMenuDisplayedIndexInGrid: null,
+      lastSelectedShot: null,
       metadataDisplayHeaders: {
         fps: true,
         frameIn: true,
@@ -564,9 +566,8 @@ export default {
         estimation: true,
         timeSpent: true
       },
-      stickedColumns: {},
       offsets: {},
-      lastSelectedShot: null
+      stickedColumns: {}
     }
   },
 
@@ -727,9 +728,9 @@ export default {
           [startShotIndex, endShotIndex] = [endShotIndex, startShotIndex]
         }
         if (startShotIndex >= 0 && endShotIndex >= 0) {
-          for (let index = startShotIndex + 1; index < endShotIndex; index++) {
+          range(startShotIndex, endShotIndex).forEach(index => {
             shotsToSelect.push(shotsFlatten[index])
-          }
+          })
         }
       }
       if (selected) {
@@ -800,7 +801,10 @@ export default {
         ...this.stickedColumns,
         [columnId]: sticked
       }
-      localStorage.setItem(this.localStorageStickKey, JSON.stringify(this.stickedColumns))
+      localStorage.setItem(
+        this.localStorageStickKey,
+        JSON.stringify(this.stickedColumns)
+      )
     },
 
     stickColumnClicked () {
@@ -810,7 +814,10 @@ export default {
 
     metadataStickColumnClicked (event) {
       this.toggleStickedColumns(this.lastMetadaDataHeaderMenuDisplayed)
-      this.showMetadataHeaderMenu(this.lastMetadaDataHeaderMenuDisplayed, event)
+      this.showMetadataHeaderMenu(
+        this.lastMetadaDataHeaderMenuDisplayed,
+        event
+      )
     },
 
     updateOffsets () {
@@ -854,7 +861,9 @@ export default {
   },
 
   mounted () {
-    this.stickedColumns = JSON.parse(localStorage.getItem(this.localStorageStickKey)) || {}
+    this.stickedColumns = JSON.parse(
+      localStorage.getItem(this.localStorageStickKey)
+    ) || {}
   }
 }
 </script>

--- a/src/components/pages/NotFound.vue
+++ b/src/components/pages/NotFound.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="not-found page has-text-centered">
-    <img src="@/assets/illustrations/404.png">
+    <img class="illustration" src="@/assets/illustrations/404.png">
     <h1 class="title">{{ $t('not_found.title') }}</h1>
     <p>
       {{ $t('not_found.text') }}

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -50,6 +50,20 @@ const TaskTypes = () => import('../components/pages/TaskTypes')
 const Departements = () => import('../components/pages/departments/Departments')
 const WrongBrowser = () => import('../components/pages/WrongBrowser')
 
+const ADMIN_PAGES = [
+  'asset-types',
+  'custom-actions',
+  'departments',
+  'logs',
+  'main-schedule',
+  'people',
+  'productions',
+  'task-status',
+  'task-types',
+  'main-schedule',
+  'settings'
+]
+
 export const routes = [
 
   {
@@ -111,14 +125,26 @@ export const routes = [
         } else {
           timezone.setTimezone()
           lang.setLocale()
+          const isProhibited =
+            !userStore.getters.isCurrentUserAdmin(userStore.state) &&
+            to &&
+            ADMIN_PAGES.includes(to.name)
           if (taskTypeStore.state.taskTypes.length === 0) {
             init(() => {
               store.commit('DATA_LOADING_END')
-              next()
+              if (isProhibited) {
+                next({ name: 'not-found' })
+              } else {
+                next()
+              }
             })
           } else {
             store.commit('DATA_LOADING_END')
-            next()
+            if (isProhibited) {
+              next({ name: 'server-down' })
+            } else {
+              next()
+            }
           }
         }
       })

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -1939,9 +1939,10 @@ const mutations = {
     if (selected) {
       state.selectedShots.set(shot.id, shot)
       state.selectedShots = new Map(state.selectedShots) // for reactivity
-      const maxX = state.displayedAssets.length
+      const maxX = state.displayedShots.length
       const maxY = state.nbValidationColumns
-      state.assetSelectionGrid = buildSelectionGrid(maxX, maxY) // unselect previously selected tasks
+      // unselect previously selected tasks
+      state.assetSelectionGrid = buildSelectionGrid(maxX, maxY)
     }
   },
 

--- a/src/store/modules/taskstatus.js
+++ b/src/store/modules/taskstatus.js
@@ -93,7 +93,7 @@ const actions = {
   },
 
   deleteTaskStatus ({ commit, state }, taskStatus) {
-    taskStatusApi.deleteTaskStatus(taskStatus)
+    return taskStatusApi.deleteTaskStatus(taskStatus)
       .then(() => {
         commit(DELETE_TASK_STATUS_END, taskStatus)
         Promise.resolve(taskStatus)


### PR DESCRIPTION
**Problem**

* It is not possible to use shift to select multiple shots
* Not found picture is too big for small screens on the not found page
* Artists can see the admin pages (not their content) by browsing it directly via the URL.
* No message is displayed when a task status deletion fails.

**Solution**

* Fix a typo in the code that handled that
* Limit picture size to 800px
* Redirect artists to admin pages when they reach an admin page
* Return properly the promise to propagate the error at the component level
