### PR TITLE
[TaskType] prevent scrolling to focused search-field on page load

### DIFF
--- a/src/components/mixins/search.js
+++ b/src/components/mixins/search.js
@@ -19,9 +19,9 @@ export const searchMixin = {
       if (this.applySearch) this.applySearch(searchQuery.search_query)
     },
 
-    focusSearchField() {
+    focusSearchField(options) {
       if (this.searchField) {
-        this.searchField.focus()
+        this.searchField.focus(options)
       }
     },
 

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -65,6 +65,7 @@
               <search-field
                 ref="task-search-field"
                 :can-save="true"
+                :focus-options="{ preventScroll: true }"
                 @change="onSearchChange"
                 @enter="saveSearchQuery"
                 @save="saveSearchQuery"
@@ -752,7 +753,7 @@ export default {
 
     initData(force) {
       this.resetTasks()
-      this.focusSearchField()
+      this.focusSearchField({ preventScroll: true })
       if (this.tasks.length < 2) {
         this.loading.entities = true
         this.errors.entities = false
@@ -761,7 +762,7 @@ export default {
           .then(() => {
             this.loading.entities = false
             this.resetTasks()
-            this.focusSearchField()
+            this.focusSearchField({ preventScroll: true })
             const searchQuery = this.searchField
               ? this.searchField.getValue()
               : ''

--- a/src/components/widgets/SearchField.vue
+++ b/src/components/widgets/SearchField.vue
@@ -14,7 +14,7 @@
         @keyup.enter="onEnterPressed"
         @focus="setFocusedStyle"
         @blur="unsetFocusedStyle"
-        v-focus
+        v-focus="focusOptions"
       />
     </div>
 
@@ -52,6 +52,9 @@ export default {
     active: {
       type: Boolean,
       default: true
+    },
+    focusOptions: {
+      type: Object
     }
   },
 
@@ -78,7 +81,7 @@ export default {
       }
     },
 
-    getValue(value) {
+    getValue() {
       if (this.$refs.input) {
         return this.$refs.input.value
       } else {
@@ -90,9 +93,9 @@ export default {
       this.$refs.input.value = value
     },
 
-    focus() {
+    focus(options) {
       if (this.$refs.input) {
-        this.$refs.input.focus()
+        this.$refs.input.focus(options)
       }
     },
 

--- a/src/main.js
+++ b/src/main.js
@@ -37,8 +37,8 @@ sync(store, router)
 // Global custom directive to enable automatic focus on field after page
 // loading.
 Vue.directive('focus', {
-  inserted(el) {
-    el.focus()
+  inserted(el, binding) {
+    el.focus(binding.value)
   }
 })
 


### PR DESCRIPTION
**Problem**
On Schedule tab of TaskType page, the page layout is broken after a page reload.

**Solution**
Prevent scrolling to the initial focused element on page load.
