### PR TITLE
[ProductionTaskType] disable the possibility to remove the start_date…

### DIFF
--- a/src/components/pages/production/ProductionTaskType.vue
+++ b/src/components/pages/production/ProductionTaskType.vue
@@ -9,12 +9,14 @@
   <td class="start-date">
    <date-field
       :disabled-dates="productionTimeRange"
+      :can-delete="false"
       v-model="startDate"
    />
   </td>
   <td class="end-date">
    <date-field
       :disabled-dates="endDateTimeRange"
+      :can-delete="false"
       v-model="endDate"
    />
   </td>


### PR DESCRIPTION
… or due_date for a task type because it's buggy and not needed

**Problem**
In production settings --> task-types we can delete the stard_date / due_date but it's buggy and useless

**Solution**
Remove the possibility for these dates to be deleted
