### PR TITLE
preview: add comments in preview

### DIFF
--- a/src/components/previews/VideoViewer.vue
+++ b/src/components/previews/VideoViewer.vue
@@ -236,14 +236,18 @@ export default {
     getDimensions () {
       const dimensions = this.getNaturalDimensions()
       const ratio = dimensions.height / dimensions.width
-      const parent = this.container.parentElement.parentElement
-      let width = Math.min(dimensions.width, parent.offsetWidth)
+      let offsetWidth = 0
+      if (this.container.parentElement) {
+        const parent = this.container.parentElement.parentElement
+        offsetWidth = parent.offsetWidth
+      }
+      let width = Math.min(dimensions.width, offsetWidth)
       if (this.isComparing) {
         // parent is used because sometimes the container width is not
         // properly computed.
         width = Math.min(
           dimensions.width,
-          parent.offsetWidth / 2
+          offsetWidth / 2
         )
       }
       let height = Math.floor(width * ratio)
@@ -308,9 +312,11 @@ export default {
         const height = dimensions.height
         if (height > 0) {
           this.container.style.height = this.defaultHeight + 'px'
-          this.videoWrapper.style.width = width + 'px'
+          // Those two lines are commented out because fixing the width was
+          //   breaking the comment section in the preview in full screen
+          // this.videoWrapper.style.width = width + 'px'
+          // this.video.style.width = width + 'px'
           this.videoWrapper.style.height = height + 'px'
-          this.video.style.width = width + 'px'
           this.video.style.height = height + 'px'
           this.$emit('size-changed', { width, height })
         }

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -99,6 +99,7 @@
                 @change-current-preview="changeCurrentPreview"
                 @add-extra-preview="onAddExtraPreview"
                 @remove-extra-preview="onRemoveExtraPreview"
+                @comment-added="onCommentAdded"
                 ref="preview-player"
               />
             </div>
@@ -582,6 +583,7 @@ export default {
           this.reset()
           this.attachedFileName = ''
           this.loading.addComment = false
+          this.$emit('comment-added')
         })
         .catch((err) => {
           console.error(err)
@@ -712,6 +714,10 @@ export default {
     onRemoveExtraPreview (preview) {
       this.currentExtraPreviewId = preview.id
       this.modals.deleteExtraPreview = true
+    },
+
+    onCommentAdded () {
+      this.taskComments = this.getTaskComments(this.task.id)
     },
 
     onCancelRemoveExtraPreview () {


### PR DESCRIPTION
**Problem**
There were no way to access comments when in fullscreen in a preview

**Solution**
Now a button :speech_balloon: is available in the fullscreen of a preview, clicking it shows the comments as bellow

- the comments are in sync between this comment section and the comment section visibile when we're not in fullscreen
- the annotations work properly (the canvas is positionned correctly)

![image](https://user-images.githubusercontent.com/9109308/127459451-77186aa2-bfa5-451d-b165-14cbadf2b50f.png)
