### PR TITLE
[preview] add upload preview in modals

### DIFF
--- a/src/components/modals/AddCommentImageModal.vue
+++ b/src/components/modals/AddCommentImageModal.vue
@@ -44,6 +44,36 @@
           {{ $t("main.cancel") }}
         </button>
       </p>
+
+      <p v-if="forms">
+        <template v-for="(form, i) in forms">
+          <img
+            class="is-fullwidth"
+            alt="uploaded file"
+            :src="getURL(form)"
+            :key="i"
+            v-if="isImage(form)"
+          >
+          <video
+            preload="auto"
+            class="is-fullwidth"
+            autoplay
+            controls
+            loop
+            muted
+            :src="getURL(form)"
+            :key="i"
+            v-else-if="isVideo(form)"
+          />
+          <iframe
+            class="is-fullwidth"
+            frameborder="0"
+            :src="getURL(form)"
+            :key="i"
+            v-else
+          />
+        </template>
+      </p>
     </div>
   </div>
 </div>
@@ -116,6 +146,18 @@ export default {
 
     onPaste (event) {
       this.$refs['image-field'].filesChange('', event.clipboardData.files)
+    },
+
+    getURL (form) {
+      return window.URL.createObjectURL(form.get('file'))
+    },
+
+    isImage (form) {
+      return form.get('file').type.startsWith('image')
+    },
+
+    isVideo (form) {
+      return form.get('file').type.startsWith('video')
     }
   },
 
@@ -137,6 +179,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.modal-content {
+  max-height: calc(100vh - 150px);
+}
+
 .modal-content .box p.text {
   margin-bottom: 1em;
 }
@@ -147,5 +193,9 @@ export default {
 
 .description {
   margin-bottom: 1em;
+}
+
+.is-fullwidth {
+  width: 100%;
 }
 </style>

--- a/src/components/modals/AddPreviewModal.vue
+++ b/src/components/modals/AddPreviewModal.vue
@@ -50,6 +50,36 @@
           {{ $t("main.cancel") }}
         </button>
       </p>
+
+      <p v-if="forms">
+        <template v-for="(form, i) in forms">
+          <img
+            class="is-fullwidth"
+            alt="uploaded file"
+            :src="getURL(form)"
+            :key="i"
+            v-if="isImage(form)"
+          >
+          <video
+            preload="auto"
+            class="is-fullwidth"
+            autoplay
+            controls
+            loop
+            muted
+            :src="getURL(form)"
+            :key="i"
+            v-else-if="isVideo(form)"
+          />
+          <iframe
+            class="is-fullwidth"
+            frameborder="0"
+            :src="getURL(form)"
+            :key="i"
+            v-else
+          />
+        </template>
+      </p>
     </div>
   </div>
 </div>
@@ -119,6 +149,18 @@ export default {
 
     onPaste (event) {
       this.$refs['preview-field'].filesChange('', event.clipboardData.files)
+    },
+
+    getURL (form) {
+      return window.URL.createObjectURL(form.get('file'))
+    },
+
+    isImage (form) {
+      return form.get('file').type.startsWith('image')
+    },
+
+    isVideo (form) {
+      return form.get('file').type.startsWith('video')
     }
   },
 
@@ -140,6 +182,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.modal-content {
+  max-height: calc(100vh - 150px);
+}
+
 .modal-content .box p.text {
   margin-bottom: 1em;
 }
@@ -150,5 +196,9 @@ export default {
 
 .description {
   margin-bottom: 1em;
+}
+
+.is-fullwidth {
+  width: 100%;
 }
 </style>


### PR DESCRIPTION
**Problem**
When uploading files in a task (preview/attachment), there was no way of telling the file we were uploading except the name

**Solution**
The 2 modals now show the file(s) we are uploading

![image](https://user-images.githubusercontent.com/9109308/127632375-fea123b9-6342-468d-9f8b-bd0b30a53b79.png)

also working for a video : 

![image](https://user-images.githubusercontent.com/9109308/127632558-857bb5f4-8c9a-4543-8678-5169afb23cb4.png)

or a PDF : 

![image](https://user-images.githubusercontent.com/9109308/127632710-77797f08-e5b2-4604-b32b-a7c3e746dc60.png)
