### PR TITLE
[logs] add preview files listing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+/logs
 *.log
 npm-debug.log*
 

--- a/src/components/pages/logs/Events.vue
+++ b/src/components/pages/logs/Events.vue
@@ -1,0 +1,265 @@
+<template>
+  <div class="mt1">
+    <div class="flexrow">
+      <date-field
+        class="flexrow-item"
+        :disabled-dates="{from: today}"
+        :label="$t('logs.current_date_label')"
+        v-model="currentDate"
+      />
+      <button-simple
+        class="flexrow-item"
+        icon="refresh"
+        @click="loadDayEvents"
+      />
+      <span class="flexrow-item nb-events">
+        {{ events.length }} {{ $t('logs.events') }}
+      </span>
+    </div>
+
+    <div class="mt2" v-if="!isLoading && events.length === 0">
+      {{ $t('logs.empty_list') }}
+    </div>
+    <div class="has-text-centered" v-if="isLoading" >
+      <spinner />
+    </div>
+    <div class="log-list" v-else>
+      <div
+        class="mt05 event-line"
+        :key="event.id"
+        @click="selectLine(event)"
+        v-for="event in events"
+      >
+        <div>
+          <span class="date tag mr1">{{ formatDate(event.created_at) }} </span>
+          <span
+            class="type tag"
+            :title="event.name.split(':')[1]"
+            :data-status="formatType(event)"
+          >
+            {{ formatType(event) }}
+          </span>
+          <span class="name tag mr1">{{ event.name.split(':')[0] }}</span>
+        </div>
+        <ul v-show="selectedEvents[event.id]">
+          <li class="flexrow">
+            <span class="key">user</span>
+            <people-avatar
+              class="flexrow-item"
+              :size="20"
+              :person="personMap.get(event.user_id)"
+              v-if="event.user_id"
+            />
+            <people-name
+              class="flexrow-item"
+              :person="personMap.get(event.user_id)"
+              v-if="event.user_id"
+            />
+          </li>
+          <li
+            class="variable"
+            :key="event.id + '-' + key"
+            v-for="key in Object.keys(event.data).sort()"
+          >
+            <span class="key">{{ key }}</span>
+            <a :href="getLink(event, key)" v-if="isLink(key)">
+              {{ event.data[key] }}
+            </a>
+            <span v-else>{{ event.data[key] }}</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+import moment from 'moment'
+import Vue from 'vue'
+
+import { formatFullDateWithRevertedTimezone } from '@/lib/time'
+import { timeMixin } from '@/components/mixins/time'
+
+import ButtonSimple from '@/components/widgets/ButtonSimple'
+import DateField from '@/components/widgets/DateField'
+import PeopleAvatar from '@/components/widgets/PeopleAvatar'
+import PeopleName from '@/components/widgets/PeopleName'
+import Spinner from '@/components/widgets/Spinner'
+
+export default {
+  name: 'Events',
+  mixins: [timeMixin],
+
+  components: {
+    ButtonSimple,
+    DateField,
+    PeopleAvatar,
+    PeopleName,
+    Spinner
+  },
+
+  data () {
+    return {
+      currentDate: new Date(),
+      events: [],
+      isLoading: true,
+      selectedEvents: {}
+    }
+  },
+
+  mounted () {
+    this.loadDayEvents()
+  },
+
+  computed: {
+    ...mapGetters([
+      'personMap',
+      'productionMap',
+      'user'
+    ]),
+
+    today () {
+      return moment().toDate()
+    }
+  },
+
+  methods: {
+    ...mapActions([
+      'loadEvents'
+    ]),
+
+    formatType (event) {
+      return event.name.split(':')[1].substring(0, 3)
+    },
+
+    loadDayEvents () {
+      const before = moment(this.currentDate).add(1, 'days')
+      const after = moment(this.currentDate)
+      this.selectedEvents = {}
+      this.isLoading = true
+      this.loadEvents({
+        after: formatFullDateWithRevertedTimezone(after, this.timezone),
+        before: formatFullDateWithRevertedTimezone(before, this.timezone)
+      })
+        .then((events) => {
+          this.isLoading = false
+          this.events = events
+        })
+        .catch((err) => {
+          this.isLoading = false
+          console.error(err)
+        })
+    },
+
+    selectLine (event) {
+      Vue.set(this.selectedEvents, event.id, !this.selectedEvents[event.id])
+    },
+
+    isLink (key) {
+      const linkKeys = ['project_id', 'task_id']
+      return linkKeys.includes(key)
+    },
+
+    getLink (event, key) {
+      const productionId = event.data.project_id
+      const entityType = key.substring(0, key.length - 3)
+      if (entityType === 'project') {
+        return `/productions/${productionId}/news-feed`
+      } else {
+        const entityId = event.data[key]
+        return `/productions/${productionId}/${entityType}s/${entityId}`
+      }
+    }
+  },
+
+  watch: {
+    currentDate () {
+      this.loadDayEvents()
+    }
+  },
+
+  metaInfo () {
+    return {
+      title: `${this.$t('logs.title')} - Kitsu`
+    }
+  }
+
+}
+</script>
+
+<style lang="scss" scoped>
+.dark {
+  .tag {
+    color: $white;
+    background: $dark-grey;
+  }
+
+  .nb-events {
+    color: $white;
+  }
+}
+
+.log-list {
+  margin-bottom: 2em;
+}
+
+.event-line {
+  cursor: pointer;
+
+  .tag {
+    border-radius: 4px;
+  }
+
+  .date {
+    font-weight: 500;
+  }
+
+  .type {
+    text-transform: uppercase;
+    min-width: 50px;
+  }
+
+  .type[data-status="new"] {
+    color: white;
+    background: $green;
+  }
+
+  .type[data-status="upd"] {
+    color: white;
+    background: $blue;
+  }
+
+  .type[data-status="add"] {
+    color: white;
+    background: $dark-purple;
+  }
+
+  .type[data-status="del"] {
+    color: white;
+    background: $red;
+  }
+
+  .type[data-status="sta"] {
+    color: white;
+    background: $pink;
+  }
+
+  .type[data-status="set"] {
+    background: $purple;
+  }
+
+  ul {
+    border-left: 3px solid $light-grey;
+    list-style-type: none;
+    margin: 1em 1em 2em 0.2em;
+    padding-left: 1em;
+
+    .key {
+      font-weight: 500;
+      width: 170px;
+      display: inline-block;
+    }
+  }
+}
+</style>

