### PR TITLE
Change todo task_status name/short_name/color + fix supervisor permission 

### DIFF
--- a/src/components/cells/TaskStatusName.vue
+++ b/src/components/cells/TaskStatusName.vue
@@ -37,7 +37,7 @@ export default {
     ]),
 
     color () {
-      if (this.entry.short_name === 'todo' && this.isDarkTheme) {
+      if (this.entry.is_default && this.isDarkTheme) {
         return '#5F626A'
       } else {
         return this.entry.color
@@ -45,7 +45,7 @@ export default {
     },
 
     textColor () {
-      if (this.entry.short_name === 'todo' && !this.isDarkTheme) {
+      if (this.entry.is_default && !this.isDarkTheme) {
         return '#333'
       } else {
         return 'white'

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -206,9 +206,9 @@ export default {
     },
 
     backgroundColor () {
-      if (this.taskStatus.short_name === 'todo' && !this.isDarkTheme) {
+      if (this.taskStatus.is_default && !this.isDarkTheme) {
         return '#ECECEC'
-      } else if (this.taskStatus.short_name === 'todo' && this.isDarkTheme) {
+      } else if (this.taskStatus.is_default && this.isDarkTheme) {
         return '#5F626A'
       } else if (this.isDarkTheme) {
         return colors.darkenColor(this.taskStatus.color)
@@ -218,7 +218,7 @@ export default {
     },
 
     color () {
-      if (this.taskStatus.short_name !== 'todo' || this.isDarkTheme) {
+      if (!this.taskStatus.is_default || this.isDarkTheme) {
         return 'white'
       } else {
         return '#333'

--- a/src/components/lists/TaskStatusList.vue
+++ b/src/components/lists/TaskStatusList.vue
@@ -13,6 +13,9 @@
           <th scope="col" class="is-done">
             {{ $t('task_status.fields.is_done') }}
           </th>
+          <th scope="col" class="is-default">
+            {{ $t('task_status.fields.is_default') }}
+          </th>
           <th scope="col" class="is-retake">
             {{ $t('task_status.fields.is_retake') }}
           </th>
@@ -37,6 +40,9 @@
           <td class="is-done">
             {{ formatBoolean(entry.is_done) }}
           </td>
+          <td class="is-default">
+            {{ formatBoolean(entry.is_default) }}
+          </td>
           <td class="is-retake">
             {{ formatBoolean(entry.is_retake) }}
           </td>
@@ -51,8 +57,7 @@
           </td>
           <row-actions-cell
             :entry-id="entry.id"
-            :hide-edit="entry.short_name === 'todo'"
-            :hide-delete="entry.short_name === 'todo'"
+            :hide-delete="entry.is_default === true"
             @edit-clicked="$emit('edit-clicked', entry)"
             @delete-clicked="$emit('delete-clicked', entry)"
           />
@@ -126,6 +131,7 @@ export default {
 
 .is-reviewable,
 .is-done,
+.is-default,
 .is-retake,
 .is-artist-allowed,
 .is-client-allowed {

--- a/src/components/modals/EditTaskStatusModal.vue
+++ b/src/components/modals/EditTaskStatusModal.vue
@@ -114,7 +114,6 @@ export default {
         name: '',
         short_name: '',
         color: '$grey999',
-        is_reviewable: 'true',
         is_done: 'false',
         is_feedback_request: 'false'
       },
@@ -182,7 +181,6 @@ export default {
           name: this.taskStatusToEdit.name,
           short_name: this.taskStatusToEdit.short_name,
           color: this.taskStatusToEdit.color,
-          is_reviewable: String(this.taskStatusToEdit.is_reviewable),
           is_done: String(this.taskStatusToEdit.is_done),
           is_retake: String(this.taskStatusToEdit.is_retake || false),
           is_artist_allowed: String(this.taskStatusToEdit.is_artist_allowed),

--- a/src/components/modals/EditTaskStatusModal.vue
+++ b/src/components/modals/EditTaskStatusModal.vue
@@ -37,26 +37,31 @@
           :label="$t('task_status.fields.is_done')"
           @enter="confirmClicked"
           v-model="form.is_done"
+          v-if="form.is_default === 'false'"
         />
         <combobox-boolean
           :label="$t('task_status.fields.is_retake')"
           @enter="confirmClicked"
           v-model="form.is_retake"
+          v-if="form.is_default === 'false'"
         />
         <combobox-boolean
           :label="$t('task_status.fields.is_artist_allowed')"
           @enter="confirmClicked"
           v-model="form.is_artist_allowed"
+          v-if="form.is_default === 'false'"
         />
         <combobox-boolean
           :label="$t('task_status.fields.is_client_allowed')"
           @enter="confirmClicked"
           v-model="form.is_client_allowed"
+          v-if="form.is_default === 'false'"
         />
         <combobox-boolean
           :label="$t('task_status.fields.is_feedback_request')"
           @enter="confirmClicked"
           v-model="form.is_feedback_request"
+          v-if="form.is_default === 'false'"
         />
 
         <color-field
@@ -115,7 +120,8 @@ export default {
         short_name: '',
         color: '$grey999',
         is_done: 'false',
-        is_feedback_request: 'false'
+        is_feedback_request: 'false',
+        is_default: 'false'
       },
       isRetakeOptions: [
         { label: this.$t('main.yes'), value: 'true' },
@@ -185,6 +191,7 @@ export default {
           is_retake: String(this.taskStatusToEdit.is_retake || false),
           is_artist_allowed: String(this.taskStatusToEdit.is_artist_allowed),
           is_client_allowed: String(this.taskStatusToEdit.is_client_allowed),
+          is_default: String(this.taskStatusToEdit.is_default || false),
           is_feedback_request:
             String(this.taskStatusToEdit.is_feedback_request || false)
         }

--- a/src/components/pages/ProductionNewsFeed.vue
+++ b/src/components/pages/ProductionNewsFeed.vue
@@ -99,7 +99,7 @@
               :title="stat.name + ': ' + stat.value"
               :style="{
                 background: stat.color,
-                color: stat.name === 'TODO' ? '#666' : 'white'
+                color: stat.is_default ? '#666' : 'white'
               }"
             >
              {{ stat.name }} : {{ stat.value }}

--- a/src/components/pages/production/NewProduction.vue
+++ b/src/components/pages/production/NewProduction.vue
@@ -696,7 +696,7 @@ export default {
       return this.taskStatus.filter(
         status => (
           this.productionToCreate.taskStatuses.indexOf(status) === -1 &&
-          status.short_name !== 'todo'
+          !status.is_default
         )
       )
     },

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -378,6 +378,7 @@ export default {
       'getTaskStatusForCurrentUser',
       'isCurrentUserAdmin',
       'isCurrentUserClient',
+      'isCurrentUserSupervisor',
       'isCurrentUserManager',
       'isSingleEpisode',
       'isTVShow',
@@ -417,13 +418,26 @@ export default {
     },
 
     isCommentingAllowed () {
-      if (!this.task) return false
-      const isManager = this.isCurrentUserManager
-      const isAssigned = this.task.assignees.find(
-        (personId) => personId === this.user.id
-      )
-      const isClient = this.isCurrentUserClient
-      return isManager || isAssigned || isClient
+      if (this.task) {
+        if (this.isCurrentUserManager) {
+          return true
+        } else if (this.isCurrentUserSupervisor) {
+          if (this.user.departments.length === 0) {
+            return true
+          } else {
+            const taskType = this.taskTypeMap.get(this.task.task_type_id)
+            return taskType.department_id && this.user.departments.includes(
+              taskType.department_id)
+          }
+        } else if (this.isCurrentUserClient) {
+          return true
+        } else if (this.task.assignees.find(
+          (personId) => personId === this.user.id
+        )) {
+          return true
+        }
+      }
+      return false
     },
 
     isSetThumbnailAllowed () {

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -285,7 +285,7 @@ export default {
     taskStatusColor () {
       const status = this.taskStatus.find(t => t.id === this.task_status_id) ||
         this.taskStatus[0]
-      if (status.short_name === 'todo') return '#666'
+      if (status.is_default) return '#666'
       const color = status.color
       if (this.isDarkTheme) {
         return colors.darkenColor(color)

--- a/src/components/widgets/ComboboxStatus.vue
+++ b/src/components/widgets/ComboboxStatus.vue
@@ -148,12 +148,12 @@ export default {
 
     backgroundColor (taskStatus) {
       if (
-        (!taskStatus || taskStatus.short_name === 'todo') &&
+        (!taskStatus || taskStatus.is_default) &&
         !this.isDarkTheme
       ) {
         return '#ECECEC'
       } else if (
-        (!taskStatus || taskStatus.short_name === 'todo') &&
+        (!taskStatus || taskStatus.is_default) &&
         this.isDarkTheme
       ) {
         return '#5F626A'
@@ -165,7 +165,7 @@ export default {
     },
 
     color (taskStatus) {
-      if ((!taskStatus || taskStatus.short_name !== 'todo') || this.isDarkTheme) {
+      if ((!taskStatus || !taskStatus.is_default) || this.isDarkTheme) {
         return 'white'
       } else {
         return '#333'

--- a/src/components/widgets/ComboboxStatusAutomation.vue
+++ b/src/components/widgets/ComboboxStatusAutomation.vue
@@ -134,12 +134,12 @@ export default {
 
     backgroundColor (statusAutomation) {
       if (
-        (!statusAutomation || statusAutomation.short_name === 'todo') &&
+        (!statusAutomation || statusAutomation.is_default) &&
         !this.isDarkTheme
       ) {
         return '#ECECEC'
       } else if (
-        (!statusAutomation || statusAutomation.short_name === 'todo') &&
+        (!statusAutomation || statusAutomation.is_default) &&
         this.isDarkTheme
       ) {
         return '#5F626A'
@@ -151,7 +151,7 @@ export default {
     },
 
     color (statusAutomation) {
-      if ((!statusAutomation || statusAutomation.short_name !== 'todo') || this.isDarkTheme) {
+      if ((!statusAutomation || !statusAutomation.is_default) || this.isDarkTheme) {
         return 'white'
       } else {
         return '#333'

--- a/src/components/widgets/ValidationTag.vue
+++ b/src/components/widgets/ValidationTag.vue
@@ -106,9 +106,9 @@ export default {
     },
 
     backgroundColor () {
-      if (this.taskStatus.short_name === 'todo' && !this.isDarkTheme) {
+      if (this.taskStatus.is_default && !this.isDarkTheme) {
         return '#ECECEC'
-      } else if (this.taskStatus.short_name === 'todo' && this.isDarkTheme) {
+      } else if (this.taskStatus.is_default && this.isDarkTheme) {
         return '#5F626A'
       } else if (this.isDarkTheme) {
         return colors.darkenColor(this.taskStatus.color)
@@ -118,7 +118,7 @@ export default {
     },
 
     color () {
-      if (this.taskStatus.short_name !== 'todo' || this.isDarkTheme) {
+      if (this.taskStatus.is_default || this.isDarkTheme) {
         return 'white'
       } else {
         return '#333'
@@ -146,7 +146,7 @@ export default {
 
     tagStyle () {
       const isStatic = !this.isStatic && !this.isCurrentUserClient
-      const isTodo = this.taskStatus.short_name.toLowerCase() === 'todo'
+      const isTodo = this.taskStatus.is_default
       if (this.thin && !isTodo) {
         return {
           background: 'transparent',

--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -9,7 +9,7 @@ export const getChartData =
     return Object.keys(statusData)
       .map((taskStatusId) => {
         const data = statusData[taskStatusId]
-        const color = data.name === 'todo' ? '#6F727A' : data.color
+        const color = data.is_default ? '#6F727A' : data.color
         return [data.name, data[valueField], color]
       })
       .sort(_sortData)

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -583,6 +583,7 @@ export default {
       color: 'Farbe',
       is_done: 'Ist erledigt',
       is_retake: 'Hat Wiederholungswert',
+      is_default: 'Is default',
       name: 'Name',
       short_name: 'Kurzname'
     }

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -582,7 +582,6 @@ export default {
       is_client_allowed: 'Ist der Kunde erlaubt',
       color: 'Farbe',
       is_done: 'Ist erledigt',
-      is_reviewable: 'Ist überprüfbar',
       is_retake: 'Hat Wiederholungswert',
       name: 'Name',
       short_name: 'Kurzname'

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -828,6 +828,7 @@ export default {
       is_done: 'Is done',
       is_feedback_request: 'Is feedback request',
       is_retake: 'Has retake value',
+      is_default: 'Is default',
       name: 'Name',
       short_name: 'Short name'
     }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -827,7 +827,6 @@ export default {
       is_client_allowed: 'Is client allowed',
       is_done: 'Is done',
       is_feedback_request: 'Is feedback request',
-      is_reviewable: 'Is reviewable',
       is_retake: 'Has retake value',
       name: 'Name',
       short_name: 'Short name'

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -692,6 +692,7 @@
                 "is_client_allowed": "Se permite al cliente",
                 "is_done": "Se hace",
                 "is_retake": "Tiene valor de retake",
+                "is_default": "Is default",
                 "name": "Nombre",
                 "short_name": "Denominación breve"
             },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -691,7 +691,6 @@
                 "is_artist_allowed": "Se permite al artista",
                 "is_client_allowed": "Se permite al cliente",
                 "is_done": "Se hace",
-                "is_reviewable": "Es revisable",
                 "is_retake": "Tiene valor de retake",
                 "name": "Nombre",
                 "short_name": "Denominación breve"

--- a/src/locales/fa.js
+++ b/src/locales/fa.js
@@ -568,7 +568,6 @@ export default {
       is_client_allowed: 'این مشتری اجازه دارد',
       color: 'رنگ',
       is_done: 'انجام شده',
-      is_reviewable: 'قابل بررسی',
       is_retake: 'بازنگری',
       name: 'نام',
       short_name: 'اسم کوتاه'

--- a/src/locales/fa.js
+++ b/src/locales/fa.js
@@ -566,6 +566,7 @@ export default {
     fields: {
       is_artist_allowed: 'این هنرمند اجازه دارد',
       is_client_allowed: 'این مشتری اجازه دارد',
+      is_default: 'Is default',
       color: 'رنگ',
       is_done: 'انجام شده',
       is_retake: 'بازنگری',

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -708,7 +708,6 @@
                 "is_artist_allowed": "Autorisé aux artistes",
                 "is_client_allowed": "Autorisé aux clents",
                 "is_done": "Est terminé",
-                "is_reviewable": "Est vérifiable",
                 "is_retake": "A valeur de retake",
                 "name": "Nom",
                 "short_name": "Nom court",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -707,6 +707,7 @@
                 "color": "Couleur",
                 "is_artist_allowed": "Autorisé aux artistes",
                 "is_client_allowed": "Autorisé aux clents",
+                "is_default": "Is default",
                 "is_done": "Est terminé",
                 "is_retake": "A valeur de retake",
                 "name": "Nom",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -690,6 +690,7 @@
                 "color": "Szín",
                 "is_artist_allowed": "Művész választhatja?",
                 "is_client_allowed": "Megrendelő állíthatja?",
+                "is_default": "Is default",
                 "is_done": "Kész?",
                 "is_retake": "Újraforgatás?",
                 "name": "Név",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -691,7 +691,6 @@
                 "is_artist_allowed": "Művész választhatja?",
                 "is_client_allowed": "Megrendelő állíthatja?",
                 "is_done": "Kész?",
-                "is_reviewable": "Ellenőrizendő?",
                 "is_retake": "Újraforgatás?",
                 "name": "Név",
                 "short_name": "Rövid név"

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -691,7 +691,6 @@
                 "is_artist_allowed": "Is artist toegestaan",
                 "is_client_allowed": "Is klant toegestaan",
                 "is_done": "Is klaar",
-                "is_reviewable": "Kan beoordeeld worden",
                 "is_retake": "Heeft heropnamewaarde",
                 "name": "Naam",
                 "short_name": "Korte naam"

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -690,6 +690,7 @@
                 "color": "Kleur",
                 "is_artist_allowed": "Is artist toegestaan",
                 "is_client_allowed": "Is klant toegestaan",
+                "is_default": "Is default",
                 "is_done": "Is klaar",
                 "is_retake": "Heeft heropnamewaarde",
                 "name": "Naam",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -564,6 +564,7 @@
                 "color": "Cor",
                 "is_artist_allowed": "Artista é permitido",
                 "is_client_allowed": "O cliente é permitido",
+                "is_default": "Is default",
                 "is_done": "Está feito",
                 "is_retake": "Tem valor de retomada",
                 "name": "Nome",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -565,7 +565,6 @@
                 "is_artist_allowed": "Artista é permitido",
                 "is_client_allowed": "O cliente é permitido",
                 "is_done": "Está feito",
-                "is_reviewable": "É revisável",
                 "is_retake": "Tem valor de retomada",
                 "name": "Nome",
                 "short_name": "Nome do curta"

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -589,6 +589,7 @@ export default {
       is_artist_allowed: 'Видна художнику',
       is_client_allowed: 'Видна клиенту',
       is_done: 'Готово',
+      is_default: 'Is default',
       is_retake: 'Отправлялся на доработку',
       name: 'Название',
       short_name: 'Краткое название'

--- a/src/locales/ru.js
+++ b/src/locales/ru.js
@@ -589,7 +589,6 @@ export default {
       is_artist_allowed: 'Видна художнику',
       is_client_allowed: 'Видна клиенту',
       is_done: 'Готово',
-      is_reviewable: 'Можно проверить',
       is_retake: 'Отправлялся на доработку',
       name: 'Название',
       short_name: 'Краткое название'

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -707,6 +707,7 @@
                 "color": "颜色",
                 "is_artist_allowed": "艺术家允许",
                 "is_client_allowed": "客户允许",
+                "is_default": "Is default",
                 "is_done": "已完成",
                 "is_retake": "重新赋值",
                 "name": "名称",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -708,7 +708,6 @@
                 "is_artist_allowed": "艺术家允许",
                 "is_client_allowed": "客户允许",
                 "is_done": "已完成",
-                "is_reviewable": "可审查",
                 "is_retake": "重新赋值",
                 "name": "名称",
                 "short_name": "简称",

--- a/src/locales/zh_tw.json
+++ b/src/locales/zh_tw.json
@@ -691,7 +691,6 @@
                 "is_artist_allowed": "Artist允許",
                 "is_client_allowed": "客戶允許",
                 "is_done": "已完成",
-                "is_reviewable": "可審查",
                 "is_retake": "重新賦值",
                 "name": "名稱",
                 "short_name": "簡稱"

--- a/src/locales/zh_tw.json
+++ b/src/locales/zh_tw.json
@@ -691,6 +691,7 @@
                 "is_artist_allowed": "Artist允許",
                 "is_client_allowed": "客戶允許",
                 "is_done": "已完成",
+                "is_default": "Is default",
                 "is_retake": "重新賦值",
                 "name": "名稱",
                 "short_name": "簡稱"

--- a/src/store/api/taskstatus.js
+++ b/src/store/api/taskstatus.js
@@ -4,7 +4,6 @@ const sanitizeTaskStatus = (taskStatus) => {
   return {
     name: taskStatus.name,
     short_name: taskStatus.short_name,
-    is_reviewable: Boolean(taskStatus.is_reviewable === 'true'),
     is_done: Boolean(taskStatus.is_done === 'true'),
     is_retake: Boolean(taskStatus.is_retake === 'true'),
     is_artist_allowed: Boolean(taskStatus.is_artist_allowed === 'true'),

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -428,7 +428,7 @@ const actions = {
 
   deleteTaskComment ({ commit, rootState }, { taskId, commentId, callback }) {
     const todoStatus = rootState.taskStatus.taskStatus.find((taskStatus) => {
-      return taskStatus.short_name === 'todo'
+      return taskStatus.is_default
     })
     return tasksApi.deleteTaskComment(taskId, commentId)
       .then(() => {

--- a/tests/unit/lib/colors.spec.js
+++ b/tests/unit/lib/colors.spec.js
@@ -4,7 +4,8 @@ describe('colors', () => {
   test('validationTextColor', () => {
     const taskTodo = {
       id: 'task-1',
-      task_status_short_name: 'todo'
+      task_status_short_name: 'todo',
+      is_default: true
     }
     const taskRunning = {
       id: 'task-1',

--- a/tests/unit/store/assets.spec.js
+++ b/tests/unit/store/assets.spec.js
@@ -1058,7 +1058,8 @@ describe('Assets store', () => {
       taskTypesStore.state.taskTypeMap = taskTypeMap
       tasksStore.state.taskStatusMap = new Map(Object.entries({
         todo: {
-          short_name: 'TODO'
+          short_name: 'TODO',
+          is_default: true
         }
       }))
       const state = {


### PR DESCRIPTION
**Problem**
- We can't edit name/short_name/color of the "todo" task_status
- taskStatus.is_reviewable is deprecated
- a supervisor can't comment tasks in his departments

**Solution**
- add new column taskStatus.is_default
- drop column taskStatus.is_reviewable
- fix permission related to supervisor

This is PR is related to this Zou PR : https://github.com/cgwire/zou/pull/460