### PR TITLE
[mattermost] checkWebhook chat_webhook_mattermost is nullable and not…

### DIFF
--- a/src/components/pages/Settings.vue
+++ b/src/components/pages/Settings.vue
@@ -178,15 +178,13 @@ export default {
     ]),
 
     checkWebhook () {
-      if (this.form.chat_webhook_mattermost === '') {
+      if (!this.form.chat_webhook_mattermost ||
+      this.form.chat_webhook_mattermost.match('/hooks/[a-zA-Z0-9]+$')) {
         this.errors.webhook_error = false
         return true
-      } else if (!this.form.chat_webhook_mattermost.match('/hooks/[a-zA-Z0-9]+$')) {
+      } else {
         this.errors.webhook_error = true
         return false
-      } else {
-        this.errors.webhook_error = false
-        return true
       }
     },
 


### PR DESCRIPTION
**Problem**

https://github.com/cgwire/kitsu/issues/823

In checkWebhook for mattermost it test only if chat_webhook_mattermost is an empty string but it can also be null when not defined so we can't use match method because it's not a String.

**Solution**
Test if chat_webhook_mattermost is evaluated to False instead 