--- a/src/components/pages/logs/PreviewFiles.vue
+++ b/src/components/pages/logs/PreviewFiles.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="mt1">
+    <spinner v-if="previewFilesLoading" :size="20" />
+    <template v-else>
+      <template v-if="previewFiles.length === 0">
+        {{ $t('logs.preview_files.empty_list') }}
+      </template>
+      <template v-else>
+        <ul>
+          <li
+            class="flexrow"
+            v-for="previewFile in previewFiles"
+            :key="previewFile.id"
+          >
+            <people-avatar
+              class="flexrow-item"
+              :size="30"
+              :person="personMap.get(previewFile.person_id)"
+              v-if="previewFile.person_id"
+            />
+            <a @click="redirectToTask(previewFile)">
+              <span class="date tag mr1">
+                {{ formatDate(previewFile.updated_at) }}
+              </span>
+              <span
+                class="status tag"
+                :data-status="previewFile.status"
+              >
+              {{ previewFile.original_name }}.{{ previewFile.extension }}
+              ({{ previewFile.status }})
+              </span>
+            </a>
+          </li>
+        </ul>
+      </template>
+    </template>
+  </div>
+</template>
+
+<script>
+import { mapActions, mapGetters } from 'vuex'
+
+import { getTaskPath } from '@/lib/path'
+
+import playlistsApi from '@/store/api/playlists'
+import tasksApi from '@/store/api/tasks'
+
+import { timeMixin } from '@/components/mixins/time'
+import PeopleAvatar from '@/components/widgets/PeopleAvatar'
+import Spinner from '@/components/widgets/Spinner'
+
+export default {
+  name: 'PreviewFiles',
+  mixins: [timeMixin],
+
+  components: {
+    PeopleAvatar,
+    Spinner
+  },
+
+  data () {
+    return {
+      previewFilesLoading: true,
+      previewFiles: []
+    }
+  },
+
+  computed: {
+    ...mapGetters([
+      'personMap',
+      'taskTypeMap',
+      'user'
+    ]),
+    displayedPreviewFiles () {
+      return this.previewFiles.filter(
+        previewFile => previewFile.status !== 'ready'
+      )
+    }
+  },
+
+  methods: {
+    ...mapActions([
+      'getTask'
+    ]),
+    async redirectToTask (previewFile) {
+      const task = await tasksApi.getTask(previewFile.task_id)
+      await this.$router.push(getTaskPath(
+        task,
+        task.project,
+        task.project.production_type === 'tvshow',
+        task.episode,
+        this.taskTypeMap
+      ))
+    }
+  },
+
+  async mounted () {
+    this.previewFiles = await playlistsApi.getPreviewFiles()
+    this.previewFilesLoading = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.dark {
+  .tag {
+    color: $white;
+    background: $dark-grey;
+  }
+}
+.tag {
+  border-radius: 4px;
+}
+
+.date {
+  font-weight: 500;
+}
+
+.status {
+  text-transform: uppercase;
+  min-width: 50px;
+}
+
+.status[data-status="broken"] {
+  color: white;
+  background: $dark-red;
+}
+
+.status[data-status="processing"] {
+  color: white;
+  background: $blue;
+}
+
+</style>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -238,7 +238,11 @@ export default {
     current_date_label: 'Show logs for',
     events: 'events listed for the current day',
     empty_list: 'There is no logs for the selected date.',
-    title: 'Logs'
+    title: 'Logs',
+    preview_files: {
+      title: 'Preview files',
+      empty_list: 'There is no broken or ongoing previews.'
+    }
   },
 
   main: {

--- a/src/store/api/playlists.js
+++ b/src/store/api/playlists.js
@@ -27,6 +27,10 @@ export default {
     return client.pget(path)
   },
 
+  getPreviewFiles () {
+    return client.pget('/api/data/preview-files')
+  },
+
   newPlaylist (playlist) {
     const data = {
       name: playlist.name,


### PR DESCRIPTION
**Problem**
A page listing the preview files was wanted

**Solution**
This adds a tab in the `Logs` page, listing the broken and processing preview files : 

![image](https://user-images.githubusercontent.com/9109308/121928159-2d819480-cd40-11eb-894d-5760813d412e.png)
