### PR TITLE
Change default selection in combobox

### DIFF
--- a/src/components/modals/CreateTasksModal.vue
+++ b/src/components/modals/CreateTasksModal.vue
@@ -122,7 +122,7 @@ export default {
       form: {
         task_type_id: ''
       },
-      selectionOnly: 'false',
+      selectionOnly: 'true',
       selectionOptions: [
         { label: this.$t('tasks.for_selection'), value: 'true' },
         { label: this.$t('tasks.for_project'), value: 'false' }


### PR DESCRIPTION
**Problem**
When a user wants to add tasks, he arrives on this modal :

![image](https://user-images.githubusercontent.com/32680314/133642091-55683a7c-47f5-4bf7-a24b-9c0a5d3d3a49.png)

![image](https://user-images.githubusercontent.com/32680314/133641184-7c9dca23-c2cc-47bc-83f8-eb09bdd9582d.jpg)
The default value of the combobox is set on "For project". However, it may lead to mistakes since a distracted user might think he's creating task for his current shot page, when he'll actually fill all his project with tasks.

**Solution**
A simple fix is to swap the default combobox values : if someone mistakenly creates tasks for current list instead of whole project, the user simply has to change the setting and launch again, preventing him from having to delete a lot of unwanted tasks.

I didn't know anything about Vue.js before this PR, so if I missed something in this minor change, let me know

