### PR TITLE
Fix/add comment

### DIFF
--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -3,7 +3,7 @@
     <div class="breakdown-columns">
       <div class="breakdown-column casting-column">
         <div class="flexrow mb1">
-          <div class="" v-if="isEpisodeCasting">
+          <div v-if="isEpisodeCasting">
             <h2 class="subtitle mt05">
               {{ $t('breakdown.episode_casting') }}
             </h2>

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -324,7 +324,7 @@
               v-show="isCurrentUserManager || isCurrentUserSupervisor"
             />
           </div>
-          <div class="" v-if="loading.assignation">
+          <div v-if="loading.assignation">
             <div class="flexrow-item">
               <spinner :size="20" class="spinner" />
             </div>
@@ -438,7 +438,7 @@
         </div>
 
         <div class="flexcolumn filler" v-if="selectedBar === 'subscribe'">
-          <div class="" v-if="loading.tasksSubscription">
+          <div v-if="loading.tasksSubscription">
             <div class="flexrow-item">
               <spinner :size="20" class="spinner" />
             </div>

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -345,6 +345,7 @@ export default {
       'currentProduction',
       'isDarkTheme',
       'isCurrentUserArtist',
+      'isCurrentUserClient',
       'uploadProgress',
       'taskStatusForCurrentUser',
       'taskTypeMap',
@@ -411,7 +412,10 @@ export default {
     resetStatus() {
       if (this.task) {
         const taskStatus = this.taskStatusMap.get(this.task.task_status_id)
-        if (!this.isCurrentUserArtist || taskStatus.is_artist_allowed) {
+        if (
+          (!this.isCurrentUserArtist || taskStatus.is_artist_allowed) &&
+          (!this.isCurrentUserClient || taskStatus.is_client_allowed)
+        ) {
           this.task_status_id = this.task.task_status_id
         } else {
           this.task_status_id = this.taskStatusForCurrentUser[0].id

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -166,15 +166,13 @@
             v-if="mode === 'publish'"
           />
           <div class="filler"></div>
-          <div class="">
-            <combobox-status
-              class="flexrow-item status-selector"
-              :narrow="true"
-              :color-only="true"
-              :task-status-list="taskStatus"
-              v-model="task_status_id"
-            />
-          </div>
+          <combobox-status
+            class="flexrow-item status-selector"
+            :narrow="true"
+            :color-only="true"
+            :task-status-list="taskStatus"
+            v-model="task_status_id"
+          />
           <button-simple
             :class="{
               button: true,

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -28,7 +28,6 @@
           />
           <strong class="flexrow-item">
             <people-name
-              class=""
               :person="comment.person"
               v-if="!isCurrentUserClient || isAuthorClient"
             />
@@ -140,7 +139,6 @@
                     />
                     <strong class="flexrow-item">
                       <people-name
-                        class=""
                         :person="personMap.get(replyComment.person_id)"
                       />
                     </strong>


### PR DESCRIPTION
**Problem**
A user with "Client" role can see the latest status of a task with the "is client allowed" right set to false.

**Solution**
Check the user rights as Client before to set the default status id.
