### PR TITLE
Fix entity thumbnail reactivity

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -628,6 +628,14 @@ body {
     background-color: #5e6169;
   }
 
+  .message {
+    background: $dark-grey;
+    .message-body {
+      border-left: 5px solid $dark-grey-lightest;
+      color: $white-grey;
+    }
+  }
+
   .vdp-datepicker__calendar {
     background-color: #36393f;
     border-color: #25282e;

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -422,7 +422,12 @@
 
         <div class="flexrow-item is-wide" v-if="selectedBar === 'thumbnails'">
           <button
-            class="button confirm-button is-wide"
+            :class="{
+              button: true,
+              'confirm-button': true,
+              'is-wide': true,
+              'is-loading': loading.setThumbnails
+            }"
             @click="confirmSetThumbnailsFromTasks"
             v-if="nbSelectedTasks > 1"
           >
@@ -444,7 +449,10 @@
               type="checkbox"
               v-model="isUseCurrentFrame"
             />
-            <span class="flexrow-item">
+            <span
+              class="flexrow-item pointer"
+              @click="isUseCurrentFrame = !isUseCurrentFrame"
+            >
               {{ $t('tasks.use_current_frame') }}
             </span>
           </div>
@@ -1223,6 +1231,7 @@ export default {
       if (this.nbSelectedTasks === 1) {
         const task = this.selectedTasks.values().next().value
         this.$emit('set-frame-thumbnail', this.isUseCurrentFrame)
+        this.loading.setThumbnails = false
       } else {
         func
           .runPromiseAsSeries(

--- a/src/components/widgets/EntityThumbnail.vue
+++ b/src/components/widgets/EntityThumbnail.vue
@@ -90,6 +90,12 @@ export default {
     }
   },
 
+  data() {
+    return {
+      timer: ''
+    }
+  },
+
   computed: {
     originalPath() {
       const previewFileId = this.previewFileId || this.entity.preview_file_id
@@ -135,11 +141,11 @@ export default {
       } else {
         if (this.width && this.width > 150) {
           return (
-            '/api/pictures/previews/preview-files/' + previewFileId + '.png'
+            '/api/pictures/previews/preview-files/' + previewFileId + '.png' + this.timer
           )
         } else {
           return (
-            '/api/pictures/thumbnails/preview-files/' + previewFileId + '.png'
+            '/api/pictures/thumbnails/preview-files/' + previewFileId + '.png' + this.timer
           )
         }
       }
@@ -156,6 +162,17 @@ export default {
       if (this.noPreview) return
       const previewFileId = this.previewFileId || this.entity.preview_file_id
       this.$store.commit('SHOW_PREVIEW_FILE', previewFileId)
+    }
+  },
+
+  watch: {
+    previewFileId() {
+      this.timer = '?t=' + new Date().valueOf()
+    },
+
+    'entity.preview_file_id'() {
+      console.log('changed')
+      this.timer = '?t=' + new Date().valueOf()
     }
   }
 }

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -1007,14 +1007,11 @@ const mutations = {
   [SET_PREVIEW](state, { entityId, taskId, previewId, taskMap }) {
     const asset = state.assetMap.get(entityId)
     if (asset) {
-      asset.preview_file_id = null
-      setTimeout(() => {
-        asset.preview_file_id = previewId
-        asset.tasks.forEach(taskId => {
-          const task = taskMap.get(taskId)
-          if (task) task.entity.preview_file_id = previewId
-        })
-      }, 1000)
+      asset.preview_file_id = previewId
+      asset.tasks.forEach(taskId => {
+        const task = taskMap.get(taskId)
+        if (task) task.entity.preview_file_id = previewId
+      })
     }
   },
 

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -611,8 +611,18 @@ const actions = {
   setPreview({ commit, state }, { taskId, entityId, previewId, frame }) {
     const taskMap = state.taskMap
     return tasksApi.setPreview(entityId, previewId, frame).then(entity => {
-      commit(SET_PREVIEW, { taskId, entityId, previewId, taskMap })
-      return Promise.resolve()
+      const task = taskMap.get(taskId)
+      if (task && task.entity_preview_file_id === previewId) {
+        commit(SET_PREVIEW, { taskId, entityId, previewId, taskMap })
+      } else {
+        // Trick needed to trigger reactivity when only the preview frame is
+        // modified and not the preview itself.
+        commit(SET_PREVIEW, { taskId, entityId, previewId: '', taskMap })
+        setTimeout(() => {
+          commit(SET_PREVIEW, { taskId, entityId, previewId, taskMap })
+          return Promise.resolve()
+        }, 0)
+      }
     })
   },
 
@@ -1235,10 +1245,7 @@ const mutations = {
 
   [SET_PREVIEW](state, { taskId, previewId }) {
     if (state.taskMap.get(taskId)) {
-      state.taskMap.get(taskId).entity.preview_file_id = 'empty'
-      setTimeout(() => {
-        state.taskMap.get(taskId).entity.preview_file_id = previewId
-      }, 200)
+      state.taskMap.get(taskId).entity.preview_file_id = previewId
     }
   },
 


### PR DESCRIPTION
**Problem**

When a thumbnail is changed based on the preview frame, the thumbnail is not refreshed.

**Solution**

Allow entity thumbnail widget to change the URL of pictures when the link stays the same but a change occurs on the preview file id. On the store side, trigger the reactivity by setting an empty preview first and put again the same preview right after.
