### PR TITLE
various commits

### DIFF
--- a/src/components/cells/DescriptionCell.vue
+++ b/src/components/cells/DescriptionCell.vue
@@ -104,6 +104,11 @@ export default {
         event.keyCode === 27
       ) {
         this.isOpen = !this.isOpen
+        if (!this.isOpen && this.isEditing) {
+          this.isEditing = false
+          const val = this.$refs.text.value
+          this.$emit('description-changed', val)
+        }
       }
     },
 

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -909,6 +909,7 @@ export default {
     castingType () {
       if (this.isShotCasting && this.sequences.length > 0) {
         this.sequenceId = this.sequences[0].id
+        this.assetTypeId = ''
       }
       if (this.isAssetCasting && this.castingAssetTypesOptions.length > 0) {
         const assetTypeId = this.$route.params.asset_type_id
@@ -935,7 +936,7 @@ export default {
     },
 
     assetTypeId () {
-      if (this.castingAssetTypesOptions) {
+      if (this.assetTypeId && this.castingAssetTypesOptions.length > 0) {
         this.setCastingAssetType(this.assetTypeId)
         this.updateUrl()
         this.resetSelection()

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -261,6 +261,7 @@ import { getTaskTypeStyle } from '@/lib/render'
 import csv from '@/lib/csv'
 import drafts from '@/lib/drafts'
 import stringHelpers from '@/lib/string'
+import { formatDate } from '@/lib/time'
 
 import AddComment from '@/components/widgets/AddComment'
 import AddPreviewModal from '@/components/modals/AddPreviewModal'
@@ -1036,7 +1037,7 @@ export default {
       var commentLines = []
       this.getCurrentTaskComments().forEach(comment => {
         commentLines.push([
-          comment.created_at,
+          formatDate(comment.created_at),
           comment.task_status.name,
           comment.person.name,
           comment.text,
@@ -1050,7 +1051,7 @@ export default {
         if (comment.replies) {
           comment.replies.forEach(reply =>
             commentLines.push([
-              reply.date,
+              formatDate(reply.date),
               'Reply',
               this.personMap.get(reply.person_id).name,
               reply.text


### PR DESCRIPTION
**Problem**
- navigation between assets/shots is broken in the breakdown we change multiple time shots to assets (assets will not reload)
- description-cell are not saved when we quit (only with ctrl+enter)
- comment.created_at column in csv exports of comments are not formatted with timezone 

**Solution**
- fix navigation between assets/shots in breakdown
- save description when we quit not only with ctrl+enter
- format comment.created_at column in csv exports of comments with timezone
