### PR TITLE
Various improvements (for playilsts mainly)

### DIFF
--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -501,13 +501,27 @@ export const annotationMixin = {
       let o = obj.target
       o = this.setObjectData(o)
       // if (this.fabricCanvas.width < 420) o.strokeWidth *= 2
-      this.addToAdditions(o)
-      this.stackAddAction(obj)
+      if (this.isLaserModeOn) {
+        this.fadeObject(o)
+      } else {
+        this.addToAdditions(o)
+        this.stackAddAction(obj)
+      }
     },
 
     onObjectMoved (obj) {
       this.addToUpdates(obj.target)
       this.saveAnnotations()
+    },
+
+    fadeObject (obj) {
+      obj.animate('opacity', '0', {
+        duration: 1500,
+        onChange: this.fabricCanvas.renderAll.bind(this.fabricCanvas),
+        onComplete: () => {
+          this.fabricCanvas.remove(obj)
+        }
+      })
     },
 
     // Undo / Redo

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -84,7 +84,6 @@
           @change="onSearchChange"
           @save="saveSearchQuery"
           :can-save="true"
-          v-if="!isActiveTab('done')"
         />
         <span class="filler"></span>
         <combobox
@@ -138,7 +137,7 @@
         :is-error="isTasksLoadingError"
         :time-spent-map="personTimeSpentMap"
         :time-spent-total="personTimeSpentTotal"
-        :hide-done="personTasksSearchText.length > 0"
+        :hide-done="personTasksSearchText.length === 0"
         :hide-day-off="!(isCurrentUserAdmin || this.user.id == this.person.id)"
         @date-changed="onDateChanged"
         @time-spent-change="onTimeSpentChange"

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -1204,7 +1204,7 @@ export default {
         p => p.revision === parseInt(versionRevision)
       ))
       setTimeout(() => {
-        this.$refs['preview-player'].setCurrentFrame(frame - 1)
+        this.$refs['preview-player'].setCurrentFrame(frame)
         this.$refs['preview-player'].focus()
       }, 20)
     },

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -22,6 +22,31 @@
     <span class="flexrow-item playlist-name">
       {{ playlist.name }}
     </span>
+    <button-simple
+      @click="isAnnotationsDisplayed = !isAnnotationsDisplayed"
+      :class="{
+        'playlist-button': true,
+        'topbar-button': true,
+        'flexrow-item': true,
+        active: isAnnotationsDisplayed
+      }"
+      icon="pen"
+      :title="$t('playlists.actions.toggle_annotations')"
+      v-if="isCurrentUserManager && !isAddingEntity"
+    />
+    <button-simple
+      @click="isLaserModeOn = !isLaserModeOn"
+      :class="{
+        'playlist-button': true,
+        'topbar-button': true,
+        'flexrow-item': true,
+        active: isLaserModeOn
+      }"
+      class="playlist-button topbar-button flexrow-item"
+      icon="laser"
+      :title="$t('playlists.actions.toggle_annotations')"
+      v-if="isCurrentUserManager && !isAddingEntity"
+    />
     <preview-room
       :ref="previewRoomRef"
       :roomId="isValidRoomId(playlist.id) ? playlist.id : ''"
@@ -203,7 +228,7 @@
         class="canvas-wrapper"
         ref="canvas-wrapper"
         oncontextmenu="return false;"
-        v-show="!isCurrentPreviewFile"
+        v-show="!isCurrentPreviewFile && isAnnotationsDisplayed"
       >
         <canvas
           id="playlist-annotation-canvas"
@@ -880,8 +905,12 @@ export default {
       comparisonEntityMissing: false,
       comparisonMode: 'sidebyside',
       currentComparisonPreviewIndex: 0,
+      handleIn: 0,
+      handleOut: 0,
+      isAnnotationsDisplayed: true,
       isBuildLaunched: false,
       isDlButtonsHidden: true,
+      isLaserModeOn: false,
       isShowingPalette: false,
       isShowingPencilPalette: false,
       isShowAnnotationsWhilePlaying: false,
@@ -1773,6 +1802,10 @@ export default {
       border: 1px solid $dark-grey-strong;
       border-radius: 10px;
       margin-right: 0.5em;
+
+      &.active {
+        color: $white;
+      }
     }
   }
 }

--- a/src/components/pages/playlists/RawVideoPlayer.vue
+++ b/src/components/pages/playlists/RawVideoPlayer.vue
@@ -65,6 +65,14 @@ export default {
     name: { // Debug purpose
       type: String,
       default: 'main'
+    },
+    handleIn: {
+      type: Number,
+      default: 0
+    },
+    handleOut: {
+      type: Number,
+      default: 0
     }
   },
 
@@ -324,10 +332,13 @@ export default {
       }, 1000 / this.fps)
     },
 
