### PR TITLE
[metadata] support new types (number, boolean)

### DIFF
--- a/src/components/cells/MetadataInput.vue
+++ b/src/components/cells/MetadataInput.vue
@@ -1,0 +1,230 @@
+<template>
+  <!-- number or text input-->
+  <input
+    class="input-editor"
+    @input="event => onMetadataFieldChanged(entity, descriptor, event)"
+    @keyup.ctrl="
+      event =>
+        onInputKeyUp(
+          event,
+          indexes.k ? getIndex(indexes.i, indexes.k) : indexes.i,
+          indexes.j
+        )
+    "
+    :type="descriptor.data_type === 'number' ? 'number' : 'text'"
+    :value="getMetadataFieldValue(descriptor, entity)"
+    v-if="
+      !descriptor.data_type ||
+      (['string', 'number'].includes(descriptor.data_type) && isEditable)
+    "
+  />
+  <!-- boolean input -->
+  <input
+    class="input-editor"
+    @input="event => onMetadataFieldChanged(entity, descriptor, event)"
+    @keyup.ctrl="
+      event =>
+        onInputKeyUp(
+          event,
+          indexes.k ? getIndex(indexes.i, indexes.k) : indexes.i,
+          indexes.j
+        )
+    "
+    type="checkbox"
+    :checked="getMetadataFieldValue(descriptor, entity) === 'true'"
+    v-else-if="descriptor.data_type === 'boolean' && isEditable"
+  />
+  <!-- checklist input -->
+  <div
+    class="metadata-value selectable"
+    v-else-if="
+      descriptor.data_type === 'checklist' &&
+      getDescriptorChecklistValues(descriptor).length
+    "
+  >
+    <p
+      v-for="(option, i) in getDescriptorChecklistValues(descriptor)"
+      :key="`${entity.id}-${descriptor.id}-${i}-${option.text}-div`"
+    >
+      <input
+        type="checkbox"
+        @change="
+          event =>
+            onMetadataChecklistChanged(entity, descriptor, option.text, event)
+        "
+        :id="`${entity.id}-${descriptor.id}-${i}-${option.text}-input`"
+        :checked="getMetadataChecklistValues(descriptor, entity)[option.text]"
+        :disabled="!isEditable"
+        :style="[isEditable ? { cursor: 'pointer' } : { cursor: 'auto' }]"
+      />
+      <label
+        :for="`${entity.id}-${descriptor.id}-${i}-${option.text}-input`"
+        :style="[isEditable ? { cursor: 'pointer' } : { cursor: 'auto' }]"
+      >
+        {{ option.text }}
+      </label>
+    </p>
+  </div>
+  <!-- list input -->
+  <span
+    class="select"
+    v-else-if="descriptor.data_type === 'list' && isEditable"
+  >
+    <select
+      class="select-input"
+      @keyup.ctrl="
+        event =>
+          onInputKeyUp(
+            event,
+            indexes.k ? getIndex(indexes.i, indexes.k) : indexes.i,
+            indexes.j
+          )
+      "
+      @change="event => onMetadataFieldChanged(entity, descriptor, event)"
+    >
+      <option
+        v-for="(option, i) in getDescriptorChoicesOptions(descriptor)"
+        :key="`desc-value-${entity.id}-${descriptor.id}-${i}-${option.label}-${option.value}`"
+        :value="option.value"
+        :selected="getMetadataFieldValue(descriptor, entity) === option.value"
+      >
+        {{ option.label }}
+      </option>
+    </select>
+  </span>
+  <!-- default -->
+  <span class="metadata-value selectable" v-else>
+    {{ getMetadataFieldValue(descriptor, entity) }}
+  </span>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import { descriptorMixin } from '@/components/mixins/descriptors'
+import { entityListMixin } from '@/components/mixins/entity_list'
+
+export default {
+  name: 'MetadataInput',
+  mixins: [entityListMixin, descriptorMixin],
+  props: {
+    entity: {
+      type: Object,
+      required: true
+    },
+    descriptor: {
+      type: Object,
+      required: true
+    },
+    indexes: {
+      type: Object,
+      required: true
+    }
+  },
+  computed: {
+    ...mapGetters(['isCurrentUserManager']),
+    isEditable() {
+      return (
+        this.isCurrentUserManager ||
+        this.isSupervisorInDepartments(this.descriptor.departments)
+      )
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.dark {
+  .select select,
+  .input-editor {
+    color: $white;
+
+    option {
+      background: $dark-grey-light;
+      color: $white;
+    }
+
+    &:focus,
+    &:active,
+    &:hover {
+      background: $dark-grey-light;
+    }
+  }
+}
+
+.input-editor {
+  color: $grey-strong;
+  height: 100%;
+  padding: 0.5rem;
+  width: 100%;
+  background: transparent;
+  border: 1px solid transparent;
+  z-index: 100;
+
+  &[type='checkbox'] {
+    display: block;
+    width: initial;
+    height: initial;
+    margin: auto;
+  }
+
+  &:active,
+  &:focus,
+  &:hover {
+    background: transparent;
+    background: white;
+  }
+
+  &:active,
+  &:focus {
+    border: 1px solid $green;
+  }
+
+  &:hover {
+    border: 1px solid $light-green;
+  }
+}
+
+.select {
+  color: $grey-strong;
+  margin: 0;
+  height: 100%;
+  width: 100%;
+  border: 1px solid transparent;
+
+  &::after {
+    border-color: transparent;
+  }
+
+  &:active,
+  &:focus,
+  &:hover {
+    &::after {
+      border-color: $green;
+    }
+  }
+
+  select {
+    color: $grey-strong;
+    height: 100%;
+    width: 100%;
+    background: transparent;
+    border-radius: 0;
+    border: 1px solid transparent;
+
+    &:focus {
+      border: 1px solid $green;
+      background: white;
+    }
+
+    &:hover {
+      background: transparent;
+      background: white;
+      border: 1px solid $light-green;
+    }
+  }
+}
+
+.metadata-value {
+  padding: 0.8rem;
+}
+</style>

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -284,104 +284,12 @@
               :key="'sticky-desc-' + asset.id + '-' + descriptor.id"
               v-for="(descriptor, j) in stickedVisibleMetadataDescriptors"
             >
-              <input
-                class="input-editor"
-                @input="
-                  event => onMetadataFieldChanged(asset, descriptor, event)
-                "
-                @keyup.ctrl="event => onInputKeyUp(event, getIndex(i, k), j)"
-                :value="getMetadataFieldValue(descriptor, asset)"
-                v-if="
-                  descriptor.choices.length === 0 &&
-                  (isCurrentUserManager ||
-                    isSupervisorInDepartments(descriptor.departments))
-                "
+              <metadata-input
+                :entity="asset"
+                :descriptor="descriptor"
+                :indexes="{ i, j, k }"
+                v-on="$listeners"
               />
-              <div
-                class="metadata-value selectable"
-                v-else-if="
-                  descriptor.choices.length > 0 &&
-                  getDescriptorChecklistValues(descriptor).length > 0
-                "
-              >
-                <p
-                  v-for="(option, i) in getDescriptorChecklistValues(
-                    descriptor
-                  )"
-                  :key="`${asset.id}-${descriptor.id}-${i}-${option.text}-div`"
-                >
-                  <input
-                    type="checkbox"
-                    @change="
-                      event =>
-                        onMetadataChecklistChanged(
-                          asset,
-                          descriptor,
-                          option.text,
-                          event
-                        )
-                    "
-                    :id="`${asset.id}-${descriptor.id}-${i}-${option.text}-input`"
-                    :checked="
-                      getMetadataChecklistValues(descriptor, asset)[option.text]
-                    "
-                    :disabled="
-                      !(
-                        isCurrentUserManager ||
-                        isSupervisorInDepartments(descriptor.departments)
-                      )
-                    "
-                    :style="[
-                      isCurrentUserManager ||
-                      isSupervisorInDepartments(descriptor.departments)
-                        ? { cursor: 'pointer' }
-                        : { cursor: 'auto' }
-                    ]"
-                  />
-                  <label
-                    :for="`${asset.id}-${descriptor.id}-${i}-${option.text}-input`"
-                    :style="[
-                      isCurrentUserManager ||
-                      isSupervisorInDepartments(descriptor.departments)
-                        ? { cursor: 'pointer' }
-                        : { cursor: 'auto' }
-                    ]"
-                  >
-                    {{ option.text }}
-                  </label>
-                </p>
-              </div>
-              <span
-                class="select"
-                v-else-if="
-                  isCurrentUserManager ||
-                  isSupervisorInDepartments(descriptor.departments)
-                "
-              >
-                <select
-                  class="select-input"
-                  @keyup.ctrl="event => onInputKeyUp(event, getIndex(i, k), j)"
-                  @change="
-                    event => onMetadataFieldChanged(asset, descriptor, event)
-                  "
-                >
-                  <option
-                    v-for="(option, i) in getDescriptorChoicesOptions(
-                      descriptor
-                    )"
-                    :key="`sticky-desc-value-${asset.id}-${descriptor.id}-${i}-${option.label}-${option.value}`"
-                    :value="option.value"
-                    :selected="
-                      getMetadataFieldValue(descriptor, asset) === option.value
-                    "
-                  >
-                    {{ option.label }}
-                  </option>
-                </select>
-              </span>
-              <span class="metadata-value selectable" v-else>
-                {{ getMetadataFieldValue(descriptor, asset) }}
-              </span>
             </td>
 
             <validation-cell
