### PR TITLE
add the possibility to filter on metadata descriptor checklist

### DIFF
--- a/src/components/modals/BuildFilterModal.vue
+++ b/src/components/modals/BuildFilterModal.vue
@@ -113,6 +113,7 @@
             locale-key-prefix="entities.build_filter."
             v-model="descriptorFilter.operator"
             v-if="!descriptorFilter.is_checklist"
+            @input="(operator) => onOperatorChanged(operator, descriptorFilter)"
           />
 
           <combobox
@@ -555,19 +556,19 @@ export default {
 
     onDescriptorChanged (descriptorFilter) {
       const descriptor = this.getDescriptor(descriptorFilter.id)
-      let isChecklist = false
+      descriptorFilter.is_checklist = false
       if (descriptor.choices.length > 0) {
         const checklistValues = this.getDescriptorChecklistValues(descriptor)
         if (checklistValues.length > 0) {
-          isChecklist = true
+          descriptorFilter.is_checklist = true
           descriptorFilter.values = [checklistValues[0]]
+          descriptorFilter.operator = '='
         } else {
           descriptorFilter.values = [descriptor.choices[0]]
         }
       } else {
         descriptorFilter.values = ['']
       }
-      descriptorFilter.is_checklist = isChecklist
     },
 
     addDescriptorFilter () {
@@ -614,6 +615,12 @@ export default {
         return this.getDescriptorChecklistValues(desc).map(
           choice => ({ label: choice.text, value: choice })
         )
+      }
+    },
+
+    onOperatorChanged (operator, descriptorFilter) {
+      if (operator !== 'in') {
+        descriptorFilter.values = [descriptorFilter.values[0]]
       }
     },
 

--- a/src/components/widgets/Combobox.vue
+++ b/src/components/widgets/Combobox.vue
@@ -28,7 +28,7 @@
         <option
           v-for="(option, i) in options"
           :key="`${i}-${option.label}-${option.value}`"
-          :value="option.value || option.label"
+          :value="option.label || option.value"
           :selected="value === option.value"
         >
           {{ getOptionLabel(option) }}
@@ -50,7 +50,7 @@ export default {
     },
     value: {
       default: '',
-      type: [Object, String]
+      type: [Object, String, Boolean]
     },
     options: {
       default: () => [],
@@ -94,11 +94,23 @@ export default {
 
   methods: {
     updateValue () {
-      this.$emit('input', this.$refs.select.value)
+      let value = this.$refs.select.value
+      this.options.forEach(option => {
+        if (option.label === value) {
+          value = option.value
+        }
+      })
+      this.$emit('input', value)
     },
 
     emitEnter () {
-      this.$emit('enter', this.$refs.select.value)
+      let value = this.$refs.select.value
+      this.options.forEach(option => {
+        if (option.label === value) {
+          value = option.value
+        }
+      })
+      this.$emit('enter', value)
     },
 
     getOptionLabel (option) {

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -72,9 +72,17 @@ const applyFiltersFunctions = {
     ) {
       let dataValue = entry.data[filter.descriptor.field_name]
       dataValue = dataValue.toLowerCase()
-      filter.values.forEach(value => {
-        isOk = isOk || dataValue.indexOf(value.toLowerCase()) >= 0
-      })
+      if (filter.values.length === 1 && filter.values[0].match(new RegExp('(:true)|(:false)$'))) {
+        const isTrue = Boolean(filter.values[0].match(new RegExp(':true$')))
+        let value = filter.values[0].replace(new RegExp('(:true)|(:false)$'), '')
+        value = value.toLowerCase()
+        dataValue = JSON.parse(dataValue)
+        isOk = isOk || ((dataValue[value] === undefined && !isTrue) || (dataValue[value] === isTrue))
+      } else {
+        filter.values.forEach(value => {
+          isOk = isOk || dataValue.indexOf(value.toLowerCase()) >= 0
+        })
+      }
     } else {
       isOk = false
     }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -208,7 +208,9 @@ export default {
       union_and: 'Match all the following filters',
       union_or: 'Match one of the following filters',
       with_thumbnail: 'With thumbnail',
-      without_thumbnail: 'Without thumbnail'
+      without_thumbnail: 'Without thumbnail',
+      checked: 'Checked',
+      not_checked: 'Not checked'
     },
 
     logs: {


### PR DESCRIPTION
**Problem**
- it's not possible to filter on metadata descriptor when it's a checklist.
- when we change from "in" operator to "equal" or "not equal" multiple values remains.

**Solution**
- add the possibility to filter on metadata descriptor when it's a checklist.
- keep only the first value when we change from "in" operator to "equal" or "not equal".
