### PR TITLE
[tasks] Fix selection scrolling glitch

### DIFF
--- a/src/components/mixins/entities.js
+++ b/src/components/mixins/entities.js
@@ -7,6 +7,12 @@ import preferences from '@/lib/preferences'
 export const entitiesMixin = {
   created() {},
 
+  data () {
+    return {
+      keepTaskPanelOpen: false
+    }
+  },
+
   mounted() {
     const departmentId = preferences.getPreference(
       this.pageName + ':departement'
@@ -248,6 +254,10 @@ export const entitiesMixin = {
       this.modals.isBuildFilterDisplayed = false
       this.searchField.setValue(query)
       this.applySearch(query)
+    },
+
+    onKeepTaskPanelOpenChanged (keepOpen) {
+      this.keepTaskPanelOpen = keepOpen
     }
   },
 

--- a/src/components/mixins/entity_list.js
+++ b/src/components/mixins/entity_list.js
@@ -181,6 +181,7 @@ export const entityListMixin = {
         validationInfo = { ...validationInfo }
         validationInfo.y += columnOffset
       }
+      this.$emit('keep-task-panel-open', true)
       if (validationInfo.isShiftKey) {
         if (this.lastSelection) {
           let startX = this.lastSelection.x
@@ -244,6 +245,10 @@ export const entityListMixin = {
           this.scrollToValidationCell(validationCell)
         })
       }
+
+      this.$nextTick(() => {
+        this.$emit('keep-task-panel-open', false)
+      })
     },
 
     onTaskUnselected(validationInfo, sticked) {

--- a/src/components/mixins/selection.js
+++ b/src/components/mixins/selection.js
@@ -62,7 +62,7 @@ export const selectionListMixin = {
     },
 
     scrollToValidationCell(validationCell) {
-      if (validationCell) {
+      if (validationCell && this.nbSelectedTasks > 0) {
         this.$nextTick(() => {
           const margin = 20
           const sideColumn = document.getElementById('side-column')
@@ -78,8 +78,8 @@ export const selectionListMixin = {
           const listRect = this.$refs.body.getBoundingClientRect()
           const isBelow = rect.bottom > listRect.bottom - margin
           const isAbove = rect.top < listRect.top + margin
-          const isRight = rect.right > listRect.right - margin - sideWidth
-          const isLeft = rect.left < listRect.left + margin
+          const isRight = rect.x + rect.width > listRect.width
+          const isLeft = rect.x < stickyHeaderWidth + margin
 
           if (isBelow) {
             const scrollingRequired = rect.bottom - listRect.bottom + margin
@@ -94,17 +94,15 @@ export const selectionListMixin = {
           }
 
           if (isRight) {
-            const scrollingRequired = rect.left - stickyHeaderWidth - 60
-            this.$nextTick(() => {
-              this.setScrollLeftPosition(
-                this.$refs.body.scrollLeft + scrollingRequired
-              )
-            })
-          } else if (isLeft) {
-            const scrollingRequired = listRect.left - rect.left + margin
+            const scrollingRequired = rect.right - listRect.right + margin
             this.setScrollLeftPosition(
-              this.$refs.body.scrollLeft - scrollingRequired
+              this.$refs.body.scrollLeft + scrollingRequired
             )
+          } else if (isLeft) {
+            const scrollingRequired = stickyHeaderWidth - rect.left + 2 * margin
+            this.setScrollLeftPosition(
+               this.$refs.body.scrollLeft - scrollingRequired
+             )
           }
         })
       }

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -100,6 +100,7 @@
           @field-changed="onFieldChanged"
           @scroll="saveScrollPosition"
           @asset-type-clicked="onAssetTypeClicked"
+          @keep-task-panel-open="onKeepTaskPanelOpenChanged"
         />
       </div>
     </div>
@@ -107,7 +108,7 @@
     <div
       id="side-column"
       class="column side-column"
-      v-show="nbSelectedTasks === 1"
+      v-show="nbSelectedTasks === 1 || this.keepTaskPanelOpen"
     >
       <task-info :task="selectedTasks.values().next().value" />
     </div>
@@ -316,8 +317,8 @@ export default {
       assetFilterTypes: ['Type'],
       deleteAllTasksLockText: null,
       descriptorToEdit: {},
-      selectedDepartment: 'ALL',
       departmentFilter: [],
+      selectedDepartment: 'ALL',
       errors: {
         addMetadata: false,
         addThumbnails: false,

--- a/src/components/pages/Edits.vue
+++ b/src/components/pages/Edits.vue
@@ -103,6 +103,7 @@
           @restore-clicked="onRestoreClicked"
           @scroll="saveScrollPosition"
           @edit-history="showEditHistoryModal"
+          @keep-task-panel-open="onKeepTaskPanelOpenChanged"
         />
       </div>
     </div>

--- a/src/components/pages/Episodes.vue
+++ b/src/components/pages/Episodes.vue
@@ -72,6 +72,7 @@
           @field-changed="onFieldChanged"
           @metadata-changed="onMetadataChanged"
           @scroll="saveScrollPosition"
+          @keep-task-panel-open="onKeepTaskPanelOpenChanged"
         />
       </div>
     </div>

--- a/src/components/pages/Sequences.vue
+++ b/src/components/pages/Sequences.vue
@@ -72,6 +72,7 @@
           @field-changed="onFieldChanged"
           @metadata-changed="onMetadataChanged"
           @scroll="saveScrollPosition"
+          @keep-task-panel-open="onKeepTaskPanelOpenChanged"
         />
       </div>
     </div>

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -109,6 +109,7 @@
           @scroll="saveScrollPosition"
           @shot-history="showShotHistoryModal"
           @sequence-clicked="onSequenceClicked"
+          @keep-task-panel-open="onKeepTaskPanelOpenChanged"
         />
       </div>
     </div>


### PR DESCRIPTION
**Problem**

The task selection tends to jump randomly

**Solution**

The selection auto-scrolling was broken due to the fact that the task panel disappeared for a millisecond causing the scroll to change before reappearing. This led to annoying scrolling behavior. The tab disappeared because to make the selection cleaner, it starts by removing all the selections before setting the new ones. It made the task panel disappear.
With this commit, I made a hack that keeps the tab open during the deselection /selection process.