### PR TITLE
Playlist-/PreviewPlayer: allow backspace to delete annotations

### DIFF
--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1768,7 +1768,7 @@ export default {
     onKeyDown (event) {
       this.displayBars()
       if (!['INPUT', 'TEXTAREA'].includes(event.target.tagName)) {
-        if (event.keyCode === 46 && this.fabricCanvas) {
+        if ((event.keyCode === 46 || event.keyCode === 8) && this.fabricCanvas) {
           this.deleteSelection()
         } else if (event.keyCode === 37) {
           event.preventDefault()

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1285,7 +1285,7 @@ export default {
 
     onKeyDown (event) {
       if (!['INPUT', 'TEXTAREA'].includes(event.target.tagName)) {
-        if (event.keyCode === 46) {
+        if (event.keyCode === 46 || event.keyCode === 8) {
           this.deleteSelection()
         } else if (event.keyCode === 37) { // arrow left
           this.goPreviousFrame()


### PR DESCRIPTION
**Problem**
osx maps the <delete> key to <backspace> which makes deleting annotations cumbersome. if you want press the <delete> key you need to press the <fn> modifier too.

**Solution**
allow the delete and the backspace key to delete annotations.
