### PR TITLE
[task-info] add timecode to comment

### DIFF
--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -100,6 +100,7 @@
                 @edit-comment="onEditComment"
                 @delete-comment="onDeleteComment"
                 @checklist-updated="saveComment"
+                @time-code-clicked="timeCodeClicked"
                 v-for="(comment, index) in currentTaskComments"
               />
             </div>
@@ -255,6 +256,8 @@ import {
   ChevronLeftIcon,
   ImageIcon
 } from 'vue-feather-icons'
+
+import { replaceTimeWithTimecode } from '@/lib/task'
 
 import AddComment from '../widgets/AddComment'
 import AddPreviewModal from '../modals/AddPreviewModal'
@@ -785,6 +788,14 @@ export default {
     },
 
     addComment (comment, attachment, checklist, taskStatusId) {
+      if (this.currentPreview && this.previewPlayer) {
+        comment = replaceTimeWithTimecode(
+          comment,
+          this.currentPreview.revision,
+          this.previewPlayer.currentTimeRaw,
+          this.currentProduction.fps
+        )
+      }
       const params = {
         taskId: this.currentTask.id,
         taskStatusId: taskStatusId,
@@ -1135,6 +1146,19 @@ export default {
         index === comments.length - 1 ||
         comment.task_status_id !== comments[index + 1].task_status_id
       )
+    },
+
+    timeCodeClicked (
+      { versionRevision, minutes, seconds, milliseconds, frame }
+    ) {
+      this.changeCurrentPreview(this.currentTaskPreviews.find(
+        p => p.revision === parseInt(versionRevision)
+      ))
+      const time = parseInt(minutes) * 60 + parseInt(seconds) + parseInt(milliseconds) / 1000
+      setTimeout(() => {
+        this.previewPlayer.setCurrentTime(time)
+        this.previewPlayer.focus()
+      }, 20)
     }
   },
 

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -187,6 +187,9 @@
       }"
       :task="task"
       :is-preview="false"
+      :current-time-raw="currentTimeRaw"
+      :current-parent-preview="currentPreview"
+      @time-code-clicked="timeCodeClicked"
     />
   </div>
 
@@ -2269,6 +2272,23 @@ export default {
         this.$options.scrubbing = false
       }
       return false
+    },
+
+    timeCodeClicked (
+      { versionRevision, minutes, seconds, milliseconds, frame }
+    ) {
+      const previews = this.currentEntity.preview_files[this.task.task_type_id]
+      const previewFile = previews.find(
+        p => p.revision === parseInt(versionRevision)
+      )
+      this.onPreviewChanged(this.currentEntity, previewFile)
+      const time = parseInt(minutes) * 60 + parseInt(seconds) + parseInt(milliseconds) / 1000
+      setTimeout(() => {
+        this.rawPlayer.setCurrentTime(time)
+        if (this.isComparing) {
+          this.$refs['raw-player-comparison'].setCurrentTime(time)
+        }
+      }, 20)
     }
   },
 

--- a/src/components/pages/playlists/PlaylistedEntity.vue
+++ b/src/components/pages/playlists/PlaylistedEntity.vue
@@ -258,6 +258,12 @@ export default {
         })
       }
       this.$emit('preview-changed', this.entity, previewFile)
+    },
+
+    'entity.preview_file_id': function () {
+      if (this.previewFileId !== this.entity.preview_file_id) {
+        this.previewFileId = this.entity.preview_file_id
+      }
     }
   }
 }

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1,5 +1,5 @@
 <template>
-<div ref="container" class="preview-player dark">
+<div ref="container" class="preview-player dark" tabindex="-1">
   <div class="preview" :style="{height: defaultHeight + 'px'}">
     <div class="flexrow filler">
       <div class="preview-container filler" ref="preview-container">
@@ -63,7 +63,10 @@
         }"
         :task="task"
         :is-preview="false"
+        :current-time-raw="currentTimeRaw"
+        :current-parent-preview="currentPreview"
         @comment-added="$emit('comment-added')"
+        @time-code-clicked="timeCodeClicked"
       />
     </div>
 
@@ -725,6 +728,24 @@ export default {
       const isRepeating =
         localPreferences.getBoolPreference('player:repeating')
       this.isRepeating = isRepeating
+    },
+
+    focus () {
+      this.$refs.container.focus()
+    },
+
+    timeCodeClicked (
+      { versionRevision, minutes, seconds, milliseconds, frame }
+    ) {
+      const preview = this.lastPreviewFiles.find(
+        p => p.revision === parseInt(versionRevision)
+      )
+      if (!preview) {
+        return
+      }
+      this.changeCurrentPreview(preview)
+      const time = parseInt(minutes) * 60 + parseInt(seconds) + parseInt(milliseconds) / 1000
+      setTimeout(this.setCurrentTime, 20, time)
     },
 
     // Video

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -20,23 +20,28 @@
     </figure>
     <div class="media-content">
       <at-ta
-        :members="team"
+        :members="atOptions"
         name-key="full_name"
         :limit="2"
       >
         <template slot="item" slot-scope="team">
