### PR TITLE
[metadata] fix default value of boolean at false

### DIFF
--- a/src/components/widgets/MetadataField.vue
+++ b/src/components/widgets/MetadataField.vue
@@ -46,7 +46,7 @@
   <!-- boolean field -->
   <combobox-boolean
     :label="descriptor.name"
-    :value="value"
+    :value="value === 'true' ? value : 'false'"
     @enter="onEnter"
     @input="updateValue"
     v-else-if="descriptor.data_type === 'boolean'"


### PR DESCRIPTION
**Problem**
For an entity (asset, shot, ...) creation form with boolean metadata, the combobox will set to `yes` by default, but the value of the data is at `undefined`.

**Solution**
Set the default value at false.
