### PR TITLE
[playlist] keep in memory the tasktype we were comparing with

### DIFF
--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -426,6 +426,7 @@
           class="playlist-button flexrow-item comparison-list"
           :options="taskTypeOptions"
           v-model="taskTypeToCompare"
+          @input="saveUserComparisonChoice"
           v-if="isComparing"
         />
         <combobox
@@ -440,13 +441,13 @@
           v-model="comparisonMode"
           v-if="isComparing"
         />
-          <div
-            class="flexrow flexrow-item comparison-list"
-            v-if="
-              isComparing && currentRevisionToCompare &&
-              currentComparisonPreviewLength > 1
-            "
-          >
+        <div
+          class="flexrow flexrow-item comparison-list"
+          v-if="
+            isComparing && currentRevisionToCompare &&
+            currentComparisonPreviewLength > 1
+          "
+        >
           <button-simple
             class="button playlist-button flexrow-item"
             icon="left"
@@ -460,6 +461,13 @@
             icon="right"
             @click="onNextComparisonPictureClicked"
           />
+        </div>
+        <div
+          class="flexrow flexrow-item comparison-missing"
+          v-if="isComparing && comparisonEntityMissing"
+        >
+          ⚠️ {{ $t('playlists.comparing_missing_plan') }}
+          {{ taskTypeMap.get(savedTaskTypeToCompare).name }}
         </div>
       </div>
     </div>
@@ -811,6 +819,7 @@ export default {
     return {
       annotations: [],
       color: '#ff3860',
+      comparisonEntityMissing: false,
       comparisonMode: 'sidebyside',
       currentComparisonPreviewIndex: 0,
       currentPreviewIndex: 0,
@@ -841,6 +850,7 @@ export default {
       playlistToEdit: {},
       playingEntityIndex: 0,
       revisionOptions: [],
+      savedTaskTypeToCompare: null,
       speed: 3,
       task: null,
       taskTypeOptions: [],
@@ -2013,22 +2023,33 @@ export default {
     },
 
     rebuildComparisonOptions () {
-      const entities = Object.values(this.entities)
-      if (entities.length > 0) {
-        let taskTypeIds = Object.keys(entities[0].preview_files)
-        entities.forEach(entity => {
-          taskTypeIds = taskTypeIds.filter(
-            taskTypeId => entity.preview_files[taskTypeId]
-          )
-        })
+      this.comparisonEntityMissing = false
+      if (this.entityList.length > 0) {
+        const taskTypeIds = Object.keys(
+          this.currentEntity.preview_files
+        ).filter(
+          taskTypeId => {
+            return !!this.currentEntity.preview_files[taskTypeId]
+          }
+        )
         this.taskTypeOptions = taskTypeIds.map((taskTypeId) => {
           return {
             label: this.taskTypeMap.get(taskTypeId).name,
             value: this.taskTypeMap.get(taskTypeId).id
           }
-        }).sort((a, b) => a.label.localeCompare(b.label))
+        }).sort((a, b) => -a.label.localeCompare(b.label))
         if (this.taskTypeOptions.length > 0) {
-          this.taskTypeToCompare = this.taskTypeOptions[0].value
+          const currentTaskTypeIndex = this.taskTypeOptions.findIndex(
+            taskTypeOption => taskTypeOption.value === this.savedTaskTypeToCompare
+          )
+          if (currentTaskTypeIndex !== -1) {
+            this.taskTypeToCompare = this.savedTaskTypeToCompare
+          } else {
+            // if we couldn't find the current task type,
+            //   then fallback to the first one in the list
+            this.taskTypeToCompare = this.taskTypeOptions[0].value
+            this.comparisonEntityMissing = !!this.savedTaskTypeToCompare
+          }
         }
         this.rebuildRevisionOptions()
       } else {
@@ -2086,6 +2107,7 @@ export default {
     },
 
     resetComparison () {
+      const wasPlaying = this.isPlaying
       this.rebuildRevisionOptions()
       this.rebuildEntityListToCompare()
       this.$nextTick(() => {
@@ -2093,6 +2115,9 @@ export default {
         const player = this.$refs['raw-player-comparison']
         player.loadEntity(this.playingEntityIndex)
         player.setCurrentTime(this.currentTimeRaw)
+        this.$nextTick(() => {
+          if (wasPlaying) this.play()
+        })
       })
     },
 
@@ -2366,6 +2391,10 @@ export default {
           this.$refs['raw-player-comparison'].setCurrentTime(time)
         }
       }, 20)
+    },
+
+    saveUserComparisonChoice () {
+      this.savedTaskTypeToCompare = this.taskTypeToCompare
     }
   },
 
@@ -2392,6 +2421,7 @@ export default {
         this.annotations = this.currentEntity.preview_file_annotations || []
       }
       this.$nextTick(() => {
+        this.rebuildComparisonOptions()
         if (this.isComparing) this.rebuildRevisionOptions()
         this.$nextTick(() => {
           this.resetCanvas()
@@ -2739,6 +2769,14 @@ progress {
 }
 .comparison-list select {
   height: 2.2em;
+}
+.comparison-missing {
+  padding: 6px 10px;
+  border: 1px solid $dark-grey;
+  border-radius: 5px;
+  background-color: $dark-grey-light;
+  font-weight: bold;
+  width: max-content;
 }
 
 .dl-button {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -481,6 +481,7 @@ export default {
     build_mp4: 'Build .mp4 (beta)',
     building: 'Building...',
     client_playlist: 'Client Playlist',
+    comparing_missing_plan: 'Plan absent! Please add it for: ',
     create_for_selection: 'Generate a playlist for shot selection',
     create_title: 'Create playlist',
     created_at: 'Created at:',


### PR DESCRIPTION
**Problem**
When a task type wasn't available in ONE of the entities, we couldn't compare using this task type.

**Solution**
With this PR it's possible, and when playing an entity without the chosen tasktype, we will fallback to the first tasktype of the list and display a warning as bellow

![2021-09-21_15-02](https://user-images.githubusercontent.com/9109308/134175753-bf9bdbe5-52d4-4393-8345-8758db98d030.png)

