### PR TITLE
[production/settings] sort task types per production

### DIFF
--- a/src/components/lists/EntityTaskList.vue
+++ b/src/components/lists/EntityTaskList.vue
@@ -143,6 +143,7 @@ export default {
   computed: {
     ...mapGetters([
       'currentProduction',
+      'getTaskTypePriority',
       'isCurrentUserClient',
       'isCurrentUserVendor',
       'personMap',
@@ -154,14 +155,12 @@ export default {
       return [...this.entries].sort((taskIdA, taskIdB) => {
         const taskA = this.getTask(taskIdA)
         const taskB = this.getTask(taskIdB)
-        const taskTypeA =
-          this.getTask(this.taskTypeMap.get(taskA.task_type_id))
-        const taskTypeB =
-          this.getTask(this.taskTypeMap.get(taskB.task_type_id))
-        if (taskTypeA.priority === taskTypeB.priority) {
+        const taskTypeAPriority = this.getTaskTypePriority(taskA.task_type_id)
+        const taskTypeBPriority = this.getTaskTypePriority(taskB.task_type_id)
+        if (taskTypeAPriority === taskTypeBPriority) {
           return this.taskTypeA.localeCompare(this.taskTypeB.name)
         } else {
-          return taskTypeA.priority - taskTypeB.priority
+          return taskTypeAPriority - taskTypeBPriority
         }
       })
     }

--- a/src/components/pages/production/NewProduction.vue
+++ b/src/components/pages/production/NewProduction.vue
@@ -732,6 +732,7 @@ export default {
       'addAssetTypeToProduction',
       'addTaskStatusToProduction',
       'addTaskTypeToProduction',
+      'loadContext',
       'newProduction',
       'setProduction',
       'uploadAssetFile',
@@ -764,8 +765,14 @@ export default {
         this.productionToCreate.shotTaskTypes
       ).map(
         // add task types
-        async (taskType) => {
-          return await this.addTaskTypeToProduction(taskType.id)
+        async (taskType, index) => {
+          const finalIndex = taskType.for_shots
+            ? index - this.productionToCreate.assetTaskTypes.length
+            : index
+          return await this.addTaskTypeToProduction({
+            taskTypeId: taskType.id,
+            priority: finalIndex + 1
+          })
         }
       ).concat(
         // add task statuses
@@ -854,6 +861,7 @@ export default {
         await this.createAssetTypes()
         await this.createAssets()
         await this.createShots()
+        await this.loadContext()
         await this.$router.push(this.createProductionRoute(createdProduction))
       } catch (error) {
         console.error(error, error.response)

--- a/src/components/pages/production/ProductionTaskType.vue
+++ b/src/components/pages/production/ProductionTaskType.vue
@@ -6,6 +6,9 @@
   <task-type-cell
     :task-type="taskType"
   />
+  <td class="priority">
+    {{ getTaskTypePriority(taskType.id) }}
+  </td>
   <td class="start-date">
    <date-field
       :disabled-dates="productionTimeRange"
@@ -66,7 +69,8 @@ export default {
 
   computed: {
     ...mapGetters([
-      'currentProduction'
+      'currentProduction',
+      'getTaskTypePriority'
     ]),
 
     productionTimeRange () {
@@ -144,5 +148,8 @@ export default {
 .field {
   margin-bottom: 0;
   width: 105px;
+}
+.priority {
+  padding-left: 2rem;
 }
 </style>

--- a/src/lib/productions.js
+++ b/src/lib/productions.js
@@ -12,3 +12,7 @@ export const PRODUCTION_TYPE_OPTIONS = [
     value: 'featurefilm'
   }
 ]
+
+export function getTaskTypePriorityOfProd (taskType, production) {
+  return production.task_types_priority[taskType.id] || taskType.priority
+}

--- a/src/lib/sorting.js
+++ b/src/lib/sorting.js
@@ -1,4 +1,5 @@
 import firstBy from 'thenby'
+import { getTaskTypePriorityOfProd } from './productions'
 
 export const sortAssets = (assets) => {
   return assets.sort(
@@ -80,10 +81,23 @@ export const sortRevisionPreviewFiles = (previewFiles) => {
   )
 }
 
-export const sortTaskTypes = (taskTypes) => {
+export const sortTaskTypes = (taskTypes, currentProduction) => {
   return taskTypes.sort(
     firstBy('for_shots')
-      .thenBy('priority')
+      .thenBy((taskTypeA, taskTypeB) => {
+        const taskTypeAPriority = getTaskTypePriorityOfProd(
+          taskTypeA, currentProduction
+        )
+        const taskTypeBPriority = getTaskTypePriorityOfProd(
+          taskTypeB, currentProduction
+        )
+        if (taskTypeAPriority > taskTypeBPriority) {
+          return 1
+        } else if (taskTypeAPriority < taskTypeBPriority) {
+          return -1
+        }
+        return 0
+      })
       .thenBy('name')
   )
 }
@@ -111,13 +125,23 @@ export const sortByDate = (entries) => {
   return entries.sort(firstBy('created_at', -1))
 }
 
-export const sortValidationColumns = (columns, taskTypeMap) => {
+export const sortValidationColumns = (
+  columns,
+  taskTypeMap,
+  currentProduction
+) => {
   return columns.sort((a, b) => {
     const taskTypeA = taskTypeMap.get(a)
     const taskTypeB = taskTypeMap.get(b)
-    if (taskTypeA.priority === taskTypeB.priority) {
+    const taskTypeAPriority = getTaskTypePriorityOfProd(
+      taskTypeA, currentProduction
+    )
+    const taskTypeBPriority = getTaskTypePriorityOfProd(
+      taskTypeB, currentProduction
+    )
+    if (taskTypeAPriority === taskTypeBPriority) {
       return taskTypeA.name.localeCompare(taskTypeB.name)
-    } else if (taskTypeA.priority > taskTypeB.priority) {
+    } else if (taskTypeAPriority > taskTypeBPriority) {
       return 1
     } else {
       return -1

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -632,6 +632,7 @@ export default {
     fields: {
       fps: 'FPS',
       name: 'Name',
+      priority: 'Priority',
       ratio: 'Ratio',
       resolution: 'Resolution',
       status: 'Status',

--- a/src/store/api/productions.js
+++ b/src/store/api/productions.js
@@ -72,8 +72,8 @@ export default {
     return client.pdel(path)
   },
 
-  addTaskTypeToProduction (productionId, taskTypeId) {
-    const data = { task_type_id: taskTypeId }
+  addTaskTypeToProduction (productionId, taskTypeId, priority) {
+    const data = { task_type_id: taskTypeId, priority }
     const path = `/api/data/projects/${productionId}/settings/task-types`
     return client.ppost(path, data)
   },

--- a/src/store/api/tasktypes.js
+++ b/src/store/api/tasktypes.js
@@ -35,6 +35,10 @@ export default {
     return client.pput(`/api/data/task-types/${taskType.id}`, data)
   },
 
+  async updateTaskTypeLink (taskTypeLink) {
+    return await client.ppost('/api/data/task-type-links', taskTypeLink)
+  },
+
   deleteTaskType (taskType) {
     return client.pdel(`/api/data/task-types/${taskType.id}`)
   },

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -6,6 +6,7 @@ import tasksStore from './tasks'
 import taskTypesStore from './tasktypes'
 import productionsStore from './productions'
 import peopleStore from './people'
+import { getTaskTypePriorityOfProd } from '@/lib/productions'
 import {
   minutesToDays
 } from '../../lib/time'
@@ -139,7 +140,10 @@ const helpers = {
   },
 
   populateTask (task, asset, production) {
-    task.name = helpers.getTaskType(task.task_type_id).priority.toString()
+    task.name = getTaskTypePriorityOfProd(
+      helpers.getTaskType(task.task_type_id),
+      production || helpers.getCurrentProduction()
+    ).toString()
     task.task_status_short_name =
       helpers.getTaskStatus(task.task_status_id).short_name
 
@@ -211,7 +215,11 @@ const helpers = {
 
   sortValidationColumns (validationColumns, assetFilledColumns, taskTypeMap) {
     const columns = [...validationColumns]
-    return sortValidationColumns(columns, taskTypeMap)
+    return sortValidationColumns(
+      columns,
+      taskTypeMap,
+      helpers.getCurrentProduction()
+    )
   },
 
   buildResult (state, {

--- a/src/store/modules/productions.js
+++ b/src/store/modules/productions.js
@@ -386,11 +386,15 @@ const actions = {
     )
   },
 
-  addTaskTypeToProduction ({ commit, state }, taskTypeId) {
+  addTaskTypeToProduction ({ commit, state }, {
+    taskTypeId,
+    priority = null
+  }) {
     commit(PRODUCTION_ADD_TASK_TYPE, taskTypeId)
     return productionsApi.addTaskTypeToProduction(
       state.currentProduction.id,
-      taskTypeId
+      taskTypeId,
+      priority
     )
   },
 

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -4,9 +4,11 @@ import peopleApi from '../api/people'
 import shotsApi from '../api/shots'
 import tasksStore from './tasks'
 import peopleStore from './people'
+import productionsStore from './productions'
 import taskTypesStore from './tasktypes'
 
 import { PAGE_SIZE } from '../../lib/pagination'
+import { getTaskTypePriorityOfProd } from '@/lib/productions'
 import {
   sortByName,
   sortSequences,
@@ -141,6 +143,9 @@ const cache = {
 }
 
 const helpers = {
+  getCurrentProduction () {
+    return productionsStore.getters.currentProduction(productionsStore.state)
+  },
   getTask (taskId) {
     return tasksStore.state.taskMap.get(taskId)
   },
@@ -167,7 +172,10 @@ const helpers = {
   },
 
   populateTask (task, shot) {
-    task.name = helpers.getTaskType(task.task_type_id).priority.toString()
+    task.name = getTaskTypePriorityOfProd(
+      helpers.getTaskType(task.task_type_id),
+      helpers.getCurrentProduction()
+    ).toString()
     task.task_status_short_name =
       helpers.getTaskStatus(task.task_status_id).short_name
 
@@ -205,7 +213,9 @@ const helpers = {
 
   sortValidationColumns (validationColumns, shotFilledColumns, taskTypeMap) {
     const columns = [...validationColumns]
-    return sortValidationColumns(columns, taskTypeMap)
+    return sortValidationColumns(
+      columns, taskTypeMap, helpers.getCurrentProduction()
+    )
   },
 
   getPeriod (task, detailLevel) {
@@ -318,7 +328,9 @@ const helpers = {
       })
     }
     const validationColumns = Object.keys(validationColumnsMap)
-    return sortValidationColumns(validationColumns, taskTypeMap)
+    return sortValidationColumns(
+      validationColumns, taskTypeMap, helpers.getCurrentProduction()
+    )
   }
 }
 

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -68,7 +68,7 @@ import {
   SET_NOTIFICATION_COUNT,
   LOAD_OPEN_PRODUCTIONS_END,
 
-  RESET_ALL
+  RESET_ALL, SET_CURRENT_PRODUCTION
 } from '../mutation-types'
 
 const helpers = {
@@ -294,7 +294,6 @@ const actions = {
         commit(LOAD_PRODUCTION_STATUS_END, context.project_status)
         commit(LOAD_DEPARTMENTS_END, context.departments)
         commit(LOAD_TASK_STATUSES_END, context.task_status)
-        commit(LOAD_TASK_TYPES_END, context.task_types)
         commit(LOAD_PEOPLE_END, {
           people: context.persons,
           production: rootGetters.currentProduction,
@@ -304,6 +303,8 @@ const actions = {
         commit(LOAD_ASSET_TYPES_END, context.asset_types)
         commit(SET_NOTIFICATION_COUNT, context.notification_count)
         commit(LOAD_OPEN_PRODUCTIONS_END, context.projects)
+        commit(SET_CURRENT_PRODUCTION, rootGetters.currentProduction.id)
+        commit(LOAD_TASK_TYPES_END, context.task_types)
       })
   }
 }

--- a/tests/unit/lib/sorting.spec.js
+++ b/tests/unit/lib/sorting.spec.js
@@ -264,19 +264,28 @@ describe('lib/sorting', () => {
 
   it('sortTaskTypes', () => {
     const entries = [
-      { for_shots: false, priority: 1, name: 'Modeling', id: 2 },
-      { for_shots: false, priority: 2, name: 'Setup', id: 5 },
-      { for_shots: false, priority: 1, name: 'Modeling Low', id: 4 },
-      { for_shots: false, priority: 1, name: 'Modeling Hi', id: 3 },
-      { for_shots: true, priority: 1, name: 'Animation', id: 1 }
+      { for_shots: false, priority: 1, name: 'Modeling', id: 'task-type-2' },
+      { for_shots: false, priority: 2, name: 'Setup', id: 'task-type-5' },
+      { for_shots: false, priority: 1, name: 'Modeling Low', id: 'task-type-4' },
+      { for_shots: false, priority: 1, name: 'Modeling Hi', id: 'task-type-3' },
+      { for_shots: true, priority: 1, name: 'Animation', id: 'task-type-1' }
     ]
-    let results = sortTaskTypes(entries)
+    const production = {
+      task_types_priority: {
+        'task-type-5': 5,
+        'task-type-4': 1,
+        'task-type-3': 4,
+        'task-type-2': 3,
+        'task-type-1': 2
+      }
+    }
+    let results = sortTaskTypes(entries, production)
     expect(results).toHaveLength(5)
-    expect(results[0].id).toEqual(2)
-    expect(results[1].id).toEqual(3)
-    expect(results[2].id).toEqual(4)
-    expect(results[3].id).toEqual(5)
-    expect(results[4].id).toEqual(1)
+    expect(results[0].id).toEqual('task-type-4')
+    expect(results[1].id).toEqual('task-type-2')
+    expect(results[2].id).toEqual('task-type-3')
+    expect(results[3].id).toEqual('task-type-5')
+    expect(results[4].id).toEqual('task-type-1')
 
     results = sortProductions([])
     expect(results).toHaveLength(0)
@@ -334,12 +343,22 @@ describe('lib/sorting', () => {
   })
 
   it('sortValidationColumns', () => {
+    const production = {
+      project_status_name: 'open',
+      name: 'Big Buck Bunny',
+      id: 3,
+      task_types_priority: {
+        'task-type-3': 1,
+        'task-type-2': 3,
+        'task-type-1': 2
+      }
+    }
     const entries = ['task-type-3', 'task-type-2', 'task-type-1']
-    let results = sortValidationColumns(entries, taskTypeMap)
+    let results = sortValidationColumns(entries, taskTypeMap, production)
     expect(results).toHaveLength(3)
-    expect(results[0]).toEqual('task-type-1')
-    expect(results[1]).toEqual('task-type-2')
-    expect(results[2]).toEqual('task-type-3')
+    expect(results[0]).toEqual('task-type-3')
+    expect(results[1]).toEqual('task-type-1')
+    expect(results[2]).toEqual('task-type-2')
 
     results = sortValidationColumns([])
     expect(results).toHaveLength(0)
@@ -465,14 +484,15 @@ describe('lib/sorting', () => {
         name: 'asset 2',
         asset_type_name: 'asset_type_name 2',
         data: { metadata1: '2' },
-        validations: new Map([['valid',  'task2']])
+        validations: new Map([['valid', 'task2']])
       },
-      { id: 2,
+      {
+        id: 2,
         canceled: true,
         name: 'asset 1',
         asset_type_name: 'asset_type_name 2',
         data: { metadata1: '2' },
-        validations: new Map([['valid',  'task2']])
+        validations: new Map([['valid', 'task2']])
       },
       {
         id: 3,
@@ -480,7 +500,7 @@ describe('lib/sorting', () => {
         name: 'asset 2',
         asset_type_name: 'asset_type_name 1',
         data: { metadata1: '2' },
-        validations: new Map([['valid',  'task2']])
+        validations: new Map([['valid', 'task2']])
       },
       {
         id: 4,
@@ -488,7 +508,7 @@ describe('lib/sorting', () => {
         name: 'asset 2',
         asset_type_name: 'asset_type_name 2',
         data: { metadata1: '1' },
-        validations: new Map([['valid',  'task1']])
+        validations: new Map([['valid', 'task1']])
       },
       {
         id: 5,
@@ -496,7 +516,7 @@ describe('lib/sorting', () => {
         name: 'asset 2',
         asset_type_name: 'asset_type_name 2',
         data: { metadata1: '2' },
-        validations: new Map([['valid',  'task2']])
+        validations: new Map([['valid', 'task2']])
       }
     ]
     const sortingMetadata = [
@@ -535,7 +555,7 @@ describe('lib/sorting', () => {
         name: 'asset 2',
         sequence_name: 'sequence_name 2',
         data: { metadata1: '2' },
-        validations: new Map([['valid',  'task2']]),
+        validations: new Map([['valid', 'task2']]),
         episode_name: 'episode 2'
       },
       {
@@ -544,7 +564,7 @@ describe('lib/sorting', () => {
         name: 'asset 1',
         sequence_name: 'sequence_name 2',
         data: { metadata1: '2' },
-        validations: new Map([['valid',  'task2']]),
+        validations: new Map([['valid', 'task2']]),
         episode_name: 'episode 2'
       },
       {
@@ -553,7 +573,7 @@ describe('lib/sorting', () => {
         name: 'asset 2',
         sequence_name: 'sequence_name 1',
         data: { metadata1: '3' },
-        validations: new Map([['valid',  'task2']]),
+        validations: new Map([['valid', 'task2']]),
         episode_name: 'episode 2'
       },
       {
@@ -562,7 +582,7 @@ describe('lib/sorting', () => {
         name: 'asset 2',
         sequence_name: 'sequence_name 1',
         data: { metadata1: '2' },
-        validations: new Map([['valid',  'task2']]),
+        validations: new Map([['valid', 'task2']]),
         episode_name: 'episode 1'
       },
       {
@@ -571,7 +591,7 @@ describe('lib/sorting', () => {
         name: 'asset 2',
         sequence_name: 'sequence_name 2',
         data: { metadata1: '1' },
-        validations: new Map([['valid',  'task1']]),
+        validations: new Map([['valid', 'task1']]),
         episode_name: 'episode 2'
       },
       {
@@ -580,7 +600,7 @@ describe('lib/sorting', () => {
         name: 'asset 2',
         sequence_name: 'sequence_name 2',
         data: { metadata1: '2' },
-        validations: new Map([['valid',  'task2']]),
+        validations: new Map([['valid', 'task2']]),
         episode_name: 'episode 2'
       }
     ]

--- a/tests/unit/store/assets.spec.js
+++ b/tests/unit/store/assets.spec.js
@@ -1,6 +1,7 @@
 import store from '@/store/modules/assets'
 import taskTypesStore from '@/store/modules/tasktypes'
 import tasksStore from '@/store/modules/tasks'
+import productionsStore from '@/store/modules/productions'
 import {
   ADD_ASSET,
   CANCEL_ASSET,
@@ -1031,6 +1032,11 @@ describe('Assets store', () => {
           name: 'Some person'
         }
       }))
+      productionsStore.state.currentProduction = {
+        task_types_priority: {
+          'task-type-id': 1
+        }
+      }
       const taskMap = new Map()
       const taskTypeMap = new Map(Object.entries({
         'task-type-id': {
@@ -1668,6 +1674,12 @@ describe('Assets store', () => {
         entity_id: 'asset-id',
         task_type_id: 'task_type_id',
         task_status_id: 'todo'
+      }
+      productionsStore.state.currentProduction = {
+        task_types_priority: {
+          'task-id': 1,
+          'old-task-id': 2
+        }
       }
       store.mutations.NEW_TASK_END(state, task)
       expect(state.assetMap.get('asset-id')).toEqual({

--- a/tests/unit/store/productions.spec.js
+++ b/tests/unit/store/productions.spec.js
@@ -520,9 +520,14 @@ describe('Productions store', () => {
         currentProduction: { id: '123' }
       }
       productionApi.addTaskTypeToProduction = jest.fn()
-      store.actions.addTaskTypeToProduction({ commit: mockCommit, state }, '456')
+      store.actions.addTaskTypeToProduction(
+        { commit: mockCommit, state },
+        { taskTypeId: '456', priority: 1 }
+      )
       expect(mockCommit).toBeCalledTimes(1)
-      expect(mockCommit).toHaveBeenNthCalledWith(1, PRODUCTION_ADD_TASK_TYPE, '456')
+      expect(mockCommit).toHaveBeenNthCalledWith(
+        1, PRODUCTION_ADD_TASK_TYPE, '456'
+      )
       expect(productionApi.addTaskTypeToProduction).toBeCalledTimes(1)
     })
 


### PR DESCRIPTION
**Problem**

task types sorting was available only on the global configuration and not per-project

**Solution**

this PR adds this feature, allowing us to sort the task types per project

![image](https://user-images.githubusercontent.com/9109308/127294053-57f4feb9-7949-4cd6-86f3-ecf172eb84a9.png)


Linked to this PR : https://github.com/cgwire/zou/pull/361