### PR TITLE
various fixes

### DIFF
--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -765,7 +765,7 @@ export const annotationMixin = {
       this.notSaved = true
       this.$options.annotatedPreview = preview
       this.$options.annotationToSave =
-        setTimeout(this.endAnnotationSaving, 3000)
+        setTimeout(() => { this.endAnnotationSaving() }, 3000)
     },
 
     endAnnotationSaving () {

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -1050,25 +1050,13 @@ export default {
         data: metadata
       }
       const shot = this.shotMap.get(entry.id)
-      if (descriptor.field_name === 'frame_in') {
-        if (
-          shot.data.frame_out &&
-          parseInt(shot.nb_frames) !==
-          parseInt(shot.data.frame_out) - parseInt(value) &&
-          parseInt(shot.data.frame_out) > parseInt(value)
-        ) {
-          data.nb_frames = parseInt(shot.data.frame_out) - parseInt(value) + 1
-        }
+      if (descriptor.field_name === 'frame_in' && shot.data.frame_out &&
+        parseInt(shot.data.frame_out) > parseInt(value)) {
+        data.nb_frames = parseInt(shot.data.frame_out) - parseInt(value) + 1
       }
-      if (descriptor.field_name === 'frame_out') {
-        if (
-          shot.data.frame_in &&
-          parseInt(shot.nb_frames) !==
-          parseInt(value) - parseInt(shot.data.frame_in) &&
-          parseInt(shot.data.frame_in) < parseInt(value)
-        ) {
-          data.nb_frames = parseInt(value) - parseInt(shot.data.frame_in) + 1
-        }
+      if (descriptor.field_name === 'frame_out' && shot.data.frame_in &&
+        parseInt(shot.data.frame_in) < parseInt(value)) {
+        data.nb_frames = parseInt(value) - parseInt(shot.data.frame_in) + 1
       }
       this.editShot(data)
     }

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1143,7 +1143,9 @@ export default {
           (annotation) => annotation.time === time
         )
       } else if (this.isPicture) {
-        return this.annotations[0]
+        return this.annotations.find(
+          (annotation) => annotation.time === 0
+        )
       }
     },
 


### PR DESCRIPTION
**Problem**
- nb_frames of shots calculation is wrong when modifying just one frame for frame_out / frame_in 
- sometimes annotations for image add wrong time for annotations (time for images must always be at 0)

**Solution**
- always calculate nb_frames if we are adding just one frame
- fix save annotations due to timeout having wrong "this" context
