### PR TITLE
[qa] FIX #822: add missing parse function to marked

### DIFF
--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -54,7 +54,7 @@ export const renderComment = (
 }
 
 export const renderMarkdown = (input) => {
-  const compiled = marked(input || '')
+  const compiled = marked.parse(input || '')
   return sanitize(compiled)
 }
 


### PR DESCRIPTION
**Problem**
See #822.

**Solution**
change marked(...) to marked.parse(...) fixes the issue.
