### PR TITLE
Various improvements

### DIFF
--- a/src/components/modals/EditProductionModal.vue
+++ b/src/components/modals/EditProductionModal.vue
@@ -29,13 +29,6 @@
           @enter="runConfirmation"
           v-model="form.project_status_id"
         />
-        <combobox
-          :label="$t('productions.fields.type')"
-          :options="productionTypeOptions"
-          localeKeyPrefix="productions.type."
-          @enter="runConfirmation"
-          v-model="form.production_type"
-        />
         <text-field v-if="productionToEdit && productionToEdit.id"
           ref="fpsField"
           :label="$t('productions.fields.fps')"

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -1282,6 +1282,10 @@ export default {
 
     isListToggled () {
       this.playlistPlayer.onWindowResize()
+    },
+
+    taskTypeId () {
+      this.loadPlaylistsData(true)
     }
   },
 

--- a/src/components/pages/Productions.vue
+++ b/src/components/pages/Productions.vue
@@ -6,11 +6,11 @@
       </div>
       <div class="level-right">
         <div class="level-item">
-          <button-simple
+          <button-link
             class="level-item"
             :text="$t('productions.new_production')"
             icon="plus"
-            @click="onNewClicked"
+            :path="{ name: 'new-production' }"
           />
         </div>
       </div>
@@ -53,14 +53,14 @@ import { mapGetters, mapActions } from 'vuex'
 import ProductionList from '../lists/ProductionList'
 import EditProductionModal from '../modals/EditProductionModal'
 import HardDeleteModal from '../modals/HardDeleteModal'
-import ButtonSimple from '../widgets/ButtonSimple'
+import ButtonLink from '../widgets/ButtonLink'
 import PageTitle from '../widgets/PageTitle'
 
 export default {
   name: 'productions',
 
   components: {
-    ButtonSimple,
+    ButtonLink,
     HardDeleteModal,
     EditProductionModal,
     PageTitle,

--- a/src/store/api/playlists.js
+++ b/src/store/api/playlists.js
@@ -65,8 +65,9 @@ export default {
     return client.pdel(path)
   },
 
-  runPlaylistBuild (playlist) {
-    const path = `/api/data/playlists/${playlist.id}/build/mp4`
+  runPlaylistBuild (playlist, full = false) {
+    let path = `/api/data/playlists/${playlist.id}/build/mp4`
+    if (full) path += '?full=true'
     return client.pget(path)
   },
 

--- a/src/store/modules/playlists.js
+++ b/src/store/modules/playlists.js
@@ -212,8 +212,8 @@ const actions = {
     commit(MARK_JOB_AS_DONE, job)
   },
 
-  runPlaylistBuild ({ commit }, playlist) {
-    return playlistsApi.runPlaylistBuild(playlist)
+  runPlaylistBuild ({ commit }, { playlist, full }) {
+    return playlistsApi.runPlaylistBuild(playlist, full)
   },
 
   changePlaylistType (


### PR DESCRIPTION
**Problem**

* Changing a production type break things if you change a production from a TV show to a short movie and vice-versa.
* A user can still create a production without giving mandatory parameters.
* It is not possible to choose the type of concatenation for the playlist. It leads to a different result, that's why the user should be able to choose.
* Playlist filtering by type is broken.

**Solution**

* Do not allow to chang a production type anymore.
* Change create production button into a link to the new production page (instead of opening a modal).
* Allow the user to select the concatenation mode when building a playlist : simple concat or full compressing of the video.
* Put back the watch of the taskTypeId parameter.
