### PR TITLE
Various fixes

### DIFF
--- a/src/components/lists/ProductionList.vue
+++ b/src/components/lists/ProductionList.vue
@@ -215,4 +215,9 @@ export default {
   min-width: 100px;
 }
 
+.fps,
+.ratio {
+  text-align: right;
+}
+
 </style>

--- a/src/components/modals/EditShotModal.vue
+++ b/src/components/modals/EditShotModal.vue
@@ -276,7 +276,7 @@ export default {
       if (frameIn &&
           frameOut &&
           frameOut > frameIn) {
-        this.form.nb_frames = frameOut - frameIn
+        this.form.nb_frames = frameOut - frameIn + 1
       }
     },
 
@@ -286,7 +286,7 @@ export default {
       if (frameIn &&
           frameOut &&
           frameOut > frameIn) {
-        this.form.nb_frames = frameOut - frameIn
+        this.form.nb_frames = frameOut - frameIn + 1
       }
     },
 

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -100,7 +100,9 @@
             :entity="entity"
             :preview-file-id="entity.preview_file_id"
             :selected="selection[entity.id]"
-            :name="entity.name"
+            :name="sequenceId === 'all'
+              ? entity.sequence_name + ' / ' + entity.name
+              : entity.name"
             :assets="castingByType[entity.id] || []"
             :read-only="!isCurrentUserManager"
             :text-mode="isTextMode"

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1352,6 +1352,8 @@ export default {
         this.fixCanvasSize(this.getCurrentPreviewDimensions())
         this.endAnnotationSaving()
         this.$nextTick(() => {
+          this.previewViewer.resize()
+          this.comparisonViewer.resize()
           this.reloadAnnotations()
           this.loadAnnotation()
         })

--- a/src/components/previews/VideoProgress.vue
+++ b/src/components/previews/VideoProgress.vue
@@ -109,9 +109,11 @@ export default {
     window.addEventListener('mouseup', this.stopHandleOutDrag)
     window.addEventListener('resize', this.onWindowResize)
     new ResizeObserver(this.onWindowResize).observe(this.progress)
-
     const progressCoordinates = this.progress.getBoundingClientRect()
     this.width = progressCoordinates.width
+    setTimeout(() => {
+      this.width = progressCoordinates.width
+    })
     this.progress.setAttribute('max', this.videoDuration)
   },
 
@@ -230,7 +232,7 @@ export default {
     },
 
     _getMouseFrame (annotation) {
-      let left = this.progress.parentElement.offsetLeft
+      let left = this.progress.getBoundingClientRect().left
       if (left === 0 && !this.fullScreen) {
         left = this.progress.parentElement.offsetParent.offsetLeft
       }
@@ -281,7 +283,6 @@ export default {
   flex-shrink: 0;
   margin: 0;
   height: 28px;
-  overflow: hidden;
   padding: 0;
   position: relative;
   width: 100%;
@@ -353,6 +354,7 @@ progress {
   color: $grey;
   display: inline-block;
   height: 28px;
+  overflow: hidden;
   padding-left: 10px;
   padding-top: 3px;
   position: absolute;

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -73,7 +73,7 @@
             name: 'todos-tab',
             params: { tab: 'todos' }
           }"
-          v-if="!isCurrentUserAdmin"
+          v-if="!isCurrentUserAdmin && !isCurrentUserClient"
         >
           {{ $t('tasks.my_tasks') }}
         </router-link>
@@ -84,7 +84,7 @@
             name: 'todos-tab',
             params: { tab: 'timesheets' }
           }"
-          v-if="!isCurrentUserAdmin"
+          v-if="!isCurrentUserAdmin && !isCurrentUserClient"
         >
           {{ $t('timesheets.title') }}
         </router-link>
@@ -388,10 +388,19 @@ export default {
         )
       }
 
+      if (!this.isCurrentUserClient) {
+        options = options.concat([
+          { label: this.$t('breakdown.title'), value: 'breakdown' }
+        ])
+      }
       options = options.concat([
-        { label: this.$t('breakdown.title'), value: 'breakdown' },
         { label: this.$t('playlists.title'), value: 'playlists' }
       ])
+
+      if (this.isCurrentUserClient) {
+        const playlistSection = options.pop()
+        options = [playlistSection].concat(options)
+      }
 
       if (!this.isCurrentUserClient) {
         options.push(
@@ -410,12 +419,12 @@ export default {
 
       // Add episodes for tv show only
       if (this.isTVShow) {
-        options.push(
+        options = options.concat([
           { label: this.$t('episodes.stats_title'), value: 'episode-stats' }
-        )
+        ])
       }
 
-      // Add asset types stats and playlists
+      // Add asset types stats
       options = options.concat([
         {
           label: this.$t('asset_types.production_title'), value: 'assetTypes'
@@ -437,9 +446,6 @@ export default {
             { label: this.$t('settings.title'), value: 'production-settings' }
           ])
         }
-      } else {
-        const playlistSection = options.pop()
-        options = [playlistSection].concat(options)
       }
 
       if (this.isCurrentUserVendor) {

--- a/src/store/api/breakdown.js
+++ b/src/store/api/breakdown.js
@@ -8,9 +8,13 @@ export default {
     return client.pget(path)
   },
 
-  getSequenceCasting (productionId, sequenceId) {
-    const path =
+  getSequenceCasting (productionId, sequenceId, episodeId) {
+    let path =
       `/api/data/projects/${productionId}/sequences/${sequenceId}/casting`
+    if (episodeId) {
+      path =
+      `/api/data/projects/${productionId}/episodes/${episodeId}/sequences/all/casting`
+    }
     return client.pget(path)
   },
 


### PR DESCRIPTION
**Problem**

* Nb frames computation is broken in the edit shot modal
* The all-sequence filter in the breakdown section returns an empty casting
* The section list for clients is messy
* The video progress doesn't work properly in the on-the-fly playlist modal
* The second video has a broken size when the comment widget is open in full-screen mode for the preview player

**Solution**

* Fix the formula in the edit shot modal for nb frames computation
* Use the proper routes to retrieve the casting for the whole project or episode
* Handle the sub-sections properly to show the Playlists first
* Change the overflow parameter, put it at the handle out widget level
* Reset both video sizes when the comment panel is open