### PR TITLE
[task] sidebar can widden once more, showing comparison opt.

### DIFF
--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -162,7 +162,7 @@
           icon="compare"
           :title="$t('playlists.actions.split_screen')"
           @click="onCompareClicked"
-          v-if="taskTypeOptions.length > 0 && fullScreen"
+          v-if="taskTypeOptions.length > 0 && isComparisonEnabled"
         />
 
         <combobox
@@ -171,7 +171,7 @@
           :is-dark="true"
           :thin="true"
           v-model="taskTypeId"
-          v-if="isComparing && (!light || fullScreen)"
+          v-if="isComparing && (!light || isComparisonEnabled)"
         />
         <combobox
           class="comparison-combobox dark"
@@ -179,7 +179,7 @@
           :is-dark="true"
           :thin="true"
           v-model="previewToCompareId"
-          v-if="isComparing && (!light || fullScreen)"
+          v-if="isComparing && (!light || isComparisonEnabled)"
         />
       </div>
 
@@ -476,6 +476,10 @@ export default {
     taskTypeMap: {
       type: Map,
       default: () => new Map()
+    },
+    forceEnableComparison: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -692,6 +696,10 @@ export default {
       } else {
         return []
       }
+    },
+
+    isComparisonEnabled () {
+      return this.fullScreen || this.forceEnableComparison
     }
   },
 

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1,7 +1,6 @@
 <template>
   <div
     class="side task-info"
-    :style="panelStyle"
     ref="side-panel"
     v-if="task"
   >
@@ -27,16 +26,30 @@
         <button-simple
           class="flexrow-item change-wideness-button"
           icon="right"
+          :title="$t('tasks.smaller')"
+          @click="toggleExtraWidth"
+          v-if="isExtraWide && isPreview"
+        />
+        <button-simple
+          class="flexrow-item change-wideness-button"
+          icon="left"
           :title="$t('tasks.bigger')"
+          @click="toggleExtraWidth"
+          v-else-if="isWide && isPreview"
+        />
+        <button-simple
+          class="flexrow-item change-wideness-button"
+          icon="right"
+          :title="$t('tasks.smaller')"
           @click="toggleWidth"
-          v-if="isWide && isPreview"
+          v-if="isWide && !isExtraWide && isPreview"
         />
         <button-simple
           class="flexrow-item change-wideness-button"
           icon="left"
           :title="$t('tasks.bigger')"
           @click="toggleWidth"
-          v-else-if="isPreview"
+          v-else-if="!isExtraWide && isPreview"
         />
         <button-simple
           class="flexrow-item set-thumbnail-button"
@@ -95,6 +108,7 @@
                 :read-only="!isCurrentUserManager"
                 :is-assigned="isAssigned"
                 :task="task"
+                :force-enable-comparison="isExtraWide"
                 @annotation-changed="onAnnotationChanged"
                 @change-current-preview="changeCurrentPreview"
                 @add-extra-preview="onAddExtraPreview"
@@ -295,6 +309,7 @@ export default {
       commentToEdit: null,
       isSubscribed: false,
       isWide: false,
+      isExtraWide: false,
       otherPreviews: [],
       taskComments: [],
       taskPreviews: [],
@@ -501,12 +516,6 @@ export default {
         return this.taskPreviews.slice(0, 5)
       } else {
         return []
-      }
-    },
-
-    panelStyle () {
-      return {
-        width: this.isWide ? 700 : 350
       }
     },
 
@@ -776,6 +785,16 @@ export default {
         panel.parentElement.style['min-width'] = '700px'
       } else {
         panel.parentElement.style['min-width'] = '350px'
+      }
+    },
+
+    toggleExtraWidth () {
+      this.isExtraWide = !this.isExtraWide
+      const panel = this.$refs['side-panel']
+      if (this.isExtraWide) {
+        panel.parentElement.style['min-width'] = '65vw'
+      } else {
+        panel.parentElement.style['min-width'] = '700px'
       }
     },
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -937,6 +937,7 @@ export default {
     select_preview_file: 'Please select a file (picture, movie or others) from your hard drive to be used as a preview for the current task:',
     show_assignations: 'Show assignations',
     show_infos: 'Show additional information',
+    smaller: 'Reduce task panel',
     subscribe_notifications: 'Subscribe to notifications',
     select_file: 'Please select the file from your hard drive you want to attach to your comment:',
     tasks: 'Tasks',


### PR DESCRIPTION
**Problem**
The comparison couldn't be seen in the task sidebar

**Solution**
add the ability to widen the task sidebar to cover 65% of the width of the screen. When this is the case, the preview viewer shows the option to compare previews.

![image](https://user-images.githubusercontent.com/9109308/131139067-19145f55-6121-4c93-b264-7ce74101d298.png)
![image](https://user-images.githubusercontent.com/9109308/131139101-bffca45d-3784-4ae6-81df-30f8e8963a23.png)
