### PR TITLE
vue.config.js: use 127.0.0.1 as api proxy address instead of localhost

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -14,7 +14,7 @@ module.exports = {
   devServer: {
     proxy: {
       '/api': {
-        target: process.env.KITSU_API_TARGET || 'http://localhost:5000',
+        target: process.env.KITSU_API_TARGET || 'http://127.0.0.1:5000',
         changeOrigin: true,
         pathRewrite: {
           '^/api': ''


### PR DESCRIPTION
On osx the proxy cannot be forwarded  from http://127.0.0.1:8080
to http://localhost:5000 . By changing the address to an ip address
it also matches the socket.io address below.