### PR TITLE
Fixes and improvements

### DIFF
--- a/src/components/pages/ProductionSettings.vue
+++ b/src/components/pages/ProductionSettings.vue
@@ -139,10 +139,10 @@
                   :task="{ task_status_id: taskStatus.id }"
                 />
               </td>
-              <td>{{ getBooleanTranslation(taskStatus.is_done) }}</td>
-              <td>{{ getBooleanTranslation(taskStatus.is_retake) }}</td>
-              <td>{{ getBooleanTranslation(taskStatus.is_artist_allowed) }}</td>
-              <td>{{ getBooleanTranslation(taskStatus.is_client_allowed) }}</td>
+              <boolean-cell :value=taskStatus.is_done />
+              <boolean-cell :value=taskStatus.is_retake />
+              <boolean-cell :value=taskStatus.is_artist_allowed />
+              <boolean-cell :value=taskStatus.is_client_allowed />
               <td>
                 <button
                   class="button"
@@ -167,6 +167,7 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 
+import BooleanCell from '@/components/cells/BooleanCell'
 import Combobox from '@/components/widgets/Combobox'
 import ComboboxStatus from '@/components/widgets/ComboboxStatus'
 import ProductionBrief from '@/components/pages/production/ProductionBrief'
@@ -178,12 +179,13 @@ import ValidationTag from '@/components/widgets/ValidationTag'
 export default {
   name: 'production-settings',
   components: {
+    BooleanCell,
+    Combobox,
+    ComboboxStatus,
     ProductionBrief,
     ProductionParameters,
     ProductionTaskTypes,
     ProductionStatusAutomations,
-    Combobox,
-    ComboboxStatus,
     ValidationTag
   },
 

--- a/src/components/pages/production/ProductionTaskType.vue
+++ b/src/components/pages/production/ProductionTaskType.vue
@@ -6,7 +6,7 @@
   <task-type-cell
     :task-type="taskType"
   />
-  <td class="start-date">
+  <!--td class="start-date">
    <date-field
       :disabled-dates="productionTimeRange"
       :can-delete="false"
@@ -19,7 +19,7 @@
       :can-delete="false"
       v-model="endDate"
    />
-  </td>
+  </td-->
   <td class="remove">
     <button
       class="button"
@@ -35,7 +35,7 @@
 import moment from 'moment'
 import { mapGetters, mapActions } from 'vuex'
 
-import DateField from '@/components/widgets/DateField'
+// import DateField from '@/components/widgets/DateField'
 import TaskTypeCell from '@/components/cells/TaskTypeName'
 
 import { parseDate } from '@/lib/time'
@@ -44,7 +44,7 @@ export default {
   name: 'production-task-type',
 
   components: {
-    DateField,
+    // DateField,
     TaskTypeCell
   },
 

--- a/src/components/pages/production/ProductionTaskTypes.vue
+++ b/src/components/pages/production/ProductionTaskTypes.vue
@@ -49,12 +49,12 @@
                 <th class="name">
                   {{ $t('task_types.fields.name') }}
                 </th>
-                <th class="start-date">
+                <!--th class="start-date">
                   {{ $t('productions.fields.start_date') }}
                 </th>
                 <th class="end-date">
                   {{ $t('productions.fields.end_date') }}
-                </th>
+                </th-->
                 <th class="remove"></th>
               </tr>
             </thead>
@@ -412,7 +412,7 @@ td p {
 }
 
 .column {
-  max-width: 800px;
+  max-width: 400px;
 }
 
 td.name {

--- a/src/directives/resizable-column.js
+++ b/src/directives/resizable-column.js
@@ -42,7 +42,7 @@ export default {
           })
         }
 
-        ths.forEach((item) => {
+        ths.forEach(item => {
           if (!item.getElementsByClassName('resizable-knob').length > 0) {
             const div = document.createElement('div')
             div.className = 'resizable-knob'

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -948,7 +948,7 @@ const mutations = {
       state.displayedAssets.push(newAsset)
       state.assetFilledColumns = getFilledColumns(state.displayedAssets)
       state.displayedAssetsLength =
-        cache.assets.length.filter(a => !a.canceled)
+        cache.assets.filter(a => !a.canceled).length
       state.displayedAssetsCount = cache.assets.length
 
       const maxX = state.displayedAssets.length


### PR DESCRIPTION
**Problem**

* The asset creation returns an error.
* Boolean cells in the production settings are not properly rendered.
* Task type dates in production settings are confusing.

**Solution**

* Fix wrong code calculating the number of assets available.
* Use the BooleanCell widget to represent boolean values.
* Remove date widgets for the task type settings (not useful, it makes more sense to set them in the schedule).