@@ -425,7 +333,6 @@
               <combobox-task-type
                 class="mb0"
                 :value="asset.ready_for"
-                production-id="this.currentProduction.id"
                 :task-type-list="readyForTaskTypes"
                 :shy="true"
                 @input="taskTypeId => onReadyForChanged(asset, taskTypeId)"
@@ -472,104 +379,12 @@
               v-for="(descriptor, j) in nonStickedVisibleMetadataDescriptors"
               v-if="isShowInfos"
             >
-              <input
-                class="input-editor"
-                @input="
-                  event => onMetadataFieldChanged(asset, descriptor, event)
-                "
-                @keyup.ctrl="event => onInputKeyUp(event, getIndex(i, k), j)"
-                :value="getMetadataFieldValue(descriptor, asset)"
-                v-if="
-                  descriptor.choices.length === 0 &&
-                  (isCurrentUserManager ||
-                    isSupervisorInDepartments(descriptor.departments))
-                "
+              <metadata-input
+                :entity="asset"
+                :descriptor="descriptor"
+                :indexes="{ i, j, k }"
+                v-on="$listeners"
               />
-              <div
-                class="metadata-value selectable"
-                v-else-if="
-                  descriptor.choices.length > 0 &&
-                  getDescriptorChecklistValues(descriptor).length > 0
-                "
-              >
-                <p
-                  v-for="(option, i) in getDescriptorChecklistValues(
-                    descriptor
-                  )"
-                  :key="`${asset.id}-${descriptor.id}-${i}-${option.text}-div`"
-                >
-                  <input
-                    type="checkbox"
-                    @change="
-                      event =>
-                        onMetadataChecklistChanged(
-                          asset,
-                          descriptor,
-                          option.text,
-                          event
-                        )
-                    "
-                    :id="`${asset.id}-${descriptor.id}-${i}-${option.text}-input`"
-                    :checked="
-                      getMetadataChecklistValues(descriptor, asset)[option.text]
-                    "
-                    :disabled="
-                      !(
-                        isCurrentUserManager ||
-                        isSupervisorInDepartments(descriptor.departments)
-                      )
-                    "
-                    :style="[
-                      isCurrentUserManager ||
-                      isSupervisorInDepartments(descriptor.departments)
-                        ? { cursor: 'pointer' }
-                        : { cursor: 'auto' }
-                    ]"
-                  />
-                  <label
-                    :for="`${asset.id}-${descriptor.id}-${i}-${option.text}-input`"
-                    :style="[
-                      isCurrentUserManager ||
-                      isSupervisorInDepartments(descriptor.departments)
-                        ? { cursor: 'pointer' }
-                        : { cursor: 'auto' }
-                    ]"
-                  >
-                    {{ option.text }}
-                  </label>
-                </p>
-              </div>
-              <span
-                class="select"
-                v-else-if="
-                  isCurrentUserManager ||
-                  isSupervisorInDepartments(descriptor.departments)
-                "
-              >
-                <select
-                  class="select-input"
-                  @keyup.ctrl="event => onInputKeyUp(event, getIndex(i, k), j)"
-                  @change="
-                    event => onMetadataFieldChanged(asset, descriptor, event)
-                  "
-                >
-                  <option
-                    v-for="(option, i) in getDescriptorChoicesOptions(
-                      descriptor
-                    )"
-                    :key="`desc-value-${asset.id}-${descriptor.id}-${i}-${option.label}-${option.value}`"
-                    :value="option.value"
-                    :selected="
-                      getMetadataFieldValue(descriptor, asset) === option.value
-                    "
-                  >
-                    {{ option.label }}
-                  </option>
-                </select>
-              </span>
-              <span class="metadata-value selectable" v-else>
-                {{ getMetadataFieldValue(descriptor, asset) }}
-              </span>
             </td>
 
             <validation-cell
@@ -670,6 +485,7 @@ import ComboboxTaskType from '@/components/widgets/ComboboxTaskType'
 import DescriptionCell from '@/components/cells/DescriptionCell'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail'
 import MetadataHeader from '@/components/cells/MetadataHeader'
+import MetadataInput from '@/components/cells/MetadataInput'
 import RowActionsCell from '@/components/cells/RowActionsCell'
 import TableHeaderMenu from '@/components/widgets/TableHeaderMenu'
 import TableInfo from '@/components/widgets/TableInfo'
