### PR TITLE
[assets] Fix asset creation and edition

### DIFF
--- a/src/components/modals/EditAssetModal.vue
+++ b/src/components/modals/EditAssetModal.vue
@@ -218,10 +218,24 @@ export default {
       return this.assetToEdit && this.assetToEdit.id
     },
 
+    getEntityTypeIdDefaultValue() {
+      let entityTypeId = this.assetToEdit.asset_type_id
+      if (!entityTypeId) {
+        entityTypeId = this.productionAssetTypeOptions[0].value
+      }
+      const isInOptions = this.productionAssetTypeOptions.find(
+        option => option.value === entityTypeId
+      )
+      if (!isInOptions) {
+        entityTypeId = this.productionAssetTypeOptions[0].value
+      }
+      return entityTypeId
+    },
+
     resetForm() {
       if (!this.isEditing()) {
         if (!this.form.entity_type_id && this.productionAssetTypes.length > 0) {
-          this.form.entity_type_id = this.productionAssetTypes[0].id
+          this.form.entity_type_id = this.productionAssetTypeOptions[0].value
         }
         if (this.openProductions.length > 0) {
           this.form.project_id = this.currentProduction
@@ -235,8 +249,9 @@ export default {
           : null
         this.form.data = {}
       } else {
+        let entityTypeId = this.getEntityTypeIdDefaultValue()
         this.form = {
-          entity_type_id: this.assetToEdit.asset_type_id,
+          entity_type_id: entityTypeId,
           project_id: this.assetToEdit.project_id,
           name: this.assetToEdit.name,
           description: this.assetToEdit.description,

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -457,16 +457,17 @@ const actions = {
         })
       }
       const createTaskPromises = taskTypeIds.map(taskTypeId => {
-        return dispatch('createTasks', {
-          entityIds: [asset.id],
-          project_id: asset.project_id,
-          task_type_id: taskTypeId,
+        dispatch('createTask', {
+          entityId: asset.id,
+          projectId: asset.project_id,
+          taskTypeId: taskTypeId,
           type: 'assets'
         })
       })
       return func
         .runPromiseAsSeries(createTaskPromises)
         .then(() => Promise.resolve(asset))
+        .catch(console.error)
     })
   },
 


### PR DESCRIPTION
**Problem**

Error occured with task creation and entity type for assets:

- When the asset list was empty, on the first creation, the tasks were not displayed.
- By default, it's not the right asset type that is applied when creating an asset.
- Same for the asset edition

**Solution**

* Use the same function as the shot page to create tasks (and ensure proper store updates)
* Use the right value (first option, not first instance asset type) to set the default value when creating or editing an asset.