-          <div class="flexrow">
-            <people-avatar
-              class="flexrow-item"
-              :person="team.item"
-              :size="20"
-              :font-size="11"
-              :no-cache="true"
-            />
-            <span class="flexrow-item">
-              {{ team.item.full_name }}
-            </span>
-          </div>
+          <template v-if="team.item.isTime">
+            ⏱️ time
+          </template>
+          <template v-else>
+            <div class="flexrow">
+              <people-avatar
+                class="flexrow-item"
+                :person="team.item"
+                :size="20"
+                :font-size="11"
+                :no-cache="true"
+              />
+              <span class="flexrow-item">
+                {{ team.item.full_name }}
+              </span>
+            </div>
+          </template>
         </template>
         <textarea
           ref="comment-textarea"
@@ -165,6 +170,7 @@ export default {
 
   data () {
     return {
+      atOptions: [],
       isDragging: false,
       text: '',
       attachment: [],
@@ -345,6 +351,18 @@ export default {
   watch: {
     task () {
       this.task_status_id = this.task.task_status_id
+    },
+
+    team: {
+      deep: true,
+      immediate: true,
+      handler () {
+        this.atOptions = this.team
+        this.atOptions.push({
+          isTime: true,
+          full_name: 'time'
+        })
+      }
     }
   }
 }

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -69,7 +69,7 @@
             </span>
           </p>
           <p
-            v-html="renderComment(comment.text, comment.mentions, personMap)"
+            v-html="renderComment(comment.text, comment.mentions, personMap, uniqueClassName)"
             class="comment-text"
             v-if="comment.text"
           >
@@ -238,7 +238,8 @@ export default {
 
   data () {
     return {
-      checklist: []
+      checklist: [],
+      uniqueClassName: (Math.random() + 1).toString(36).substring(2)
     }
   },
 
@@ -286,6 +287,19 @@ export default {
           this.$options.silent = false
         })
     }
+    Array.from(
+      document.getElementsByClassName(this.uniqueClassName)
+    ).forEach(element => {
+      element.addEventListener('click', this.timeCodeClicked)
+    })
+  },
+
+  destroyed () {
+    Array.from(
+      document.getElementsByClassName(this.uniqueClassName)
+    ).forEach(element => {
+      element.removeEventListener('click', this.timeCodeClicked)
+    })
   },
 
   computed: {
@@ -483,6 +497,10 @@ export default {
 
     acknowledgeComment (comment) {
       this.$emit('ack-comment', comment)
+    },
+
+    timeCodeClicked (event) {
+      this.$emit('time-code-clicked', event.target.dataset)
     },
 
     renderComment

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -1,5 +1,6 @@
 import marked from 'marked'
 import sanitizeHTML from 'sanitize-html'
+import { TIME_CODE_REGEX } from './task'
 
 export const sanitize = (html) => {
   return sanitizeHTML(html, {
@@ -19,18 +20,35 @@ export const getTaskTypeStyle = (task) => {
   }
 }
 
-export const renderComment = (input, mentions, personMap) => {
+export const renderComment = (
+  input, mentions, personMap, className = ''
+) => {
   let compiled = marked(input || '')
   if (mentions) {
     mentions.forEach(personId => {
       const person = personMap.get(personId)
-      compiled = compiled.replace(
+      compiled = compiled.replaceAll(
         `@${person.full_name}`,
         `<a class="mention" href="/people/${person.id}">@${person.full_name}</a>`
       )
     })
   }
-  return sanitize(compiled)
+  compiled = sanitize(compiled)
+
+  return compiled.replaceAll(
+    TIME_CODE_REGEX,
+    function (match, p1, p2, p3, p4, p5, offset, string) {
+      return `<a
+        class="mention timecode ${className}"
+        href="#"
+        data-version-revision="${p1}"
+        data-minutes="${p2}"
+        data-seconds="${p3}"
+        data-milliseconds="${p4}"
+        data-frame="${p5}"
+      >${match}</a>`
+    }
+  )
 }
 
 export const renderMarkdown = (input) => {

--- a/src/lib/task.js
+++ b/src/lib/task.js
@@ -1,0 +1,16 @@
+import { formatFrame, formatTime } from './video'
+
+export const TIME_CODE_REGEX = /v(\d+)~(\d+):(\d+)\.(\d+) \((\d+)\)/g
+
+export function replaceTimeWithTimecode (
+  comment,
+  currentPreviewRevision,
+  currentTimeRaw,
+  fps
+) {
+  const frame = formatFrame(currentTimeRaw, fps)
+  const formatedTime = formatTime(currentTimeRaw)
+  return comment.replaceAll(
+    '@time', `v${currentPreviewRevision}~${formatedTime} (${frame})`
+  )
+}


### PR DESCRIPTION
**Problem**
A feature was wanted : the ablity to add a `@time` tag in a comment under a preview. This comment would link to the current time of the video

**Solution**
This feature has been implemented.

![step 1](https://user-images.githubusercontent.com/9109308/130987599-7f774927-1242-4f96-90b4-6039d27f814c.png)
![step 2](https://user-images.githubusercontent.com/9109308/130987592-bf69837f-7d0d-4374-a2cc-ea9b68efa663.png)
![step 3](https://user-images.githubusercontent.com/9109308/130987584-609d649a-d3fb-4e37-b475-f97271d35234.png)


**Note**

I've had a lot of bugs while testing this. Mainly because de components are interdependants (playlistplayer, task-info, task, previewplayer...) and I had to test a lot of places at once (task sidebar, task sidebar in fullscreen, task detail, playlist, playlist in fullscreen..).

I think I've tested everything but it would be a good idea if someone else could test it before deploying this in prod.