### PR TITLE
[todos] show metadata-columns according to user departments in todos/…

### DIFF
--- a/scripts/missinglocales.js
+++ b/scripts/missinglocales.js
@@ -12,7 +12,7 @@ const firstLevelKeysEn = Object.keys(en.default)
 
 const locales = [fr, es, de]
 
-  locales.forEach(locale => {
+locales.forEach(locale => {
   const firstLevelKeysComp = Object.keys(locale.default)
   const difference = firstLevelKeysEn.filter(
     x => !firstLevelKeysComp.includes(x)

--- a/src/components/cells/MetadataHeader.vue
+++ b/src/components/cells/MetadataHeader.vue
@@ -19,6 +19,7 @@
       <span
         class="metadata-menu-button header-icon"
         @click="$emit('show-metadata-header-menu', $event)"
+        v-if="!noMenu"
       >
         <chevron-down-icon
           :size="'12'"
@@ -47,6 +48,10 @@ export default {
     left: {
       type: String,
       default: '0px'
+    },
+    noMenu: {
+      type: Boolean,
+      default: false
     }
   },
   components: { ChevronDownIcon, DepartmentName },

--- a/src/components/lists/TimeSpentTaskList.vue
+++ b/src/components/lists/TimeSpentTaskList.vue
@@ -141,7 +141,6 @@ export default {
 
     getTaskPath (task) {
       const project = this.productionMap.get(task.project_id)
-      console.log(project)
       const isTVShow = project.production_type === 'tvshow'
       const episode = { id: project.first_episode_id }
       return getTaskPath(task, null, isTVShow, episode, this.taskTypeMap)

--- a/src/components/mixins/descriptors.js
+++ b/src/components/mixins/descriptors.js
@@ -120,7 +120,13 @@ export const descriptorMixin = {
     },
 
     getMetadataFieldValue (descriptor, entity) {
-      return entity.data ? entity.data[descriptor.field_name] || '' : ''
+      if (entity.data) {
+        return entity.data[descriptor.field_name] || ''
+      } else if (entity.entity_data) {
+        return entity.entity_data[descriptor.field_name] || ''
+      } else {
+        return ''
+      }
     },
 
     getDescriptorChecklistValues (descriptor) {


### PR DESCRIPTION
…done

**Problem**
- we can't see metadata-columns in todos/done page 

**Solution**
- show metadata-columns according to the user's departments 

We need this PR for Zou : https://github.com/cgwire/zou/pull/481
