### PR TITLE
Various fixes and improvement

### DIFF
--- a/src/components/cells/TaskTypeName.vue
+++ b/src/components/cells/TaskTypeName.vue
@@ -49,7 +49,7 @@ export default {
   margin: 0.7em;
   padding: 1em;
   font-size: 1em;
-  color: $grey-strong;
+  color: var(--text);
   border-radius: 0;
   font-weight: bold;
 }

--- a/src/components/modals/AddCommentImageModal.vue
+++ b/src/components/modals/AddCommentImageModal.vue
@@ -16,7 +16,7 @@
       </p>
 
       <file-upload
-        ref="image-field"
+        ref="file-field"
         :label="$t('main.select_file')"
         :accept="extensions"
         :multiple="true"
@@ -141,8 +141,8 @@ export default {
     ...mapGetters([
     ]),
 
-    imageField () {
-      return this.$refs['image-field']
+    fileField () {
+      return this.$refs['file-field']
     }
   },
 
@@ -159,7 +159,7 @@ export default {
     },
 
     reset () {
-      this.imageField.reset()
+      this.fileField.reset()
       this.forms = null
     },
 
@@ -179,6 +179,10 @@ export default {
 
     isVideo (form) {
       return form.get('file').type.startsWith('video')
+    },
+
+    isPdf (form) {
+      return form.get('file').type.indexOf('pdf') > 0
     },
 
     addFiles (files) {

--- a/src/components/pages/ProductionQuota.vue
+++ b/src/components/pages/ProductionQuota.vue
@@ -10,7 +10,7 @@
         <combobox-task-type
           class="flexrow-item"
           :label="$t('quota.type_label')"
-          :task-type-list="shotTaskTypes"
+          :task-type-list="productionShotTaskTypes"
           v-model="taskTypeId"
         />
       </div>
@@ -140,6 +140,7 @@ export default {
     ...mapGetters([
       'currentEpisode',
       'currentProduction',
+      'productionShotTaskTypes',
       'shotTaskTypes',
       'personMap'
     ]),

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -820,11 +820,11 @@ export default {
     month_label: 'Month',
     no_quota: 'There is no quota for this task type.',
     name: 'Name',
-    quota_day: 'Quota per day',
-    quota_week: 'Quota per week',
-    quota_month: 'Quota per month',
+    quota_day: 'Quotas per day',
+    quota_week: 'Quotas per week',
+    quota_month: 'Quotas per month',
     year_label: 'Year',
-    title: 'Quota',
+    title: 'Quotas',
     type_label: 'Type'
   },
 

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -746,9 +746,9 @@
             "month_label": "Mois",
             "no_quota": "Il n'y a pas de quota pour ce type de tâche.",
             "name": "Nom",
-            "quota_day": "Quota par jour",
-            "quota_week": "Quota par semaine",
-            "quota_month": "Quota par mois",
+            "quota_day": "Quotas par jour",
+            "quota_week": "Quotas par semaine",
+            "quota_month": "Quotas par mois",
             "year_label": "Année",
             "title": "Quotas",
             "type_label": "Type"


### PR DESCRIPTION
**Problem**

* We can't see the frame number when dragging the timeline bar in the videos.
* The task type name is hidden in the dark mode for task type tags.
* The attachment modal doesn't support file uploading anymore other than pictures or movies
* The quota page allows selecting too many task types.

**Solution**

* Display a small div with the frame number following the mouse when the mouse is over the video progress element.
* Fix text color: use main variables instead of a given one
* Fix pdf file handling
* Display only required production task types