@@ -692,6 +508,7 @@ export default {
     ComboboxTaskType,
     DescriptionCell,
     EntityThumbnail,
+    MetadataInput,
     MetadataHeader,
     RowActionsCell,
     TableInfo,
@@ -947,7 +764,7 @@ export default {
 
     onReadyForChanged(asset, taskTypeId) {
       if (this.selectedAssets.has(asset.id)) {
-        this.selectedAssets.forEach((asset, _) => {
+        this.selectedAssets.forEach(asset => {
           const data = { id: asset.id, ready_for: taskTypeId }
           this.$emit('asset-changed', data)
         })
@@ -1172,100 +989,20 @@ td.ready-for {
   max-width: 80vh;
 }
 
+input[type='number']::-webkit-outer-spin-button,
+input[type='number']::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type='number'] {
+  -moz-appearance: textfield;
+}
+
 // Metadata cell CSS
 
 td.metadata-descriptor {
   height: 3.1rem;
   padding: 0;
-}
-
-.dark {
-  th .input-editor,
-  td .select select,
-  td .input-editor {
-    color: $white;
-
-    option {
-      background: $dark-grey-light;
-      color: $white;
-    }
-
-    &:focus,
-    &:active,
-    &:hover {
-      background: $dark-grey-light;
-    }
-  }
-}
-
-th .input-editor,
-td .input-editor {
-  color: $grey-strong;
-  height: 100%;
-  padding: 0.5rem;
-  width: 100%;
-  background: transparent;
-  border: 1px solid transparent;
-  z-index: 100;
-
-  &:active,
-  &:focus,
-  &:hover {
-    background: transparent;
-    background: white;
-  }
-
-  &:active,
-  &:focus {
-    border: 1px solid $green;
-  }
-
-  &:hover {
-    border: 1px solid $light-green;
-  }
-}
-
-td .select {
-  color: $grey-strong;
-  margin: 0;
-  height: 100%;
-  width: 100%;
-  border: 1px solid transparent;
-
-  &::after {
-    border-color: transparent;
-  }
-
-  &:active,
-  &:focus,
-  &:hover {
-    &::after {
-      border-color: $green;
-    }
-  }
-
-  select {
-    color: $grey-strong;
-    height: 100%;
-    width: 100%;
-    background: transparent;
-    border-radius: 0;
-    border: 1px solid transparent;
-
-    &:focus {
-      border: 1px solid $green;
-      background: white;
-    }
-
-    &:hover {
-      background: transparent;
-      background: white;
-      border: 1px solid $light-green;
-    }
-  }
-}
-
-.metadata-value {
-  padding: 0.8rem;
 }
 </style>

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -290,104 +290,12 @@
               :key="edit.id + '-' + descriptor.id"
               v-for="(descriptor, j) in stickedVisibleMetadataDescriptors"
             >
-              <input
-                class="input-editor"
-                @input="
-                  event => onMetadataFieldChanged(edit, descriptor, event)
-                "
-                @keyup.ctrl="event => onInputKeyUp(event, i, j)"
-                :value="getMetadataFieldValue(descriptor, edit)"
-                v-if="
-                  descriptor.choices.length === 0 &&
-                  (isCurrentUserManager ||
-                    isSupervisorInDepartments(descriptor.departments))
-                "
+              <metadata-input
+                :entity="edit"
+                :descriptor="descriptor"
+                :indexes="{ i, j }"
+                v-on="$listeners"
               />
-              <div
-                class="metadata-value selectable"
-                v-else-if="
-                  descriptor.choices.length > 0 &&
-                  getDescriptorChecklistValues(descriptor).length > 0
-                "
-              >
-                <p
-                  v-for="(option, i) in getDescriptorChecklistValues(
-                    descriptor
-                  )"
-                  :key="`${edit.id}-${descriptor.id}-${i}-${option.text}-div`"
-                >
-                  <input
-                    type="checkbox"
-                    @change="
-                      event =>
-                        onMetadataChecklistChanged(
-                          edit,
-                          descriptor,
-                          option.text,
-                          event
-                        )
-                    "
-                    :id="`${edit.id}-${descriptor.id}-${i}-${option.text}-input`"
-                    :checked="
-                      getMetadataChecklistValues(descriptor, edit)[option.text]
-                    "
-                    :disabled="
-                      !(
-                        isCurrentUserManager ||
-                        isSupervisorInDepartments(descriptor.departments)
-                      )
-                    "
-                    :style="[
-                      isCurrentUserManager ||
-                      isSupervisorInDepartments(descriptor.departments)
-                        ? { cursor: 'pointer' }
-                        : { cursor: 'auto' }
-                    ]"
-                  />
-                  <label
-                    :for="`${edit.id}-${descriptor.id}-${i}-${option.text}-input`"
-                    :style="[
-                      isCurrentUserManager ||
-                      isSupervisorInDepartments(descriptor.departments)
-                        ? { cursor: 'pointer' }
-                        : { cursor: 'auto' }
-                    ]"
-                  >
-                    {{ option.text }}
-                  </label>
-                </p>
-              </div>
-              <span
-                class="select"
-                v-else-if="
-                  isCurrentUserManager ||
-                  isSupervisorInDepartments(descriptor.departments)
-                "
-              >
-                <select
-                  class="select-input"
-                  @keyup.ctrl="event => onInputKeyUp(event, i, j)"
-                  @change="
-                    event => onMetadataFieldChanged(edit, descriptor, event)
-                  "
-                >
-                  <option
-                    v-for="(option, i) in getDescriptorChoicesOptions(
-                      descriptor
-                    )"
-                    :key="`${edit.id}-${descriptor.id}-${i}-${option.label}-${option.value}`"
-                    :value="option.value"
-                    :selected="
-                      getMetadataFieldValue(descriptor, edit) === option.value
-                    "
-                  >
-                    {{ option.label }}
-                  </option>
-                </select>
-              </span>
-              <span class="metadata-value selectable" v-else>
-                {{ getMetadataFieldValue(descriptor, edit) }}
-              </span>
             </td>
 
             <validation-cell
@@ -435,104 +343,12 @@
               v-for="(descriptor, j) in nonStickedVisibleMetadataDescriptors"
               v-if="isShowInfos"
             >
-              <input
-                class="input-editor"
-                @input="
-                  event => onMetadataFieldChanged(edit, descriptor, event)
-                "
-                @keyup.ctrl="event => onInputKeyUp(event, i, j)"
-                :value="getMetadataFieldValue(descriptor, edit)"
-                v-if="
-                  descriptor.choices.length === 0 &&
-                  (isCurrentUserManager ||
-                    isSupervisorInDepartments(descriptor.departments))
-                "
+              <metadata-input
+                :entity="edit"
+                :descriptor="descriptor"
+                :indexes="{ i, j }"
+                v-on="$listeners"
               />
-              <div
-                class="metadata-value selectable"
-                v-else-if="
-                  descriptor.choices.length > 0 &&
-                  getDescriptorChecklistValues(descriptor).length > 0
-                "
-              >
-                <p
-                  v-for="(option, i) in getDescriptorChecklistValues(
-                    descriptor
-                  )"
-                  :key="`${edit.id}-${descriptor.id}-${i}-${option.text}-div`"
-                >
-                  <input
-                    type="checkbox"
-                    @change="
-                      event =>
-                        onMetadataChecklistChanged(
-                          edit,
-                          descriptor,
-                          option.text,
-                          event
-                        )
-                    "
-                    :id="`${edit.id}-${descriptor.id}-${i}-${option.text}-input`"
-                    :checked="
-                      getMetadataChecklistValues(descriptor, edit)[option.text]
-                    "
-                    :disabled="
-                      !(
-                        isCurrentUserManager ||
-                        isSupervisorInDepartments(descriptor.departments)
-                      )
-                    "
-                    :style="[
-                      isCurrentUserManager ||
-                      isSupervisorInDepartments(descriptor.departments)
-                        ? { cursor: 'pointer' }
-                        : { cursor: 'auto' }
-                    ]"
-                  />
-                  <label
-                    :for="`${edit.id}-${descriptor.id}-${i}-${option.text}-input`"
-                    :style="[
-                      isCurrentUserManager ||
-                      isSupervisorInDepartments(descriptor.departments)
-                        ? { cursor: 'pointer' }
-                        : { cursor: 'auto' }
-                    ]"
-                  >
-                    {{ option.text }}
-                  </label>
-                </p>
-              </div>
-              <span
-                class="select"
-                v-else-if="
-                  isCurrentUserManager ||
-                  isSupervisorInDepartments(descriptor.departments)
-                "
-              >
-                <select
-                  class="select-input"
-                  @keyup.ctrl="event => onInputKeyUp(event, i, j)"
-                  @change="
-                    event => onMetadataFieldChanged(edit, descriptor, event)
-                  "
-                >
-                  <option
-                    v-for="(option, i) in getDescriptorChoicesOptions(
-                      descriptor
-                    )"
-                    :key="`${edit.id}-${descriptor.id}-${i}-${option.label}-${option.value}`"
-                    :value="option.value"
-                    :selected="
-                      getMetadataFieldValue(descriptor, edit) === option.value
-                    "
-                  >
-                    {{ option.label }}
-                  </option>
-                </select>
-              </span>
-              <span class="metadata-value selectable" v-else>
-                {{ getMetadataFieldValue(descriptor, edit) }}
-              </span>
             </td>
 
             <td
