### PR TITLE
[qa] specify the required nodejs version in package.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -85,5 +85,8 @@
     "vue-template-compiler": "2.6.14",
     "webpack": "5.40.0"
   },
-  "babel": {}
+  "babel": {},
+  "engines": {
+    "node": ">=16.0"
+  }
 }


### PR DESCRIPTION
**Problem**
Kitsu needs nodeJS >=16.0

**Solution**
Add a requirement in package.json for nodeJS >=16.0
