### PR TITLE
Make task type tag readable in dark theme

### DIFF
--- a/src/components/widgets/TaskTypeName.vue
+++ b/src/components/widgets/TaskTypeName.vue
@@ -100,6 +100,7 @@ export default {
 
 .dark .tag {
   background: $dark-grey-lightest;
+  color: white;
 }
 
 .delete-times:hover {


### PR DESCRIPTION
**Problem**
Text on the task type tag is almost unreadable in dark theme, see, for example, the Task Types page:

![2022-01-14-153302_1028x938_scrot](https://user-images.githubusercontent.com/176934/149533073-9ce147c9-bc81-49ed-8106-cfa59b2a677f.png)


**Solution**
Overriding text color under `.dark` class in TaskTypeName fixes the issue:

![2022-01-14-153319_1017x932_scrot](https://user-images.githubusercontent.com/176934/149533241-d8995f3a-a0d5-4cf7-b2fb-25ba17600264.png)