### PR TITLE
[playlist] show pictures a given number of frames

### DIFF
--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -420,6 +420,8 @@ import firstBy from 'thenby'
 import moment from 'moment-timezone'
 import { mapGetters, mapActions } from 'vuex'
 import { PlusIcon, XIcon } from 'vue-feather-icons'
+
+import { DEFAULT_NB_FRAMES_PICTURE } from '@/lib/playlist'
 import { formatDate } from '@/lib/time'
 import { getPlaylistPath } from '@/lib/path'
 import {
@@ -829,7 +831,9 @@ export default {
             entity.preview_file_annotations,
           preview_file_previews:
             entityInfo.preview_file_previews ||
-            entity.preview_file_previews
+            entity.preview_file_previews,
+          preview_nb_frames: entityInfo.nb_frames ||
+            entity.nb_frames || DEFAULT_NB_FRAMES_PICTURE
         }
         this.previewFileEntityMap.set(
           playlistEntity.preview_file_id,

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -244,7 +244,7 @@
         min="0"
         class="frame-per-image-input"
         :title="$t('playlists.actions.frames_per_picture')"
-        v-model="framesPerImage"
+        v-model="framesPerImage[playingEntityIndex]"
       >
     </template>
     <span
@@ -749,6 +749,7 @@ import Spinner from '@/components/widgets/Spinner'
 import TaskInfo from '@/components/sides/TaskInfo'
 
 import { annotationMixin } from '@/components/mixins/annotation'
+import { DEFAULT_NB_FRAMES_PICTURE } from '@/lib/playlist'
 import { domMixin } from '@/components/mixins/dom'
 
 export default {
@@ -810,7 +811,7 @@ export default {
       entityList: [],
       entityListToCompare: [],
       fabricCanvas: null,
-      framesPerImage: 48,
+      framesPerImage: [],
       framesSeenOfPicture: 0,
       fullScreen: false,
       isCommentsHidden: true,
@@ -1780,17 +1781,27 @@ export default {
         this.onPlayNextEntityClicked()
         if (this.isCurrentPreviewPicture) {
           this.framesSeenOfPicture = 0
-          setTimeout(this.continuePlayingPlaylist, 100, this.playingEntityIndex, Date.now())
+          setTimeout(
+            this.continuePlayingPlaylist,
+            100,
+            this.playingEntityIndex,
+            Date.now()
+          )
         }
       }
     },
 
     continuePlayingPlaylist (entityIndex, startMs) {
-      const durationToWaitMs = this.framesPerImage * 1000 / this.fps
+      const framesPerImage = this.framesPerImage[entityIndex]
+      const durationToWaitMs = framesPerImage * 1000 / this.fps
       const durationWaited = Date.now() - startMs
       if (durationWaited < durationToWaitMs) {
-        setTimeout(this.continuePlayingPlaylist, 100, entityIndex, startMs)
-        this.framesSeenOfPicture = Math.floor((durationWaited / 1000) * this.fps)
+        setTimeout(
+          this.continuePlayingPlaylist, 100, entityIndex, startMs
+        )
+        this.framesSeenOfPicture = Math.floor(
+          (durationWaited / 1000) * this.fps
+        )
         return
       }
 
@@ -2381,6 +2392,12 @@ export default {
       this.currentPreviewIndex = 0
       this.currentComparisonPreviewuIndex = 0
       this.entityList = Object.values(this.entities)
+      console.log(this.entityList)
+      this.entityList.forEach((entity, i) => {
+        this.framesPerImage[i] = entity.preview_nb_frames ||
+          DEFAULT_NB_FRAMES_PICTURE
+      })
+      console.log({ framesPerImage: this.framesPerImage })
       this.playingEntityIndex = 0
       this.pause()
       if (this.rawPlayer) this.rawPlayer.setCurrentTime(0)

--- a/src/components/pages/playlists/RawVideoPlayer.vue
+++ b/src/components/pages/playlists/RawVideoPlayer.vue
@@ -4,13 +4,13 @@
     ref="player1"
     preload="auto"
     :muted="muted"
-    @ended="playNext"
+    @ended="$emit('play-next')"
   />
   <video
     ref="player2"
     preload="auto"
     :muted="muted"
-    @ended="playNext"
+    @ended="$emit('play-next')"
   />
 </div>
 </template>

--- a/src/lib/playlist.js
+++ b/src/lib/playlist.js
@@ -1,0 +1,1 @@
+export const DEFAULT_NB_FRAMES_PICTURE = 48

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -544,6 +544,7 @@ export default {
       files_next: 'Next file for this revision',
       files_position: 'File index for this revision',
       files_previous: 'Previous file for this revision',
+      frames_per_picture: 'Frames per picture',
       fullscreen: 'See file in full screen',
       looping: 'Loop on current video',
       mute: 'Mute',

--- a/src/store/modules/playlists.js
+++ b/src/store/modules/playlists.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import { DEFAULT_NB_FRAMES_PICTURE } from '@/lib/playlist'
 import playlistsApi from '../api/playlists'
 import { sortByDate } from '../../lib/sorting'
 import { removeModelFromList, updateModelFromList } from '../../lib/models'
@@ -338,7 +339,8 @@ const mutations = {
       preview_file_id: entity.preview_file_id,
       preview_file_extension: entity.preview_file_extension,
       preview_file_annotations: entity.preview_file_annotations,
-      preview_files: entity.preview_files
+      preview_files: entity.preview_files,
+      preview_nb_frames: entity.nb_frames || DEFAULT_NB_FRAMES_PICTURE
     })
   },
 


### PR DESCRIPTION
**Problem**
The pictures werent shown when launching a playlist

**Solution**
The pictures are now shown a given and customable amount of time (48 frames per default) before going to the next picture/video


![image](https://user-images.githubusercontent.com/9109308/130597767-1ae70b9c-48a1-4001-b785-34f538514e91.png)
