### PR TITLE
[qa] Fix extract annotations when player is in fullscreen

### DIFF
--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1020,8 +1020,10 @@ export default {
     },
 
     async extractAnnotationSnapshots () {
+      let previewPlayer = this.$refs['preview-player']
+      if (!previewPlayer) previewPlayer = this.$parent
       this.$refs['add-comment'].showAnnotationLoading()
-      const files = await this.$refs['preview-player'].extractAnnotationSnapshots()
+      const files = await previewPlayer.extractAnnotationSnapshots()
       this.$refs['add-comment'].hideAnnotationLoading()
       this.$refs['add-comment'].setAnnotationSnapshots(files)
       return files


### PR DESCRIPTION
**Problem**
- when play is in fullscreen we can't extract annotations

**Solution**
- fix extract annotations when play is in fullscreen
