### PR TITLE
[qa] set @google/model-viewer version to 1.10.1 because the last vers…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:functional": "$(npm bin)/cypress open"
   },
   "dependencies": {
-    "@google/model-viewer": "^1.9.2",
+    "@google/model-viewer": "1.10.1",
     "async": "3.2.0",
     "bowser": "2.11.0",
     "chart.js": "2.9.4",


### PR DESCRIPTION
…ion (1.11.0) failed to compile with webpack

**Problem**
The last version of @google/model-viewer module (1.11.0) is buggy with webpack it fails to compile. it's also not a good idea not to put a specific version. 

**Solution**
Set @google/model-viewer module to last working version (1.10.1)
