### PR TITLE
Various fixes

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -540,10 +540,12 @@
     v-if="!isEmptyList && !isLoading"
   >
     {{ displayedAssetsLength }} {{ $tc('assets.number', displayedAssetsLength) }}
+    <span v-show="displayedAssetsTimeSpent > 0 || displayedAssetsEstimation > 0">
     ({{ formatDuration(displayedAssetsTimeSpent) }}
-     {{ $tc('main.days_spent', displayedAssetsTimeSpent) }},
-     {{ formatDuration(displayedAssetsEstimation) }}
-     {{ $tc('main.man_days', displayedAssetsEstimation) }})
+       {{ $tc('main.days_spent', displayedAssetsTimeSpent) }},
+       {{ formatDuration(displayedAssetsEstimation) }}
+       {{ $tc('main.man_days', displayedAssetsEstimation) }})
+    </span>
   </p>
 
 </div>
@@ -650,6 +652,7 @@ export default {
       'episodeMap',
       'currentEpisode',
       'currentProduction',
+      'displayedAssetsCount',
       'displayedAssetsLength',
       'displayedAssetsTimeSpent',
       'displayedAssetsEstimation',
@@ -678,7 +681,7 @@ export default {
     },
 
     isEmptyList () {
-      return this.displayedAssetsLength === 0 &&
+      return this.displayedAssetsCount === 0 &&
              !this.isLoading &&
              !this.isError &&
              (!this.assetSearchText || this.assetSearchText.length === 0)
@@ -696,7 +699,7 @@ export default {
         !this.isLoading &&
         !this.isError &&
         (
-          this.displayedAssetsLength > 0
+          this.displayedAssetsCount > 0
         )
       )
     },
@@ -892,7 +895,7 @@ export default {
 
     onInputKeyUp (event, i, j) {
       const listWidth = this.visibleMetadataDescriptors.length
-      const listHeight = this.displayedAssetsLength
+      const listHeight = this.displayedAssetsCount
       this.keyMetadataNavigation(listWidth, listHeight, i, j, event.key)
     },
 

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -490,10 +490,12 @@
     v-if="!isEmptyList && !isLoading"
   >
     {{ displayedEditsLength }} {{ $tc('edits.number', displayedEditsLength) }}
+    <span v-if="displayedEditsTimeSpent > 0 || displayedEditsEstimation > 0">
     ({{ formatDuration(displayedEditsTimeSpent) }}
      {{ $tc('main.days_spent', displayedEditsTimeSpent) }},
      {{ formatDuration(displayedEditsEstimation) }}
      {{ $tc('main.man_days', displayedEditsEstimation) }})
+    </span>
   </p>
 
 </div>
@@ -593,6 +595,7 @@ export default {
       'episodeMap',
       'currentEpisode',
       'displayedEditsEstimation',
+      'displayedEditsCount',
       'displayedEditsLength',
       'displayedEditsTimeSpent',
       'isBigThumbnails',
@@ -639,7 +642,7 @@ export default {
         !this.isLoading &&
         !this.isError &&
         (
-          this.displayedEditsLength > 0
+          this.displayedEditsCount > 0
         )
       )
     },
@@ -759,7 +762,7 @@ export default {
 
     onInputKeyUp (event, i, j) {
       const listWidth = this.visibleMetadataDescriptors.length + 4
-      const listHeight = this.displayedEditsLength
+      const listHeight = this.displayedEditsCount
       this.keyMetadataNavigation(listWidth, listHeight, i, j, event.key)
       return this.pauseEvent(event)
     },

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -661,12 +661,17 @@
     v-if="!isEmptyList && !isLoading"
   >
     {{ displayedShotsLength }} {{ $tc('shots.number', displayedShotsLength) }}
+    <span v-if="displayedShotsFrames">
+    -
+       {{ displayedShotsFrames }}
+       {{ $tc('main.nb_frames', displayedShotsFrames) }}
+    </span>
+    <span v-show="displayedShotsTimeSpent > 0 || displayedShotsEstimation > 0">
     ({{ formatDuration(displayedShotsTimeSpent) }}
-     {{ $tc('main.days_spent', displayedShotsTimeSpent) }},
-     {{ formatDuration(displayedShotsEstimation) }}
-     {{ $tc('main.man_days', displayedShotsEstimation) }},
-     {{ displayedShotsFrames }} {{ $tc('main.nb_frames', displayedShotsFrames) }})
-
+       {{ $tc('main.days_spent', displayedShotsTimeSpent) }},
+       {{ formatDuration(displayedShotsEstimation) }}
+       {{ $tc('main.man_days', displayedShotsEstimation) }})
+    </span>
   </p>
 
 </div>
@@ -769,6 +774,7 @@ export default {
       'currentProduction',
       'currentEpisode',
       'displayedShotsEstimation',
+      'displayedShotsCount',
       'displayedShotsLength',
       'displayedShotsTimeSpent',
       'displayedShotsFrames',
@@ -822,7 +828,7 @@ export default {
         !this.isLoading &&
         !this.isError &&
         (
-          this.displayedShotsLength > 0
+          this.displayedShotsCount > 0
         )
       )
     },
@@ -976,7 +982,7 @@ export default {
 
     onInputKeyUp (event, i, j) {
       const listWidth = this.visibleMetadataDescriptors.length + 4
-      const listHeight = this.displayedShotsLength
+      const listHeight = this.displayedShotsCount
       this.keyMetadataNavigation(listWidth, listHeight, i, j, event.key)
       return this.pauseEvent(event)
     },

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -989,9 +989,11 @@ export default {
         shotsToChange = [entry]
       }
 
+      const cleanValue = this.sanitizeIntegerLight(value)
+
       shotsToChange.forEach(shot => {
         this.$emit('field-changed', {
-          entry: shot, fieldName: 'nb_frames', value: this.sanitizeInteger(value)
+          entry: shot, fieldName: 'nb_frames', value: cleanValue
         })
       })
     },

--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -358,6 +358,7 @@ export const annotationMixin = {
     ) {
       if (!obj) return
       if (this.getObjectById(obj.id)) return
+      let path, text
       this.objIndex.set(obj.id, obj)
       let scaleMultiplierX = 1
       let scaleMultiplierY = 1
@@ -402,7 +403,7 @@ export const annotationMixin = {
           strokeMultiplier = canvasWidth / this.fabricCanvas.width
         }
         if (this.fabricCanvas.width < 420) strokeMultiplier /= 2
-        const path = new fabric.Path(
+        path = new fabric.Path(
           obj.path,
           {
             ...base,
@@ -425,7 +426,7 @@ export const annotationMixin = {
         this.fabricCanvas.add(path)
         this.$options.silentAnnnotation = false
       } else if ((obj.type === 'i-text') || (obj.type === 'text')) {
-        const text = new fabric.IText(
+        text = new fabric.IText(
           obj.text,
           {
             ...base,
@@ -453,6 +454,7 @@ export const annotationMixin = {
         this.fabricCanvas.add(text)
         this.$options.silentAnnnotation = false
       }
+      return path || text
     },
 
     // Events
@@ -562,7 +564,9 @@ export const annotationMixin = {
       o = this.setObjectData(o)
       // if (this.fabricCanvas.width < 420) o.strokeWidth *= 2
       if (this.isLaserModeOn) {
+        const currentTime = this.getCurrentTime()
         this.fadeObject(o)
+        this.postAnnotationAddition(currentTime, o.serialize())
       } else {
         this.addToAdditions(o)
         this.stackAddAction(obj)
@@ -575,6 +579,7 @@ export const annotationMixin = {
     },
 
     fadeObject (obj) {
+      if (!obj) return
       obj.animate('opacity', '0', {
         duration: 1500,
         onChange: this.fabricCanvas.renderAll.bind(this.fabricCanvas),

--- a/src/components/mixins/format.js
+++ b/src/components/mixins/format.js
@@ -62,6 +62,15 @@ export const formatListMixin = {
         if (value && value.length > 0) val = parseInt(value) || 0
       }
       return val
+    },
+
+    sanitizeIntegerLight (value) {
+      let val = null
+      if (typeof value === 'string') {
+        value = value.replace(/\D/g, '')
+        if (value && value.length > 0) val = parseInt(value) || null
+      }
+      return val
     }
   }
 }

--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -365,12 +365,12 @@ export const playerMixin = {
 
     playClicked () {
       this.play()
-      this.updatePlayingStatus()
+      this.updateRoomStatus()
     },
 
     pauseClicked () {
       this.pause()
-      this.updatePlayingStatus()
+      this.updateRoomStatus()
     },
 
     play () {
@@ -541,11 +541,13 @@ export const playerMixin = {
     onHandleInChanged ({ frameNumber, save }) {
       this.handleIn = frameNumber
       if (save) this._saveHandles()
+      this.updateRoomStatus()
     },
 
     onHandleOutChanged ({ frameNumber, save }) {
       this.handleOut = frameNumber
       if (save) this._saveHandles()
+      this.updateRoomStatus()
     },
 
     _saveHandles () {
@@ -595,7 +597,7 @@ export const playerMixin = {
     onRepeatClicked () {
       this.clearFocus()
       this.isRepeating = !this.isRepeating
-      this.updatePlayingStatus()
+      this.updateRoomStatus()
     },
 
     onToggleSoundClicked () {
@@ -755,7 +757,7 @@ export const playerMixin = {
         this.saveUserComparisonChoice()
         this.comparisonEntityMissing = false
       })
-      this.updatePlayingStatus()
+      this.updateRoomStatus()
     },
 
     onSpeedClicked () {
@@ -765,7 +767,7 @@ export const playerMixin = {
       if (this.speed === 2) rate = 0.5
       if (this.speed === 1) rate = 0.25
       this.setPlayerSpeed(rate)
-      this.updatePlayingStatus()
+      this.updateRoomStatus()
     },
 
     setPlayerSpeed (rate) {
@@ -1075,6 +1077,7 @@ export const playerMixin = {
     onMetadataLoaded (event) {
       this.$nextTick(() => {
         this.resetCanvasSize()
+        if (this.resetHeight) this.resetHeight()
       })
     },
 

--- a/src/components/modals/EditPersonModal.vue
+++ b/src/components/modals/EditPersonModal.vue
@@ -155,6 +155,12 @@
       </div>
       <div
         class="error has-text-right mt1"
+        v-if="isUserLimitError"
+      >
+        {{ $t('people.user_limit_error') }}
+      </div>
+      <div
+        class="error has-text-right mt1"
         v-if="isError"
       >
         {{ $t('people.create_error') }}
@@ -176,23 +182,51 @@ import DepartmentName from '@/components/widgets/DepartmentName'
 export default {
   name: 'edit-modal',
   mixins: [modalMixin],
-  props: [
-    'active',
-    'cancelRoute',
-    'errorText',
-    'isLoading',
-    'isCreateInviteLoading',
-    'isInvitationSuccess',
-    'isInvitationError',
-    'isInviteLoading',
-    'isError',
-    'onConfirmClicked',
-    'personToEdit',
-    'text'
-  ],
+  props: {
+    active: {
+      type: Boolean,
+      default: false
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
+    },
+    isCreateInviteLoading: {
+      type: Boolean,
+      default: false
+    },
+    isInviteLoading: {
+      type: Boolean,
+      default: false
+    },
+    isInvitationSuccess: {
+      type: Boolean,
+      default: false
+    },
+    isInvitationError: {
+      type: Boolean,
+      default: false
+    },
+    isUserLimitError: {
+      type: Boolean,
+      default: false
+    },
+    isError: {
+      type: Boolean,
+      default: false
+    },
+    personToEdit: {
+      type: Object,
+      default: () => {}
+    }
+  },
 
   data () {
     return {
+      activeOptions: [
+        { label: this.$t('main.yes'), value: 'true' },
+        { label: this.$t('main.no'), value: 'false' }
+      ],
       isValidEmail: false,
       form: {
         first_name: '',
@@ -203,7 +237,6 @@ export default {
         active: 'true',
         departments: []
       },
-
       roleOptions: [
         { label: 'user', value: 'user' },
         { label: 'supervisor', value: 'supervisor' },
@@ -211,10 +244,6 @@ export default {
         { label: 'client', value: 'client' },
         { label: 'vendor', value: 'vendor' },
         { label: 'admin', value: 'admin' }
-      ],
-      activeOptions: [
-        { label: this.$t('main.yes'), value: 'true' },
-        { label: this.$t('main.no'), value: 'false' }
       ],
       selectedDepartment: null
     }

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -257,10 +257,10 @@ export default {
         } else {
           startDate = moment()
         }
-        if (startDate.isBefore(taskTypeElement.startDate)) {
+        if (taskTypeElement && startDate.isBefore(taskTypeElement.startDate)) {
           startDate = taskTypeElement.startDate.clone()
         }
-        if (startDate.isAfter(taskTypeElement.endDate)) {
+        if (taskTypeElement && startDate.isAfter(taskTypeElement.endDate)) {
           startDate = taskTypeElement.endDate.clone().add(-1, 'days')
         }
         if (item.end_date) {

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -257,9 +257,18 @@ export default {
         } else {
           startDate = moment()
         }
+        if (startDate.isBefore(taskTypeElement.startDate)) {
+          startDate = taskTypeElement.startDate.clone()
+        }
+        if (startDate.isAfter(taskTypeElement.endDate)) {
+          startDate = taskTypeElement.endDate.clone().add(-1, 'days')
+        }
         if (item.end_date) {
           endDate = parseDate(item.end_date)
         } else {
+          endDate = startDate.clone().add(1, 'days')
+        }
+        if (endDate.isBefore(startDate)) {
           endDate = startDate.clone().add(1, 'days')
         }
         const scheduleItem = {
@@ -301,14 +310,14 @@ export default {
         }
 
         this[action](parameters)
-          .then((scheduleItems) => {
+          .then(scheduleItems => {
             taskTypeElement.loading = false
             taskTypeElement.children = this.convertScheduleItems(
               taskTypeElement,
               scheduleItems
             )
           })
-          .catch((err) => {
+          .catch(err => {
             console.error(err)
             taskTypeElement.loading = false
             taskTypeElement.children = []

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -511,7 +511,7 @@
           class="playlist-button flexrow-item comparison-list"
           :options="comparisonModeOptions"
           v-model="comparisonMode"
-          @input="updatePlayingStatus"
+          @input="updateRoomStatus"
           v-if="isComparing"
         />
         <div
@@ -1230,7 +1230,7 @@ export default {
 
     entityListClicked (entityIndex) {
       this.playEntity(entityIndex)
-      this.updatePlayingStatus()
+      this.updateRoomStatus()
     },
 
     removeEntity (entity) {
@@ -1262,10 +1262,10 @@ export default {
 
     onPlayNext () {
       const nextEntity = this.entityList[this.nextEntityIndex]
-      this.resetHandles(nextEntity)
       if (this.isRepeating && this.isCurrentPreviewMovie) {
         this.rawPlayer.playNext()
       } else if (nextEntity.preview_file_extension === 'mp4') {
+        this.resetHandles(nextEntity)
         this.rawPlayer.playNext(this.handleIn)
         this.syncComparisonPlayer()
         this._setCurrentTimeOnHandleIn()
@@ -1576,40 +1576,40 @@ export default {
       const index = this.currentPreviewIndex - 1
       this.currentPreviewIndex =
         index < 0 ? this.currentEntityPreviewLength - 1 : index
-      this.updatePlayingStatus()
+      this.updateRoomStatus()
     },
 
     onNextPreviewClicked () {
       const index = this.currentPreviewIndex + 1
       this.currentPreviewIndex =
         index > this.currentEntityPreviewLength - 1 ? 0 : index
-      this.updatePlayingStatus()
+      this.updateRoomStatus()
     },
 
     onPreviousComparisonPictureClicked () {
       const index = this.currentComparisonPreviewIndex - 1
       this.currentComparisonPreviewIndex =
         index < 0 ? this.currentComparisonPreviewLength - 1 : index
-      this.updatePlayingStatus()
+      this.updateRoomStatus()
     },
 
     onNextComparisonPictureClicked () {
       const index = this.currentComparisonPreviewIndex + 1
       this.currentComparisonPreviewIndex =
         index > this.currentComparisonPreviewLength - 1 ? 0 : index
-      this.updatePlayingStatus()
+      this.updateRoomStatus()
     },
 
     onTaskTypeToCompareChanged () {
       this.saveUserComparisonChoice()
       this.rebuildEntityListToCompare()
-      this.updatePlayingStatus()
+      this.updateRoomStatus()
     },
 
     onRevisionToCompareChanged () {
       if (this.isComparing) {
         this.rebuildEntityListToCompare()
-        this.updatePlayingStatus()
+        this.updateRoomStatus()
         this.$nextTick(() => {
           this.pause()
           this.rawPlayerComparison.loadEntity(this.playingEntityIndex)
@@ -1744,6 +1744,7 @@ export default {
       this.rebuildComparisonOptions()
       this.clearCanvas()
       this.annotations = []
+      this.isComparing = false
       if (this.entityList.length === 0) {
         this.clearPlayer()
       }
@@ -1785,6 +1786,10 @@ export default {
         this.resetHeight()
         this.loadWaveForm()
       }
+    },
+
+    isLaserModeOn () {
+      this.updateRoomStatus()
     }
   },
 

--- a/src/components/pages/playlists/RawVideoPlayer.vue
+++ b/src/components/pages/playlists/RawVideoPlayer.vue
@@ -92,6 +92,10 @@ export default {
     this.player1.addEventListener('loadedmetadata', this.emitLoadedEvent)
     window.addEventListener('resize', this.resetHeight)
     this.$options.currentTimeCalls = []
+    if (this.video && this.video.readyState === 4) {
+      this.$emit('metadata-loaded', event)
+      this.resetHeight()
+    }
   },
 
   beforeDestroy () {

--- a/src/components/previews/VideoProgress.vue
+++ b/src/components/previews/VideoProgress.vue
@@ -267,9 +267,9 @@ export default {
   border-radius: 2px;
   cursor: pointer;
   display: inline-block;
-  height: 24px;
+  height: 20px;
   position: absolute;
-  top: 2px;
+  top: 4px;
 }
 
 .progress-wrapper {

--- a/src/components/widgets/PageSubtitle.vue
+++ b/src/components/widgets/PageSubtitle.vue
@@ -15,7 +15,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.subtitle {
+h2.subtitle {
+  border: 0;
   margin-top: 2em;
   margin-bottom: 1em;
 }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -515,7 +515,7 @@ export default {
     confirm_edit: 'Save user changes',
     create: 'Create user',
     create_invite: 'Create user and send invitation',
-    create_error: 'An  error occurred while creating or update this user. You may have reach your user limit. Please contact our support team for more information.',
+    create_error: 'A server error occurred while creating or update this user. Please contact our support team for more information.',
     delete_error: 'An error occurred while deleting this user. There are probably data linked to it. Are you sure this user has no assignation or wrote no comment?',
     delete_text: 'Are you sure you want to remove {personName} from your database? Every related comments and previews will be deleted. Please confirm by typing the full user name below.',
     edit_title: 'Edit user',
@@ -531,6 +531,7 @@ export default {
     team: 'Team',
     title: 'People',
     unactive: 'Unactive',
+    user_limit_error: 'You have reach your user limit. Please contact our team to upgrade your plan.',
     fields: {
       active: 'Active',
       departments: 'Departments',

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -655,7 +655,7 @@
                 "add_shots_button": "Ajouter des plans",
                 "add_shots_description": "Ajouter ou importer des plans pour ta production",
                 "assets_to_import": "Assets à importer",
-                "create_production": "Créer la production",
+                "create_production": "Créer une nouvelle production",
                 "create_button": "Toute est bon, c'est parti !",
                 "create_button_disabled": "Remplissez tout le formulaire pour continuer",
                 "error": "Une erreur est survenue en créant la production",

--- a/src/store/api/client.js
+++ b/src/store/api/client.js
@@ -59,8 +59,10 @@ const client = {
             errors.backToLogin()
             reject(err)
           } else {
-            if (err) reject(err)
-            else resolve(res.body)
+            if (err) {
+              err.body = res ? res.body : ''
+              reject(err)
+            } else resolve(res.body)
           }
         })
     })

--- a/src/store/api/shots.js
+++ b/src/store/api/shots.js
@@ -71,6 +71,8 @@ export default {
     }
     if (shot.nb_frames) {
       data.nb_frames = parseInt(shot.nb_frames)
+    } else {
+      data.nb_frames = null
     }
     if (
       shot.frameOut !== undefined ||

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -149,12 +149,13 @@ const helpers = {
   setListStats (state, edits) {
     let timeSpent = 0
     let estimation = 0
-    edits.forEach(edit => {
+    edits.filter(e => !e.canceled).forEach(edit => {
       timeSpent += edit.timeSpent
       estimation += edit.estimation
     })
     Object.assign(state, {
-      displayedEditsLength: edits.length,
+      displayedEditsCount: edits.length,
+      displayedEditsLength: edits.filter(e => !e.canceled).length,
       displayedEditsTimeSpent: timeSpent,
       displayedEditsEstimation: estimation
     })
@@ -276,6 +277,7 @@ const initialState = {
   isEditTime: false,
 
   displayedEdits: [],
+  displayedEditsCount: 0,
   displayedEditsLength: 0,
   displayedEditsTimeSpent: 0,
   displayedEditsEstimation: 0,
@@ -315,6 +317,7 @@ const getters = {
   editSelectionGrid: state => state.editSelectionGrid,
 
   displayedEdits: state => state.displayedEdits,
+  displayedEditsCount: state => state.displayedEditsCount,
   displayedEditsLength: state => state.displayedEditsLength,
   displayedEditsTimeSpent: state => state.displayedEditsTimeSpent,
   displayedEditsEstimation: state => state.displayedEditsEstimation,
@@ -680,6 +683,7 @@ const mutations = {
     state.isEditsLoadingError = false
 
     state.displayedEdits = []
+    state.displayedEditsCount = 0
     state.displayedEditsLength = 0
     state.displayedEstimation = 0
     state.editSearchQueries = []
@@ -1046,7 +1050,8 @@ const mutations = {
 
     state.displayedEdits.push(edit)
     state.displayedEdits = sortEdits(state.displayedEdits)
-    state.displayedEditsLength = cache.edits.length
+    state.displayedEditsCount = cache.edits.length
+    state.displayedEditsLength = cache.edits.filter(e => !e.canceled).length
     state.editFilledColumns = getFilledColumns(state.displayedEdits)
 
     const maxX = state.displayedEdits.length
@@ -1067,10 +1072,10 @@ const mutations = {
     cache.editIndex = buildEditIndex(cache.edits)
     state.displayedEdits =
       removeModelFromList(state.displayedEdits, editToDelete)
-    if (editToDelete.timeSpent) {
+    if (editToDelete.timeSpent && !editToDelete.canceled) {
       state.displayedEditsTimeSpent -= editToDelete.timeSpent
     }
-    if (editToDelete.estimation) {
+    if (editToDelete.estimation && !editToDelete.canceled) {
       state.displayedEditsEstimation -= editToDelete.estimation
     }
   },

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -420,7 +420,8 @@ const mutations = {
     cache.todosIndex = buildTaskIndex(tasks)
     const keywords = getKeyWords(state.todosSearchText)
     const searchResult = indexSearch(cache.todosIndex, keywords)
-    state.displayedTodos = searchResult || state.todos
+    state.displayedTodos =
+      (searchResult || state.todos).filter(t => !t.entity_canceled)
     if (userFilters.todos && userFilters.todos.all) {
       state.todoSearchQueries = userFilters.todos.all
     } else {
@@ -479,7 +480,8 @@ const mutations = {
     const keywords = getKeyWords(searchText)
     let searchResult = indexSearch(cache.todosIndex, keywords)
     state.todosSearchText = searchText
-    state.displayedTodos = searchResult || state.todos
+    state.displayedTodos =
+      (searchResult || state.todos).filter(t => !t.entity_canceled)
     searchResult = indexSearch(cache.doneIndex, keywords)
     state.displayedDoneTasks = searchResult || cache.doneTasks
   },

--- a/tests/unit/store/assets.spec.js
+++ b/tests/unit/store/assets.spec.js
@@ -772,6 +772,7 @@ describe('Assets store', () => {
         displayedAssets: 1,
         assetFilledColumns: 1,
         assetSearchQueries: 1,
+        displayedAssetsCount: 100,
         displayedAssetsLength: 100,
         displayedAssetsTimeSpent: 1000,
         displayedAssetsEstimation: 1000
@@ -786,6 +787,7 @@ describe('Assets store', () => {
         displayedAssets: [],
         assetFilledColumns: {},
         assetSearchQueries: [],
+        displayedAssetsCount: 0,
         displayedAssetsLength: 0,
         displayedAssetsTimeSpent: 0,
         displayedAssetsEstimation: 0,
@@ -805,6 +807,7 @@ describe('Assets store', () => {
         displayedAssets: 1,
         assetFilledColumns: 1,
         assetSearchQueries: 1,
+        displayedAssetsCount: 100,
         displayedAssetsLength: 100,
         displayedAssetsTimeSpent: 1000,
         displayedAssetsEstimation: 1000
@@ -821,6 +824,7 @@ describe('Assets store', () => {
         displayedAssets: [],
         assetFilledColumns: {},
         assetSearchQueries: [],
+        displayedAssetsCount: 0,
         displayedAssetsLength: 0,
         displayedAssetsTimeSpent: 0,
         displayedAssetsEstimation: 0,
@@ -991,7 +995,8 @@ describe('Assets store', () => {
           3: {}
         },
         displayedAssetsEstimation: 0,
-        displayedAssetsLength: 4,
+        displayedAssetsCount: 4,
+        displayedAssetsLength: 2,
         displayedAssetsTimeSpent: 0,
         assetSearchQueries: 'assetSearchQueries',
         assetMap: new Map(Object.entries({
@@ -1092,7 +1097,7 @@ describe('Assets store', () => {
       }
       const asset = {
         id: '1',
-        canceled: true,
+        canceled: false,
         asset_type_name: 'assettypename2',
         name: 'name4',
         timeSpent: 0,
@@ -1118,7 +1123,7 @@ describe('Assets store', () => {
       })
       expect(asset).toEqual({
         id: '1',
-        canceled: true,
+        canceled: false,
         asset_type_name: 'assettypename2',
         name: 'name4',
         episode_id: undefined,
@@ -1174,7 +1179,7 @@ describe('Assets store', () => {
         assetMap: new Map(Object.entries({
           1: {
             asset_type_name: 'assettypename2',
-            canceled: true,
+            canceled: false,
             description: 'azerty',
             episode_id: undefined,
             estimation: 200,
@@ -1199,7 +1204,7 @@ describe('Assets store', () => {
         displayedAssets: [
           {
             asset_type_name: 'assettypename2',
-            canceled: true,
+            canceled: false,
             description: 'azerty',
             episode_id: undefined,
             estimation: 200,
@@ -1219,12 +1224,13 @@ describe('Assets store', () => {
           }
         ],
         displayedAssetsEstimation: 200,
+        displayedAssetsCount: 1,
         displayedAssetsLength: 1,
         displayedAssetsTimeSpent: 100
       })
       expect(store.cache.assets).toEqual([{
         asset_type_name: 'assettypename2',
-        canceled: true,
+        canceled: false,
         description: 'azerty',
         episode_id: undefined,
         estimation: 200,
@@ -1278,6 +1284,7 @@ describe('Assets store', () => {
         displayedAssetsTimeSpent: 100,
         displayedAssetsEstimation: 200,
         assetFilledColumns: null,
+        displayedAssetsCount: 1,
         displayedAssetsLength: 1
       }
       store.mutations.REMOVE_ASSET(state, assetToDelete)
@@ -1287,6 +1294,7 @@ describe('Assets store', () => {
         displayedAssetsTimeSpent: 0,
         displayedAssetsEstimation: 0,
         assetFilledColumns: {},
+        displayedAssetsCount: 0,
         displayedAssetsLength: 0
       })
       expect(store.cache.assetIndex !== null).toBeTruthy()
@@ -1508,6 +1516,7 @@ describe('Assets store', () => {
         },
         displayedAssets: [],
         displayedAssetsEstimation: 0,
+        displayedAssetsCount: 0,
         displayedAssetsLength: 0,
         displayedAssetsTimeSpent: 0
       })
@@ -1866,6 +1875,7 @@ describe('Assets store', () => {
         },
         displayedAssets: [],
         displayedAssetsEstimation: 0,
+        displayedAssetsCount: 0,
         displayedAssetsLength: 0,
         displayedAssetsTimeSpent: 0
       })
@@ -1955,6 +1965,7 @@ describe('Assets store', () => {
         displayedAssetTypesLength: 0,
         displayedAssets: [],
         displayedAssetsEstimation: 0,
+        displayedAssetsCount: 0,
         displayedAssetsLength: 0,
         displayedAssetsTimeSpent: 0,
         filteredAssets: [],


### PR DESCRIPTION
**Problem**

* When a user creation fails, the reason is ambiguous, whether it comes from a server error or from a user limit.
* In the schedule page, the task type sub-elements disappear when the dates were previously wrongly set.
* Laser mode and handles are not synced when the user is in the review room.
* Annotation marks are too big and hide the timeline.
* The number of frames on a shot cannot be removed.
* Deleted shots and assets are counted in the overall count in entity pages.

**Solution**

* Display a different error message when there is an error due to the user limit.
* Make the start date of an element consistently superior to the start date of the parent element.
* Add laser mode and handles to the review room description and apply them when a new description is received.
* Make annotation marks smaller. 
* When the "number of frames" field is set to 0, set it to null.
* Do not include canceled shots in the overall count.
