### PR TITLE
Chrome video position needs to be managed separately

### DIFF
--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -489,8 +489,10 @@ export const playerMixin = {
       this.clearCanvas()
       this.rawPlayer.goPreviousFrame()
       if (this.isComparing) this.syncComparisonPlayer()
+      const isChromium = !!window.chrome
+      const change = isChromium ? this.frameDuration : 0
       const annotation = this.getAnnotation(
-        this.rawPlayer.getCurrentTime()
+        this.rawPlayer.getCurrentTime() - change
       )
       if (annotation) this.loadSingleAnnotation(annotation)
     },
@@ -499,8 +501,10 @@ export const playerMixin = {
       this.clearCanvas()
       this.rawPlayer.goNextFrame()
       if (this.isComparing) this.syncComparisonPlayer()
+      const isChromium = !!window.chrome
+      const change = isChromium ? this.frameDuration : 0
       const annotation = this.getAnnotation(
-        this.rawPlayer.getCurrentTime()
+        this.rawPlayer.getCurrentTime() - change
       )
       if (annotation) this.loadSingleAnnotation(annotation)
     },
@@ -843,7 +847,9 @@ export const playerMixin = {
     onMaxDurationUpdate(duration) {
       if (duration) {
         duration = floorToFrame(duration, this.fps)
-        this.maxDurationRaw = duration
+        const isChromium = !!window.chrome
+        const change = isChromium ? this.frameDuration : 0
+        this.maxDurationRaw = duration + change
         this.maxDuration = this.formatTime(duration)
         this.resetHandles()
       } else {

--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -534,7 +534,6 @@ export default {
       this.$nextTick(() => {
         this.getCurrentShot()
           .then(shot => {
-            console.log('reset', shot)
             this.currentShot = shot
             return this.loadShotCasting(this.currentShot)
           })
@@ -552,7 +551,6 @@ export default {
     init() {
       this.getCurrentShot()
         .then(shot => {
-          console.log('sht', shot)
           this.currentShot = shot
           this.currentSection = this.route.query.section || 'casting'
           this.casting.isLoading = true

--- a/src/components/pages/playlists/RawVideoPlayer.vue
+++ b/src/components/pages/playlists/RawVideoPlayer.vue
@@ -415,22 +415,26 @@ export default {
     },
 
     runSetCurrentTime(currentTime) {
+      const isChromium = !!window.chrome
+      const change = isChromium ? this.frameDuration : 0
       if (
         this.currentPlayer &&
-        this.currentPlayer.currentTime !== currentTime
+        this.currentPlayer.currentTime !== currentTime + change
       ) {
         // tweaks needed because the html video player is messy with frames
-        this.currentPlayer.currentTime = currentTime + 0.01
+        this.currentPlayer.currentTime = currentTime + change + 0.01
         this.onTimeUpdate()
       }
     },
 
     onTimeUpdate() {
+      const isChromium = !!window.chrome
+      const change = isChromium ? this.frameDuration : 0
       if (this.currentPlayer) {
         this.currentTimeRaw =
-          this.currentPlayer.currentTime
+          this.currentPlayer.currentTime - change
       } else {
-        this.currentTimeRaw = 0
+        this.currentTimeRaw = 0 + change
       }
       this.$emit(
         'frame-update',

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -816,7 +816,9 @@ export default {
     changeMaxDuration(duration) {
       if (duration) {
         duration = floorToFrame(duration, this.fps)
-        this.videoDuration = duration
+        const isChromium = !!window.chrome
+        const change = isChromium ? this.frameDuration : 0
+        this.videoDuration = duration + change
         this.maxDuration = this.formatTime(
           this.videoDuration - this.frameDuration
         )

--- a/src/components/previews/VideoProgress.vue
+++ b/src/components/previews/VideoProgress.vue
@@ -267,8 +267,11 @@ export default {
           ? annotation.time
           : this.videoDuration * ratio
       if (duration < 0) duration = 0
-      if (duration > this.videoDuration) {
-        duration = this.videoDuration
+
+      const isChromium = !!window.chrome
+      const change = isChromium ? this.frameDuration : 0
+      if (duration > this.videoDuration - change) {
+        duration = this.videoDuration - change
       }
       const frameNumber = Math.floor(duration / this.frameDuration)
       return { frameNumber, position }

--- a/src/components/previews/VideoViewer.vue
+++ b/src/components/previews/VideoViewer.vue
@@ -329,11 +329,13 @@ export default {
       if (this.$options.currentTimeCalls.length === 0) {
         this.$options.running = false
       } else {
+        const isChromium = !!window.chrome
+        let change = isChromium ? this.frameDuration + 0.01 : 0.01
         this.$options.running = true
         const currentTime = this.$options.currentTimeCalls.shift()
         if (this.video.currentTime !== currentTime) {
           // tweaks needed because the html video player is messy with frames
-          this.video.currentTime = currentTime + 0.01
+          this.video.currentTime = currentTime + change
           this.onTimeUpdate()
         }
         setTimeout(() => {
@@ -348,10 +350,11 @@ export default {
       } else {
         time = floorToFrame(time, this.fps)
       }
+
       if (time < this.frameDuration) {
         time = 0
-      } else if (time > floorToFrame(this.video.duration, this.fps) - this.frameDuration) {
-        time = floorToFrame(this.video.duration, this.fps) - this.frameDuration
+      } else if (time > floorToFrame(this.video.duration, this.fps)) {
+        time = floorToFrame(this.video.duration, this.fps)
       }
       this.setCurrentTime(time)
       return time
@@ -395,10 +398,12 @@ export default {
     },
 
     onTimeUpdate() {
+      const isChromium = !!window.chrome
+      const change = isChromium ? this.frameDuration : 0
       if (this.video) {
-        this.currentTimeRaw = this.video.currentTime
+        this.currentTimeRaw = this.video.currentTime - change
       } else {
-        this.currentTimeRaw = 0
+        this.currentTimeRaw = 0 + change
       }
       this.$emit(
         'frame-update',
@@ -438,6 +443,9 @@ export default {
     goNextFrame() {
       const time = this.getLastPushedCurrentTime()
       const newTime = time + this.frameDuration
+      const isChromium = !!window.chrome
+      let change = !isChromium ? this.frameDuration : 0
+      if (newTime > this.video.duration - change) return
       return this._setRoundedTime(newTime)
     },
 


### PR DESCRIPTION
**Problem**

Chrome and Firefox don't manage videos the same way anymore. It is needed to manage frames in video players differently.

**Solution**

Adapt the source code to display the frame corresponding to what is selected in the progress bar.
