### PR TITLE
[metadata] fix permission check for supervisor in departments

### DIFF
--- a/src/components/cells/MetadataInput.vue
+++ b/src/components/cells/MetadataInput.vue
@@ -13,7 +13,7 @@
     "
     :value="getMetadataFieldValue(descriptor, entity)"
     v-if="
-      !descriptor.data_type || (descriptor.data_type === 'string' && isEditable)
+      (!descriptor.data_type || descriptor.data_type === 'string') && isEditable
     "
   />
   <!-- number input -->
@@ -138,7 +138,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['isCurrentUserManager']),
+    ...mapGetters(['isCurrentUserManager', 'isCurrentUserSupervisor', 'user']),
     isEditable() {
       return (
         this.isCurrentUserManager ||

--- a/src/components/pages/breakdown/ShotLine.vue
+++ b/src/components/pages/breakdown/ShotLine.vue
@@ -330,10 +330,12 @@ export default {
   computed: {
     ...mapGetters([
       'isCurrentUserManager',
+      'isCurrentUserSupervisor',
       'isFrameIn',
       'isFrameOut',
       'isFrames',
-      'isShowInfosBreakdown'
+      'isShowInfosBreakdown',
+      'user'
     ]),
 
     chunks() {

--- a/src/components/widgets/MetadataField.vue
+++ b/src/components/widgets/MetadataField.vue
@@ -99,7 +99,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['isCurrentUserManager']),
+    ...mapGetters(['isCurrentUserManager', 'isCurrentUserSupervisor', 'user']),
 
     descriptorChecklistValues() {
       return this.getDescriptorChecklistValues(this.descriptor)


### PR DESCRIPTION
**Problem**
- As supervisor, I cannot update the metadata configured for my departments.

**Solution**
- Fix permission check in entity lists and breakdown page, due to missing getters. 
