### PR TITLE
Various fixes

### DIFF
--- a/src/components/modals/EditPlaylistModal.vue
+++ b/src/components/modals/EditPlaylistModal.vue
@@ -172,6 +172,7 @@ export default {
       if (this.isEditing) {
         this.form.name = this.playlistToEdit.name
         this.form.for_entity = this.playlistToEdit.for_entity
+        this.form.for_client = this.playlistToEdit.for_client
         this.form.is_for_all =
           this.currentEpisode && this.currentEpisode.id === 'all'
         this.form.task_type_id = this.playlistToEdit.task_type_id

--- a/src/components/modals/ManageShotsModal.vue
+++ b/src/components/modals/ManageShotsModal.vue
@@ -199,15 +199,15 @@ export default {
       shotPaddingOptions: [
         {
           label: '1',
-          padding: '1'
+          value: '1'
         },
         {
           label: '2',
-          padding: '2'
+          value: '2'
         },
         {
           label: '10',
-          padding: '10'
+          value: '10'
         }
       ],
       shotPadding: '1'

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1389,4 +1389,8 @@ export default {
     }
   }
 }
+
+.preview-column-content {
+  border-radius: 5px;
+}
 </style>

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -805,17 +805,18 @@ export default {
 }
 
 .user-menu {
-  position: fixed;
-  width: 220px;
-  min-width: 220px;
-  right: 0;
   background-color: white;
-  padding: 1em 1em 1em 1em;
-  z-index: 203;
   box-shadow: 2px 3px 3px rgba(0,0,0,0.2);
   border-left: 1px solid $white-grey;
   border-bottom: 1px solid $white-grey;
+  border-bottom-left-radius: 10px;
+  min-width: 220px;
+  padding: 1em 1em 1em 1em;
+  position: fixed;
   transition: top .5s ease;
+  right: 0;
+  width: 220px;
+  z-index: 203;
 }
 
 .user-menu ul {

--- a/src/components/widgets/ComboboxSimple.vue
+++ b/src/components/widgets/ComboboxSimple.vue
@@ -61,9 +61,7 @@ export default {
   },
 
   mounted () {
-    if (this.options.length > 0) {
-      this.selectedOption = this.options[0]
-    }
+    this.resetOptions()
   },
 
   computed: {
@@ -84,11 +82,9 @@ export default {
       } else {
         return option.label
       }
-    }
-  },
+    },
 
-  watch: {
-    options () {
+    resetOptions () {
       if (this.options.length > 0) {
         const option = this.options.find(o => o.value === this.value)
         if (option) {
@@ -97,6 +93,12 @@ export default {
           this.selectedOption = this.options[0]
         }
       }
+    }
+  },
+
+  watch: {
+    options () {
+      this.resetOptions()
     },
 
     value () {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1123,7 +1123,7 @@ export default {
     set_preview: 'Set this preview as thumbnail',
     set_preview_error: 'An error occurred while setting preview as thumbnail',
     set_preview_done: 'This preview is used as thumbnail for the current entity.',
-    select_preview_file: 'Please select files (picture, movie or others) from your hard drive to be used as a new preview revision for the current task:',
+    select_preview_file: 'Please select files (pictures, movies or others) from your hard drive to be used as a new preview revision for the current task:',
     show_assignations: 'Show assignations',
     show_infos: 'Show additional information',
     small_thumbnails: 'Show small thumbnails',


### PR DESCRIPTION
**Problem**

* On playlist creation the for client flag is not properly selected
* Shot padding during the creation is broken
* On publication, the previous comment status is marked as modified.

**Solution**

* Set the right default value and update the simple choice widget to handle properly default value (not using the first choice but the choice matching the default value).
* Set value in the combo box options, not only labels
* Do not update last comment after a task modification during a comment operation (that was needed in case of change while editing a comment).
