### PR TITLE
[qa][comment] Fix date in comments (it was in HH:mm if it wasn't the …

### DIFF
--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -542,10 +542,10 @@ export default {
 
     renderDate (date) {
       date = moment(date)
-      if (moment().diff(date, 'days') > 1) {
-        return date.tz(this.user.timezone).format('MM/DD')
-      } else {
+      if (moment().isSame(date, 'd')) {
         return date.tz(this.user.timezone).format('HH:mm')
+      } else {
+        return date.tz(this.user.timezone).format('MM/DD')
       }
     },
 


### PR DESCRIPTION
…same day than today, typically if the date of the comment was yesterday less than 24 hours ago)

**Problem**
- The date in comments is not correctly displayed, typically if a comment is posted yesterday (less than 24 hours ago) the comment date is displayed as HH:mm 

**Solution**
- It was in HH:mm if the difference between now and the comment date was < at 24 hours (1 day). It has to be the same day instead. 
