### PR TITLE
[socketio] change configuration in VueWebSocket to use external socket.io-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "sanitize-html": "2.4.0",
     "sass": "1.37.5",
     "sass-loader": "10.0.1",
+    "socket.io-client": "2.4.0",
     "superagent": "6.1.0",
     "textarea-caret": "3.1.0",
     "thenby": "1.3.4",

--- a/src/main.js
+++ b/src/main.js
@@ -16,10 +16,11 @@ import vuescroll from 'vue-scroll'
 import VueTextareaAutosize from 'vue-textarea-autosize'
 import VTooltip from 'v-tooltip'
 import VueWebsocket from 'vue-websocket'
+import IO from 'socket.io-client'
 
 import 'v-autocomplete/dist/v-autocomplete.css'
 
-Vue.use(VueWebsocket, '/events')
+Vue.use(VueWebsocket, IO, '/events')
 Vue.config.productionTip = false
 Vue.use(Autocomplete)
 Vue.use(Meta)


### PR DESCRIPTION
**Problem**
I have changed the configuration for VueWebSocket in this PR, socket.io-client is now outside of the module.

**Solution**
Change the configuration for VueWebSocket
