### PR TITLE
[metadata] fix data refresh on update column name

### DIFF
--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -1148,9 +1148,10 @@ const mutations = {
       previousDescriptorFieldName !== descriptor.field_name
     ) {
       cache.assets.forEach(asset => {
-        asset.data[descriptor.field_name] =
-          asset.data[previousDescriptorFieldName]
-        delete asset.data[previousDescriptorFieldName]
+        const data = { ...asset.data }
+        data[descriptor.field_name] = data[previousDescriptorFieldName]
+        delete data[previousDescriptorFieldName]
+        asset.data = data
       })
     }
   },

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -1076,9 +1076,10 @@ const mutations = {
   ) {
     if (descriptor.entity_type === 'Edit' && previousDescriptorFieldName) {
       cache.edits.forEach(edit => {
-        edit.data[descriptor.field_name] =
-          edit.data[previousDescriptorFieldName]
-        delete edit.data[previousDescriptorFieldName]
+        const data = { ...edit.data }
+        data[descriptor.field_name] = data[previousDescriptorFieldName]
+        delete data[previousDescriptorFieldName]
+        edit.data = data
       })
     }
   },

--- a/src/store/modules/episodes.js
+++ b/src/store/modules/episodes.js
@@ -49,6 +49,7 @@ import {
   SET_EPISODE_STATS,
   SET_EPISODES_WITH_TASKS,
   UPDATE_EPISODE,
+  UPDATE_METADATA_DESCRIPTOR_END,
   RESET_ALL
 } from '@/store/mutation-types'
 
@@ -950,6 +951,20 @@ const mutations = {
         episodeTaskId => episodeTaskId === task.id
       )
       episode.tasks.splice(taskIndex, 1)
+    }
+  },
+
+  [UPDATE_METADATA_DESCRIPTOR_END](
+    state,
+    { descriptor, previousDescriptorFieldName }
+  ) {
+    if (descriptor.entity_type === 'Episode' && previousDescriptorFieldName) {
+      cache.episodes.forEach(episode => {
+        const data = { ...episode.data }
+        data[descriptor.field_name] = data[previousDescriptorFieldName]
+        delete data[previousDescriptorFieldName]
+        episode.data = data
+      })
     }
   }
 }

--- a/src/store/modules/sequences.js
+++ b/src/store/modules/sequences.js
@@ -56,6 +56,7 @@ import {
   SET_SEQUENCES_WITH_TASKS,
   UNLOCK_SEQUENCE,
   UPDATE_SEQUENCE,
+  UPDATE_METADATA_DESCRIPTOR_END,
   RESET_ALL
 } from '@/store/mutation-types'
 
@@ -1019,6 +1020,24 @@ const mutations = {
   [UNLOCK_SEQUENCE](state, sequence) {
     sequence = state.sequenceMap.get(sequence.id)
     if (sequence) sequence.lock = false
+  },
+
+  [UPDATE_METADATA_DESCRIPTOR_END](
+    state,
+    { descriptor, previousDescriptorFieldName }
+  ) {
+    if (
+      descriptor.entity_type === 'Sequence' &&
+      previousDescriptorFieldName &&
+      previousDescriptorFieldName !== descriptor.field_name
+    ) {
+      cache.sequences.forEach(sequence => {
+        const data = { ...sequence.data }
+        data[descriptor.field_name] = data[previousDescriptorFieldName]
+        delete data[previousDescriptorFieldName]
+        sequence.data = data
+      })
+    }
   }
 }
 

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -1240,9 +1240,10 @@ const mutations = {
   ) {
     if (descriptor.entity_type === 'Shot' && previousDescriptorFieldName) {
       cache.shots.forEach(shot => {
-        shot.data[descriptor.field_name] =
-          shot.data[previousDescriptorFieldName]
-        delete shot.data[previousDescriptorFieldName]
+        const data = { ...shot.data }
+        data[descriptor.field_name] = data[previousDescriptorFieldName]
+        delete data[previousDescriptorFieldName]
+        shot.data = data
       })
     }
   },


### PR DESCRIPTION
**Problem**
After renaming a custom metadata column, the existing data on the entity list are reset to empty.

**Solution**
Fix data reactivity when updating metadata on stores.
