### PR TITLE
[playlist] compare with every available task types

### DIFF
--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1936,12 +1936,13 @@ export default {
     rebuildComparisonOptions () {
       const entities = Object.values(this.entities)
       if (entities.length > 0) {
-        let taskTypeIds = Object.keys(entities[0].preview_files)
-        entities.forEach(entity => {
-          taskTypeIds = taskTypeIds.filter(
-            taskTypeId => entity.preview_files[taskTypeId]
-          )
-        })
+        const taskTypeIds = Object.keys(
+          entities[this.playingEntityIndex].preview_files
+        ).filter(
+          taskTypeId => {
+            return !!entities[this.playingEntityIndex].preview_files[taskTypeId]
+          }
+        )
         this.taskTypeOptions = taskTypeIds.map((taskTypeId) => {
           return {
             label: this.taskTypeMap.get(taskTypeId).name,
@@ -2295,6 +2296,7 @@ export default {
         this.annotations = this.currentEntity.preview_file_annotations || []
       }
       this.$nextTick(() => {
+        this.rebuildComparisonOptions()
         if (this.isComparing) this.rebuildRevisionOptions()
         this.$nextTick(() => {
           this.resetCanvas()


### PR DESCRIPTION
**Problem**
In the playlist player, a bug occurred where we could only compare with certain task types.

**Solution**
This bug was caused by the fact that we selected only the task types of the first entity of the playlist (I don't know why) AND we were keeping only the task types which have a preview on ALL the entities.

The 2 constraints have been removed : 
- the task types available are the ones of the currently playing entity
- the task types are no more filtered depending of the presence of previews of the same task type on other entities in the playlist

Moreover, when changing the playing entity, we recompute the tasktypes options in the comparison dropdown

![image](https://user-images.githubusercontent.com/9109308/131099857-8512446b-f894-4e60-b1e8-93537b8e04b4.png)
