### PR TITLE
Fix annotations position

### DIFF
--- a/src/components/mixins/fullscreen.js
+++ b/src/components/mixins/fullscreen.js
@@ -24,7 +24,7 @@ export const fullScreenMixin = {
   methods: {
     isFullScreen() {
       return !!(
-        document.fullScreen ||
+        document.fullscreen ||
         document.webkitIsFullScreen ||
         document.mozFullScreen ||
         document.msFullscreenElement ||

--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -541,7 +541,7 @@ export const playerMixin = {
 
     isFullScreen() {
       return !!(
-        document.fullScreen ||
+        document.fullscreen ||
         document.webkitIsFullScreen ||
         document.mozFullScreen ||
         document.msFullscreenElement ||
@@ -1107,7 +1107,7 @@ export const playerMixin = {
       }
     },
 
-    onMetadataLoaded(event) {
+    onMetadataLoaded() {
       this.$nextTick(() => {
         this.resetCanvasSize()
         if (this.resetHeight) this.resetHeight()
@@ -1157,7 +1157,7 @@ export const playerMixin = {
       return false
     },
 
-    onCanvasReleased(event) {
+    onCanvasReleased() {
       if (this.isCurrentPreviewMovie && this.$options.scrubbing) {
         this.$options.scrubbing = false
       }

--- a/src/components/pages/playlists/AnnotationBar.vue
+++ b/src/components/pages/playlists/AnnotationBar.vue
@@ -55,7 +55,7 @@ export default {
 
     isFullScreen() {
       return !!(
-        document.fullScreen ||
+        document.fullscreen ||
         document.webkitIsFullScreen ||
         document.mozFullScreen ||
         document.msFullscreenElement ||

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1243,20 +1243,20 @@ export default {
       }, 1000)
     },
 
-    onPlayPreviousEntityClicked(forcePlay = false) {
+    onPlayPreviousEntityClicked() {
       this.clearFocus()
       this.playEntity(this.previousEntityIndex)
       this.sendUpdatePlayingStatus()
     },
 
-    onPlayNextEntity(forcePlay = false) {
+    onPlayNextEntity() {
       this.clearFocus()
       this.playEntity(this.nextEntityIndex)
       this.sendUpdatePlayingStatus()
     },
 
-    onPlayNextEntityClicked(forcePlay = false) {
-      this.onPlayNextEntity(forcePlay)
+    onPlayNextEntityClicked() {
+      this.onPlayNextEntity()
       this.sendUpdatePlayingStatus()
     },
 
@@ -2213,14 +2213,6 @@ progress {
 
 .comparison-buttons {
   position: relative;
-}
-
-.comparison-combos {
-  /*
-  position: absolute;
-  top: 33px;
-  z-index: 50;
-  */
 }
 
 .comparison-index {

--- a/src/components/previews/PictureViewer.vue
+++ b/src/components/previews/PictureViewer.vue
@@ -261,7 +261,20 @@ export default {
       this.pictureBig.height = height
       this.pictureGif.width = width
       this.pictureGif.height = height
-      if (this.isPicture) this.$emit('size-changed', dimensions)
+
+      if (this.isPicture) {
+        const pictureElement = this.isGif
+          ? this.pictureGif
+          : this.fullScreen
+          ? this.pictureBig
+          : this.picture
+        const picturePosition = pictureElement.getBoundingClientRect()
+        const containerPosition = this.container.getBoundingClientRect()
+        const top = picturePosition.top - containerPosition.top
+        const left = picturePosition.left - containerPosition.left
+
+        this.$emit('size-changed', { width, height, top, left })
+      }
     },
 
     setPicturePath() {

--- a/src/components/previews/PreviewViewer.vue
+++ b/src/components/previews/PreviewViewer.vue
@@ -3,7 +3,7 @@
     <div
       class="center status-message"
       :style="{ height: defaultHeight + 'px' }"
-      v-show="isBroken"
+      v-if="isBroken"
     >
       <p>This preview is broken.</p>
     </div>
@@ -12,7 +12,7 @@
       class="center status-message"
       :style="{ height: defaultHeight + 'px' }"
       title="Video processing in progress..."
-      v-show="isProcessing"
+      v-if="isProcessing"
     >
       <spinner :is-processing="true" />
     </div>
@@ -77,11 +77,7 @@
       v-if="isPdf"
     /-->
 
-    <div
-      class="center"
-      :style="{ height: defaultHeight + 'px' }"
-      v-show="isFile"
-    >
+    <div class="center" :style="{ height: defaultHeight + 'px' }" v-if="isFile">
       <a
         class="button mt2"
         ref="preview-file"
@@ -271,10 +267,7 @@ export default {
     originalDlPath() {
       if (this.preview) {
         const type = this.isMovie ? 'movies' : 'pictures'
-        return (
-          `/api/${type}/originals/preview-files/` +
-          `${this.preview.id}/download`
-        )
+        return `/api/${type}/originals/preview-files/${this.preview.id}/download`
       } else {
         return ''
       }
@@ -358,18 +351,9 @@ export default {
     },
 
     resize() {
-      if (this.videoViewer) this.videoViewer.onWindowResize()
+      if (this.pictureViewer) this.pictureViewer.resetPicture()
+      if (this.videoViewer) this.videoViewer.mountVideo()
       if (this.isSound) this.soundViewer.redraw()
-    },
-
-    getPreviewDimensions() {
-      const dimensions = { width: 0, height: 0 }
-      if (this.isMovie) {
-        return this.videoViewer.getDimensions()
-      } else if (this.isPicture) {
-        return this.pictureViewer.getDimensions()
-      }
-      return dimensions
     },
 
     setCurrentFrame(frameNumber) {
@@ -381,9 +365,8 @@ export default {
       this.videoViewer.setCurrentTimeRaw(time)
     },
 
-    getCurrentTimeRaw(time) {
-      if (this.isMovie) return this.videoViewer.currentTimeRaw
-      else return 0
+    getCurrentTimeRaw() {
+      return this.isMovie ? this.videoViewer.currentTimeRaw : 0
     },
 
     // Loupe

--- a/src/components/previews/PreviewViewer.vue
+++ b/src/components/previews/PreviewViewer.vue
@@ -5,13 +5,13 @@
       :style="{ height: defaultHeight + 'px' }"
       v-if="isBroken"
     >
-      <p>This preview is broken.</p>
+      <p>{{ $t('preview.broken') }}</p>
     </div>
 
     <div
       class="center status-message"
       :style="{ height: defaultHeight + 'px' }"
-      title="Video processing in progress..."
+      :title="$t('preview.processing')"
       v-if="isProcessing"
     >
       <spinner :is-processing="true" />

--- a/src/components/previews/VideoViewer.vue
+++ b/src/components/previews/VideoViewer.vue
@@ -140,6 +140,8 @@ export default {
           },
           false
         )
+        this.video.addEventListener('resize', this.resetSize)
+        this.video.addEventListener('timeupdate', this.resetSize)
         this.video.addEventListener('loadedmetadata', () => {
           this.configureVideo()
           this.onWindowResize()
@@ -157,29 +159,6 @@ export default {
           this.$refs.movie.style.height = this.defaultHeight + 'px'
           this.isLoading = false
         })
-
-        /*
-        this.video.addEventListener('seeking', () => {
-          console.log('seeking')
-        })
-
-        this.video.addEventListener('seeked', () => {
-          console.log('seeked')
-        })
-
-        this.video.addEventListener('canplay', () => {
-          console.log('canplay')
-        })
-
-        this.video.addEventListener('canplaythrough', () => {
-          console.log('canplaythrough')
-        })
-
-        this.video.addEventListener('stalled', () => {
-          console.log('stalled')
-          this.isLoading = true
-        })
-        */
 
         window.addEventListener('resize', this.onWindowResize)
       }
@@ -287,7 +266,7 @@ export default {
 
     getDimensions() {
       const dimensions = this.getNaturalDimensions()
-      const ratio = dimensions.height / dimensions.width
+      const ratio = dimensions.height / dimensions.width || 1
       const fullWidth = this.container.offsetWidth
       const fullHeight = this.container.offsetHeight
       let width = fullWidth
@@ -387,13 +366,15 @@ export default {
       const height = dimensions.height
       if (height > 0) {
         this.container.style.height = this.defaultHeight + 'px'
-        // Those two lines are commented out because fixing the width was
-        //   breaking the comment section in the preview in full screen
-        // this.videoWrapper.style.width = width + 'px'
-        // this.video.style.width = width + 'px'
-        this.videoWrapper.style.height = height + 'px'
         this.video.style.height = height + 'px'
-        this.$emit('size-changed', { width, height })
+
+        const videoPosition = this.video.getBoundingClientRect()
+        const containerPosition = this.container.getBoundingClientRect()
+        const top = videoPosition.top - containerPosition.top
+        const left = videoPosition.left - containerPosition.left
+        this.$emit('size-changed', { width, height, top, left })
+      } else {
+        this.$emit('size-changed', { width: 0, height: 0, top: 0, left: 0 })
       }
     },
 
@@ -527,6 +508,10 @@ export default {
   flex-direction: column;
   align-content: flex-end;
   height: 100%;
+  width: 100%;
+  text-align: center;
+  background: #36393f;
+  overflow: hidden;
 }
 
 .video-wrapper {
@@ -538,14 +523,8 @@ export default {
   text-align: center;
   margin: auto;
   width: 100%;
+  height: 100%;
   position: relative;
-}
-
-.video-player {
-  width: 100%;
-  text-align: center;
-  background: #36393f;
-  overflow: hidden;
 }
 
 video {

--- a/src/components/previews/VideoViewer.vue
+++ b/src/components/previews/VideoViewer.vue
@@ -131,6 +131,7 @@ export default {
           this.onWindowResize()
           this.isLoading = false
           this.setCurrentTime(0)
+          this.setCurrentTimeRaw(0)
           this.$emit('video-loaded')
         }
         this.video.addEventListener(
@@ -147,6 +148,7 @@ export default {
           this.onWindowResize()
           this.isLoading = false
           this.setCurrentTime(0)
+          this.setCurrentTimeRaw(0)
           this.$emit('video-loaded')
         })
 

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1248,7 +1248,6 @@ export default {
     refreshPreviewPlay() {
       if (this.$refs['preview-player']) {
         this.$refs['preview-player'].previewViewer.resize()
-        this.$refs['preview-player'].fixCanvasSize()
       }
     }
   },

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1342,6 +1342,11 @@ export default {
     }
   },
 
+  preview: {
+    broken: 'This preview is broken.',
+    processing: 'Video processing in progress...'
+  },
+
   search: {
     limit: 'Max number of results:',
     match_details: 'match found in {target}',


### PR DESCRIPTION
**Problem**
- On specific conditions, the position of the annotations drawn over the preview image or video can be shifted (eg. after resizing, in fullscreen mode with Chrome, ...)
- Some texts are not translated

**Solution**
- Refactor the way to set the position of annotation canvas.
- Add missing translation keys
