### PR TITLE
[csv] fix exports csv of shots when there's episode

### DIFF
--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -626,7 +626,8 @@ const actions = {
     }
     const lines = shots.map(shot => {
       let shotLine = []
-      if (isTVShow) shotLine.push(shot.episode_name)
+      if (isTVShow)
+        shotLine.push(rootGetters.episodeMap.get(shot.episode_id).name)
       shotLine = shotLine.concat([
         shot.sequence_name,
         shot.name,


### PR DESCRIPTION
**Problem**
- when exporting csv of shots if the production is a tv show the episode name is empty
**Solution**
- fix exporting csv of shots if the production is a tv show the episode name is empty
