### PR TITLE
[perf] improve loading data with parallel api calls

### DIFF
--- a/src/store/modules/people.js
+++ b/src/store/modules/people.js
@@ -340,9 +340,12 @@ const actions = {
   },
 
   async fetchPersonTasks({ commit, state, rootGetters }, personId) {
-    let tasks = await peopleApi.getPersonTasks(personId)
-    const doneTasks = await peopleApi.getPersonDoneTasks(personId)
-    tasks = tasks.concat(doneTasks)
+    const tasks = (
+      await Promise.all([
+        peopleApi.getPersonTasks(personId),
+        peopleApi.getPersonDoneTasks(personId)
+      ])
+    ).flat()
     tasks.forEach(task => {
       populateTask(task)
       task.taskStatus = helpers.getTaskStatus(task.task_status_id)


### PR DESCRIPTION
**Problem**
- On team schedule, the person tasks are loaded sequentially

**Solution**
- Load data in parallel in order to speed up UX
