### PR TITLE
[shots] increase the max value of custom fps

### DIFF
--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -480,7 +480,7 @@
               <input
                 class="input-editor"
                 min="0"
-                max="60"
+                max="1000"
                 step="0.001"
                 type="number"
                 :value="getMetadataFieldValue({ field_name: 'fps' }, shot)"

--- a/src/components/modals/EditShotModal.vue
+++ b/src/components/modals/EditShotModal.vue
@@ -61,7 +61,7 @@
             ref="fpsField"
             :label="$t('shots.fields.fps')"
             type="number"
-            :max="60"
+            :max="1000"
             :step="0.001"
             v-model="form.fps"
             @enter="runConfirmation"


### PR DESCRIPTION
**Problem**
On Shot list, you cannot set a custom frame rate higher than 60 fps.

**Solution**
 Increase the max value of custom fps to 1000 (eg. for slow motion video camera)
