### PR TITLE
[tasks] Handle wrongly formatted descriptor choices

### DIFF
--- a/src/components/mixins/descriptors.js
+++ b/src/components/mixins/descriptors.js
@@ -140,9 +140,17 @@ export const descriptorMixin = {
 
     getDescriptorChecklistValues (descriptor) {
       const values = descriptor.choices.reduce((result, choice) => {
-        if (choice && choice.startsWith('[x] ')) {
+        if (
+          choice &&
+          typeof(choice) === "string" &&
+          choice.startsWith('[x] ')
+        ) {
           result.push({ text: choice.slice(4), checked: true })
-        } else if (choice && choice.startsWith('[ ] ')) {
+        } else if (
+          choice &&
+          typeof(choice) === "string" &&
+          choice.startsWith('[ ] ')
+        ) {
           result.push({ text: choice.slice(4), checked: false })
         }
         return result


### PR DESCRIPTION
**Problem**

When the format of choices in the descriptor is not the expected one the list displaying crashes.

**Solution**

Use only string to build choices combobox options.

