### PR TITLE
Various improvements

### DIFF
--- a/src/components/pages/EntitySearch.vue
+++ b/src/components/pages/EntitySearch.vue
@@ -1,6 +1,15 @@
 <template>
   <div class="entity-search page">
     <form class="search-form" @submit.prevent="onResultSelected()">
+      <div>
+        <combobox-production
+          class="flexrow-item production-field"
+          :label="$t('main.production')"
+          :production-list="productionList"
+          v-model="productionId"
+        />
+      </div>
+
       <div class="search-field">
         <span class="search-icon">
           <search-icon width="20" />
@@ -27,6 +36,7 @@
           @change="search"
           v-model="searchFilter.shots"
         />
+
         <div class="filler"></div>
         <span class="flexrow-item no-margin">
           {{ $t('search.limit') }}
@@ -204,6 +214,7 @@ import { SearchIcon } from 'vue-feather-icons'
 
 import Checkbox from '@/components/widgets/Checkbox'
 import Combobox from '@/components/widgets/Combobox'
+import ComboboxProduction from '@/components/widgets/ComboboxProduction'
 import EntityPreview from '@/components/widgets/EntityPreview'
 // import PeopleAvatar from '@/components/widgets/PeopleAvatar'
 import Spinner from '@/components/widgets/Spinner'
