### PR TITLE
[qa] Fix edit of assets metadata descriptors

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -239,13 +239,7 @@ export default {
       },
 
       'asset:update' (eventData) {
-        console.log(
-          'asset-update',
-          eventData,
-          this.assetMap.get(eventData.asset_id)
-        )
         if (this.assetMap.get(eventData.asset_id)) {
-          console.log('asset-update ok reload')
           this.loadAsset(eventData.asset_id)
         }
       },

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -1030,19 +1030,6 @@ export default {
     }
   },
 
-  socket: {
-    events: {
-      'asset:update' (eventData) {
-        // TODO Would loadAsset be more optimized? Its logic is not fully adapted to do it smartly
-        // if (this.assetMap.get(eventData.asset_id)) {
-        //   this.loadAsset(eventData.asset_id)
-        // }
-
-        this.loadAssets()
-      }
-    }
-  },
-
   metaInfo () {
     if (this.isTVShow) {
       return { title: this.tvShowPageTitle }

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -1076,7 +1076,6 @@ const actions = {
 
 const mutations = {
   [LOAD_EPISODES_START] (state) {
-    console.log('LOAD_EPISODES_START')
     cache.episodes = []
     cache.result = []
     cache.episodeIndex = {}


### PR DESCRIPTION
**Problem**
- When editing a metadata descriptor in assets page in always reload the assets

**Solution**
- Remove the useless socket io event listener in assets page + console.log
