### PR TITLE
Update for development-environment : version of nodeJS

### DIFF
--- a/docs/development-environment/README.md
+++ b/docs/development-environment/README.md
@@ -5,7 +5,7 @@
 Prior to setting up the Kitsu development environment make sure you have
 the following elements installed:
 
-* Node.js 8.x or superior
+* Node.js 16.x or superior
 * A [Zou development instance](https://zou.cg-wire.com/development/) up and running on port 5000
 * A [Zou Events development instance](https://zou.cg-wire.com/development/) up and running on port 5001 (optional)
 


### PR DESCRIPTION
Increase version of nodeJS required by Kitsu

**Problem**
<!--- Explain the problem --> The version of nodeJS required for Kitsu is 16.X, in the documentation it says 8.X.

**Solution**
<!--- Describe the change, including rationale and design decisions --> Change the version required in the documentation.
