### PR TITLE
[playlists] Fix annotation loading

### DIFF
--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -490,7 +490,7 @@ export const playerMixin = {
       this.rawPlayer.goPreviousFrame()
       if (this.isComparing) this.syncComparisonPlayer()
       const annotation = this.getAnnotation(
-        this.rawPlayer.getCurrentTime() - this.frameDuration
+        this.rawPlayer.getCurrentTime()
       )
       if (annotation) this.loadSingleAnnotation(annotation)
     },
@@ -500,7 +500,7 @@ export const playerMixin = {
       this.rawPlayer.goNextFrame()
       if (this.isComparing) this.syncComparisonPlayer()
       const annotation = this.getAnnotation(
-        this.rawPlayer.getCurrentTime() - this.frameDuration
+        this.rawPlayer.getCurrentTime()
       )
       if (annotation) this.loadSingleAnnotation(annotation)
     },


### PR DESCRIPTION
**Problem**

In the playlists, when changing position via the keyboard, it loads the annotation from the following frame when there are annotations.

**Solution**

Load annotations for the current time without adding an additional frame (needed by a previous hack).
