### PR TITLE
taskStatus undefined bug

### DIFF
--- a/src/components/widgets/ComboboxStatus.vue
+++ b/src/components/widgets/ComboboxStatus.vue
@@ -182,14 +182,13 @@ export default {
     },
 
     backgroundColor (taskStatus) {
-      const isTodo = taskStatus.name === 'Todo'
       if (
-        (!taskStatus || isTodo) &&
+        (!taskStatus || taskStatus.name === 'Todo') &&
         !this.isDarkTheme
       ) {
         return '#ECECEC'
       } else if (
-        (!taskStatus || isTodo) &&
+        (!taskStatus || taskStatus.name === 'Todo') &&
         this.isDarkTheme
       ) {
         return '#5F626A'
@@ -201,8 +200,7 @@ export default {
     },
 
     color (taskStatus) {
-      const isTodo = taskStatus.name === 'Todo'
-      if ((!taskStatus || !isTodo) || this.isDarkTheme) {
+      if ((!taskStatus || taskStatus.name !== 'Todo') || this.isDarkTheme) {
         return 'white'
       } else {
         return '#333'


### PR DESCRIPTION
**Problem**
In src/components/widgets/ComboboxStatus.vue there's a bug if taskStatus is undefined (it can be undefined for example if a client hasn't any task types allowed)

**Solution**
In src/components/widgets/ComboboxStatus.vue fix bug if taskStatus is undefined