### PR TITLE
[search] fix js error on press Enter if empty result

### DIFF
--- a/src/components/tops/GlobalSearchField.vue
+++ b/src/components/tops/GlobalSearchField.vue
@@ -240,9 +240,14 @@ export default {
     },
 
     onElementSelected() {
-      document.getElementById('result-link-' + this.selectedIndex).click()
-      this.isSearchActive = false
-      this.searchQuery = ''
+      const element = document.getElementById(
+        `result-link-${this.selectedIndex}`
+      )
+      if (element) {
+        element.click()
+        this.isSearchActive = false
+        this.searchQuery = ''
+      }
     },
 
     onBlur(event) {


### PR DESCRIPTION
**Problem**
- On top search bar, if you press Enter key with an empty result, an JS error is raised.

**Solution**
- Check the HTML element before triggering the action.
