### PR TITLE
Feature - Task assign in Team Schedule

### DIFF
--- a/src/components/pages/TeamSchedule.vue
+++ b/src/components/pages/TeamSchedule.vue
@@ -65,6 +65,7 @@
         :is-loading="loading.schedule"
         :multiline="true"
         :start-date="startDate"
+        :with-milestones="false"
         :zoom-level="zoomLevel"
         @item-changed="onScheduleItemChanged"
         @root-element-expanded="expandPersonElement"

--- a/src/components/pages/TeamSchedule.vue
+++ b/src/components/pages/TeamSchedule.vue
@@ -64,10 +64,13 @@
         :is-error="errors.schedule"
         :is-loading="loading.schedule"
         :multiline="true"
+        :reassignable="true"
         :start-date="startDate"
         :with-milestones="false"
         :zoom-level="zoomLevel"
         @item-changed="onScheduleItemChanged"
+        @item-assign="onScheduleItemAssigned"
+        @item-unassign="onScheduleItemUnassigned"
         @root-element-expanded="expandPersonElement"
       />
     </div>
@@ -158,9 +161,11 @@ export default {
 
   methods: {
     ...mapActions([
+      'assignSelectedTasks',
       'fetchPersonTasks',
       'getPersonsTasksDates',
       'loadPeople',
+      'unassignPersonFromTask',
       'updateTask'
     ]),
 
@@ -285,6 +290,24 @@ export default {
       if (item.type === 'Task') {
         await this.saveTaskScheduleItem(item)
         await this.loadPersonDates(true)
+      }
+    },
+
+    onScheduleItemAssigned(item, person) {
+      if (item.type === 'Task') {
+        this.assignSelectedTasks({
+          personId: person.id,
+          taskIds: [item.id]
+        })
+      }
+    },
+
+    onScheduleItemUnassigned(item, person) {
+      if (item.type === 'Task') {
+        this.unassignPersonFromTask({
+          person,
+          task: item
+        })
       }
     },
 

--- a/src/components/pages/schedule/Schedule.vue
+++ b/src/components/pages/schedule/Schedule.vue
@@ -176,7 +176,7 @@
         </div>
       </div>
 
-      <div class="timeline">
+      <div class="timeline" ref="timeline">
         <div
           ref="timeline-header"
           class="timeline-header"
@@ -769,6 +769,10 @@ export default {
       return this.$refs.schedule
     },
 
+    timeline() {
+      return this.$refs.timeline
+    },
+
     timelineContent() {
       return this.$refs['timeline-content']
     },
@@ -1288,7 +1292,14 @@ export default {
           })
         }
       } else {
-        this.resetSelection()
+        // reset selection if click on timeline only
+        let target = event.target
+        while (target && target !== this.timeline) {
+          target = target.parentNode
+        }
+        if (target) {
+          this.resetSelection()
+        }
       }
       this.isChangeStartDate = false
       this.isChangeEndDate = false

--- a/src/components/pages/schedule/Schedule.vue
+++ b/src/components/pages/schedule/Schedule.vue
@@ -314,6 +314,7 @@
               ref="timeline-position"
               class="timeline-position"
               :style="timelinePositionStyle"
+              v-show="!isChangeDates"
             ></div>
             <div
               class="milestone-vertical-line"
@@ -323,6 +324,8 @@
               v-if="!isWeekMode"
             ></div>
             <div
+              class="root-drop"
+              :data-id="rootElement.id"
               :key="'entity-line-' + rootElement.id"
               v-for="rootElement in hierarchy"
             >
