### PR TITLE
[automations] Fix store reactivity

### DIFF
--- a/src/store/modules/statusautomation.js
+++ b/src/store/modules/statusautomation.js
@@ -12,6 +12,7 @@ import {
 
 const initialState = {
   statusAutomations: [],
+  statusAutomationMap: new Map(),
 
   editStatusAutomation: {
     isLoading: false,


### PR DESCRIPTION
**Problem**
If you add or delete status automations from the main Settings page, the changes are not correctly applied to the form "{production} > Settings > Status Automations" for eg.

**Solution**
Fix missing state initialization on data store to enable reactivity.
