### PR TITLE
Schedule improvements and fixes

### DIFF
--- a/src/components/mixins/entity.js
+++ b/src/components/mixins/entity.js
@@ -1,0 +1,129 @@
+import {
+  getFirstStartDate,
+  getLastEndDate,
+  parseDate
+} from '@/lib/time'
+import moment from 'moment'
+
+/*
+ * Common functions to shot and asset pages.
+ */
+export const entityMixin = {
+
+  created () {
+  },
+
+  mounted () {
+  },
+
+  beforeDestroy () {
+  },
+
+  computed: {
+    currentTasks () {
+      const entity = this.currentAsset || this.currentShot
+      return entity
+        ? entity
+          .tasks
+          .map(taskId => this.taskMap.get(taskId))
+          .filter(task => task)
+          .sort((a, b) => {
+            const taskTypeA = this.taskTypeMap.get(a.task_type_id)
+            const taskTypeB = this.taskTypeMap.get(b.task_type_id)
+            return taskTypeA.priority > taskTypeB.priority
+          })
+        : []
+    },
+
+    tasksStartDate () {
+      if (this.scheduleItems.length > 0) {
+        return getFirstStartDate(this.scheduleItems[0].children)
+      } else {
+        return moment()
+      }
+    },
+
+    tasksEndDate () {
+      if (this.scheduleItems.length > 0) {
+        return getLastEndDate(this.scheduleItems[0].children)
+      } else {
+        return moment().add(30, 'days')
+      }
+    },
+
+    scheduleItems () {
+      console.log(this.currentTasks)
+      let manDays = 0
+      const rootElement = {
+        avatar: false,
+        id: 'root',
+        name: 'Tasks',
+        color: '#888',
+        for_shots: false,
+        priority: 1,
+        expanded: true,
+        loading: false,
+        children: [],
+        editable: false
+      }
+      const limitStartDate = moment()
+      const children = this.currentTasks.map(task => {
+        const estimation = this.formatDuration(task.estimation)
+        let startDate = limitStartDate.clone()
+        let endDate
+
+        if (!task.start_date && !task.real_start_date &&
+            !task.due_date && !task.end_date) return null
+
+        if (task.start_date) {
+          startDate = parseDate(task.start_date)
+        } else if (task.real_start_date) {
+          startDate = parseDate(task.real_start_date)
+        }
+
+        if (task.due_date) {
+          endDate = parseDate(task.due_date)
+        } else if (task.end_date) {
+          endDate = parseDate(task.end_date)
+        } else if (task.estimation) {
+          endDate = startDate.clone().add(estimation, 'days')
+        }
+
+        if (!endDate || endDate.isBefore(startDate)) {
+          endDate = startDate.clone().add(1, 'days')
+        }
+        if (estimation) manDays += task.estimation
+        const taskType = this.taskTypeMap.get(task.task_type_id)
+
+        return {
+          ...task,
+          name: taskType.name,
+          startDate: startDate,
+          endDate: endDate,
+          expanded: false,
+          loading: false,
+          man_days: estimation,
+          editable: false,
+          unresizable: false,
+          parentElement: rootElement,
+          color: taskType.color,
+          children: []
+        }
+      }).filter(c => c !== null)
+      const rootStartDate = getFirstStartDate(children)
+      const rootEndDate = getLastEndDate(children)
+      console.log(children)
+      Object.assign(rootElement, {
+        children: children,
+        startDate: rootStartDate,
+        endDate: rootEndDate,
+        man_days: manDays
+      })
+      return [rootElement]
+    }
+
+  },
+
+  methods: {
+  }
+}

--- a/src/components/pages/Asset.vue
+++ b/src/components/pages/Asset.vue
@@ -67,6 +67,24 @@
       </div>
     </div>
 
