### PR TITLE
[playlist] keep the same task type comparison in playlist

### DIFF
--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -2030,7 +2030,14 @@ export default {
           }
         }).sort((a, b) => a.label.localeCompare(b.label))
         if (this.taskTypeOptions.length > 0) {
-          this.taskTypeToCompare = this.taskTypeOptions[0].value
+          const currentTaskTypeIndex = this.taskTypeOptions.findIndex(
+            taskTypeOption => taskTypeOption.value === this.taskTypeToCompare
+          )
+          if (currentTaskTypeIndex === -1) {
+            // if we couldn't find the current task type,
+            //   then fallback to the first one in the list
+            this.taskTypeToCompare = this.taskTypeOptions[0].value
+          }
         }
         this.rebuildRevisionOptions()
       } else {


### PR DESCRIPTION
**Problem**
Dans une playlist, lorsqu'on veut comparer la playlist avec un type de tâches autre que celui affiché par défaut (le premier type de tâche par ordre alphabétique). Le type de tâche comparé au plan d'après se remet sur celui affiché par défaut.
 Par exemple je veux comparer la playlist layout T2 avec le layout T1. Je change donc le type de tâche à comparer d'animatic 2D à Layout T1, mais à tous les changements de plans lors de la lecture de la playlist, le type de tâche comparé se remet sur animatic 2D.

**Solution**
Tant que le type de tache existe bien dans le plan suivant, ce type de tache sera utilisé. 

:warning: :warning:  Si ce type de tache n'existe pas, le 1er type de tache sera remis par défaut, et ceci jusqu'à la fin de la playlist