### PR TITLE
Allow clients to browse previews

### DIFF
--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -2,7 +2,7 @@
 <td
   ref="cell"
   :class="{
-    validation: selectable && !isCurrentUserClient,
+    validation: selectable,
     selected: selectable & selected
   }"
   :style="{
@@ -296,7 +296,7 @@ export default {
 
     select (event) {
       const isUserClick = event.isUserClick !== false
-      if (this.selectable && !this.isCurrentUserClient) {
+      if (this.selectable) {
         if (this.$refs.cell &&
             this.$refs.cell.className.indexOf('selected') < 0) {
           this.$emit('select', {

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -403,6 +403,7 @@ export default {
       'getTaskComment',
       'isCurrentUserAdmin',
       'isCurrentUserArtist',
+      'isCurrentUserClient',
       'isCurrentUserManager',
       'isSingleEpisode',
       'isTVShow',
@@ -419,6 +420,7 @@ export default {
 
     isPreviewButtonVisible () {
       return (
+        this.isCurrentUserManager &&
         this.currentTask &&
         this.currentTask.entity &&
         this.currentTask.entity.preview_file_id !== this.currentPreviewId &&
@@ -462,8 +464,12 @@ export default {
     },
 
     isCommentingAllowed () {
-      return this.isCurrentUserManager || this.currentTask.assignees.find(
-        (personId) => personId === this.user.id
+      return (
+        this.isCurrentUserManager ||
+        this.isCurrentUserClient ||
+        this.currentTask.assignees.find(
+          (personId) => personId === this.user.id
+        )
       )
     },
 
@@ -1459,7 +1465,7 @@ video {
 .page-header .tag {
   border-radius: 0;
   font-weight: bold;
-  color: $grey-strong;
+  margin-right: 0.5em;
 }
 
 .assignees {

--- a/src/components/previews/VideoProgress.vue
+++ b/src/components/previews/VideoProgress.vue
@@ -184,6 +184,7 @@ progress::-moz-progress-bar {
 }
 
 progress::-webkit-progress-value {
+  background-color: #43B581;
   opacity: 0.6;
 }
 

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -422,9 +422,8 @@ export default {
       const isAssigned = this.task.assignees.find(
         (personId) => personId === this.user.id
       )
-      const isClientInPlaylist =
-        this.$route.path.indexOf('playlist') > 0 && this.isCurrentUserClient
-      return isManager || isAssigned || isClientInPlaylist
+      const isClient = this.isCurrentUserClient
+      return isManager || isAssigned || isClient
     },
 
     isSetThumbnailAllowed () {

--- a/src/components/widgets/TaskTypeName.vue
+++ b/src/components/widgets/TaskTypeName.vue
@@ -1,7 +1,7 @@
 <template>
 <router-link
   :to="taskTypePath"
-  v-if="productionId"
+  v-if="productionId && !isCurrentUserClient"
 >
   <span
     class="tag task-type-name"
@@ -48,6 +48,7 @@ export default {
 
   computed: {
     ...mapGetters([
+      'isCurrentUserClient'
     ]),
 
     color () {
@@ -84,13 +85,13 @@ export default {
 
 <style lang="scss" scoped>
 .tag {
-  margin: 0;
-  padding: 0 0.7em;
-  font-size: 0.9em;
-  line-height: 0.8em;
-  color: $grey-strong;
   border-radius: 0;
+  color: var(--text);
+  font-size: 0.9em;
   font-weight: bold;
+  line-height: 0.8em;
+  padding: 0 0.7em;
+  margin: 0;
 }
 
 .tag.deletable {
@@ -98,7 +99,6 @@ export default {
 }
 
 .dark .tag {
-  color: $white-grey;
   background: $dark-grey-lightest;
 }
 
@@ -119,5 +119,7 @@ export default {
 }
 
 .no-link {
+  color: var(--text);
+  cursor: default;
 }
 </style>


### PR DESCRIPTION
**Problem**

It is not possible for clients to browse previews through the entity list While it's something they want to be able to do. They can't post comment too, which is sometimes annoying for them.

**Solution**

Unlock the UI component need not to allow access to previews from the entity list. Allow clients to post comment from there.
