### PR TITLE
[qa] fix valid value for FPS

### DIFF
--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -480,7 +480,8 @@
               <input
                 class="input-editor"
                 min="0"
-                step="1"
+                max="60"
+                step="0.001"
                 type="number"
                 :value="getMetadataFieldValue({ field_name: 'fps' }, shot)"
                 @keydown="onNumberFieldKeyDown"

--- a/src/components/modals/EditProductionModal.vue
+++ b/src/components/modals/EditProductionModal.vue
@@ -44,8 +44,11 @@
             v-if="productionToEdit && productionToEdit.id"
             ref="fpsField"
             :label="$t('productions.fields.fps')"
-            v-model="form.fps"
+            type="number"
+            :max="60"
+            :step="0.001"
             @enter="runConfirmation"
+            v-model="form.fps"
             v-focus
           />
           <text-field

--- a/src/components/modals/EditShotModal.vue
+++ b/src/components/modals/EditShotModal.vue
@@ -60,8 +60,10 @@
           <text-field
             ref="fpsField"
             :label="$t('shots.fields.fps')"
-            v-model="form.fps"
             type="number"
+            :max="60"
+            :step="0.001"
+            v-model="form.fps"
             @enter="runConfirmation"
           />
           <text-field

--- a/src/components/pages/production/NewProduction.vue
+++ b/src/components/pages/production/NewProduction.vue
@@ -60,7 +60,7 @@
               :label="$t('productions.fields.fps')"
               type="number"
               :max="60"
-              :step="0.01"
+              :step="0.001"
               :placeholder="$t('productions.creation.placeholder_fps')"
               :errored="!hasValidFPS"
               v-model="productionToCreate.settings.fps"

--- a/src/components/pages/production/ProductionParameters.vue
+++ b/src/components/pages/production/ProductionParameters.vue
@@ -59,6 +59,8 @@
         <text-field
           ref="fpsField"
           type="number"
+          :max="60"
+          :step="0.001"
           :label="$t('productions.fields.fps')"
           @enter="runConfirmation"
           v-focus


### PR DESCRIPTION
**Problem**
In the shot list, 23.976 fps is marked as an invalid value, but is (related to https://github.com/cgwire/kitsu/issues/1127)

**Solution**
Harmonize all FPS input fields to allow three decimal places and 60 fps max.
