### PR TITLE
Various fixes

### DIFF
--- a/src/components/pages/MainSchedule.vue
+++ b/src/components/pages/MainSchedule.vue
@@ -97,7 +97,7 @@ export default {
       startDate: moment(),
       selectedStartDate: null,
       selectedEndDate: null,
-      zoomLevel: 2,
+      zoomLevel: 0,
       zoomOptions: [
         { label: 'Week', value: 0 },
         { label: '1', value: 1 },

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -187,6 +187,8 @@
           ref="schedule-widget"
           :start-date="productionStartDate"
           :end-date="productionEndDate"
+          :sub-start-date="taskTypeStartDate"
+          :sub-end-date="taskTypeEndDate"
           :hierarchy="schedule.scheduleItems"
           :zoom-level=schedule.zoomLevel
           :height="schedule.scheduleHeight"
@@ -286,6 +288,7 @@ import { CornerLeftUpIcon } from 'vue-feather-icons'
 import ActionPanel from '@/components/tops/ActionPanel'
 import ButtonSimple from '@/components/widgets/ButtonSimple'
 import DateField from '@/components/widgets/DateField'
+import Combobox from '@/components/widgets/Combobox'
 import ComboboxStyled from '@/components/widgets/ComboboxStyled'
 import ComboboxNumber from '@/components/widgets/ComboboxNumber'
 import EstimationHelper from '@/components/pages/tasktype/EstimationHelper'
@@ -407,6 +410,7 @@ export default {
     ButtonSimple,
     CornerLeftUpIcon,
     ComboboxNumber,
+    Combobox,
     ComboboxStyled,
     DateField,
     EstimationHelper,
@@ -552,6 +556,14 @@ export default {
       'taskMap',
       'user'
     ]),
+
+    taskTypeStartDate () {
+      return moment(this.schedule.taskTypeStartDate)
+    },
+
+    taskTypeEndDate () {
+      return moment(this.schedule.taskTypeEndDate)
+    },
 
     isSupervisorInDepartment () {
       const departments = this.user.departments || []
@@ -789,7 +801,8 @@ export default {
     },
 
     setCurrentScheduleItem () {
-      if (this.isTVShow) {
+      const isShots = this.$route.path.includes('shots')
+      if (this.isTVShow && isShots) {
         return this.loadEpisodeScheduleItems({
           production: this.currentProduction,
           taskType: this.currentTaskType
@@ -813,7 +826,7 @@ export default {
             if (!items) {
               Promise.resolve([])
             } else {
-              this.currentScheduleItem = items.find((item) => {
+              this.currentScheduleItem = items.find(item => {
                 return item.task_type_id === this.currentTaskType.id
               })
               Promise.resolve(this.currentScheduleItem)
@@ -1208,7 +1221,7 @@ export default {
           if (item.estimation) {
             item.endDate = addBusinessDays(
               item.startDate,
-              Math.ceil(minutesToDays(this.organisation, item.estimation))
+              Math.ceil(minutesToDays(this.organisation, item.estimation)) - 1
             )
           }
           item = { ...this.$options.savingBuffer[item.id] }

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -253,6 +253,7 @@
       :silent="isCommentsHidden"
       :current-time-raw="currentTimeRaw"
       :current-parent-preview="currentPreview"
+      panel-name="playlist-side-panel"
       @time-code-clicked="onTimeCodeClicked"
     />
   </div>
@@ -1869,6 +1870,8 @@ export default {
 .playlist-footer {
   overflow-x: scroll;
   width: 100%;
+  min-height: 30px;
+  padding-right: 5px;
 }
 
 .playlisted-entities {

--- a/src/components/pages/schedule/Schedule.vue
+++ b/src/components/pages/schedule/Schedule.vue
@@ -146,12 +146,12 @@
                 {{ childElement.name }}
               </span>
               <span
-                class="flexrow-item"
+                class="flexrow flexrow-item man-days-unit-wrapper"
                 v-if="childElement.editable"
                 v-show="!hideManDays"
               >
                 <input
-                  class="man-days-unit flexrow-item"
+                  class="flexrow-item man-days-unit"
                   type="number"
                   min="0"
                   placeholder="0"
@@ -159,7 +159,7 @@
                   @input="onChildEstimationChanged($event, childElement, rootElement)"
                   :value="formatDuration(childElement.man_days)"
                 />
-                {{ $t('schedule.md') }}
+                <span>{{ $t('schedule.md') }}</span>
               </span>
               <span
                 class="man-days-unit flexrow-item"
@@ -309,6 +309,22 @@
           @mousedown="startBrowsing"
           @mousewheel="$emit('change-zoom', $event)"
         >
+          <div
+            ref="timeline-sub-start"
+            class="sub-zone"
+            :style="timelineSubStartStyle"
+            v-if="subStartDate"
+          >
+          </div>
+
+          <div
+            ref="timeline-sub-end"
+            class="sub-zone"
+            :style="timelineSubEndStyle"
+            v-if="subEndDate"
+          >
+          </div>
+
           <div
             ref="timeline-today-position"
             class="timeline-position today"
@@ -516,6 +532,14 @@ export default {
     hierarchy: {
       default: () => [],
       type: Array
+    },
+    subEndDate: {
+      type: Object,
+      default: null
+    },
+    subStartDate: {
+      type: Object,
+      default: null
     },
     startDate: {
       type: Object,
@@ -767,6 +791,24 @@ export default {
         width: `${this.cellWidth}px`,
         left: `${this.getTimebarLeft({ startDate: today }) - 3}px`,
         display: isVisible ? 'block' : 'none'
+      }
+    },
+
+    timelineSubStartStyle () {
+      let diff = this.dateDiff(this.startDate, this.subStartDate)
+      if (diff < 0) diff = 0
+      return {
+        left: 0,
+        width: `${this.cellWidth * diff}px`
+      }
+    },
+
+    timelineSubEndStyle () {
+      let diff = this.dateDiff(this.subEndDate, this.endDate)
+      if (diff < 0) diff = 0
+      return {
+        right: 0,
+        width: `${this.cellWidth * diff}px`
       }
     },
 
@@ -1760,7 +1802,7 @@ export default {
   }
 
   input {
-    width: 50px;
+    width: 30px;
     text-align: right;
     background: transparent;
     margin-right: 0.2em;
@@ -1769,7 +1811,9 @@ export default {
 
   .man-days-unit {
     color: $dark-grey;
-    font-size: 0.7em;
+    font-size: 0.8em;
+    margin-right: .3em;
+    display: inline;
   }
 
   .avatar {
@@ -1777,6 +1821,15 @@ export default {
     margin: 0;
     padding: 0;
   }
+}
+
+.child-name .entity-name span.man-days-unit-wrapper {
+  padding-left: 0;
+  width: 60px;
+  text-align: right;
+}
+.child-name .entity-name span.man-days-unit-wrapper span {
+  padding-left: 0;
 }
 
 .children {
@@ -1952,5 +2005,13 @@ input::-webkit-inner-spin-button {
 
 input[type=number] {
   -moz-appearance: textfield;
+}
+
+.sub-zone {
+  background: $black;
+  position: absolute;
+  opacity: .8;
+  top: 0;
+  bottom: 0;
 }
 </style>

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -321,6 +321,10 @@ export default {
     silent: {
       type: Boolean,
       default: false
+    },
+    panelName: {
+      type: String,
+      default: 'todefine'
     }
   },
 
@@ -1148,7 +1152,11 @@ export default {
         // Wait for data to be reinitialized by App.vue to update comments.
         if (task && eventData.task_id === task.id) {
           setTimeout(() => {
-            this.taskComments = this.getTaskComments(task.id)
+            const task = this.getTask()
+            // in case the task changed during the timeout
+            if (task && eventData.task_id === task.id) {
+              this.taskComments = this.getTaskComments(task.id)
+            }
           }, 1000)
         }
       },
@@ -1161,7 +1169,9 @@ export default {
           if (
             this.task &&
             comments &&
-            comments.length !== this.taskComments.length
+            comments.length !== this.taskComments.length &&
+            eventData.task_id === this.task.id &&
+            !this.loading.task
           ) {
             this.taskComments = comments
             this.taskPreviews = this.getTaskPreviews(this.task.id)


### PR DESCRIPTION
**Problem**

* After a status change, the side panel displays the wrong comments if the task is changed.
* The playlist player button bar looks broken.
* The task type schedule is broken: dates are modified when the bar is moved.
* The production schedule has wrong links for shot task types when it's a tv show.
* The dates sets in the production schedule are not properly reflected in the task type schedule.

**Solution**

* Handle more properly the `task:update` event. The application of changes uses a timeout. The task information were retrieved before the timeout run. Which was wrong.
* Set a minimum height for the playlist player button bar.
* Calculate properly the end date from the new start date.
* Remove links for shot task types, let them only on episode names.
* Show a sub zone in the task type schedule showing where is the period allowed for this task type.