@@ -654,6 +470,7 @@ import ButtonSimple from '@/components/widgets/ButtonSimple'
 import DescriptionCell from '@/components/cells/DescriptionCell'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail'
 import MetadataHeader from '@/components/cells/MetadataHeader'
+import MetadataInput from '@/components/cells/MetadataInput'
 import RowActionsCell from '@/components/cells/RowActionsCell'
 import TableMetadataHeaderMenu from '@/components/widgets/TableMetadataHeaderMenu'
 import TableMetadataSelectorMenu from '@/components/widgets/TableMetadataSelectorMenu'
@@ -718,6 +535,7 @@ export default {
     DescriptionCell,
     EntityThumbnail,
     MetadataHeader,
+    MetadataInput,
     RowActionsCell,
     TableHeaderMenu,
     TableMetadataHeaderMenu,

--- a/src/components/lists/EpisodeList.vue
+++ b/src/components/lists/EpisodeList.vue
@@ -244,51 +244,12 @@
               v-for="(descriptor, j) in stickedVisibleMetadataDescriptors"
               v-if="isShowInfos"
             >
-              <input
-                class="input-editor"
-                @input="
-                  event => onMetadataFieldChanged(episode, descriptor, event)
-                "
-                @keyup.ctrl="event => onInputKeyUp(event, i, j)"
-                :value="getMetadataFieldValue(descriptor, episode)"
-                v-if="
-                  descriptor.choices.length === 0 &&
-                  (isCurrentUserManager ||
-                    isSupervisorInDepartments(descriptor.departments))
-                "
+              <metadata-input
+                :entity="episode"
+                :descriptor="descriptor"
+                :indexes="{ i, j }"
+                v-on="$listeners"
               />
-              <span
-                class="select"
-                v-else-if="
-                  isCurrentUserManager ||
-                  isSupervisorInDepartments(descriptor.departments)
-                "
-              >
-                <select
-                  class="select-input"
-                  @keyup.ctrl="event => onInputKeyUp(event, i, j)"
-                  @change="
-                    event => onMetadataFieldChanged(episode, descriptor, event)
-                  "
-                >
-                  <option
-                    v-for="(option, i) in getDescriptorChoicesOptions(
-                      descriptor
-                    )"
-                    :key="`${episode.id}-${descriptor.id}-${i}-${option.label}-${option.value}`"
-                    :value="option.value"
-                    :selected="
-                      getMetadataFieldValue(descriptor, episode) ===
-                      option.value
-                    "
-                  >
-                    {{ option.label }}
-                  </option>
-                </select>
-              </span>
-              <span class="metadata-value selectable" v-else>
-                {{ getMetadataFieldValue(descriptor, episode) }}
-              </span>
             </td>
 
             <validation-cell
@@ -338,51 +299,12 @@
               v-for="(descriptor, j) in nonStickedVisibleMetadataDescriptors"
               v-if="isShowInfos"
             >
-              <input
-                class="input-editor"
-                @input="
-                  event => onMetadataFieldChanged(episode, descriptor, event)
-                "
-                @keyup.ctrl="event => onInputKeyUp(event, i, j)"
-                :value="getMetadataFieldValue(descriptor, episode)"
-                v-if="
-                  descriptor.choices.length === 0 &&
-                  (isCurrentUserManager ||
-                    isSupervisorInDepartments(descriptor.departments))
-                "
+              <metadata-input
+                :entity="episode"
+                :descriptor="descriptor"
+                :indexes="{ i, j }"
+                v-on="$listeners"
               />
-              <span
-                class="select"
-                v-else-if="
-                  isCurrentUserManager ||
-                  isSupervisorInDepartments(descriptor.departments)
-                "
-              >
-                <select
-                  class="select-input"
-                  @keyup.ctrl="event => onInputKeyUp(event, i, j)"
-                  @change="
-                    event => onMetadataFieldChanged(episode, descriptor, event)
-                  "
-                >
-                  <option
-                    v-for="(option, i) in getDescriptorChoicesOptions(
-                      descriptor
-                    )"
-                    :key="`${episode.id}-${descriptor.id}-${i}-${option.label}-${option.value}`"
-                    :value="option.value"
-                    :selected="
-                      getMetadataFieldValue(descriptor, episode) ===
-                      option.value
-                    "
-                  >
-                    {{ option.label }}
-                  </option>
-                </select>
-              </span>
-              <span class="metadata-value selectable" v-else>
-                {{ getMetadataFieldValue(descriptor, episode) }}
-              </span>
             </td>
 
             <td
@@ -514,6 +436,7 @@ import ButtonSimple from '@/components/widgets/ButtonSimple'
 import DescriptionCell from '@/components/cells/DescriptionCell'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail'
 import MetadataHeader from '@/components/cells/MetadataHeader'
+import MetadataInput from '@/components/cells/MetadataInput'
 import RowActionsCell from '@/components/cells/RowActionsCell'
 import TableMetadataHeaderMenu from '@/components/widgets/TableMetadataHeaderMenu'
 import TableMetadataSelectorMenu from '@/components/widgets/TableMetadataSelectorMenu'
@@ -585,6 +508,7 @@ export default {
     DescriptionCell,
     EntityThumbnail,
     MetadataHeader,
+    MetadataInput,
     RowActionsCell,
     TableHeaderMenu,
     TableMetadataHeaderMenu,

--- a/src/components/lists/SequenceList.vue
+++ b/src/components/lists/SequenceList.vue
@@ -239,51 +239,12 @@
               v-for="(descriptor, j) in stickedVisibleMetadataDescriptors"
               v-if="isShowInfos"
             >
-              <input
-                class="input-editor"
-                @input="
-                  event => onMetadataFieldChanged(sequence, descriptor, event)
-                "
-                @keyup.ctrl="event => onInputKeyUp(event, i, j)"
-                :value="getMetadataFieldValue(descriptor, sequence)"
-                v-if="
-                  descriptor.choices.length === 0 &&
-                  (isCurrentUserManager ||
-                    isSupervisorInDepartments(descriptor.departments))
-                "
+              <metadata-input
+                :entity="sequence"
+                :descriptor="descriptor"
+                :indexes="{ i, j }"
+                v-on="$listeners"
               />
-              <span
-                class="select"
-                v-else-if="
-                  isCurrentUserManager ||
-                  isSupervisorInDepartments(descriptor.departments)
-                "
-              >
-                <select
-                  class="select-input"
-                  @keyup.ctrl="event => onInputKeyUp(event, i, j)"
-                  @change="
-                    event => onMetadataFieldChanged(sequence, descriptor, event)
-                  "
-                >
-                  <option
-                    v-for="(option, i) in getDescriptorChoicesOptions(
-                      descriptor
-                    )"
-                    :key="`${sequence.id}-${descriptor.id}-${i}-${option.label}-${option.value}`"
-                    :value="option.value"
-                    :selected="
-                      getMetadataFieldValue(descriptor, sequence) ===
-                      option.value
-                    "
-                  >
-                    {{ option.label }}
-                  </option>
-                </select>
-              </span>
-              <span class="metadata-value selectable" v-else>
-                {{ getMetadataFieldValue(descriptor, sequence) }}
-              </span>
             </td>
 
             <validation-cell
