### PR TITLE
[qa] fix links in schedule when we click on task types

### DIFF
--- a/src/lib/path.js
+++ b/src/lib/path.js
@@ -155,7 +155,13 @@ export const getTaskTypeSchedulePath = (
 ) => {
   const route = getContextRoute('task-type-schedule', productionId, episodeId)
   route.params.task_type_id = taskTypeId
-  route.params.type = type
+  if (type === 'shot') {
+    route.params.type = 'shots'
+  } else if (type === 'asset') {
+    route.params.type = 'assets'
+  } else if (type === 'edit') {
+    route.params.type = 'edits'
+  }
   return route
 }
 

--- a/tests/unit/lib/path.spec.js
+++ b/tests/unit/lib/path.spec.js
@@ -237,7 +237,7 @@ describe('path', () => {
       name: 'task-type-schedule',
       params: {
         task_type_id: 1,
-        type: 'shot',
+        type: 'shots',
         production_id: 2
       }
     })
@@ -245,7 +245,7 @@ describe('path', () => {
       name: 'episode-task-type-schedule',
       params: {
         task_type_id: 1,
-        type: 'shot',
+        type: 'shots',
         production_id: 2,
         episode_id: 3
       }


### PR DESCRIPTION
**Problem**
https://github.com/cgwire/kitsu/issues/880
Links in the schedule page are broken

**Solution**
Fix link construction (assets, shots, edits needs to be plural)