### PR TITLE
[metadata] fix data refresh on update column name

### DIFF
--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -1074,7 +1074,11 @@ const mutations = {
     state,
     { descriptor, previousDescriptorFieldName }
   ) {
-    if (descriptor.entity_type === 'Edit' && previousDescriptorFieldName) {
+    if (
+      descriptor.entity_type === 'Edit' &&
+      previousDescriptorFieldName &&
+      previousDescriptorFieldName !== descriptor.field_name
+    ) {
       cache.edits.forEach(edit => {
         const data = { ...edit.data }
         data[descriptor.field_name] = data[previousDescriptorFieldName]

--- a/src/store/modules/episodes.js
+++ b/src/store/modules/episodes.js
@@ -958,7 +958,11 @@ const mutations = {
     state,
     { descriptor, previousDescriptorFieldName }
   ) {
-    if (descriptor.entity_type === 'Episode' && previousDescriptorFieldName) {
+    if (
+      descriptor.entity_type === 'Episode' &&
+      previousDescriptorFieldName &&
+      previousDescriptorFieldName !== descriptor.field_name
+    ) {
       cache.episodes.forEach(episode => {
         const data = { ...episode.data }
         data[descriptor.field_name] = data[previousDescriptorFieldName]

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -1238,7 +1238,11 @@ const mutations = {
     state,
     { descriptor, previousDescriptorFieldName }
   ) {
-    if (descriptor.entity_type === 'Shot' && previousDescriptorFieldName) {
+    if (
+      descriptor.entity_type === 'Shot' &&
+      previousDescriptorFieldName &&
+      previousDescriptorFieldName !== descriptor.field_name
+    ) {
       cache.shots.forEach(shot => {
         const data = { ...shot.data }
         data[descriptor.field_name] = data[previousDescriptorFieldName]


### PR DESCRIPTION
**Problem**
For edit/episode/shot pages, on list/checklist metadata column editing (eg. add new item), the column is cleared until page refresh.

**Solution**
Fix data reactivity on store
