### PR TITLE
Improve sync of metadata

### DIFF
--- a/src/store/api/client.js
+++ b/src/store/api/client.js
@@ -4,8 +4,8 @@ import errors from '@/lib/errors'
 const client = {
   get(path, callback) {
     superagent.get(path).end((err, res) => {
-      // if (res.statusCode === 401) return errors.backToLogin()
-      callback(err, res.body)
+      // if (res?.statusCode === 401) return errors.backToLogin()
+      callback(err, res?.body)
     })
   },
 
@@ -14,8 +14,8 @@ const client = {
       .post(path)
       .send(data)
       .end((err, res) => {
-        if (res.statusCode === 401) return errors.backToLogin()
-        callback(err, res.body)
+        if (res?.statusCode === 401) return errors.backToLogin()
+        callback(err, res?.body)
       })
   },
 
@@ -24,20 +24,20 @@ const client = {
       .put(path)
       .send(data)
       .end((err, res) => {
-        if (res.statusCode === 401) return errors.backToLogin()
-        callback(err, res.body)
+        if (res?.statusCode === 401) return errors.backToLogin()
+        callback(err, res?.body)
       })
   },
 
   del(path, callback) {
     superagent.del(path).end((err, res) => {
-      if (res.statusCode === 401) return errors.backToLogin()
-      callback(err, res.body)
+      if (res?.statusCode === 401) return errors.backToLogin()
+      callback(err, res?.body)
     })
   },
 
   pget(path) {
-    return superagent.get(path).then(res => res.body)
+    return superagent.get(path).then(res => res?.body)
   },
 
   ppost(path, data) {
@@ -46,14 +46,14 @@ const client = {
         .post(path)
         .send(data)
         .end((err, res) => {
-          if (res.statusCode === 401) {
+          if (res?.statusCode === 401) {
             errors.backToLogin()
             return reject(err)
           } else {
             if (err) {
               err.body = res ? res.body : ''
               return reject(err)
-            } else return resolve(res.body)
+            } else return resolve(res?.body)
           }
         })
     })
@@ -68,12 +68,12 @@ const client = {
       request,
       promise: new Promise((resolve, reject) => {
         request.end((err, res) => {
-          if (res.statusCode === 401) {
+          if (res?.statusCode === 401) {
             errors.backToLogin()
             return reject(err)
           } else {
             if (err) return reject(err)
-            else return resolve(res.body)
+            else return resolve(res?.body)
           }
         })
       })
@@ -86,14 +86,14 @@ const client = {
         .put(path)
         .send(data)
         .end((err, res) => {
-          if (res.statusCode === 401) {
+          if (res?.statusCode === 401) {
             errors.backToLogin()
             reject(err)
           } else {
             if (err) {
               err.body = res ? res.body : ''
               return reject(err)
-            } else return resolve(res.body)
+            } else return resolve(res?.body)
           }
         })
     })
@@ -105,14 +105,14 @@ const client = {
         .del(path)
         .send(data)
         .end((err, res) => {
-          if (res.statusCode === 401) {
+          if (res?.statusCode === 401) {
             errors.backToLogin()
             reject(err)
           } else {
             if (err) {
               err.body = res ? res.body : ''
               return reject(err)
-            } else return resolve(res.body)
+            } else return resolve(res?.body)
           }
         })
     })

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -482,11 +482,10 @@ const actions = {
     const assetTypeMap = rootState.assetTypes.assetTypeMap
     commit(LOCK_ASSET, data)
     commit(EDIT_ASSET_END, { newAsset: data, assetTypeMap })
-    return assetsApi.updateAsset(data).then(asset => {
+    return assetsApi.updateAsset(data).finally(() => {
       setTimeout(() => {
         commit(UNLOCK_ASSET, data)
       }, 2000)
-      return Promise.resolve(asset)
     })
   },
 

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -435,7 +435,7 @@ const actions = {
 
   newAsset({ commit, dispatch, state, rootGetters }, data) {
     if (cache.assets.find(asset => asset.name === data.name)) {
-      return Promise.reject(new Error('Asset already exsists'))
+      return Promise.reject(new Error('Asset already exists'))
     }
     return assetsApi.newAsset(data).then(asset => {
       const assetTypeMap = rootGetters.assetTypeMap
@@ -477,7 +477,7 @@ const actions = {
         return asset.name === data.name && data.id !== asset.id
       })
     if (existingAsset) {
-      return Promise.reject(new Error('Asset already exsists'))
+      return Promise.reject(new Error('Asset already exists'))
     }
     const assetTypeMap = rootState.assetTypes.assetTypeMap
     commit(LOCK_ASSET, data)

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -405,7 +405,7 @@ const actions = {
    */
   loadAsset({ commit, state, rootGetters }, assetId) {
     const asset = state.assetMap.get(assetId)
-    if (asset && asset.lock) return
+    if (asset?.lock) return
 
     const personMap = rootGetters.personMap
     const production = rootGetters.currentProduction
@@ -1157,12 +1157,16 @@ const mutations = {
 
   [LOCK_ASSET](state, asset) {
     asset = state.assetMap.get(asset.id)
-    asset.lock = true
+    if (asset) {
+      asset.lock = !asset.lock ? 1 : asset.lock + 1
+    }
   },
 
   [UNLOCK_ASSET](state, asset) {
     asset = state.assetMap.get(asset.id)
-    asset.lock = false
+    if (asset) {
+      asset.lock = !asset.lock ? 0 : asset.lock - 1
+    }
   },
 
   [RESET_ALL](state) {

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -371,7 +371,7 @@ const actions = {
    */
   loadEdit({ commit, state, rootGetters }, editId) {
     const edit = rootGetters.editMap.get(editId)
-    if (edit && edit.lock) return
+    if (edit?.lock) return
 
     const personMap = rootGetters.personMap
     const production = rootGetters.currentProduction
@@ -1089,12 +1089,16 @@ const mutations = {
 
   [LOCK_EDIT](state, edit) {
     edit = state.editMap.get(edit.id)
-    if (edit) edit.lock = true
+    if (edit) {
+      edit.lock = !edit.lock ? 1 : edit.lock + 1
+    }
   },
 
   [UNLOCK_EDIT](state, edit) {
     edit = state.editMap.get(edit.id)
-    if (edit) edit.lock = false
+    if (edit) {
+      edit.lock = !edit.lock ? 0 : edit.lock - 1
+    }
   },
 
   [RESET_ALL](state) {

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -404,7 +404,7 @@ const actions = {
           (!isTVShow || ed.parent_id === edit.parent_id)
       )
     ) {
-      return Promise.reject(new Error('Edit already exsists'))
+      return Promise.reject(new Error('Edit already exists'))
     }
     return editsApi.newEdit(edit).then(edit => {
       commit(NEW_EDIT_END, edit)

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -427,11 +427,10 @@ const actions = {
   editEdit({ commit, state }, data) {
     commit(LOCK_EDIT, data)
     commit(EDIT_EDIT_END, data)
-    return editsApi.updateEdit(data).then(edit => {
+    return editsApi.updateEdit(data).finally(() => {
       setTimeout(() => {
-        commit(UNLOCK_EDIT, edit)
+        commit(UNLOCK_EDIT, data)
       }, 2000)
-      return Promise.resolve(edit)
     })
   },
 

--- a/src/store/modules/episodes.js
+++ b/src/store/modules/episodes.js
@@ -422,7 +422,7 @@ const actions = {
 
   newEpisode({ commit, dispatch, state, rootGetters }, episode) {
     if (cache.episodes.find(ep => ep.name === episode.name)) {
-      return Promise.reject(new Error('Episode already exsists'))
+      return Promise.reject(new Error('Episode already exists'))
     }
     return shotsApi.newEpisode(episode).then(episode => {
       commit(NEW_EPISODE_END, episode)

--- a/src/store/modules/sequences.js
+++ b/src/store/modules/sequences.js
@@ -449,11 +449,15 @@ const actions = {
 
   editSequence({ commit, state }, data) {
     commit(LOCK_SEQUENCE, data)
-    return shotsApi.updateSequence(data).then(sequence => {
-      commit(EDIT_SEQUENCE_END, sequence)
-      commit(UNLOCK_SEQUENCE, data)
-      return Promise.resolve(sequence)
-    })
+    return shotsApi
+      .updateSequence(data)
+      .then(sequence => {
+        commit(EDIT_SEQUENCE_END, sequence)
+        return sequence
+      })
+      .finally(() => {
+        commit(UNLOCK_SEQUENCE, data)
+      })
   },
 
   deleteSequence({ commit, state }, sequence) {

--- a/src/store/modules/sequences.js
+++ b/src/store/modules/sequences.js
@@ -427,7 +427,7 @@ const actions = {
           (!isTVShow || seq.episode_id === sequence.episode_id)
       )
     ) {
-      return Promise.reject(new Error('Sequence already exsists'))
+      return Promise.reject(new Error('Sequence already exists'))
     }
     return shotsApi.newSequence(sequence).then(sequence => {
       commit(NEW_SEQUENCE_END, { sequence, episodeMap })

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -440,7 +440,7 @@ const actions = {
    */
   loadShot({ commit, state, rootGetters }, shotId) {
     const shot = rootGetters.shotMap.get(shotId)
-    if (shot && shot.lock) return
+    if (shot?.lock) return
 
     const personMap = rootGetters.personMap
     const production = rootGetters.currentProduction
@@ -1263,12 +1263,16 @@ const mutations = {
 
   [LOCK_SHOT](state, shot) {
     shot = state.shotMap.get(shot.id)
-    if (shot) shot.lock = true
+    if (shot) {
+      shot.lock = !shot.lock ? 1 : shot.lock + 1
+    }
   },
 
   [UNLOCK_SHOT](state, shot) {
     shot = state.shotMap.get(shot.id)
-    if (shot) shot.lock = false
+    if (shot) {
+      shot.lock = !shot.lock ? 0 : shot.lock - 1
+    }
   },
 
   [RESET_ALL](state) {

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -494,11 +494,10 @@ const actions = {
       newShot: data,
       sequences: rootGetters.displayedSequences
     })
-    return shotsApi.updateShot(data).then(shot => {
+    return shotsApi.updateShot(data).finally(() => {
       setTimeout(() => {
-        commit(UNLOCK_SHOT, shot)
+        commit(UNLOCK_SHOT, data)
       }, 2000)
-      return Promise.resolve(shot)
     })
   },
 

--- a/tests/unit/store/assets.spec.js
+++ b/tests/unit/store/assets.spec.js
@@ -1916,14 +1916,19 @@ describe('Assets store', () => {
       store.mutations.LOCK_ASSET(state, asset)
       expect(asset).toEqual({
         id: 'asset-id',
-        lock: true
+        lock: 1
+      })
+      store.mutations.LOCK_ASSET(state, asset)
+      expect(asset).toEqual({
+        id: 'asset-id',
+        lock: 2
       })
     })
 
     test('UNLOCK_ASSET', () => {
       const asset = {
         id: 'asset-id',
-        lock: true
+        lock: 2
       }
       const state = {
         assetMap: new Map(Object.entries({
@@ -1933,7 +1938,12 @@ describe('Assets store', () => {
       store.mutations.UNLOCK_ASSET(state, asset)
       expect(asset).toEqual({
         id: 'asset-id',
-        lock: false
+        lock: 1
+      })
+      store.mutations.UNLOCK_ASSET(state, asset)
+      expect(asset).toEqual({
+        id: 'asset-id',
+        lock: 0
       })
     })
 


### PR DESCRIPTION
**Problem**
- On entity list (assets, shots, ....) for a text metadata, If a user types text quickly with a slow network, text synchronization errors appear.
- On saving fails, a entity will remain locked on client side until next page reload.
- On network connection lost, the API client can fail to handle the response.

**Solution**
- Use a counter-based lock for each updated Entity, in order to unlock only when changes are saving.
- Always unlock entity after attempted update (success or fail).
- Improve response handling for failed API requests.