@@ -335,51 +296,12 @@
               v-for="(descriptor, j) in nonStickedVisibleMetadataDescriptors"
               v-if="isShowInfos"
             >
-              <input
-                class="input-editor"
-                @input="
-                  event => onMetadataFieldChanged(sequence, descriptor, event)
-                "
-                @keyup.ctrl="event => onInputKeyUp(event, i, j)"
-                :value="getMetadataFieldValue(descriptor, sequence)"
-                v-if="
-                  descriptor.choices.length === 0 &&
-                  (isCurrentUserManager ||
-                    isSupervisorInDepartments(descriptor.departments))
-                "
+              <metadata-input
+                :entity="sequence"
+                :descriptor="descriptor"
+                :indexes="{ i, j }"
+                v-on="$listeners"
               />
-              <span
-                class="select"
-                v-else-if="
-                  isCurrentUserManager ||
-                  isSupervisorInDepartments(descriptor.departments)
-                "
-              >
-                <select
-                  class="select-input"
-                  @keyup.ctrl="event => onInputKeyUp(event, i, j)"
-                  @change="
-                    event => onMetadataFieldChanged(sequence, descriptor, event)
-                  "
-                >
-                  <option
-                    v-for="(option, i) in getDescriptorChoicesOptions(
-                      descriptor
-                    )"
-                    :key="`${sequence.id}-${descriptor.id}-${i}-${option.label}-${option.value}`"
-                    :value="option.value"
-                    :selected="
-                      getMetadataFieldValue(descriptor, sequence) ===
-                      option.value
-                    "
-                  >
-                    {{ option.label }}
-                  </option>
-                </select>
-              </span>
-              <span class="metadata-value selectable" v-else>
-                {{ getMetadataFieldValue(descriptor, sequence) }}
-              </span>
             </td>
 
             <td
@@ -491,6 +413,7 @@ import ButtonSimple from '@/components/widgets/ButtonSimple'
 import DescriptionCell from '@/components/cells/DescriptionCell'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail'
 import MetadataHeader from '@/components/cells/MetadataHeader'
+import MetadataInput from '@/components/cells/MetadataInput'
 import RowActionsCell from '@/components/cells/RowActionsCell'
 import TableMetadataHeaderMenu from '@/components/widgets/TableMetadataHeaderMenu'
 import TableMetadataSelectorMenu from '@/components/widgets/TableMetadataSelectorMenu'
@@ -555,6 +478,7 @@ export default {
     DescriptionCell,
     EntityThumbnail,
     MetadataHeader,
+    MetadataInput,
     RowActionsCell,
     TableHeaderMenu,
     TableMetadataHeaderMenu,

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -316,104 +316,12 @@
               :key="shot.id + '-' + descriptor.id"
               v-for="(descriptor, j) in stickedVisibleMetadataDescriptors"
             >
-              <input
-                class="input-editor"
-                @input="
-                  event => onMetadataFieldChanged(shot, descriptor, event)
-                "
-                @keyup.ctrl="event => onInputKeyUp(event, getIndex(i, k), j)"
-                :value="getMetadataFieldValue(descriptor, shot)"
-                v-if="
-                  descriptor.choices.length === 0 &&
-                  (isCurrentUserManager ||
-                    isSupervisorInDepartments(descriptor.departments))
-                "
+              <metadata-input
+                :entity="shot"
+                :descriptor="descriptor"
+                :indexes="{ i, j, k }"
+                v-on="$listeners"
               />
-              <div
-                class="metadata-value selectable"
-                v-else-if="
-                  descriptor.choices.length > 0 &&
-                  getDescriptorChecklistValues(descriptor).length > 0
-                "
-              >
-                <p
-                  v-for="(option, i) in getDescriptorChecklistValues(
-                    descriptor
-                  )"
-                  :key="`${shot.id}-${descriptor.id}-${i}-${option.text}-div`"
-                >
-                  <input
-                    type="checkbox"
-                    @change="
-                      event =>
-                        onMetadataChecklistChanged(
-                          shot,
-                          descriptor,
-                          option.text,
-                          event
-                        )
-                    "
-                    :id="`${shot.id}-${descriptor.id}-${i}-${option.text}-input`"
-                    :checked="
-                      getMetadataChecklistValues(descriptor, shot)[option.text]
-                    "
-                    :disabled="
-                      !(
-                        isCurrentUserManager ||
-                        isSupervisorInDepartments(descriptor.departments)
-                      )
-                    "
-                    :style="[
-                      isCurrentUserManager ||
-                      isSupervisorInDepartments(descriptor.departments)
-                        ? { cursor: 'pointer' }
-                        : { cursor: 'auto' }
-                    ]"
-                  />
-                  <label
-                    :for="`${shot.id}-${descriptor.id}-${i}-${option.text}-input`"
-                    :style="[
-                      isCurrentUserManager ||
-                      isSupervisorInDepartments(descriptor.departments)
-                        ? { cursor: 'pointer' }
-                        : { cursor: 'auto' }
-                    ]"
-                  >
-                    {{ option.text }}
-                  </label>
-                </p>
-              </div>
-              <span
-                class="select"
-                v-else-if="
-                  isCurrentUserManager ||
-                  isSupervisorInDepartments(descriptor.departments)
-                "
-              >
-                <select
-                  class="select-input"
-                  @keyup.ctrl="event => onInputKeyUp(event, getIndex(i, k), j)"
-                  @change="
-                    event => onMetadataFieldChanged(shot, descriptor, event)
-                  "
-                >
-                  <option
-                    v-for="(option, i) in getDescriptorChoicesOptions(
-                      descriptor
-                    )"
-                    :key="`${shot.id}-${descriptor.id}-${i}-${option.label}-${option.value}`"
-                    :value="option.value"
-                    :selected="
-                      getMetadataFieldValue(descriptor, shot) === option.value
-                    "
-                  >
-                    {{ option.label }}
-                  </option>
-                </select>
-              </span>
-              <span class="metadata-value selectable" v-else>
-                {{ getMetadataFieldValue(descriptor, shot) }}
-              </span>
             </td>
 
             <validation-cell
@@ -663,105 +571,12 @@
               v-for="(descriptor, j) in nonStickedVisibleMetadataDescriptors"
               v-if="isShowInfos"
             >
-              <input
-                :ref="`editor-${getIndex(i, k)}-${j}`"
-                class="input-editor"
-                @input="
-                  event => onMetadataFieldChanged(shot, descriptor, event)
-                "
-                @keyup.ctrl="event => onInputKeyUp(event, getIndex(i, k), j)"
-                :value="getMetadataFieldValue(descriptor, shot)"
-                v-if="
-                  descriptor.choices.length === 0 &&
-                  (isCurrentUserManager ||
-                    isSupervisorInDepartments(descriptor.departments))
-                "
+              <metadata-input
+                :entity="shot"
+                :descriptor="descriptor"
+                :indexes="{ i, j, k }"
+                v-on="$listeners"
               />
