### PR TITLE
Various fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1892,6 +1892,11 @@ th.validation-cell {
   }
 }
 
+.input.date-input {
+  border-radius: 10px;
+}
+
+
 .date-input::placeholder {
   border-radius: 10px;
   color: $light-grey;

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -99,6 +99,7 @@
               v-if="
                 isCurrentUserManager &&
                 isShowInfos &&
+                !isAssetsOnly &&
                 metadataDisplayHeaders.readyFor
               "
             >
@@ -327,6 +328,7 @@
               v-if="
                 isCurrentUserManager &&
                 isShowInfos &&
+                !isAssetsOnly &&
                 metadataDisplayHeaders.readyFor
               "
             >
@@ -676,6 +678,10 @@ export default {
         },
         ...sortTaskTypes(this.productionShotTaskTypes, this.currentProduction)
       ]
+    },
+
+    isAssetsOnly () {
+      return this.currentProduction.production_type === 'assets'
     }
   },
 

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -201,13 +201,14 @@
             @click="selectTask($event, index, task)"
             v-for="(task, index) in taskGroup.tasks"
           >
-            <entity-thumbnail
+            <entity-preview
               class="flexrow-item"
               :entity="getEntity(task.entity.id)"
-              :width="200"
               :height="133"
+              :width="200"
               :empty-width="200"
               :empty-height="133"
+              :show-movie="false"
               no-preview
               v-if="task.entity"
             />
@@ -241,13 +242,14 @@
         @click="selectTask($event, index, task)"
         v-for="(task, index) in displayedTasks"
       >
-        <entity-thumbnail
+        <entity-preview
           class="flexrow-item"
           :entity="getEntity(task.entity.id)"
-          :width="200"
           :height="133"
+          :width="200"
           :empty-width="200"
           :empty-height="133"
+          :show-movie="false"
           no-preview
           v-if="task.entity"
         />
@@ -300,6 +302,7 @@ import { formatListMixin } from '@/components/mixins/format'
 import { domMixin } from '@/components/mixins/dom'
 
 import DateField from '@/components/widgets/DateField'
+import EntityPreview from '@/components/widgets/EntityPreview'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail'
 import PeopleAvatarWithMenu from '@/components/widgets/PeopleAvatarWithMenu'
 import TableInfo from '@/components/widgets/TableInfo'
