### PR TITLE
Improve entity search page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -837,6 +837,10 @@ a:hover {
   padding-bottom: 0em;
 }
 
+.pb1 {
+  padding-bottom: 1em;
+}
+
 .pt0 {
   padding-top: 0em;
 }

--- a/src/components/pages/EntitySearch.vue
+++ b/src/components/pages/EntitySearch.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="entity-search page">
-    <form @submit.prevent="onResultSelected()">
+    <form class="search-form" @submit.prevent="onResultSelected()">
       <div class="search-field">
         <span class="search-icon">
           <search-icon width="20" />
@@ -12,27 +12,36 @@
           v-model.trim="searchQuery"
         />
       </div>
-      <div class="search-filter pa1 flexrow">
-        <checkbox
-          :toggle="true"
-          :label="$t('assets.title')"
-          @change="search"
-          v-model="searchFilter.assets"
+      <div class="search-options pa1 flexrow">
+        <div class="search-filter flexrow">
+          <checkbox
+            :toggle="true"
+            :label="$t('assets.title')"
+            @change="search"
+            v-model="searchFilter.assets"
+          />
+          <checkbox
+            :toggle="true"
+            :label="$t('shots.title')"
+            @change="search"
+            v-model="searchFilter.shots"
+          />
+          <!--
+          <checkbox
+            :toggle="true"
+            :label="$t('people.title')"
+            @change="search"
+            v-model="searchFilter.persons"
+          />
+          -->
+        </div>
+        <combobox
+          class="search-limit"
+          :label="$t('search.limit')"
+          :options="limitOptions"
+          v-model="limit"
+          @input="search"
         />
-        <checkbox
-          :toggle="true"
-          :label="$t('shots.title')"
-          @change="search"
-          v-model="searchFilter.shots"
-        />
-        <!--
-        <checkbox
-          :toggle="true"
-          :label="$t('people.title')"
-          @change="search"
-          v-model="searchFilter.persons"
-        />
-        -->
       </div>
     </form>
     <div class="search-results mb2">
@@ -196,9 +205,12 @@ import { SearchIcon } from 'vue-feather-icons'
 // import peopleStore from '@/store/modules/people'
 
 import Checkbox from '@/components/widgets/Checkbox'
+import Combobox from '@/components/widgets/Combobox'
 import EntityPreview from '@/components/widgets/EntityPreview'
 // import PeopleAvatar from '@/components/widgets/PeopleAvatar'
 import Spinner from '@/components/widgets/Spinner'