-              <div
-                class="metadata-value selectable"
-                v-else-if="
-                  descriptor.choices.length > 0 &&
-                  getDescriptorChecklistValues(descriptor).length > 0
-                "
-              >
-                <p
-                  v-for="(option, i) in getDescriptorChecklistValues(
-                    descriptor
-                  )"
-                  :key="`${shot.id}-${descriptor.id}-${i}-${option.text}-div`"
-                >
-                  <input
-                    type="checkbox"
-                    @change="
-                      event =>
-                        onMetadataChecklistChanged(
-                          shot,
-                          descriptor,
-                          option.text,
-                          event
-                        )
-                    "
-                    :id="`${shot.id}-${descriptor.id}-${i}-${option.text}-input`"
-                    :checked="
-                      getMetadataChecklistValues(descriptor, shot)[option.text]
-                    "
-                    :disabled="
-                      !(
-                        isCurrentUserManager ||
-                        isSupervisorInDepartments(descriptor.departments)
-                      )
-                    "
-                    :style="[
-                      isCurrentUserManager ||
-                      isSupervisorInDepartments(descriptor.departments)
-                        ? { cursor: 'pointer' }
-                        : { cursor: 'auto' }
-                    ]"
-                  />
-                  <label
-                    :for="`${shot.id}-${descriptor.id}-${i}-${option.text}-input`"
-                    :style="[
-                      isCurrentUserManager ||
-                      isSupervisorInDepartments(descriptor.departments)
-                        ? { cursor: 'pointer' }
-                        : { cursor: 'auto' }
-                    ]"
-                  >
-                    {{ option.text }}
-                  </label>
-                </p>
-              </div>
-              <span
-                class="select"
-                v-else-if="
-                  isCurrentUserManager ||
-                  isSupervisorInDepartments(descriptor.departments)
-                "
-              >
-                <select
-                  class="select-input"
-                  @keyup.ctrl="event => onInputKeyUp(event, getIndex(i, k), j)"
-                  @change="
-                    event => onMetadataFieldChanged(shot, descriptor, event)
-                  "
-                >
-                  <option
-                    v-for="(option, i) in getDescriptorChoicesOptions(
-                      descriptor
-                    )"
-                    :key="`${shot.id}-${descriptor.id}-${i}-${option.label}-${option.value}`"
-                    :value="option.value"
-                    :selected="
-                      getMetadataFieldValue(descriptor, shot) === option.value
-                    "
-                  >
-                    {{ option.label }}
-                  </option>
-                </select>
-              </span>
-              <span class="metadata-value selectable" v-else>
-                {{ getMetadataFieldValue(descriptor, shot) }}
-              </span>
             </td>
 
             <validation-cell
@@ -869,6 +684,7 @@ import DescriptionCell from '@/components/cells/DescriptionCell'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail'
 import InfoQuestionMark from '@/components/widgets/InfoQuestionMark'
 import MetadataHeader from '@/components/cells/MetadataHeader'
+import MetadataInput from '@/components/cells/MetadataInput'
 import RowActionsCell from '@/components/cells/RowActionsCell'
 import TableMetadataHeaderMenu from '@/components/widgets/TableMetadataHeaderMenu'
 import TableMetadataSelectorMenu from '@/components/widgets/TableMetadataSelectorMenu'