+    <div class="infos schedule" v-if="scheduleItems.length > 0">
+      <page-subtitle class="schedule-title" text="Schedule" />
+      <div class="wrapper">
+        <schedule
+          ref="schedule-widget"
+          :start-date="tasksStartDate"
+          :end-date="tasksEndDate"
+          :hierarchy="scheduleItems"
+          :zoom-level="2"
+          :height="400"
+          :is-loading="false"
+          :is-estimation-linked="true"
+          :hide-root="true"
+          :with-milestones="false"
+        />
+      </div>
+    </div>
+
     <div class="asset-casted-in">
       <page-subtitle :text="$t('assets.cast_in')" />
       <div v-if="currentAsset">
@@ -189,6 +207,8 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
+import { entityMixin } from '@/components/mixins/entity'
+import { formatListMixin } from '@/components/mixins/format'
 
 import { ChevronLeftIcon } from 'vue-feather-icons'
 import ButtonSimple from '../widgets/ButtonSimple'
@@ -198,11 +218,13 @@ import EntityTaskList from '../lists/EntityTaskList'
 import EntityThumbnail from '../widgets/EntityThumbnail'
 import PageTitle from '../widgets/PageTitle'
 import PageSubtitle from '../widgets/PageSubtitle'
+import Schedule from '../pages/schedule/Schedule'
 import TableInfo from '../widgets/TableInfo'
 import TaskInfo from '../sides/TaskInfo'
 
 export default {
   name: 'asset',
+  mixins: [entityMixin, formatListMixin],
   components: {
     ButtonSimple,
     ChevronLeftIcon,
@@ -212,6 +234,7 @@ export default {
     EntityTaskList,
     PageSubtitle,
     PageTitle,
+    Schedule,
     TableInfo,
     TaskInfo
   },
@@ -266,6 +289,8 @@ export default {
       'isTVShow',
       'isCurrentUserManager',
       'route',
+      'taskMap',
+      'taskTypeMap',
       'shotId'
     ]),
 
@@ -539,6 +564,22 @@ h2.subtitle {
 
 .datatable-row {
   user-select: text;
+}
+
+.schedule {
+  position: relative;
+  height: 280px;
+  padding: 10px;
+
+  .schedule-title {
+    margin-bottom: 5px;
+  }
+
+  .wrapper {
+    background: $dark-grey-2;
+    height: 230px;
+    border-radius: 10px;
+  }
 }
 
 @media screen and (max-width: 768px) {

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -524,7 +524,12 @@ export default {
       Object.keys(this.selection)
         .filter(key => this.selection[key])
         .forEach((entityId) => {
-          this.addAssetToCasting({ entityId, assetId, nbOccurences: 1 })
+          this.addAssetToCasting({
+            entityId,
+            assetId,
+            nbOccurences: 1,
+            label: this.castingType === 'shot' ? 'animate' : 'fixed'
+          })
           this.saveCasting(entityId)
             .catch(console.error)
         })

--- a/src/components/pages/MainSchedule.vue
+++ b/src/components/pages/MainSchedule.vue
@@ -18,6 +18,7 @@
           :monday-first="true"
           format="yyyy-MM-dd"
           v-model="selectedStartDate"
+          disabled
         />
       </div>
       <div class="flexrow-item field">
@@ -32,6 +33,7 @@
           :monday-first="true"
           format="yyyy-MM-dd"
           v-model="selectedEndDate"
+          disabled
         />
       </div>
       <combobox-number

--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -31,7 +31,7 @@
       <page-subtitle :text="$t('shots.tasks')" />
       <entity-task-list
         class="task-list"
-        :entries="currentTasks"
+        :entries="currentTasks.map(t => t.id)"
         :is-loading="!currentShot"
         :is-error="false"
         @task-selected="onTaskSelected"
@@ -105,6 +105,25 @@
             </tbody>
         </table>
       </div>
+      </div>
+    </div>
+
+    <div class="infos schedule" v-if="scheduleItems.length > 0">
+      <page-subtitle class="schedule-title" text="Schedule" />
+      <div class="wrapper">
+        <schedule
+          ref="schedule-widget"
+          class="schedule-widget"
+          :start-date="tasksStartDate"
+          :end-date="tasksEndDate"
+          :hierarchy="scheduleItems"
+          :zoom-level="2"
+          :height="385"
+          :is-loading="false"
+          :is-estimation-linked="true"
+          :hide-root="true"
+          :with-milestones="false"
+        />
       </div>
     </div>
 
@@ -185,6 +204,8 @@ import { mapGetters, mapActions } from 'vuex'
 import { ChevronLeftIcon } from 'vue-feather-icons'
 
 import { episodifyRoute } from '@/lib/path'
+import { entityMixin } from '@/components/mixins/entity'
+import { formatListMixin } from '@/components/mixins/format'
 
 import ButtonSimple from '@/components/widgets/ButtonSimple'
 import DescriptionCell from '@/components/cells/DescriptionCell'
@@ -193,11 +214,13 @@ import EntityThumbnail from '@/components/widgets/EntityThumbnail'
 import EntityTaskList from '@/components/lists/EntityTaskList'
 import PageTitle from '@/components/widgets/PageTitle'
 import PageSubtitle from '@/components/widgets/PageSubtitle'
+import Schedule from '../pages/schedule/Schedule'
 import TableInfo from '@/components/widgets/TableInfo'
 import TaskInfo from '@/components/sides/TaskInfo'
 
 export default {
   name: 'shot',
+  mixins: [entityMixin, formatListMixin],
   components: {
     ButtonSimple,
     ChevronLeftIcon,
@@ -207,6 +230,7 @@ export default {
     EntityTaskList,
     PageSubtitle,
     PageTitle,
+    Schedule,
     TableInfo,
     TaskInfo
   },
@@ -261,12 +285,10 @@ export default {
       'route',
       'shotMap',
       'shotMetadataDescriptors',
-      'shotsPath'
+      'shotsPath',
+      'taskMap',
+      'taskTypeMap'
     ]),
-
-    currentTasks () {
-      return this.currentShot ? this.currentShot.tasks : []
-    },
 
     title () {
       if (this.currentShot) {
@@ -532,6 +554,22 @@ h2.subtitle {
 
 .datatable-row {
   user-select: text;
+}
+
+.schedule {
+  position: relative;
+  height: 280px;
+  padding: 10px;
+
+  .schedule-title {
+    margin-bottom: 5px;
+  }
+
+  .wrapper {
+    background: $dark-grey-2;
+    height: 230px;
+    border-radius: 10px;
+  }
 }
 
 @media screen and (max-width: 768px) {

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -85,8 +85,26 @@ export const getWeekRange = (year, currentYear) => {
   }
 }
 
-export const getFirstStartDate = (items) => {
+export const getFirstStartDateByField = (items) => {
   let startDate = moment()
+  items.forEach(item => {
+    const sDate = parseDate(item.start_date)
+    if (sDate.isBefore(startDate)) startDate = sDate
+  })
+  return startDate
+}
+
+export const getLastEndDateByField = (items) => {
+  let endDate = moment()
+  items.forEach(item => {
+    const eDate = parseDate(item.end_date)
+    if (eDate.isAfter(endDate)) endDate = eDate
+  })
+  return endDate
+}
+
+export const getFirstStartDate = (items) => {
+  let startDate = items[0].startDate
   items.forEach((item) => {
     if (item.startDate.isBefore(startDate)) startDate = item.startDate.clone()
   })
@@ -94,7 +112,7 @@ export const getFirstStartDate = (items) => {
 }
 
 export const getLastEndDate = (items) => {
-  let endDate = moment().add(3, 'months')
+  let endDate = items[0].endDate
   items.forEach(item => {
     if (item.endDate.isAfter(endDate)) endDate = item.endDate.clone()
   })

--- a/src/store/modules/breakdown.js
+++ b/src/store/modules/breakdown.js
@@ -105,10 +105,10 @@ const actions = {
 
   addAssetToCasting (
     { commit, rootState },
-    { entityId, assetId, nbOccurences }
+    { entityId, assetId, nbOccurences, label }
   ) {
     const asset = rootState.assets.assetMap.get(assetId)
-    commit(CASTING_ADD_TO_CASTING, { entityId, asset, nbOccurences })
+    commit(CASTING_ADD_TO_CASTING, { entityId, asset, nbOccurences, label })
   },
 
   removeAssetFromCasting (
@@ -277,7 +277,7 @@ const mutations = {
     state.castingByType = { ...state.castingByType }
   },
 
-  [CASTING_ADD_TO_CASTING] (state, { entityId, asset, nbOccurences }) {
+  [CASTING_ADD_TO_CASTING] (state, { entityId, asset, nbOccurences, label }) {
     if (!state.casting[entityId]) state.casting[entityId] = []
     const previousAsset = state.casting[entityId].find(
       a => a.asset_id === asset.id
@@ -291,7 +291,8 @@ const mutations = {
         asset_name: asset.name,
         asset_type_name: asset.asset_type_name,
         nb_occurences: nbOccurences,
-        preview_file_id: asset.preview_file_id
+        preview_file_id: asset.preview_file_id,
+        label
       }
       state.casting[entityId].push(newAsset)
     }

--- a/tests/unit/pages/schedule.spec.js
+++ b/tests/unit/pages/schedule.spec.js
@@ -138,19 +138,22 @@ describe('Schedule', () => {
 
     test('displayedDays', () => {
       const days = wrapper.vm.displayedDays
-      expect(days[5].day()).toEqual(1)
+      expect(days[4].day()).toEqual(5)
+      expect(days[5].day()).toEqual(6)
+      expect(days[6].day()).toEqual(0)
+      expect(days[7].day()).toEqual(1)
     })
 
     test('nbDisplayedDays', () => {
       const nbDays = wrapper.vm.nbDisplayedDays
-      expect(nbDays).toEqual(133)
+      expect(nbDays).toEqual(185)
     })
 
     test('displayedDaysIndex', () => {
       const daysIndex = wrapper.vm.displayedDaysIndex
-      expect(daysIndex['2019-08-01']).toEqual(23)
+      expect(daysIndex['2019-08-01']).toEqual(31)
       expect(daysIndex['2019-07-01']).toEqual(0)
-      expect(daysIndex['2019-08-15']).toEqual(33)
+      expect(daysIndex['2019-08-15']).toEqual(45)
     })
 
     test('totalManDays', () => {
@@ -173,7 +176,7 @@ describe('Schedule', () => {
     })
 
     test('timelineTodayPositionStyle', () => {
-      const left = wrapper.vm.businessDiff(wrapper.vm.startDate, moment()) * 60
+      const left = wrapper.vm.dateDiff(wrapper.vm.startDate, moment()) * 60
       wrapper.setProps({ zoomLevel: 3 })
       expect(wrapper.vm.timelineTodayPositionStyle).toEqual({
         display: 'none',
@@ -195,7 +198,7 @@ describe('Schedule', () => {
     describe('Layout', () => {
       test('resetScheduleSize', () => {
         wrapper.vm.resetScheduleSize()
-        expect(wrapper.vm.timelineContent.style.width).toEqual('7980px')
+        expect(wrapper.vm.timelineContent.style.width).toEqual('11100px')
         expect(wrapper.vm.timelineContentWrapper.style.height)
           .toEqual('-250px')
         expect(wrapper.vm.entityList.style.height).toEqual('-169px')
@@ -227,7 +230,7 @@ describe('Schedule', () => {
         expect(wrapper.vm.currentElement.startDate.format('YYYY-MM-DD'))
           .toEqual(moment('2019-08-13').format('YYYY-MM-DD'))
         expect(wrapper.vm.currentElement.endDate.format('YYYY-MM-DD'))
-          .toEqual(moment('2019-08-30').format('YYYY-MM-DD'))
+          .toEqual(moment('2019-09-01').format('YYYY-MM-DD'))
       })
       test('changeStartDate', () => {
         wrapper.vm.moveTimebarLeftSide(timeElement, initialEvent)
@@ -239,7 +242,7 @@ describe('Schedule', () => {
          wrapper.vm.moveTimebarRightSide(timeElement, initialEvent)
          wrapper.vm.changeEndDate(event)
          expect(wrapper.vm.currentElement.endDate.format('YYYY-MM-DD'))
-           .toEqual(moment('2019-08-30').format('YYYY-MM-DD'))
+           .toEqual(moment('2019-09-01').format('YYYY-MM-DD'))
       })
       test('scrollScheduleHeight', () => {
         wrapper.vm.timelineContentWrapper.scrollLeft = 150
@@ -406,13 +409,15 @@ describe('Schedule', () => {
         expect(cssClass).toEqual({
           'day-name': true,
           'new-week': true,
-          'new-month': true
+          'new-month': true,
+          weekend: false
         })
         cssClass = wrapper.vm.dayClass(days[2], 2)
         expect(cssClass).toEqual({
           'day-name': true,
           'new-week': false,
-          'new-month': false
+          'new-month': false,
+          weekend: false
         })
       })
 
@@ -420,8 +425,8 @@ describe('Schedule', () => {
         const days = wrapper.vm.daysAvailable
         let dayStyle = wrapper.vm.dayStyle(days[6])
         expect(dayStyle).toEqual({
-          'min-width': '0px',
-          'max-width': '0px'
+          'min-width': '60px',
+          'max-width': '60px'
         })
         dayStyle = wrapper.vm.dayStyle(days[2])
         expect(dayStyle).toEqual({
@@ -449,8 +454,8 @@ describe('Schedule', () => {
         })
         expect(timebarStyle).toEqual({
           'cursor': 'ew-resize',
-          'left': (33 * 60 + 5) + 'px',
-          'width': 14 * 60 - 10 + 'px'
+          'left': (45 * 60 + 5) + 'px',
+          'width': 18 * 60 - 10 + 'px'
         })
         timebarStyle = wrapper.vm.timebarStyle({
           startDate: moment('2019-08-15', 'YYYY-MM-DD'),
@@ -459,8 +464,8 @@ describe('Schedule', () => {
         })
         expect(timebarStyle).toEqual({
           'cursor': 'default',
-          'left': (33 * 60 + 5) + 'px',
-          'width': 14 * 60 - 10 + 'px'
+          'left': (45 * 60 + 5) + 'px',
+          'width': 18 * 60 - 10 + 'px'
         })
       })
 
@@ -472,7 +477,7 @@ describe('Schedule', () => {
           startDate: moment('2019-08-15', 'YYYY-MM-DD'),
           endDate: moment('2019-09-01', 'YYYY-MM-DD')
         })
-        expect(timebarLeft).toEqual(33 * 60 + 5)
+        expect(timebarLeft).toEqual(45 * 60 + 5)
       })
 
       test('getTimebarWidth', () => {
@@ -480,7 +485,7 @@ describe('Schedule', () => {
           startDate: moment('2019-08-15', 'YYYY-MM-DD'),
           endDate: moment('2019-09-01', 'YYYY-MM-DD')
         })
-        expect(timebarWidth).toEqual(14 * 60 - 10)
+        expect(timebarWidth).toEqual(18 * 60 - 10)
       })
     })
   })


### PR DESCRIPTION
**Problem**

* Not displaying weekends makes the schedule hard to read
* Dates in the main schedule have no effects
* The layout is not properly aligned
* In the task type schedule, when a task has no dates, it is not properly displayed
* There is no schedule representation for assets or shots.

**Solution**

* Put back weekends inside the schedule
* Disable date fields in the main schedule
* Adapt the layout depending if there are milestones or not
* When there is no date add tasks at the beginning of the schedule
* Add schedule widgets in asset and shot pages
