### PR TITLE
[preview-comments] paste image in modals

### DIFF
--- a/src/components/modals/AddCommentImageModal.vue
+++ b/src/components/modals/AddCommentImageModal.vue
@@ -92,10 +92,6 @@ export default {
     }
   },
 
-  mounted () {
-    this.forms = null
-  },
-
   computed: {
     ...mapGetters([
     ])
@@ -116,6 +112,10 @@ export default {
     reset () {
       this.$refs['image-field'].reset()
       this.forms = null
+    },
+
+    onPaste (event) {
+      this.$refs['image-field'].filesChange('', event.clipboardData.files)
     }
   },
 
@@ -123,6 +123,15 @@ export default {
     active () {
       this.reset()
     }
+  },
+
+  mounted () {
+    this.forms = null
+    window.addEventListener('paste', this.onPaste, false)
+  },
+
+  beforeDestroy () {
+    window.removeEventListener('paste', this.onPaste)
   }
 }
 </script>

--- a/src/components/modals/AddPreviewModal.vue
+++ b/src/components/modals/AddPreviewModal.vue
@@ -1,8 +1,11 @@
 <template>
-<div :class="{
-  'modal': true,
-  'is-active': active
-}">
+<div
+  id="modal"
+  :class="{
+    'modal': true,
+    'is-active': active
+  }"
+>
   <div class="modal-background" @click="$emit('cancel')" ></div>
 
   <div class="modal-content">
@@ -95,10 +98,6 @@ export default {
     }
   },
 
-  mounted () {
-    this.forms = null
-  },
-
   computed: {
     ...mapGetters([
     ])
@@ -116,6 +115,10 @@ export default {
     reset () {
       this.$refs['preview-field'].reset()
       this.forms = null
+    },
+
+    onPaste (event) {
+      this.$refs['preview-field'].filesChange('', event.clipboardData.files)
     }
   },
 
@@ -123,6 +126,15 @@ export default {
     active () {
       this.reset()
     }
+  },
+
+  mounted () {
+    this.forms = null
+    window.addEventListener('paste', this.onPaste, false)
+  },
+
+  beforeDestroy () {
+    window.removeEventListener('paste', this.onPaste)
   }
 }
 </script>


### PR DESCRIPTION
**Problem**
Copy-pasting an image in the attachment/preview modals in the comment section of a task had no effect

**Solution**
Copy-pasting an image now selects the image as if it were selected by the `browse` button