@@ -893,6 +709,7 @@ export default {
     EntityThumbnail,
     InfoQuestionMark,
     MetadataHeader,
+    MetadataInput,
     RowActionsCell,
     TableHeaderMenu,
     TableMetadataHeaderMenu,
@@ -1488,49 +1305,5 @@ input[type='number'] {
 td.metadata-descriptor {
   height: 3.1rem;
   padding: 0;
-}
-
-td .select {
-  color: $grey-strong;
-  margin: 0;
-  height: 100%;
-  width: 100%;
-  border: 1px solid transparent;
-
-  &::after {
-    border-color: transparent;
-  }
-
-  &:active,
-  &:focus,
-  &:hover {
-    &::after {
-      border-color: $green;
-    }
-  }
-
-  select {
-    color: $grey-strong;
-    height: 100%;
-    width: 100%;
-    background: transparent;
-    border-radius: 0;
-    border: 1px solid transparent;
-
-    &:focus {
-      border: 1px solid $green;
-      background: white;
-    }
-
-    &:hover {
-      background: transparent;
-      background: white;
-      border: 1px solid $light-green;
-    }
-  }
-}
-
-.metadata-value {
-  padding: 0.8rem;
 }
 </style>

--- a/src/components/mixins/descriptors.js
+++ b/src/components/mixins/descriptors.js
@@ -41,37 +41,44 @@ export const descriptorMixin = {
     },
 
     onMetadataFieldChanged(entry, descriptor, event) {
+      let value
+      if (descriptor.data_type === 'boolean') {
+        value = event.target.checked ? 'true' : 'false'
+      } else {
+        value = event.target.value
+      }
+
       if (this.selectedShots.has(entry.id)) {
         // if the line is selected, also modify the cells of the other selected
         // lines.
-        this.selectedShots.forEach((shot, _) => {
-          this.emitMetadataChanged(shot, descriptor, event.target.value)
+        this.selectedShots.forEach(shot => {
+          this.emitMetadataChanged(shot, descriptor, value)
         })
       } else if (this.selectedAssets.has(entry.id)) {
         // if the line is selected, also modify the cells of the other selected
         // lines.
-        this.selectedAssets.forEach((asset, _) => {
-          this.emitMetadataChanged(asset, descriptor, event.target.value)
+        this.selectedAssets.forEach(asset => {
+          this.emitMetadataChanged(asset, descriptor, value)
         })
       } else if (this.selectedEdits.has(entry.id)) {
         // if the line is selected, also modify the cells of the other selected
         // lines.
-        this.selectedEdits.forEach((edit, _) => {
-          this.emitMetadataChanged(edit, descriptor, event.target.value)
+        this.selectedEdits.forEach(edit => {
+          this.emitMetadataChanged(edit, descriptor, value)
         })
       } else if (this.selectedEpisodes && this.selectedEpisodes.has(entry.id)) {
         // if the line is selected, also modify the cells of the other selected
         // lines.
-        this.selectedEpisodes.forEach((edit, _) => {
-          this.emitMetadataChanged(edit, descriptor, event.target.value)
+        this.selectedEpisodes.forEach(episode => {
+          this.emitMetadataChanged(episode, descriptor, value)
         })
       } else {
-        this.emitMetadataChanged(entry, descriptor, event.target.value)
+        this.emitMetadataChanged(entry, descriptor, value)
       }
     },
 
     onMetadataChecklistChanged(entry, descriptor, option, event) {
-      var values = this.getMetadataChecklistValues(descriptor, entry)
+      const values = this.getMetadataChecklistValues(descriptor, entry)
       values[option] = event.target.checked
       event.target.value = JSON.stringify(values)
       this.onMetadataFieldChanged(entry, descriptor, event)
@@ -150,7 +157,7 @@ export const descriptorMixin = {
     },
 
     getMetadataChecklistValues(descriptor, entity) {
-      var values = {}
+      let values
       try {
         values = JSON.parse(this.getMetadataFieldValue(descriptor, entity))
       } catch {

--- a/src/components/modals/EditEditModal.vue
+++ b/src/components/modals/EditEditModal.vue
@@ -41,14 +41,76 @@
             :key="descriptor.id"
             v-for="descriptor in editMetadataDescriptors"
           >
+            <div
+              class="field"
+              v-if="
+                descriptor.data_type === 'checklist' &&
+                getDescriptorChecklistValues(descriptor).length
+              "
+              :key="`${descriptor.id}-checklist-wrapper`"
+            >
+              <label class="label" :key="`${descriptor.id}-${descriptor.name}`">
+                {{ descriptor.name }}</label
+              >
+              <div
+                class="checkbox-wrapper"
+                v-for="(option, i) in getDescriptorChecklistValues(descriptor)"
+                :key="`${descriptor.id}-${i}-${option.text}-wrapper`"
+              >
+                <input
+                  type="checkbox"
+                  @change="
+                    event =>
+                      onMetadataCheckboxChanged(descriptor, option.text, event)
+                  "
+                  :id="`${descriptor.id}-${i}-${option.text}-checkbox`"
+                  :checked="
+                    getMetadataChecklistValues(descriptor, editToEdit)[
+                      option.text
+                    ]
+                  "
+                  :disabled="
+                    !(
+                      isCurrentUserManager ||
+                      isSupervisorInDepartments(descriptor.departments)
+                    )
+                  "
+                  :style="[
+                    isCurrentUserManager ||
+                    isSupervisorInDepartments(descriptor.departments)
+                      ? { cursor: 'pointer' }
+                      : { cursor: 'auto' }
+                  ]"
+                />
+                <label
+                  class="checkbox-label"
+                  :for="`${descriptor.id}-${i}-${option.text}-checkbox`"
+                  :style="[
+                    isCurrentUserManager ||
+                    isSupervisorInDepartments(descriptor.departments)
+                      ? { cursor: 'pointer' }
+                      : { cursor: 'auto' }
+                  ]"
+                >
+                  <span>{{ option.text }}</span>
+                </label>
+              </div>
+            </div>
             <combobox
-              v-if="descriptor.choices.length > 0"
+              v-else-if="descriptor.data_type === 'list'"
               :label="descriptor.name"
               :options="getDescriptorChoicesOptions(descriptor)"
               v-model="form.data[descriptor.field_name]"
             />
+            <combobox-boolean
+              :label="descriptor.name"
+              @enter="runConfirmation"
+              v-model="form.data[descriptor.field_name]"
+              v-else-if="descriptor.data_type === 'boolean'"
+            />
             <text-field
               :label="descriptor.name"
+              :type="descriptor.data_type"
               v-model="form.data[descriptor.field_name]"
               @enter="runConfirmation"
               v-else
@@ -71,17 +133,22 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 import { modalMixin } from '@/components/modals/base_modal'
+import { descriptorMixin } from '@/components/mixins/descriptors'
+import { entityListMixin } from '@/components/mixins/entity_list'
+
 import Combobox from '@/components/widgets/Combobox'
+import ComboboxBoolean from '@/components/widgets/ComboboxBoolean'
 import ModalFooter from '@/components/modals/ModalFooter'
 import TextField from '@/components/widgets/TextField'
 import TextareaField from '@/components/widgets/TextareaField'
 
 export default {
   name: 'edit-edit-modal',
-  mixins: [modalMixin],
+  mixins: [descriptorMixin, entityListMixin, modalMixin],
 
   components: {
     Combobox,
+    ComboboxBoolean,
     ModalFooter,
     TextField,
     TextareaField
@@ -135,6 +202,7 @@ export default {
       'edits',
       'episodes',
       'getOpenProductionOptions',
+      'isCurrentUserManager',
       'isTVShow',
       'openProductions'
     ]),
@@ -153,6 +221,17 @@ export default {
 
   methods: {
     ...mapActions([]),
+
+    onMetadataCheckboxChanged(descriptor, option, event) {
+      let values
+      try {
+        values = JSON.parse(this.form.data[descriptor.field_name])
+      } catch {
+        values = {}
+      }
+      values[option] = event.target.checked
+      this.form.data[descriptor.field_name] = JSON.stringify(values)
+    },
 
     runConfirmation() {
       if (this.isEditing()) {
@@ -258,5 +337,20 @@ export default {
 
 .modal-content {
   max-height: 80%;
+}
+
+.checkbox-wrapper {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.checkbox-label {
+  display: inline-flex;
+  position: relative;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  white-space: normal;
+  cursor: pointer;
 }
 </style>

--- a/src/components/modals/EditSequenceModal.vue
+++ b/src/components/modals/EditSequenceModal.vue
@@ -36,16 +36,78 @@
             :key="descriptor.id"
             v-for="descriptor in sequenceMetadataDescriptors"
           >
+            <div
+              class="field"
+              v-if="
+                descriptor.data_type === 'checklist' &&
+                getDescriptorChecklistValues(descriptor).length
+              "
+              :key="`${descriptor.id}-checklist-wrapper`"
+            >
+              <label class="label" :key="`${descriptor.id}-${descriptor.name}`">
+                {{ descriptor.name }}</label
+              >
+              <div
+                class="checkbox-wrapper"
+                v-for="(option, i) in getDescriptorChecklistValues(descriptor)"
+                :key="`${descriptor.id}-${i}-${option.text}-wrapper`"
+              >
+                <input
+                  type="checkbox"
+                  @change="
+                    event =>
+                      onMetadataCheckboxChanged(descriptor, option.text, event)
+                  "
+                  :id="`${descriptor.id}-${i}-${option.text}-checkbox`"
+                  :checked="
+                    getMetadataChecklistValues(descriptor, sequenceToEdit)[
+                      option.text
+                    ]
+                  "
+                  :disabled="
+                    !(
+                      isCurrentUserManager ||
+                      isSupervisorInDepartments(descriptor.departments)
+                    )
+                  "
+                  :style="[
+                    isCurrentUserManager ||
+                    isSupervisorInDepartments(descriptor.departments)
+                      ? { cursor: 'pointer' }
+                      : { cursor: 'auto' }
+                  ]"
+                />
+                <label
+                  class="checkbox-label"
+                  :for="`${descriptor.id}-${i}-${option.text}-checkbox`"
+                  :style="[
+                    isCurrentUserManager ||
+                    isSupervisorInDepartments(descriptor.departments)
+                      ? { cursor: 'pointer' }
+                      : { cursor: 'auto' }
+                  ]"
+                >
+                  <span>{{ option.text }}</span>
+                </label>
+              </div>
+            </div>
             <combobox
-              v-if="descriptor.choices.length > 0"
+              v-else-if="descriptor.data_type === 'list'"
               :label="descriptor.name"
               :options="getDescriptorChoicesOptions(descriptor)"
               v-model="form.data[descriptor.field_name]"
             />
-            <text-field
+            <combobox-boolean
               :label="descriptor.name"
               @enter="runConfirmation"
               v-model="form.data[descriptor.field_name]"
+              v-else-if="descriptor.data_type === 'boolean'"
+            />
+            <text-field
+              :label="descriptor.name"
+              :type="descriptor.data_type"
+              v-model="form.data[descriptor.field_name]"
+              @enter="runConfirmation"
               v-else
             />
           </div>
@@ -66,16 +128,22 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 import { modalMixin } from '@/components/modals/base_modal'
+import { descriptorMixin } from '@/components/mixins/descriptors'
+import { entityListMixin } from '@/components/mixins/entity_list'
+
 import Combobox from '@/components/widgets/Combobox'
+import ComboboxBoolean from '@/components/widgets/ComboboxBoolean'
 import ModalFooter from '@/components/modals/ModalFooter'
 import TextField from '@/components/widgets/TextField'
 import TextareaField from '@/components/widgets/TextareaField'
 
 export default {
   name: 'edit-sequence-modal',
-  mixins: [modalMixin],
+  mixins: [descriptorMixin, entityListMixin, modalMixin],
+
   components: {
     Combobox,
+    ComboboxBoolean,
     ModalFooter,
     TextField,
     TextareaField
@@ -126,11 +194,26 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentProduction', 'sequenceMetadataDescriptors'])
+    ...mapGetters([
+      'currentProduction',
+      'isCurrentUserManager',
+      'sequenceMetadataDescriptors'
+    ])
   },
 
   methods: {
     ...mapActions([]),
+
+    onMetadataCheckboxChanged(descriptor, option, event) {
+      let values
+      try {
+        values = JSON.parse(this.form.data[descriptor.field_name])
+      } catch {
+        values = {}
+      }
+      values[option] = event.target.checked
+      this.form.data[descriptor.field_name] = JSON.stringify(values)
+    },
 
     getDescriptorChoicesOptions(descriptor) {
       const values = descriptor.choices.map(c => ({ label: c, value: c }))
@@ -194,5 +277,20 @@ export default {
 }
 .info-message {
   margin-top: 1em;
+}
+
+.checkbox-wrapper {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.checkbox-label {
+  display: inline-flex;
+  position: relative;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  white-space: normal;
+  cursor: pointer;
 }
 </style>

--- a/src/components/modals/EditShotModal.vue
+++ b/src/components/modals/EditShotModal.vue
@@ -82,14 +82,76 @@
             :key="descriptor.id"
             v-for="descriptor in shotMetadataDescriptors"
           >
+            <div
+              class="field"
+              v-if="
+                descriptor.data_type === 'checklist' &&
+                getDescriptorChecklistValues(descriptor).length
+              "
+              :key="`${descriptor.id}-checklist-wrapper`"
+            >
+              <label class="label" :key="`${descriptor.id}-${descriptor.name}`">
+                {{ descriptor.name }}</label
+              >
+              <div
+                class="checkbox-wrapper"
+                v-for="(option, i) in getDescriptorChecklistValues(descriptor)"
+                :key="`${descriptor.id}-${i}-${option.text}-wrapper`"
+              >
+                <input
+                  type="checkbox"
+                  @change="
+                    event =>
+                      onMetadataCheckboxChanged(descriptor, option.text, event)
+                  "
+                  :id="`${descriptor.id}-${i}-${option.text}-checkbox`"
+                  :checked="
+                    getMetadataChecklistValues(descriptor, shotToEdit)[
+                      option.text
+                    ]
+                  "
+                  :disabled="
+                    !(
+                      isCurrentUserManager ||
+                      isSupervisorInDepartments(descriptor.departments)
+                    )
+                  "
+                  :style="[
+                    isCurrentUserManager ||
+                    isSupervisorInDepartments(descriptor.departments)
+                      ? { cursor: 'pointer' }
+                      : { cursor: 'auto' }
+                  ]"
+                />
+                <label
+                  class="checkbox-label"
+                  :for="`${descriptor.id}-${i}-${option.text}-checkbox`"
+                  :style="[
+                    isCurrentUserManager ||
+                    isSupervisorInDepartments(descriptor.departments)
+                      ? { cursor: 'pointer' }
+                      : { cursor: 'auto' }
+                  ]"
+                >
+                  <span>{{ option.text }}</span>
+                </label>
+              </div>
+            </div>
             <combobox
-              v-if="descriptor.choices.length > 0"
+              v-else-if="descriptor.data_type === 'list'"
               :label="descriptor.name"
               :options="getDescriptorChoicesOptions(descriptor)"
               v-model="form.data[descriptor.field_name]"
             />
+            <combobox-boolean
+              :label="descriptor.name"
+              @enter="runConfirmation"
+              v-model="form.data[descriptor.field_name]"
+              v-else-if="descriptor.data_type === 'boolean'"
+            />
             <text-field
               :label="descriptor.name"
+              :type="descriptor.data_type"
               v-model="form.data[descriptor.field_name]"
               @enter="runConfirmation"
               v-else
@@ -111,19 +173,24 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import { formatListMixin } from '@/components/mixins/format'
 import { modalMixin } from '@/components/modals/base_modal'
+import { descriptorMixin } from '@/components/mixins/descriptors'
+import { entityListMixin } from '@/components/mixins/entity_list'
+import { formatListMixin } from '@/components/mixins/format'
+
 import Combobox from '@/components/widgets/Combobox'
+import ComboboxBoolean from '@/components/widgets/ComboboxBoolean'
 import ModalFooter from '@/components/modals/ModalFooter'
 import TextField from '@/components/widgets/TextField'
 import TextareaField from '@/components/widgets/TextareaField'
 
 export default {
   name: 'edit-shot-modal',
-  mixins: [formatListMixin, modalMixin],
+  mixins: [descriptorMixin, entityListMixin, formatListMixin, modalMixin],
 
   components: {
     Combobox,
+    ComboboxBoolean,
     ModalFooter,
     TextField,
     TextareaField
@@ -164,6 +231,7 @@ export default {
   computed: {
     ...mapGetters([
       'currentProduction',
+      'isCurrentUserManager',
       'openProductions',
       'sequenceOptions',
       'sequences',
@@ -197,6 +265,17 @@ export default {
 
   methods: {
     ...mapActions(['loadSequences']),
+
+    onMetadataCheckboxChanged(descriptor, option, event) {
+      let values
+      try {
+        values = JSON.parse(this.form.data[descriptor.field_name])
+      } catch {
+        values = {}
+      }
+      values[option] = event.target.checked
+      this.form.data[descriptor.field_name] = JSON.stringify(values)
+    },
 
     runConfirmation() {
       if (this.isEditing()) {
@@ -324,5 +403,20 @@ export default {
 
 .modal-content {
   max-height: 80%;
+}
+
+.checkbox-wrapper {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.checkbox-label {
+  display: inline-flex;
+  position: relative;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  white-space: normal;
+  cursor: pointer;
 }
 </style>

--- a/src/components/widgets/Checklist.vue
+++ b/src/components/widgets/Checklist.vue
@@ -24,7 +24,7 @@
         @keyup.up.native="focusPrevious(index)"
         @keyup.down.native="focusNext(index)"
         :disabled="entry.text.length !== 0 && disabled"
-        v-model="entry.text"
+        v-model.trim="entry.text"
       ></textarea-autosize>
     </div>
   </div>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -809,13 +809,15 @@ export default {
       add_failed: 'An error occurred while adding metadata to your project.',
       add_new_values: 'There is currently no available values.',
       available_values: 'Available values',
-      choices: 'List of values',
+      boolean: 'Checkbox',
       checklist: 'Checklist',
+      choices: 'List of values',
       delete_text: 'Are you sure you want to delete this column and related data for all assets of this production?',
       delete_error: 'An error occurred while deleting this metadata column.',
       edit_title: 'Edit metadata column',
       error: 'An error occurred while adding the metadata column. Make sure there is no column with similar name and that all fields are filled. If the problem is persists, please contact the support team.',
-      free: 'Free value',
+      number: 'Number',
+      string: 'Text',
       title: 'Add metadata column'
     },
 

--- a/src/store/api/productions.js
+++ b/src/store/api/productions.js
@@ -111,6 +111,7 @@ export default {
     return new Promise((resolve, reject) => {
       const data = {
         name: descriptor.name,
+        data_type: descriptor.data_type,
         choices: descriptor.values,
         for_client: descriptor.for_client === 'true',
         entity_type: descriptor.entity_type,
@@ -144,6 +145,7 @@ export default {
       const data = {
         id: descriptor.id,
         name: descriptor.name,
+        data_type: descriptor.data_type,
         choices: descriptor.values,
         for_client: descriptor.for_client === 'true',
         entity_type: descriptor.entity_type,


### PR DESCRIPTION
**Problem**

-  Some users need to have a numeric value in theirs custom column metadata.   
Currently it's limited to a free string value or a list of values.

**Solution**
- Extends metadata with new data types:
  - string
  - **number**
  - **boolean**
  - list
  - checklist
