### PR TITLE
doc(DEVELOPMENT): Typo in Node.js minimal version

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ Start developing for Kitsu using Docker on Windows, Linux and OSX.
 
 **Prerequisites**
 
-- [Node.js 6.x](https://nodejs.org/en/) or greater
+- [Node.js 16.x](https://nodejs.org/en/) or greater
 - [Docker 1.13](https://store.docker.com/search?type=edition&offering=community) or greater
 
 **Setup**


### PR DESCRIPTION
**Problem**
Regarding the engine key in [package.json file](https://github.com/cgwire/kitsu/blob/master/package.json#L88) I think it was supposed `16` and not `6`

**Solution**
6 to 16