-    playNext () {
+    playNext (handleIn) {
       if (!this.isPlaying) return
+      handleIn = handleIn || this.handleIn
       if (this.isRepeating) {
-        this.currentPlayer.currentTime = this.frameDuration
+        this.currentPlayer.currentTime = this.handleIn
+          ? this.handleIn * this.frameDuration
+          : this.frameDuration
         this.currentPlayer.play()
         this.$emit('repeat')
       } else {
@@ -337,6 +348,9 @@ export default {
 
         if (this.currentPlayer) this.currentPlayer.style.display = 'none'
         if (this.nextPlayer) {
+          this.nextPlayer.currentTime = handleIn
+            ? handleIn * this.frameDuration
+            : this.frameDuration
           this.nextPlayer.style.display = 'block'
           this.nextPlayer.play()
         }

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1022,7 +1022,7 @@ export default {
         p => p.revision === parseInt(versionRevision)
       ))
       setTimeout(() => {
-        this.$refs['preview-player'].setCurrentFrame(frame - 1)
+        this.$refs['preview-player'].setCurrentFrame(frame)
         this.$refs['preview-player'].focus()
       }, 20)
     },

--- a/src/components/widgets/ButtonSimple.vue
+++ b/src/components/widgets/ButtonSimple.vue
@@ -155,7 +155,20 @@
     :class="iconClass"
     v-if="icon === 'music'"
   />
-
+  <pen-tool-icon
+    :class="iconClass"
+    v-if="icon === 'pen'"
+  />
+  <square-icon
+    :class="iconClass"
+    v-if="icon === 'eraser'"
+  />
+  <span
+    :class="iconClass"
+    v-if="icon === 'laser'"
+  >
+    ⦿
+  </span>
   <span
     :class="{
       text: true,
@@ -190,6 +203,7 @@ import {
   MusicIcon,
   PaperclipIcon,
   PauseIcon,
+  PenToolIcon,
   PlayIcon,
   PlusIcon,
   RefreshCwIcon,
@@ -199,10 +213,11 @@ import {
   SendIcon,
   SkipBackIcon,
   SkipForwardIcon,
+  SquareIcon,
   TrashIcon,
   TypeIcon,
-  UploadIcon,
   TriangleIcon,
+  UploadIcon,
   VolumeXIcon,
   Volume2Icon,
   XIcon
@@ -231,6 +246,7 @@ export default {
     MusicIcon,
     PaperclipIcon,
     PauseIcon,
+    PenToolIcon,
     PlayIcon,
     PlusIcon,
     RefreshCwIcon,
@@ -240,6 +256,7 @@ export default {
     SendIcon,
     SkipBackIcon,
     SkipForwardIcon,
+    SquareIcon,
     TrashIcon,
     TypeIcon,
     UploadIcon,

--- a/src/store/modules/people.js
+++ b/src/store/modules/people.js
@@ -125,7 +125,10 @@ const helpers = {
 }
 
 const cache = {
-  peopleIndex: {}
+  peopleIndex: {},
+  personDoneTasksIndex: {},
+  personDoneTasks: [],
+  personTasksIndex: {}
 }
 
 const initialState = {
@@ -163,7 +166,6 @@ const initialState = {
   personTasks: [],
   displayedPersonTasks: [],
   displayedPersonDoneTasks: [],
-  personTasksIndex: {},
   personTasksSearchText: '',
   personTaskSelectionGrid: {},
   personTaskSearchQueries: [],
@@ -727,9 +729,9 @@ const mutations = {
     state.personTaskSelectionGrid = personTaskSelectionGrid
     state.personTasks = sortTasks(tasks, taskTypeMap)
 
-    state.personTasksIndex = buildTaskIndex(tasks)
+    cache.personTasksIndex = buildTaskIndex(tasks)
     const keywords = getKeyWords(state.personTasksSearchText)
-    const searchResult = indexSearch(state.personTasksIndex, keywords)
+    const searchResult = indexSearch(cache.personTasksIndex, keywords)
 
     state.displayedPersonTasks = searchResult || state.personTasks
     if (userFilters.persontasks && userFilters.persontasks.all) {
@@ -742,14 +744,18 @@ const mutations = {
   [LOAD_PERSON_DONE_TASKS_END] (state, tasks) {
     tasks.forEach(populateTask)
     state.displayedPersonDoneTasks = tasks
+    cache.personDoneTasksIndex = buildTaskIndex(tasks)
   },
 
   [SET_PERSON_TASKS_SEARCH] (state, searchText) {
     state.displayedPersonTasks = []
     const keywords = getKeyWords(searchText)
-    const searchResult = indexSearch(state.personTasksIndex, keywords)
+    let searchResult = indexSearch(cache.personTasksIndex, keywords)
     state.personTasksSearchText = searchText
     state.displayedPersonTasks = searchResult || state.personTasks
+
+    searchResult = indexSearch(cache.personDoneTasksIndex, keywords)
+    state.displayedPersonDoneTasks = searchResult || cache.personDoneTasks
   },
 
   [SAVE_PERSON_TASKS_SEARCH_END] (state, { searchQuery }) {
@@ -779,7 +785,8 @@ const mutations = {
         task_status_color: taskStatus.color
       })
 
-      state.personTasksIndex = buildTaskIndex(state.personTasks)
+      cache.personTasksIndex = buildTaskIndex(state.personTasks)
+      cache.personDoneTasksIndex = buildTaskIndex(cache.personDoneTasks)
     }
   },
 
@@ -865,8 +872,11 @@ const mutations = {
   },
 
   [RESET_ALL] (state, people) {
-    cache.peopleIndex = {}
     Object.assign(state, { ...initialState })
+    cache.peopleIndex = {}
+    cache.personTasksIndex = {}
+    cache.personDoneTasksIndex = {}
+    cache.personDoneTasks = []
   },
 
   [SAVE_PEOPLE_SEARCH_END] (state, { searchQuery }) {


### PR DESCRIPTION
**Problem**

* It's not possible to set handles to shots in playlists.
* It's impossible to draw annotations in the playlist to show something.
* It's impossible to hide annotations in playlists to see what is below.
* The timecode tag clicking inside the task page brings to the frame before the tagged one.
* It's not possible to search for done tasks in the playlist.

**Solution**

* Add handles in the video progress bar that are saved at the shot level. Use that information to start and stop the playing.
* Add a button to show/hide annotations
* Add a button to set the laser mode on (annotations fade after 2 seconds)
* Increment the frame number before applying it to the player.
* Add the search field to the done section in the person page.