### PR TITLE
[previews] fix preview height on fullscreen mode

### DIFF
--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -22,6 +22,7 @@
               class="preview-viewer"
               :big="big"
               :default-height="defaultHeight"
+              :margin-bottom="marginBottom"
               :full-screen="fullScreen"
               :is-comparing="isComparing && isComparisonEnabled"
               :is-hd="isHd"
@@ -43,6 +44,7 @@
               class="comparison-preview-viewer"
               :big="big"
               :default-height="defaultHeight"
+              :margin-bottom="marginBottom"
               :full-screen="fullScreen"
               :is-comparing="isComparing && isComparisonEnabled"
               :is-hd="isHd"
@@ -624,13 +626,16 @@ export default {
       }
     },
 
+    marginBottom() {
+      let margin = 30
+      if (this.isOrdering) margin += 140
+      if (this.isMovie) margin += 60
+      return margin
+    },
+
     defaultHeight() {
       if (this.fullScreen) {
-        let height = screen.height - 40 // arbitrarily remove 40px from height for specific screens (e.g. with notch)
-        if (this.isOrdering) height -= 140
-        if (this.isMovie) height -= 60
-        else height -= 30
-        return height
+        return screen.height - this.marginBottom
       } else {
         let bigHeight = screen.height > 800 ? 470 : 300
         if (this.isMovie) bigHeight = screen.height > 800 ? 442 : 272

--- a/src/components/previews/PreviewViewer.vue
+++ b/src/components/previews/PreviewViewer.vue
@@ -1,5 +1,11 @@
 <template>
-  <div ref="container" class="preview-viewer dark">
+  <div
+    ref="container"
+    class="preview-viewer dark"
+    :style="{
+      maxHeight: fullScreen ? `calc(100vh - ${marginBottom}px)` : null
+    }"
+  >
     <div
       class="center status-message"
       :style="{ height: defaultHeight + 'px' }"
@@ -133,6 +139,10 @@ export default {
       default: false
     },
     defaultHeight: {
+      type: Number,
+      default: 0
+    },
+    marginBottom: {
       type: Number,
       default: 0
     },


### PR DESCRIPTION
**Problem**
- When the previews are in fullscreen mode, the menu bar can be hidden depending on the type of screen.

**Solution**
- Use a dynamic max-height rule for the preview in fullscreen mode.
