### PR TITLE
Fix preview

### DIFF
--- a/src/components/previews/PictureViewer.vue
+++ b/src/components/previews/PictureViewer.vue
@@ -101,16 +101,14 @@ export default {
 
     if (this.panzoom) {
       const pictures = [this.picture, this.pictureBig, this.pictureGif]
-      pictures.forEach(picture => {
-        this.panzoomInstances.push(
-          panzoom(picture, {
-            bounds: true,
-            boundsPadding: 0.2,
-            maxZoom: 5,
-            minZoom: 1
-          })
-        )
-      })
+      this.panzoomInstances = pictures.map(picture =>
+        panzoom(picture, {
+          bounds: true,
+          boundsPadding: 0.2,
+          maxZoom: 5,
+          minZoom: 1
+        })
+      )
     }
   },
 

--- a/src/components/previews/PictureViewer.vue
+++ b/src/components/previews/PictureViewer.vue
@@ -271,6 +271,8 @@ export default {
         const top = picturePosition.top - containerPosition.top
         const left = picturePosition.left - containerPosition.left
 
+        this.resetPanZoom()
+
         this.$emit('size-changed', { width, height, top, left })
       }
     },

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -626,7 +626,7 @@ export default {
 
     defaultHeight() {
       if (this.fullScreen) {
-        let height = screen.height - 50 // arbitrarily remove 50px from height for specific screens (e.g. with notch)
+        let height = screen.height - 40 // arbitrarily remove 40px from height for specific screens (e.g. with notch)
         if (this.isOrdering) height -= 140
         if (this.isMovie) height -= 60
         else height -= 30

--- a/src/components/previews/VideoViewer.vue
+++ b/src/components/previews/VideoViewer.vue
@@ -146,7 +146,7 @@ export default {
           false
         )
         this.video.addEventListener('resize', this.resetSize)
-        this.video.addEventListener('timeupdate', this.resetSize)
+
         this.video.addEventListener('loadedmetadata', () => {
           this.configureVideo()
           this.onWindowResize()


### PR DESCRIPTION
**Problem**
- after clicking on an annotation during playback, the video may freeze.
- on fullscreen, the image is sometimes shifted by the panzoom library.
- on fullscreen, the preview content has too much margin.

**Solution**
- fix video playblack freezes 
- fix panzoom glitch on fullscreen mode
- improve hack for fullscreen mode