+
+const AVAILABLE_LIMITS = [10, 20, 50]
 
 export default {
   name: 'entity-search',
@@ -206,6 +218,7 @@ export default {
 
   components: {
     Checkbox,
+    Combobox,
     EntityPreview,
     // PeopleAvatar,
     SearchIcon,
@@ -215,6 +228,8 @@ export default {
   data() {
     return {
       isLoading: false,
+      limit: AVAILABLE_LIMITS[0],
+      limitOptions: AVAILABLE_LIMITS.map(value => ({ label: value, value })),
       selectedIndex: 0,
       searchQuery: '',
       searchFilter: {
@@ -292,7 +307,7 @@ export default {
 
       this.searchData({
         query: this.searchQuery,
-        limit: 10,
+        limit: this.limit,
         index_names
       })
         .then(results => {
@@ -410,9 +425,12 @@ export default {
   margin-top: 0;
 }
 
-.search-field {
+.search-form {
   max-width: 800px;
   margin: auto;
+}
+
+.search-field {
   padding-top: 40px;
   position: relative;
   width: 100%;
@@ -432,11 +450,21 @@ export default {
   }
 }
 
-.search-filter {
-  position: relative;
-  max-width: 800px;
-  margin: auto;
-  gap: 2em;
+.search-options {
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0 2em;
+
+  .search-filter {
+    gap: 2em;
+  }
+
+  .search-limit {
+    display: inline-flex;
+    align-items: center;
+    margin-top: 8px;
+    gap: 0.5em;
+  }
 }
 
 .search-results {

--- a/src/components/pages/EntitySearch.vue
+++ b/src/components/pages/EntitySearch.vue
@@ -71,7 +71,7 @@
                 :entity="entity"
               />
               <router-link
-                class="result-name"
+                class="result-description"
                 :id="`result-link-${entity.id}`"
                 :to="entityPath(entity, 'asset')"
               >
@@ -80,6 +80,10 @@
                 </div>
                 <div class="entity-name">
                   {{ entity.asset_type_name }} / {{ entity.name }}
+                </div>
+                <div class="match">
+                  <span class="match-icon"><search-icon width="15" /></span>
+                  {{ getMatchDetails(entity) }}
                 </div>
               </router-link>
             </div>
@@ -110,7 +114,7 @@
                 :entity="entity"
               />
               <router-link
-                class="result-name"
+                class="result-description"
                 :id="`result-link-${entity.id}`"
                 :to="entityPath(entity, 'shot')"
               >
@@ -122,6 +126,12 @@
                     {{ entity.episode_name }} /
                   </template>
                   {{ entity.sequence_name }} / {{ entity.name }}
+                </div>
+                <div class="match">
+                  <span class="match-icon"><search-icon width="15" /></span>
+                  <span class="match-details">{{
+                    getMatchDetails(entity)
+                  }}</span>
                 </div>
               </router-link>
             </div>
@@ -156,7 +166,7 @@
                     :person="person"
                     :size="200"
                   />
-                  <div class="result-name">
+                  <div class="result-description">
                     <div class="person-name">{{ person.name }}</div>
                     <div class="person-email">{{ person.email }}</div>
                     <div class="person-role">
@@ -350,6 +360,22 @@ export default {
 
     personPath(person) {
       return getPersonPath(person.id)
+    },
+
+    getMatchDetails(entity) {
+      const target = entity.matched_terms?.[0]?.[0]
+      const term = entity.matched_terms?.[0]?.[1]
+      if (target?.startsWith('data_')) {
+        return this.$t('search.match_details_2', {
+          term,
+          target: target.replace('data_', '')
+        })
+      } else {
+        return this.$t('search.match_details', {
+          term,
+          target
+        })
+      }
     }
   },
 
@@ -426,7 +452,7 @@ export default {
   }
 
   .result {
-    height: 280px;
+    height: 300px;
     background: var(--background);
     border-radius: 1em;
     padding-top: 1em;
@@ -440,10 +466,23 @@ export default {
       background: var(--background-hover);
     }
 
-    .result-name {
+    .result-description {
       color: var(--text-strong);
       font-weight: bold;
       padding: 0.3em 1em;
+    }
+
+    .match {
+      display: inline-flex;
+      color: var(--text-alt);
+      font-weight: normal;
+      margin-top: 0.5em;
+      opacity: 0.7;
+
+      .match-icon {
+        margin-top: -2px;
+        margin-right: 0.5em;
+      }
     }
   }
 }

--- a/src/components/pages/EntitySearch.vue
+++ b/src/components/pages/EntitySearch.vue
@@ -19,7 +19,6 @@
           v-model="searchFilter.assets"
         />
         <checkbox
-          :disabled="true"
           :toggle="true"
           :label="$t('shots.title')"
           v-model="searchFilter.shots"
@@ -208,7 +207,7 @@ export default {
       searchQuery: '',
       searchFilter: {
         assets: true,
-        shots: false,
+        shots: true,
         persons: false
       },
       results: {

--- a/src/components/pages/EntitySearch.vue
+++ b/src/components/pages/EntitySearch.vue
@@ -337,7 +337,15 @@ export default {
 
       if (this.searchQuery.length > 2) {
         this.isLoading = true
-        this.searchData({ query: this.searchQuery, limit: 10 })
+        const index_names = Object.entries(this.searchFilter)
+          .map(([k, v]) => (v ? k : undefined))
+          .filter(Boolean)
+
+        this.searchData({
+          query: this.searchQuery,
+          limit: 10,
+          index_names
+        })
           .then(results => {
             // results.persons?.forEach(person => {
             //   peopleStore.helpers.addAdditionalInformation(person)

--- a/src/components/pages/EntitySearch.vue
+++ b/src/components/pages/EntitySearch.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="entity-search page">
-    <form @submit.prevent="onElementSelected()">
+    <form @submit.prevent="onResultSelected()">
       <div class="search-field">
         <span class="search-icon">
           <search-icon width="20" />
@@ -59,6 +59,7 @@
                 'selected-result': flattenResults[selectedIndex] === entity
               }"
               :key="entity.id"
+              @mouseover="selectResultById(entity.id)"
               v-for="entity in this.results.assets"
             >
               <entity-preview
@@ -97,6 +98,7 @@
                 'selected-result': flattenResults[selectedIndex] === entity
               }"
               :key="entity.id"
+              @mouseover="selectResultById(entity.id)"
               v-for="entity in this.results.shots"
             >
               <entity-preview
@@ -139,6 +141,7 @@
                 'selected-result': flattenResults[selectedIndex] === person
               }"
               :key="person.id"
+              @mouseover="selectResultById(person.id)"
               v-for="person in this.results.persons"
             >
               <router-link
@@ -293,7 +296,11 @@ export default {
       }
     },
 
-    onElementSelected() {
+    selectResultById(id) {
+      this.selectedIndex = this.flattenResults.findIndex(item => item.id === id)
+    },
+
+    onResultSelected() {
       const item = this.flattenResults[this.selectedIndex]
       if (item) {
         document.getElementById(`result-link-${item.id}`).click()
@@ -407,17 +414,21 @@ export default {
 
   .result {
     height: 280px;
-    background: $white-grey-light;
+    background: var(--background);
     border-radius: 1em;
     padding-top: 1em;
     box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
+
+    .dark & {
+      background: var(--background-alt);
+    }
 
     &.selected-result {
       background: var(--background-hover);
     }
 
     .result-name {
-      color: $mid-grey;
+      color: var(--text-strong);
       font-weight: bold;
       padding: 0.3em 1em;
     }

--- a/src/components/pages/EntitySearch.vue
+++ b/src/components/pages/EntitySearch.vue
@@ -16,18 +16,20 @@
         <checkbox
           :toggle="true"
           :label="$t('assets.title')"
+          @change="search"
           v-model="searchFilter.assets"
         />
         <checkbox
           :toggle="true"
           :label="$t('shots.title')"
+          @change="search"
           v-model="searchFilter.shots"
         />
         <!--
         <checkbox
           :toggle="true"
           :label="$t('people.title')"
-          v-if="results.persons"
+          @change="search"
           v-model="searchFilter.persons"
         />
         -->
@@ -272,6 +274,30 @@ export default {
   methods: {
     ...mapActions(['searchData']),
 
+    search() {
+      this.isLoading = true
+      const index_names = Object.entries(this.searchFilter)
+        .map(([k, v]) => (v ? k : undefined))
+        .filter(Boolean)
+
+      this.searchData({
+        query: this.searchQuery,
+        limit: 10,
+        index_names
+      })
+        .then(results => {
+          // results.persons?.forEach(person => {
+          //   peopleStore.helpers.addAdditionalInformation(person)
+          // })
+          delete results.persons
+          this.results = results
+        })
+        .catch(console.error)
+        .finally(() => {
+          this.isLoading = false
+        })
+    },
+
     selectPrevious() {
       this.selectedIndex--
       if (this.selectedIndex < 0) {
@@ -336,27 +362,7 @@ export default {
       }
 
       if (this.searchQuery.length > 2) {
-        this.isLoading = true
-        const index_names = Object.entries(this.searchFilter)
-          .map(([k, v]) => (v ? k : undefined))
-          .filter(Boolean)
-
-        this.searchData({
-          query: this.searchQuery,
-          limit: 10,
-          index_names
-        })
-          .then(results => {
-            // results.persons?.forEach(person => {
-            //   peopleStore.helpers.addAdditionalInformation(person)
-            // })
-            delete results.persons
-            this.results = results
-          })
-          .catch(console.error)
-          .finally(() => {
-            this.isLoading = false
-          })
+        this.search()
       } else {
         this.clearSearchResult()
       }

--- a/src/components/widgets/Combobox.vue
+++ b/src/components/widgets/Combobox.vue
@@ -50,7 +50,7 @@ export default {
     },
     value: {
       default: '',
-      type: [Object, String, Boolean]
+      type: [Object, String, Boolean, Number]
     },
     options: {
       default: () => [],

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1325,8 +1325,11 @@ export default {
   },
 
   search: {
+    limit: 'Max number of results',
+    match_details: '"{term}" found in {target}',
+    match_details_2: '"{term}" found in {target} metadata',
+    placeholder: 'Search for an entity in the database...',
     title: 'Entity Search',
-    placeholder: 'Search for an entity in the database...'
   },
 
   timesheets: {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -465,7 +465,8 @@ export default {
     yes: 'Yes',
     search: {
       type: 'Type 3 characters at least to perform the research',
-      no_result: 'There are no results for this search'
+      no_result: 'There are no results for this search',
+      no_filter: 'Select at least one filter to perform the research'
     },
     csv: {
       choose: 'Choose',
@@ -1324,7 +1325,8 @@ export default {
   },
 
   search: {
-    title: 'Entity Search'
+    title: 'Entity Search',
+    placeholder: 'Search for an entity in the database...'
   },
 
   timesheets: {

--- a/src/store/api/client.js
+++ b/src/store/api/client.js
@@ -134,9 +134,9 @@ const client = {
     return client.pget(path)
   },
 
-  searchData(query, limit) {
+  searchData(query, limit, index_names) {
     const path = '/api/data/search'
-    return client.ppost(path, { query, limit })
+    return client.ppost(path, { query, limit, index_names })
   }
 }
 

--- a/src/store/modules/main.js
+++ b/src/store/modules/main.js
@@ -66,11 +66,11 @@ const actions = {
     return client.getEvents(after, before)
   },
 
-  searchData(_, { query, limit }) {
+  searchData(_, { query, limit, index_names }) {
     if (!limit) {
       limit = 3
     }
-    return client.searchData(query, limit)
+    return client.searchData(query, limit, index_names)
   }
 }
 


### PR DESCRIPTION
**Problem**
The global entity search page should be improved to search by entity type and search in name, description or metadata.

**Solution**
- add toggeable filters by entity type
- group results by entity type
- save the current search in query params (for history navigation)
- select the max number of results
- show the target match found on each result