@@ -312,6 +315,7 @@ export default {
 
   components: {
     DateField,
+    EntityPreview,
     EntityThumbnail,
     PeopleAvatarWithMenu,
     TableInfo,

--- a/src/components/lists/TodosList.vue
+++ b/src/components/lists/TodosList.vue
@@ -207,7 +207,6 @@
               :task-test="entry"
               :is-border="false"
               :is-assignees="false"
-              :selectable="!done"
               :clickable="false"
               :selected="
                 selectionGrid && selectionGrid[i] ? selectionGrid[i][0] : false
@@ -446,6 +445,7 @@ export default {
     },
 
     onTaskSelected(validationInfo) {
+      validationInfo.done = this.done
       if (validationInfo.isShiftKey) {
         if (this.lastSelection) {
           let startX = this.lastSelection.x

--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -804,7 +804,7 @@ export const playerMixin = {
     },
 
     setPlayerSpeed(rate) {
-      this.rawPlayer.setSpeed(rate)
+      if (this.rawPlayer) this.rawPlayer.setSpeed(rate)
       if (this.rawPlayerComparison) this.rawPlayerComparison.setSpeed(rate)
     },
 

--- a/src/components/modals/BuildFilterModal.vue
+++ b/src/components/modals/BuildFilterModal.vue
@@ -194,6 +194,18 @@
           v-model="hasThumbnail.value"
         />
 
+        <h3 class="subtitle flexrow-item mt2" v-if="isAssets">
+          {{ $t('assets.fields.ready_for') }}
+        </h3>
+        <div class="flexrow" v-if="isAssets">
+          <combobox-task-type
+            class="flexrow-item"
+            :task-type-list="readyForTaskTypeList"
+            open-top
+            v-model="readyFor.taskTypeId"
+          />
+        </div>
+
         <h3 class="subtitle flexrow-item mt2" v-if="isShots">
           {{ $t('entities.build_filter.is_assets_ready') }}
         </h3>
@@ -308,6 +320,9 @@ export default {
           { label: 'without_thumbnail', value: '-withthumbnail' }
         ]
       },
+      readyFor: {
+        taskTypeId: '',
+      },
       isAssetsReady: {
         value: 'nofilter',
         taskTypeId: '',
@@ -351,6 +366,7 @@ export default {
       'productionAssetTypes',
       'productionTaskStatuses',
       'productionTaskTypes',
+      'productionShotTaskTypes',
       'sequenceSearchText',
       'sequenceMetadataDescriptors',
       'sequenceValidationColumns',
@@ -388,6 +404,16 @@ export default {
       )
     },
 
+    readyForTaskTypeList() {
+      return [
+        {
+          id: '',
+          color: '#999',
+          name: this.$t('news.all')
+        }
+      ].concat(this.productionShotTaskTypes)
+    },
+
     team() {
       return this.currentProduction.team.map(pId => this.personMap.get(pId))
     },
@@ -422,6 +448,7 @@ export default {
       query = this.applyAssignationChoice(query)
       query = this.applyThumbnailChoice(query)
       query = this.applyUnionChoice(query)
+      query = this.applyReadyForChoice(query)
       query = this.applyAssetsReadyChoice(query)
       return query.trim()
     },
@@ -495,6 +522,15 @@ export default {
     applyUnionChoice(query) {
       if (this.union === 'or') {
         query = ` +(${query.trim()})`
+      }
+      return query
+    },
+
+    applyReadyForChoice(query) {
+      if (this.readyFor.taskTypeId !== '') {
+        const taskType = this.taskTypeMap.get(this.readyFor.taskTypeId)
+        console.log(this.readyFor.taskTypeId, taskType)
+        query = ` readyfor=[${taskType.name.toLowerCase()}]`
       }
       return query
     },
@@ -637,6 +673,8 @@ export default {
             this.setFiltersFromAssignedToQuery(filter)
           } else if (filter.type === 'thumbnail') {
             this.setFiltersFromThumbnailQuery(filter)
+          } else if (filter.type === 'readyfor') {
+            this.setFiltersFromReadyForQuery(filter)
           } else if (filter.type === 'assetsready') {
             this.setFiltersFromAssetsReadyQuery(filter)
           }
@@ -721,6 +759,10 @@ export default {
       }
     },
 
+    setFiltersFromReadyForQuery(filter) {
+      this.readyFor.taskTypeId = filter.value
+    },
+
     setFiltersFromAssetsReadyQuery(filter) {
       this.isAssetsReady.taskTypeId = filter.value
       this.isAssetsReady.value = filter.excluding
@@ -758,6 +800,7 @@ export default {
         this.reset()
         this.assignation.taskTypeId =
           this.taskTypeList.length > 0 ? this.taskTypeList[0].id : ''
+        this.readyFor.taskTypeId = ''
         this.setFiltersFromCurrentQuery()
       }
     }

--- a/src/components/modals/BuildFilterModal.vue
+++ b/src/components/modals/BuildFilterModal.vue
@@ -194,10 +194,13 @@
           v-model="hasThumbnail.value"
         />
 
-        <h3 class="subtitle flexrow-item mt2" v-if="isAssets">
+        <h3
+          class="subtitle flexrow-item mt2"
+          v-if="isAssets && !isAssetsOnly"
+        >
           {{ $t('assets.fields.ready_for') }}
         </h3>
-        <div class="flexrow" v-if="isAssets">
+        <div class="flexrow" v-if="isAssets && !isAssetsOnly">
           <combobox-task-type
             class="flexrow-item"
             :task-type-list="readyForTaskTypeList"
@@ -382,6 +385,10 @@ export default {
     },
     isShots() {
       return this.entityType === 'shot'
+    },
+
+    isAssetsOnly () {
+      return this.currentProduction.production_type === 'assets'
     },
 
     assetTypeOptions() {

--- a/src/components/modals/EditAssetModal.vue
+++ b/src/components/modals/EditAssetModal.vue
@@ -154,6 +154,11 @@ export default {
     }
   },
 
+  mounted() {
+    this.resetForm()
+    this.assetSuccessText = ''
+  },
+
   computed: {
     ...mapGetters([
       'assets',
@@ -182,11 +187,6 @@ export default {
       })
       return options
     }
-  },
-
-  mounted() {
-    this.resetForm()
-    this.assetSuccessText = ''
   },
 
   methods: {

--- a/src/components/modals/EditPersonModal.vue
+++ b/src/components/modals/EditPersonModal.vue
@@ -44,10 +44,10 @@
             v-model="form.phone"
           />
 
-          <div class="departments">
+          <div class="departments field">
             <label class="label">{{ $t('people.fields.departments') }}</label>
             <div
-              class="department-element mb1"
+              class="department-element mb1 mt05"
               :key="departmentId"
               @click="removeDepartment(departmentId)"
               v-for="departmentId in form.departments"
@@ -66,7 +66,7 @@
                 v-if="selectableDepartments.length > 0"
               />
               <button
-                class="button is-success flexrow-item mb2"
+                class="button is-success flexrow-item"
                 :class="{
                   'is-disabled': selectedDepartment === null
                 }"

--- a/src/components/modals/EditPlaylistModal.vue
+++ b/src/components/modals/EditPlaylistModal.vue
@@ -122,7 +122,11 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentEpisode', 'productionTaskTypes']),
+    ...mapGetters([
+      'currentEpisode',
+      'currentProduction',
+      'productionTaskTypes'
+    ]),
 
     isEditing() {
       return this.playlistToEdit && this.playlistToEdit.id
@@ -130,10 +134,19 @@ export default {
 
     forEntityOptions() {
       if (
-        this.currentEpisode &&
-        ['main', 'all'].includes(this.currentEpisode.id)
+        (
+          this.currentEpisode &&
+          ['main', 'all'].includes(this.currentEpisode.id)
+        ) ||
+        this.currentProduction.production_type === 'assets'
       ) {
         return [{ label: this.$t('assets.title'), value: 'asset' }]
+      } else if (
+        this.currentProduction.production_type === 'shots'
+      ){
+        return [
+          { label: this.$t('shots.title'), value: 'shot' }
+        ]
       } else {
         return [
           { label: this.$t('assets.title'), value: 'asset' },
@@ -143,9 +156,13 @@ export default {
     },
 
     defaultForEntity() {
+      const isOnlyAssets = this.currentProduction.production_type === 'assets'
+      const isOnlyShots = this.currentProduction.production_type === 'shots'
       const isAssetEpisode =
         this.currentEpisode && ['all', 'main'].includes(this.currentEpisode.id)
-      return isAssetEpisode ? 'asset' : 'shot'
+      return (isAssetEpisode || isOnlyAssets) && !isOnlyShots
+        ? 'asset'
+        : 'shot'
     },
 
     taskTypeList() {

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -457,15 +457,23 @@ export default {
     ]),
 
     castingTypeOptions() {
-      const options = [
-        {
-          label: this.$t('assets.title'),
-          value: 'asset'
-        }
-      ]
+      const isAssetsOnly = this.currentProduction.production_type === 'assets'
+      const isShotsOnly = this.currentProduction.production_type === 'shots'
+      const options = []
+      if (!isShotsOnly) {
+        options.push(
+          {
+            label: this.$t('assets.title'),
+            value: 'asset'
+          }
+        )
+      }
       if (
-        !this.isTVShow ||
-        (this.currentEpisode && this.currentEpisode.id !== 'main')
+        !isAssetsOnly &&
+        (
+          !this.isTVShow ||
+          (this.currentEpisode && this.currentEpisode.id !== 'main')
+        )
       ) {
         options.unshift({
           label: this.$t('shots.title'),
@@ -696,7 +704,10 @@ export default {
             this.setCastingSequence(this.sequenceId || 'all')
           }
           this.resetSelection()
-          if (this.currentEpisode && this.currentEpisode.id === 'main') {
+          if (
+            (this.currentEpisode && this.currentEpisode.id === 'main') ||
+            this.currentProduction.production_type === 'assets'
+          ) {
             this.castingType = 'asset'
           }
         })

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -758,6 +758,10 @@ export default {
               this.resetScheduleItems()
               this.resetScheduleScroll()
             }
+
+            this.dueDateFilter = this.$route.query.duedate || 'all'
+            this.estimationFilter = this.$route.query.late || 'all'
+            this.onSearchChange(this.$route.query.search)
           })
           .catch(err => {
             console.error(err)
@@ -915,7 +919,24 @@ export default {
         })
     },
 
+    updateUrlParams() {
+      const search = this.searchField.getValue()
+      const duedate = this.dueDateFilter
+      const late = this.estimationFilter
+      this.$router.push({
+        query: { search, duedate, late }
+      })
+    },
+
     // Tasks
+
+    applyTaskFilters() {
+      this.onSearchChange(this.searchField.getValue())
+      this.sortTasks()
+      this.$refs['task-list'].resetSelection()
+      this.updateUrlParams()
+      this.clearSelectedTasks()
+    },
 
     onTaskSelected(task) {
       this.currentTask = task
@@ -1365,17 +1386,11 @@ export default {
     },
 
     dueDateFilter() {
-      this.onSearchChange(this.searchField.getValue())
-      this.sortTasks()
-      this.$refs['task-list'].resetSelection()
-      this.clearSelectedTasks()
+      this.applyTaskFilters()
     },
 
     estimationFilter() {
-      this.onSearchChange(this.searchField.getValue())
-      this.sortTasks()
-      this.$refs['task-list'].resetSelection()
-      this.clearSelectedTasks()
+      this.applyTaskFilters()
     },
 
     currentSort() {

--- a/src/components/pages/Todos.vue
+++ b/src/components/pages/Todos.vue
@@ -101,6 +101,7 @@
           :tasks="displayedDoneTasks"
           :is-loading="isTodosLoading"
           :is-error="isTodosLoadingError"
+          :selection-grid="doneSelectionGrid"
           :done="true"
           v-if="isTabActive('done')"
         />
@@ -124,8 +125,11 @@
       </div>
     </div>
 
-    <div class="column side-column" v-if="nbSelectedTasks === 1">
-      <task-info :task="selectedTasks.values().next().value" />
+    <div class="column side-column" v-if="nbSelectedTasks >= 1">
+      <task-info
+        :task="selectedTasks.values().next().value"
+        with-actions
+      />
     </div>
   </div>
 </template>
@@ -209,6 +213,7 @@ export default {
     ...mapGetters([
       'displayedDoneTasks',
       'displayedTodos',
+      'doneSelectionGrid',
       'isTodosLoading',
       'isTodosLoadingError',
       'nbSelectedTasks',
@@ -308,6 +313,7 @@ export default {
 
   methods: {
     ...mapActions([
+      'clearSelectedTasks',
       'loadTodos',
       'loadOpenProductions',
       'removeTodoSearch',
@@ -346,6 +352,7 @@ export default {
       } else {
         this.activeTab = 'todos'
       }
+      this.clearSelectedTasks()
     },
 
     onSearchChange(text) {

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1653,19 +1653,23 @@ export default {
     },
 
     configureWaveForm() {
-      this.wavesurfer = WaveSurfer.create({
-        container: '#waveform',
-        waveColor: '#00B242', // green
-        progressColor: '#008732', // dark-green,
-        height: 60,
-        responsive: true,
-        fillParent: true,
-        minPxPerSec: 1,
-        backend: 'MediaElement'
-      })
-      this.wavesurfer.on('seek', position => {
-        this.setCurrentTimeRaw(this.maxDurationRaw * position)
-      })
+      try {
+        this.wavesurfer = WaveSurfer.create({
+          container: '#waveform',
+          waveColor: '#00B242', // green
+          progressColor: '#008732', // dark-green,
+          height: 60,
+          responsive: true,
+          fillParent: true,
+          minPxPerSec: 1,
+          backend: 'MediaElement'
+        })
+        this.wavesurfer.on('seek', position => {
+          this.setCurrentTimeRaw(this.maxDurationRaw * position)
+        })
+      } catch(err) {
+        console.error(err)
+      }
     },
 
     loadWaveForm() {

--- a/src/components/pages/production/NewProduction.vue
+++ b/src/components/pages/production/NewProduction.vue
@@ -155,6 +155,7 @@
           "
           :step="3"
           :is-completed="hasValidAssetTaskTypes"
+          v-if="productionToCreate.settings.type !== 'shots'"
         >
           <draggable
             v-model="productionToCreate.assetTaskTypes"
@@ -187,7 +188,11 @@
             $t('productions.creation.select_shot_task_type_description')
           "
           :step="4"
-          :is-completed="hasValidShotTaskTypes"
+          :is-completed="
+            hasValidShotTaskTypes ||
+            productionToCreate.settings.type === 'assets'
+          "
+          v-if="productionToCreate.settings.type !== 'assets'"
         >
           <draggable
             v-model="productionToCreate.shotTaskTypes"
@@ -248,6 +253,7 @@
           :subtitle="$t('productions.creation.add_asset_types_description')"
           :step="6"
           :is-completed="hasValidAssetTypes"
+          v-if="productionToCreate.settings.type !== 'shots'"
         >
           <div class="flexrow asset-types mb1">
             <span
@@ -311,12 +317,6 @@
             >
               {{ $t('productions.creation.import_shots_button') }}
             </button>
-            <!--            <button-->
-            <!--              class="button ml1"-->
-            <!--              @click="toggleModal('isAddShotsDisplayed')"-->
-            <!--            >-->
-            <!--              + {{ $t('productions.creation.add_shots_button') }}-->
-            <!--            </button>-->
           </div>
         </timeline-item>
         <section class="has-text-centered mt2">
@@ -687,10 +687,19 @@ export default {
       return (
         this.hasValidName &&
         this.hasValidSettings &&
-        this.hasValidAssetTaskTypes &&
-        this.hasValidShotTaskTypes &&
+        (
+          this.hasValidAssetTaskTypes ||
+          this.productionToCreate.settings.type === 'shots'
+        ) &&
+        (
+          this.hasValidShotTaskTypes ||
+          this.productionToCreate.settings.type === 'assets'
+        ) &&
         this.hasValidTaskStatuses &&
-        this.hasValidAssetTypes
+        (
+          this.hasValidAssetTypes ||
+          this.productionToCreate.settings.type === 'shots'
+        )
       )
     },
 
@@ -904,7 +913,9 @@ export default {
         await this.createTaskTypesAndStatuses()
         await this.createAssetTypes()
         await this.createAssets()
-        await this.createShots()
+        if (this.productionToCreate.production_type !== 'assets') {
+          await this.createShots()
+        }
         await this.loadContext()
         await this.$router.push(this.createProductionRoute(createdProduction))
       } catch (error) {

--- a/src/components/pages/production/ProductionTaskTypes.vue
+++ b/src/components/pages/production/ProductionTaskTypes.vue
@@ -31,13 +31,7 @@
 
       <div
         v-else
-        v-for="(taskListObject, index) in [
-          assetTaskTypes,
-          shotTaskTypes,
-          editTaskTypes,
-          sequenceTaskTypes,
-          episodeTaskTypes
-        ]"
+        v-for="(taskListObject, index) in taskTypeGroups"
         :key="index"
       >
         <h2 class="section-title">
@@ -162,6 +156,30 @@ export default {
           t => !this.currentProduction.task_types.includes(t.id)
         )
       )
+    },
+
+    isAssetsOnly() {
+      return this.currentProduction.production_type === 'assets'
+    },
+
+    isShotsOnly() {
+      return this.currentProduction.production_type === 'shots'
+    },
+
+    taskTypeGroups() {
+      let groups = []
+      if (!this.isShotsOnly) {
+        groups.push(this.assetTaskTypes)
+      }
+      if (!this.isAssetsOnly) {
+        groups = groups.concat([
+          this.shotTaskTypes,
+          this.editTaskTypes,
+          this.sequenceTaskTypes,
+          this.episodeTaskTypes
+        ])
+      }
+      return groups
     }
   },
 

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1680,7 +1680,11 @@ export default {
     },
 
     isAnnotationsDisplayed() {
-      this.previewViewer.resetZoom()
+      if (this.isAnnotationsDisplayed) {
+        this.$nextTick(() => {
+          this.previewViewer.resetZoom()
+        })
+      }
       if (!this.isAnnotationsDisplayed) {
         this.isDrawing = false
       }
@@ -1901,5 +1905,9 @@ export default {
 #resize-annotation-canvas,
 #annotation-snapshot {
   display: none;
+}
+
+.preview-viewer {
+  overflow: hidden;
 }
 </style>

--- a/src/components/previews/PreviewViewer.vue
+++ b/src/components/previews/PreviewViewer.vue
@@ -412,7 +412,12 @@ export default {
     },
 
     resetZoom() {
-      this.pictureViewer.resetPanZoom()
+      if (this.pictureViewer) {
+        this.pictureViewer.resetPanZoom()
+      }
+      if (this.videoViewer) {
+        this.videoViewer.resetPanZoom()
+      }
     }
   },
 

--- a/src/components/previews/VideoViewer.vue
+++ b/src/components/previews/VideoViewer.vue
@@ -34,6 +34,7 @@
 </template>
 
 <script>
+import panzoom from 'panzoom'
 import { mapGetters } from 'vuex'
 
 import { formatFrame, formatTime, floorToFrame, ceilToFrame } from '@/lib/video'
@@ -183,12 +184,23 @@ export default {
         window.addEventListener('resize', this.onWindowResize)
       }
     }, 0)
+
+    var element = document.querySelector('.video-player')
+    if (!this.panzoom) {
+      this.panzoom = panzoom(element, {
+        bounds: true,
+        boundsPadding: 0.2,
+        maxZoom: 5,
+        minZoom: 1
+      })
+    }
   },
 
   beforeDestroy() {
     this.pause()
     window.removeEventListener('keydown', this.onKeyDown)
     window.removeEventListener('resize', this.onWindowResize)
+    if (this.panzoom) this.panzoom.dispose()
   },
 
   computed: {
@@ -451,25 +463,37 @@ export default {
           this.mountVideo()
         }, 400)
       }
+    },
+
+    resetPanZoom() {
+      this.panzoom.moveTo(0, 0)
+      this.panzoom.zoomAbs(0, 0, 1)
     }
   },
 
   watch: {
     preview() {
+      this.resetPanZoom()
       this.maxDuration = '00:00.000'
       this.pause()
     },
 
     light() {
+      this.resetPanZoom()
       this.mountVideo()
     },
 
     isComparing() {
+      this.resetPanZoom()
       this.mountVideo()
     },
 
     isMuted() {
       this.video.muted = this.isMuted
+    },
+
+    fullScreen() {
+      this.resetPanZoom()
     }
   }
 }
@@ -513,6 +537,7 @@ export default {
   width: 100%;
   text-align: center;
   background: #36393f;
+  overflow: hidden;
 }
 
 video {

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -17,9 +17,12 @@
             :title="$t('menu.change_status')"
             @click="selectBar('change-status')"
             v-if="
-              (isCurrentUserManager ||
+              (
+                isCurrentUserManager ||
                 isSupervisorInDepartment ||
-                isInDepartment) &&
+                isInDepartment ||
+                isCurrentViewTodos
+              ) &&
               !isEntitySelection &&
               isTaskSelection &&
               nbSelectedTasks > 1
@@ -83,7 +86,7 @@
               active: selectedBar === 'subscribe'
             }"
             :title="$t('menu.subscribe')"
-            v-if="isTaskSelection"
+            v-if="isTaskSelection && !isCurrentViewTodos"
             @click="selectBar('subscribe')"
           >
             <eye-icon />
@@ -103,6 +106,7 @@
             v-if="
               (isCurrentViewAsset ||
                 isCurrentViewShot ||
+                isCurrentViewTodos ||
                 isCurrentViewTaskType) &&
               !isEntitySelection &&
               isTaskSelection &&
@@ -899,7 +903,7 @@ export default {
 
     isCurrentViewTodos() {
       return (
-        this.$route.path.indexOf('todos') > 0 ||
+        this.$route.path.indexOf('my-tasks') > 0 ||
         this.$route.path.indexOf('people/') > 0
       )
     },
@@ -957,11 +961,15 @@ export default {
     isInDepartment() {
       return this.selectedTaskIds.every(taskId => {
         const task = this.taskMap.get(taskId)
-        const taskType = this.taskTypeMap.get(task.task_type_id)
-        return (
-          taskType.department_id &&
-          this.user.departments.includes(taskType.department_id)
-        )
+        if (task) {
+          const taskType = this.taskTypeMap.get(task.task_type_id)
+          return (
+            taskType.department_id &&
+            this.user.departments.includes(taskType.department_id)
+          )
+        } else {
+          return true // We are in the artist todolist.
+        }
       })
     },
 
@@ -1398,6 +1406,10 @@ export default {
           this.selectedBar === this.lastSelectedBar
         }
       }
+    },
+
+    selectedTasks () {
+      this.selectedTaskIds = Array.from(this.selectedTasks.keys())
     },
 
     currentProduction() {

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -41,7 +41,8 @@
                 isSupervisorInDepartment ||
                 isInDepartment) &&
               !isEntitySelection &&
-              isTaskSelection
+              isTaskSelection &&
+              !isCurrentUserArtist
             "
           >
             <user-icon />
@@ -70,7 +71,7 @@
               active: selectedBar === 'thumbnails'
             }"
             :title="$t('menu.set_thumbnails')"
-            v-if="isTaskSelection"
+            v-if="isTaskSelection && !this.isCurrentUserArtist"
             @click="selectBar('thumbnails')"
           >
             <image-icon />
@@ -840,6 +841,16 @@ export default {
         this.selectedShots.size > 0 ||
         this.selectedEdits.size > 0
       )
+    },
+
+    isAssigned() {
+      if (!this.isCurrentUserArtist) return
+      if (this.nbSelectedTasks === 0) return
+      const selectedTasks = Array.from(this.selectedTasks.values())
+      let isAssigned = selectedTasks.some(task => {
+        return task.assignees.includes(this.user.id)
+      })
+      return isAssigned
     },
 
     nbSelectedAssets() {

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -399,12 +399,17 @@ export default {
     },
 
     sectionOptions() {
-      let options = [
-        { label: this.$t('assets.title'), value: 'assets' },
-        { label: this.$t('shots.title'), value: 'shots' }
-      ]
+      let options = []
+      const isNotOnlyAssets = this.currentProduction.production_type !== 'assets'
+      const isNotOnlyShots = this.currentProduction.production_type !== 'shots'
 
-      if (!this.isCurrentUserClient) {
+      if (isNotOnlyShots) {
+        options.push({ label: this.$t('assets.title'), value: 'assets' })
+      }
+      if (isNotOnlyAssets) {
+        options.push({ label: this.$t('shots.title'), value: 'shots' })
+      }
+      if (!this.isCurrentUserClient && isNotOnlyAssets) {
         options.push({ label: this.$t('sequences.title'), value: 'sequences' })
       }
 
@@ -438,10 +443,12 @@ export default {
       options = options.concat([{ label: 'separator', value: 'separator' }])
 
       // Add sequences
-      options.push({
-        label: this.$t('sequences.stats_title'),
-        value: 'sequence-stats'
-      })
+      if (isNotOnlyAssets) {
+        options.push({
+          label: this.$t('sequences.stats_title'),
+          value: 'sequence-stats'
+        })
+      }
 
       // Add episodes for tv show only
       if (this.isTVShow) {
@@ -451,21 +458,25 @@ export default {
       }
 
       // Add asset types stats
-      options = options.concat([
-        {
-          label: this.$t('asset_types.production_title'),
-          value: 'assetTypes'
-        }
-      ])
+      if (isNotOnlyShots) {
+        options = options.concat([
+          {
+            label: this.$t('asset_types.production_title'),
+            value: 'assetTypes'
+          }
+        ])
+      }
 
       // Show these sections to studio members only.
       if (!this.isCurrentUserClient) {
         options = options.concat([
           { label: 'separator', value: 'separator' },
           { label: this.$t('schedule.title'), value: 'schedule' },
-          { label: this.$t('quota.title'), value: 'quota' },
-          { label: this.$t('people.team'), value: 'team' }
         ])
+        if (isNotOnlyAssets) {
+          options.push({ label: this.$t('quota.title'), value: 'quota' })
+        }
+        options.push({ label: this.$t('people.team'), value: 'team' })
 
         if (this.isCurrentUserAdmin || this.isCurrentUserManager) {
           options = options.concat([

--- a/src/components/widgets/ComboboxDepartment.vue
+++ b/src/components/widgets/ComboboxDepartment.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="field">
+  <div>
     <label class="label" v-if="label.length > 0">
       {{ label }}
     </label>
@@ -213,14 +213,14 @@ export default {
 
 .selected-department-line {
   background: $white;
-  padding: 0.4em;
+  padding: 0.2em;
   flex: 1;
 }
 
 .department-line {
   background: $white;
   cursor: pointer;
-  padding: 0.4em;
+  padding: 0.2em;
   margin: 0;
 
   &:hover {

--- a/src/components/widgets/EntityPreview.vue
+++ b/src/components/widgets/EntityPreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="preview-wrapper preview-video" v-if="isMovie">
+  <div class="preview-wrapper preview-video" v-if="isMovie && showMovie">
     <video-viewer
       ref="video-viewer"
       :is-repeating="true"
@@ -103,6 +103,10 @@ export default {
     },
     isRoundedTopBorder: {
       default: false,
+      type: Boolean
+    },
+    showMovie: {
+      default: true,
       type: Boolean
     }
   },

--- a/src/lib/productions.js
+++ b/src/lib/productions.js
@@ -26,11 +26,16 @@ export const PRODUCTION_STYLE_OPTIONS = [
   { label: '3d', value: '3d' },
   { label: '2d3d', value: '2d3d' },
   { label: 'vfx', value: 'vfx' },
-  { label: 'stop_motion', value: 'stop-motion' },
+  { label: 'commercial', value: 'commercial' },
+  { label: 'vr', value: 'vr' },
   { label: 'motion_design', value: 'motion-design' },
   { label: 'archviz', value: 'archviz' },
-  { label: 'commercial', value: 'commercial' },
-  { label: 'catalog', value: 'catalog' }
+  { label: 'stop_motion', value: 'stop-motion' },
+  { label: 'catalog', value: 'catalog' },
+  { label: 'nft', value: 'nft' },
+  { label: 'video_game', value: 'video-game' },
+  { label: 'immersive', value: 'immersive' },
+  { label: 'ar', value: 'ar' }
 ]
 
 export function getTaskTypePriorityOfProd(taskType, production) {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -618,6 +618,7 @@ export default {
       role: 'Role'
     },
     role: {
+      all: 'All',
       admin: 'Studio Manager',
       client: 'Client',
       manager: 'Production Manager',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -864,6 +864,7 @@ export default {
       archviz: 'Archviz',
       commercial: 'Commercial',
       catalog: 'Catalog',
+      immersive: 'Immersive Experience',
       metaverse: 'Metaverse',
       motion_design: 'Motion Design',
       nft: 'NFT collection',

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -871,7 +871,7 @@ const mutations = {
         state.taskComments[task.id].length > 0 &&
         !locks[task.id]
       ) {
-        const comment = state.taskComments[task.id][0]
+        const comment = state.taskComments[task.id].find(c => !c.pinned)
         Object.assign(comment, {
           task_status_id: task.task_status_id,
           task_status: state.taskStatusMap.get(task.task_status_id)

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -105,6 +105,7 @@ const initialState = {
   displayedTodos: [],
   displayedDoneTasks: [],
   todosSearchText: '',
+  doneSelectionGrid: {},
   todoSelectionGrid: {},
   todoSearchQueries: [],
   userFilters: {},
@@ -138,6 +139,7 @@ const getters = {
 
   displayedTodos: state => state.displayedTodos,
   displayedDoneTasks: state => state.displayedDoneTasks,
+  doneSelectionGrid: state => state.doneSelectionGrid,
   todosSearchText: state => state.todosSearchText,
   todoSelectionGrid: state => state.todoSelectionGrid,
   todoSearchQueries: state => state.todoSearchQueries,
@@ -578,6 +580,7 @@ const mutations = {
       const taskStatus = helpers.getTaskStatus(task.task_status_id)
       task.taskStatus = taskStatus
     })
+    state.doneSelectionGrid = buildSelectionGrid(tasks.length, 1)
     cache.doneIndex = buildTaskIndex(tasks)
     cache.doneTasks = tasks
     state.displayedDoneTasks = tasks
@@ -644,19 +647,38 @@ const mutations = {
   },
 
   [ADD_SELECTED_TASK](state, validationInfo) {
-    if (state.todoSelectionGrid && state.todoSelectionGrid[validationInfo.x]) {
+    if (
+      validationInfo.done &&
+      state.doneSelectionGrid &&
+      state.doneSelectionGrid[validationInfo.x]
+    ) {
+      state.doneSelectionGrid[validationInfo.x][validationInfo.y] = true
+    } else if (
+      state.todoSelectionGrid &&
+      state.todoSelectionGrid[validationInfo.x]
+    ) {
       state.todoSelectionGrid[validationInfo.x][validationInfo.y] = true
     }
   },
 
   [REMOVE_SELECTED_TASK](state, validationInfo) {
-    if (state.todoSelectionGrid && state.todoSelectionGrid[validationInfo.x]) {
+    if (
+      validationInfo.done &&
+      state.doneSelectionGrid &&
+      state.doneSelectionGrid[validationInfo.x]
+    ) {
+      state.doneSelectionGrid[validationInfo.x][validationInfo.y] = false
+    } else if (
+      state.todoSelectionGrid &&
+      state.todoSelectionGrid[validationInfo.x]
+    ) {
       state.todoSelectionGrid[validationInfo.x][validationInfo.y] = false
     }
   },
 
   [CLEAR_SELECTED_TASKS](state) {
     state.todoSelectionGrid = clearSelectionGrid(state.todoSelectionGrid)
+    state.doneSelectionGrid = clearSelectionGrid(state.doneSelectionGrid)
   },
 
   [SET_TODO_LIST_SCROLL_POSITION](state, scrollPosition) {

--- a/tests/unit/lib/filtering.spec.js
+++ b/tests/unit/lib/filtering.spec.js
@@ -459,6 +459,21 @@ describe('lib/filtering', () => {
       expect(filters[0].values).toEqual(['blue', 'red'])
       expect(filters[0].excluding).toEqual(false)
     })
+
+    it('readyfor=[animation] in query case', () => {
+      const filters = getFilters({
+        entryIndex,
+        assetTypes,
+        taskTypes,
+        taskStatuses,
+        descriptors,
+        persons,
+        query: 'readyfor=[animation]'
+      })
+      expect(filters).toHaveLength(1)
+      expect(filters[0].type).toEqual('readyfor')
+      expect(filters[0].value).toEqual('task-type-1')
+    })
   })
 
   describe('applyFilters', () => {
@@ -820,6 +835,39 @@ describe('lib/filtering', () => {
         taskMap
       )
       expect(results).toHaveLength(2)
+    })
+
+    it('readyfor=[Animation]', () => {
+      const assetEntries = [
+        {
+          name: 'Bunny',
+          id: 'asset-1',
+          data: { },
+          validations: new Map([['task-type-1', 'task-1']]),
+          tasks: ['task-1'],
+          ready_for: 'task-type-1'
+        },
+        {
+          name: 'Lama',
+          id: 'asset-1',
+          data: { },
+          validations: new Map([['task-type-1', 'task-1']]),
+          tasks: ['task-1'],
+          ready_for: 'task-type-2'
+        }
+      ]
+      const filters = [
+        {
+          type: 'readyfor',
+          value: 'task-type-1'
+        }
+      ]
+      const results = applyFilters(
+        assetEntries,
+        filters,
+        taskMap
+      )
+      expect(results).toHaveLength(1)
     })
   })
 })


### PR DESCRIPTION
**Problem**

* Contact sheet thumbnails are broken (not properly sized and pixelated).
* It's not possible to zoom in on the video player.
* The ready for field is not filterable.
* Task page filters are not set in the URL.
* People are not filterable via their role in the people page.
* Artists can't select multiple tasks in their todo-list and they can't select done tasks
* Assets only production show shots related sections.
* Shots only production show assets related sections.

**Solution**

* Use the entity preview widget instead of the thumbnail widget.
* Add zoom and pan in the video player when annotations are deactivated.
* Add a `readyfor=` filter and an entry in the filter builder.
* Add filters to the query URL and grab them when mounting the page.
* Add two filters to the people page: one for departments and one for roles.
* Allow artists to modify multi selection and select done tasks to open the task panel.
* Show only assets related sections for asset only productions.
* Show only shots related sections for shot only productions.
