### PR TITLE
[qa] fix search icon position on input of entity search page

### DIFF
--- a/src/components/pages/EntitySearch.vue
+++ b/src/components/pages/EntitySearch.vue
@@ -448,7 +448,7 @@ export default {
 }
 
 .search-field {
-  padding-top: 0px;
+  padding-top: 0;
   position: relative;
   width: 100%;
 
@@ -462,7 +462,7 @@ export default {
     position: absolute;
     color: $grey;
     z-index: 4;
-    top: 55px;
+    top: 15px;
     left: 10px;
   }
 }


### PR DESCRIPTION
**Problem**
Wrong css icon on Entity Search page
![icon](https://github.com/cgwire/kitsu/assets/493223/ea9ec97a-3dff-4d44-9946-8524af3c6867)


**Solution**
Fix icon position
