### PR TITLE
[comment] fix comment form with empty checklist item

### DIFF
--- a/src/components/modals/EditCommentModal.vue
+++ b/src/components/modals/EditCommentModal.vue
@@ -55,7 +55,11 @@
           </label>
           <checklist
             class="comment-checklist"
-            :checklist="form.checklist"
+            :checklist="
+              form.checklist.length
+                ? form.checklist
+                : [{ checked: false, text: '' }]
+            "
             @add-item="onAddChecklistItem"
             @remove-task="removeTask"
           />
@@ -192,12 +196,10 @@ export default {
         const result = {
           id: this.commentToEdit.id,
           ...this.form,
+          checklist: this.form.checklist.filter(item => item.text.length),
           newAttachmentFiles: this.attachmentFiles,
           attachmentFilesToDelete: this.attachmentFilesToDelete
         }
-        const isEmptyChecklist =
-          result.checklist.length === 1 && result.checklist[0].text === ''
-        if (isEmptyChecklist) result.checklist = []
         this.$emit('confirm', result)
       }
     },
@@ -246,8 +248,6 @@ export default {
     },
 
     onAddChecklistItem(item) {
-      this.form.checklist[item.index].text =
-        this.form.checklist[item.index].text.trim()
       delete item.index
       this.form.checklist.push(item)
     }

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -389,6 +389,8 @@ export default {
         if (!this.showCommentArea) text = ''
         attachments = []
         checklist = []
+      } else {
+        checklist = checklist.filter(item => item.text.length)
       }
       text = replaceTimeWithTimecode(text, this.revision, this.time, this.fps)
       this.$emit('add-comment', text, attachments, checklist, taskStatusId)
@@ -404,7 +406,6 @@ export default {
     },
 
     onAddChecklistItem(item) {
-      this.checklist[item.index].text = this.checklist[item.index].text.trim()
       delete item.index
       this.checklist.push(item)
     },


### PR DESCRIPTION
**Problem**
The comment form allows empty items to be pushed into the checklist (see screenshot below)
In addition, the user can hide the form if there are no more items (see issue #1059).

Form:
![comment-issue-1](https://user-images.githubusercontent.com/493223/229530697-ceaa6ec1-fcd8-439e-a325-b93043a57438.jpg)

View:
![comment-issue-2](https://user-images.githubusercontent.com/493223/229530705-d8fd9eec-cfc7-46e5-875f-ffa6307c5b59.jpg)


**Solution**
Filter the checklist items before saving, and keep a form placeholder if all items are removed.