@@ -505,6 +508,7 @@ export default {
       selection: [],
       isBrowsingX: false,
       isBrowsingY: false,
+      isChangeDates: false,
       isChangeSize: false,
       milestoneToEdit: {
         date: moment()
@@ -587,6 +591,10 @@ export default {
     multiline: {
       type: Boolean,
       default: false
+    },
+    reassignable: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -595,7 +603,7 @@ export default {
     this.addEvents(this.domEvents)
   },
 
-  destroyed() {
+  beforeDestroy() {
     this.removeEvents(this.domEvents)
     document.body.style.cursor = 'default'
   },
@@ -978,6 +986,45 @@ export default {
         this.getClientX(event) - this.initialClientX - this.cellWidth / 2
       const dayChange = Math.ceil(change / this.cellWidth)
 
+      if (this.reassignable) {
+        let target = event.target
+        while (
+          target &&
+          (!target.classList || !target.classList.contains('root-drop'))
+        ) {
+          target = target.parentNode
+        }
+        const currentRootElement = this.currentElement.parentElement
+
+        if (target && currentRootElement.id !== target.dataset.id) {
+          const newRootElement = this.hierarchy.find(
+            rootElement => rootElement.id === target.dataset.id
+          )
+          if (newRootElement.expanded) {
+            this.selection.forEach(item => {
+              const previousRootElement = item.parentElement
+              // update assignation in element hierarchy
+              item.parentElement = newRootElement
+              previousRootElement.children =
+                previousRootElement.children.filter(child => {
+                  if (child.id !== item.id) {
+                    this.$emit('item-unassign', item, previousRootElement)
+                    return true
+                  }
+                  return false
+                })
+              newRootElement.children = newRootElement.children.filter(
+                child => child.id !== item.id
+              )
+              newRootElement.children.push(item)
+              this.$emit('item-assign', item, newRootElement)
+              this.refreshItemPositions(previousRootElement)
+            })
+            this.refreshItemPositions(newRootElement)
+          }
+        }
+      }
+
       if (this.lastStartDate.isBefore(this.startDate)) {
         this.lastStartDate = this.startDate.clone()
       }
@@ -1155,7 +1202,9 @@ export default {
         this.lastStartDate = timeElement.startDate.clone()
         this.lastEndDate = timeElement.endDate.clone()
         this.initialClientX = this.getClientX(event)
-        document.body.style.cursor = 'ew-resize'
+        document.body.style.cursor = this.reassignable
+          ? 'all-scroll'
+          : 'ew-resize'
 
         this.updateSelection(timeElement, event)
       }
@@ -1359,7 +1408,7 @@ export default {
       }
     },
 
-    dayStyle(day) {
+    dayStyle() {
       return {
         'min-width': this.cellWidth + 'px',
         'max-width': this.cellWidth + 'px'
@@ -1390,7 +1439,11 @@ export default {
       const style = {
         left: this.getTimebarLeft(timeElement) + 'px',
         width: this.getTimebarWidth(timeElement) + 'px',
-        cursor: timeElement.editable ? 'ew-resize' : 'default'
+        cursor: timeElement.editable
+          ? !root && this.reassignable
+            ? 'all-scroll'
+            : 'ew-resize'
+          : 'default'
       }
       if (root) {
         style['background-color'] = timeElement.color
@@ -1408,7 +1461,11 @@ export default {
       return {
         left: this.getTimebarLeft(timeElement) + 'px',
         width: this.getTimebarWidth(timeElement) + 'px',
-        cursor: timeElement.editable ? 'ew-resize' : 'default',
+        cursor: timeElement.editable
+          ? this.reassignable
+            ? 'all-scroll'
+            : 'ew-resize'
+          : 'default',
         background: timeElement.color || rootElement.color
       }
     },

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -672,8 +672,8 @@ const actions = {
     })
   },
 
-  assignSelectedTasks({ commit, state }, { personId, callback }) {
-    const selectedTaskIds = Array.from(state.selectedTasks.keys())
+  assignSelectedTasks({ commit, state }, { personId, taskIds, callback }) {
+    const selectedTaskIds = taskIds || Array.from(state.selectedTasks.keys())
     tasksApi.assignTasks(personId, selectedTaskIds, err => {
       if (!err) commit(ASSIGN_TASKS, { selectedTaskIds, personId })
       if (callback) callback(err)


### PR DESCRIPTION
**Problem**
In the Task Schedule, you can move a task on the timeline but not change the assigned person.

**Solution**
- Allow to drag and drop, one or more tasks to another person. Moving is only allowed if the root item is expanded.
- Unselect items only if click on the timeline zone, in order to allow to click outside the timeline without losing the selection (eg. to expand an item of schedule)
