### PR TITLE
Minor fixes to Edits page

### DIFF
--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -432,7 +432,7 @@
     ({{ formatDuration(displayedEditsTimeSpent) }}
      {{ $tc('main.days_spent', displayedEditsTimeSpent) }},
      {{ formatDuration(displayedEditsEstimation) }}
-     {{ $tc('main.man_days', displayedEditsEstimation) }}
+     {{ $tc('main.man_days', displayedEditsEstimation) }})
   </p>
 
 </div>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -821,7 +821,7 @@ export default {
     empty_list: 'There are no edits in the production. What about creating some?',
     empty_list_client: 'There are no edits in this production.',
     new_edit: 'New edit',
-    number: 'edits | edits',
+    number: 'edit | edits',
     title: 'Edits',
     fields: {
       name: 'name',


### PR DESCRIPTION
**Problem**
![Clipboard - March 14, 2022 4 51 PM](https://user-images.githubusercontent.com/176934/158212379-fab5e243-f9a2-4b0b-80b2-e1c254c40b62.png)

Should be this instead:
![2022-03-14-170450_363x67_scrot](https://user-images.githubusercontent.com/176934/158212716-a33a7238-c72c-4d61-8ce8-663c66ea63d9.png)


**Solution**
Updated `en.js` and added a missing bracket in `EditList.vue`.
