### PR TITLE
Fix breakdown import

### DIFF
--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -242,21 +242,6 @@ export default {
           value: 'asset'
         }
       ],
-      csvColumns: [
-        'Episode',
-        'Parent',
-        'Name',
-        'Asset Type',
-        'Asset',
-        'Occurences',
-        'Label'
-      ],
-      dataMatchers: [
-        'Episode',
-        'Name',
-        'Asset Type',
-        'Asset'
-      ],
       editedAsset: null,
       editedEntityId: null,
       editedAssetLinkLabel: null,
@@ -380,6 +365,39 @@ export default {
         }
       })
       return casting
+    },
+
+    csvColumns () {
+      return this.isTVShow
+        ? [
+          'Episode',
+          'Parent',
+          'Name',
+          'Asset Type',
+          'Asset',
+          'Occurences',
+          'Label'
+        ] : [
+          'Parent',
+          'Name',
+          'Asset Type',
+          'Asset',
+          'Occurences',
+          'Label'
+        ]
+    },
+
+    dataMatchers () {
+      return this.isTVShow
+        ? [
+          'Episode',
+          'Name',
+          'Asset Type',
+          'Asset'
+        ] : ['Name',
+          'Asset Type',
+          'Asset'
+        ]
     }
   },
 

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -344,7 +344,13 @@ export default {
     },
 
     castingEntities () {
-      return this.isShotCasting ? this.castingSequenceShots : this.castingAssetTypeAssets
+      if (this.isShotCasting) return this.castingSequenceShots
+      else {
+        if (this.isTVShow) {
+          return this.castingAssetTypeAssets.filter(
+            asset => asset.episode_id === this.currentEpisode.id)
+        } else return this.castingAssetTypeAssets
+      }
     },
 
     editLabelModal () {
@@ -455,6 +461,9 @@ export default {
             this.isLoading = false
             this.displayMoreAssets()
             this.setCastingAssetTypes()
+            if (this.assetTypeId) {
+              this.setCastingAssetType(this.assetTypeId)
+            }
             this.resetSelection()
           })
       })


### PR DESCRIPTION
**Problem**
- when we want to upload a csv for breakdown it always need "episode" column 
- when we do breakdown for assets it's not filtered by episode for a tv show
- when we do breakdown for assets and we change the currently selected episode it's not correctly reloaded 

**Solution**
- if it's not a tv show we don't need an "episode" column when uploading a csv
- filter assets by episode for a tv show
- correctly reload assets when we select a different episode for a tv show

This PR is related to this one : 
https://github.com/cgwire/zou/pull/458