@@ -217,6 +228,7 @@ export default {
   components: {
     Checkbox,
     Combobox,
+    ComboboxProduction,
     EntityPreview,
     // PeopleAvatar,
     SearchIcon,
@@ -228,6 +240,7 @@ export default {
       isLoading: false,
       limit: AVAILABLE_LIMITS[0],
       limitOptions: AVAILABLE_LIMITS.map(value => ({ label: value, value })),
+      productionId: '',
       selectedIndex: 0,
       searchQuery: '',
       searchFilter: {
@@ -266,7 +279,10 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['productionMap']),
+    ...mapGetters([
+      'openProductions',
+      'productionMap'
+    ]),
 
     searchField() {
       return this.$refs['search-field']
@@ -291,6 +307,15 @@ export default {
         !this.searchFilter.assets && !this.searchFilter.shots
         // && !this.searchFilter.persons
       )
+    },
+
+    productionList() {
+      return [
+        {
+          id: '',
+          name: this.$t('main.all')
+        }
+      ].concat([...this.openProductions])
     }
   },
 
@@ -306,6 +331,7 @@ export default {
       this.searchData({
         query: this.searchQuery,
         limit: this.limit,
+        productionId: this.productionId,
         index_names
       })
         .then(results => {
@@ -382,6 +408,10 @@ export default {
   },
 
   watch: {
+    productionId() {
+      this.search()
+    },
+
     searchQuery() {
       if (this.searchQuery.length) {
         this.$router.push({ query: { search: this.searchQuery } })
@@ -418,7 +448,7 @@ export default {
 }
 
 .search-field {
-  padding-top: 40px;
+  padding-top: 0px;
   position: relative;
   width: 100%;
 
@@ -435,6 +465,11 @@ export default {
     top: 55px;
     left: 10px;
   }
+}
+
+.production-field {
+  margin-bottom: 1em;
+  margin-top: 1em;
 }
 
 .search-options {

--- a/src/components/pages/People.vue
+++ b/src/components/pages/People.vue
@@ -233,7 +233,6 @@ export default {
     this.loadPeople(() => {
       this.setSearchFromUrl()
       this.onSearchChange()
-      console.log(this.selectedDepartment, this.role)
     }) // Needed to show department informations
   },
 

--- a/src/components/pages/TeamSchedule.vue
+++ b/src/components/pages/TeamSchedule.vue
@@ -208,27 +208,18 @@ export default {
       let endDate
 
       if (
-        !task.start_date &&
-        !task.real_start_date &&
-        !task.due_date &&
-        !task.end_date
+        !task.start_date ||
+        !task.due_date
       )
         return null
 
       if (task.start_date) {
         startDate = parseSimpleDate(task.start_date)
-      } else if (task.real_start_date) {
-        startDate = parseSimpleDate(task.real_start_date)
-      }
-
+      } 
       const estimation = this.formatDuration(task.estimation)
       if (task.due_date) {
         endDate = parseSimpleDate(task.due_date)
-      } else if (task.end_date) {
-        endDate = parseSimpleDate(task.end_date)
-      } else if (task.estimation) {
-        endDate = startDate.clone().add(estimation, 'days')
-      }
+      } 
 
       if (!endDate || endDate.isBefore(startDate)) {
         endDate = startDate.clone().add(1, 'days')

--- a/src/components/pages/TeamSchedule.vue
+++ b/src/components/pages/TeamSchedule.vue
@@ -38,6 +38,11 @@
           :options="zoomOptions"
           v-model="zoomLevel"
         />
+        <combobox-department
+          class="combobox-department flexrow-item"
+          label="Department"
+          v-model="selectedDepartment"
+        />
       </div>
 
       <schedule
@@ -65,10 +70,15 @@ import { en, fr } from 'vuejs-datepicker/dist/locale'
 import Datepicker from 'vuejs-datepicker'
 import { getPersonTabPath } from '@/lib/path'
 
-import { getFirstStartDate, getLastEndDate, parseDate } from '@/lib/time'
+import {
+  getFirstStartDate,
+  getLastEndDate,
+  parseSimpleDate
+} from '@/lib/time'
 import colors from '@/lib/colors'
 
 import { formatListMixin } from '@/components/mixins/format'
+import ComboboxDepartment from '@/components/widgets/ComboboxDepartment'
 import ComboboxNumber from '@/components/widgets/ComboboxNumber'
 import Schedule from '@/components/pages/schedule/Schedule'
 import { firstBy } from 'thenby'
@@ -77,6 +87,7 @@ export default {
   name: 'team-schedule',
   mixins: [formatListMixin],
   components: {
+    ComboboxDepartment,
     ComboboxNumber,
     Datepicker,
     Schedule
@@ -84,11 +95,13 @@ export default {
 
   data() {
     return {
+      endDate: moment().add(3, 'months'),
+      personDates: {},
       scheduleItems: [],
-      startDate: moment(),
-      endDate: moment().add(1, 'months'),
-      selectedStartDate: null,
+      selectedDepartment: '',
       selectedEndDate: null,
+      selectedStartDate: null,
+      startDate: moment(),
       zoomLevel: 1,
       zoomOptions: [
         // { label: 'Week', value: 0 },
@@ -110,7 +123,11 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['displayedPeople', 'taskTypeMap', 'user']),
+    ...mapGetters([
+      'displayedPeople',
+      'taskTypeMap',
+      'user'
+    ]),
 
     locale() {
       if (this.user.locale === 'fr_FR') {
@@ -122,14 +139,41 @@ export default {
   },
 
   methods: {
-    ...mapActions(['fetchPersonTasks', 'loadPeople']),
+    ...mapActions([
+      'fetchPersonTasks',
+      'getPersonsTasksDates',
+      'loadPeople'
+    ]),
 
     async reset() {
       this.loading.schedule = true
+      const personDatesList = await this.getPersonsTasksDates()
+      const scheduleStartDate = moment()
+      this.personDates = {}
+      personDatesList.forEach(p => {
+        this.personDates[p.person_id] = {
+          endDate: parseSimpleDate(p.max_date),
+          startDate: parseSimpleDate(p.min_date),
+        }
+      })
       await this.loadPeople()
-      this.scheduleItems = this.convertScheduleItems(this.displayedPeople)
+      const people = this.selectedDepartment
+        ? this.displayedPeople.filter(
+          p => p.departments.includes(this.selectedDepartment)
+        )
+        : this.displayedPeople
+      this.scheduleItems = this.convertScheduleItems(people)
       this.startDate = moment()
-      this.endDate = moment().add(1, 'months')
+      this.endDate = moment().add(3, 'months')
+      Object.values(this.personDates).forEach(dates => {
+        if (dates.startDate.isBefore(this.startDate)) {
+          this.startDate = dates.startDate.clone()
+        }
+        if (dates.endDate.isAfter(this.endDate)) {
+          this.endDate = dates.endDate.clone()
+        }
+      })
+
       this.selectedStartDate = this.startDate.toDate()
       this.selectedEndDate = this.endDate.toDate()
       // this.loading.schedule = false
@@ -137,15 +181,22 @@ export default {
 
     convertScheduleItems(scheduleItems) {
       return scheduleItems.map(item => {
+        let startDate = moment()
+        let endDate = moment()
+        const personDates = this.personDates[item.id]
+        if (personDates && personDates.startDate && personDates.endDate) {
+          startDate = parseSimpleDate(personDates.startDate)
+          endDate = parseSimpleDate(personDates.endDate)
+        }
         return {
           ...item,
           avatar: true,
           color: item.color || colors.fromString(item.name, true),
-          startDate: moment(),
-          endDate: moment(),
+          startDate,
+          endDate,
           expanded: false,
           loading: false,
-          editable: true,
+          editable: false,
           route: getPersonTabPath(item.id, 'schedule'),
           children: []
         }
@@ -165,16 +216,16 @@ export default {
         return null
 
       if (task.start_date) {
-        startDate = parseDate(task.start_date)
+        startDate = parseSimpleDate(task.start_date)
       } else if (task.real_start_date) {
-        startDate = parseDate(task.real_start_date)
+        startDate = parseSimpleDate(task.real_start_date)
       }
 
       const estimation = this.formatDuration(task.estimation)
       if (task.due_date) {
-        endDate = parseDate(task.due_date)
+        endDate = parseSimpleDate(task.due_date)
       } else if (task.end_date) {
-        endDate = parseDate(task.end_date)
+        endDate = parseSimpleDate(task.end_date)
       } else if (task.estimation) {
         endDate = startDate.clone().add(estimation, 'days')
       }
@@ -217,7 +268,7 @@ export default {
           : moment()
         const endDate = element.children.length
           ? getLastEndDate(element.children)
-          : moment().add(1, 'months')
+          : moment().add(3, 'months')
 
         if (startDate.isBefore(this.startDate)) {
           this.startDate = startDate
@@ -241,7 +292,11 @@ export default {
 
   socket: {},
 
-  watch: {},
+  watch: {
+    selectedDepartment () {
+      this.reset()
+    }
+  },
 
   metaInfo() {
     return {

--- a/src/components/pages/schedule/Schedule.vue
+++ b/src/components/pages/schedule/Schedule.vue
@@ -59,7 +59,8 @@
                 <people-avatar
                   :person="rootElement"
                   :is-link="false"
-                  :size="30"
+                  :font-size="14"
+                  :size="28"
                   :no-cache="true"
                   v-else
                 />
@@ -341,7 +342,6 @@
                     ')'
                   "
                   :style="timebarStyle(rootElement, true)"
-                  v-if="!multiline"
                 >
                   <div class="timebar" v-show="isVisible(rootElement)">
                     <div
@@ -646,7 +646,7 @@ export default {
         momentDay.newMonth = nextDay.newMonth
         momentDay.weekend = nextDay.weekend
         momentDay.text = momentDay.format('YYYY-MM-DD')
-        momentDay.monthText = momentDay.format('MMMM')
+        momentDay.monthText = momentDay.format('MMMM YY')
         momentDay.dayNumber = momentDay.format('DD')
         momentDay.dayText = momentDay.format('ddd')[0]
         days.push(momentDay)
@@ -704,7 +704,7 @@ export default {
           momentDay.newMonth =
             weeks.length === 0 ||
             momentDay.month() !== weeks[weeks.length - 1].month()
-          momentDay.monthText = momentDay.format('MMMM')
+          momentDay.monthText = momentDay.format('MMMM YY')
           weeks.push(momentDay)
         }
         dayDate = nextDay
@@ -1292,12 +1292,16 @@ export default {
 
     entityLineStyle(timeElement, root = false, header = false) {
       const style = {}
+      let color = timeElement.color
+      if (root && timeElement.full_name) { // is a person
+        color = '#CCC'
+      }
       if (root) {
-        style['border-left'] = '1px solid ' + timeElement.color
-        style['border-top'] = '1px solid ' + timeElement.color
-        style['border-bottom'] = '1px solid ' + timeElement.color
+        style['border-left'] = '1px solid ' + color
+        style['border-top'] = '1px solid ' + color
+        style['border-bottom'] = '1px solid ' + color
         if (header) {
-          style.background = timeElement.color
+          style.background = color
         }
       }
       if (timeElement.expanded) {
@@ -1387,8 +1391,12 @@ export default {
     },
 
     childrenStyle(rootElement, isMultiline = false, setBackground = false) {
+      let color = rootElement.color
+      if (rootElement.full_name) { // is a person
+        color = '#CCC'
+      }
       const style = {
-        'border-bottom': `1px solid ${rootElement.color}`
+        'border-bottom': `1px solid ${color}`
       }
       if (isMultiline) {
         const nbLines = this.getNbLines(rootElement)
@@ -1694,7 +1702,7 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
 .entity-line {
   font-size: 1.2em;
   height: 40px;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
   padding: 0.5em;
 
   .flexrow-item {
@@ -1931,8 +1939,8 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
   line-height: 1.1em;
 
   &.root {
-    border-top-left-radius: 1em;
-    border-bottom-left-radius: 1em;
+    border-top-left-radius: 10px;
+    border-bottom-left-radius: 10px;
   }
 
   &.root.expanded {
@@ -1955,7 +1963,7 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
   }
 
   .avatar {
-    box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.3);
+    box-shadow: 0 0 3px 0 rgba(0, 0, 0, 0.3);
     margin: 0;
     padding: 0;
   }

--- a/src/components/pages/schedule/Schedule.vue
+++ b/src/components/pages/schedule/Schedule.vue
@@ -332,7 +332,10 @@
                 v-show="!hideRoot"
               >
                 <div
-                  class="timebar-wrapper"
+                  :class="{
+                    'timebar-wrapper': true,
+                    thinner: multiline
+                  }"
                   :title="
                     rootElement.name +
                     ' (' +
@@ -2138,6 +2141,11 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
 
   .timebar {
     width: calc(100% - 0.2em);
+  }
+
+  &.thinner {
+    height: 14px;
+    top: 14px;
   }
 }
 

--- a/src/store/api/client.js
+++ b/src/store/api/client.js
@@ -134,9 +134,11 @@ const client = {
     return client.pget(path)
   },
 
-  searchData(query, limit, index_names) {
+  searchData(query, limit, index_names, productionId) {
     const path = '/api/data/search'
-    return client.ppost(path, { query, limit, index_names })
+    const data = { query, limit, index_names }
+    if (productionId !== 'all') data.project_id = productionId
+    return client.ppost(path, data)
   }
 }
 

--- a/src/store/api/people.js
+++ b/src/store/api/people.js
@@ -225,6 +225,9 @@ export default {
   },
 
   getPersonDoneTasks(personId, callback) {
+    if (!callback) {
+      return client.pget(`/api/data/persons/${personId}/done-tasks`)
+    }
     client.get(`/api/data/persons/${personId}/done-tasks`, callback)
   },
 

--- a/src/store/api/tasks.js
+++ b/src/store/api/tasks.js
@@ -255,5 +255,9 @@ export default {
   updateRevisionPreviewPosition(previewId, position) {
     const path = `/api/actions/preview-files/${previewId}/update-position`
     return client.pput(path, { position: position + 1 })
+  },
+
+  getPersonsTasksDates() {
+    return client.pget('/api/data/persons/task-dates')
   }
 }

--- a/src/store/modules/main.js
+++ b/src/store/modules/main.js
@@ -75,11 +75,11 @@ const actions = {
     })
   },
 
-  searchData(_, { query, limit, index_names }) {
+  searchData(_, { query, limit, productionId, index_names }) {
     if (!limit) {
       limit = 3
     }
-    return client.searchData(query, limit, index_names)
+    return client.searchData(query, limit, index_names, productionId)
   }
 }
 

--- a/src/store/modules/people.js
+++ b/src/store/modules/people.js
@@ -340,7 +340,9 @@ const actions = {
   },
 
   async fetchPersonTasks({ commit, state, rootGetters }, personId) {
-    const tasks = await peopleApi.getPersonTasks(personId)
+    let tasks = await peopleApi.getPersonTasks(personId)
+    const doneTasks = await peopleApi.getPersonDoneTasks(personId)
+    tasks = tasks.concat(doneTasks)
     tasks.forEach(task => {
       populateTask(task)
       task.taskStatus = helpers.getTaskStatus(task.task_status_id)

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -820,6 +820,10 @@ const actions = {
       payload.previewId,
       payload.newIndex
     )
+  },
+
+  getPersonsTasksDates({ commit }) {
+    return tasksApi.getPersonsTasksDates()
   }
 }
 


### PR DESCRIPTION
**Problem**

* It's not possible to filter search results by production, it may clutter the results.
* The team schedule doesn't show the main status bars

**Solution**

* Add a combobox to select the production to search on and send the parameter to the API.
* Get start and end date of all tasks for persons from the API. Then display them as root bars of the schedule.
