### PR TITLE
[tasks] fix scroll on edit comment modal

### DIFF
--- a/src/components/modals/EditCommentModal.vue
+++ b/src/components/modals/EditCommentModal.vue
@@ -281,10 +281,6 @@ textarea {
   padding: 0.5em;
 }
 
-.modal-content {
-  overflow: initial;
-}
-
 .comment-checklist {
   overflow-y: auto;
   max-height: 200px;


### PR DESCRIPTION
**Problem**
When the edit comment popup is too high, the scroll is missing to validate the form.

related to #1052  

**Solution**
Enable scroll on overflow
