### PR TITLE
[previews] fix preview height on fullscreen mode

### DIFF
--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -627,9 +627,9 @@ export default {
     },
 
     marginBottom() {
-      let margin = 30
-      if (this.isOrdering) margin += 140
-      if (this.isMovie) margin += 60
+      let margin = 32 // buttons bar
+      if (this.isMovie) margin += 28 // progress bar
+      if (this.isOrdering) margin += 140 // ordering menu
       return margin
     },
 


### PR DESCRIPTION
**Problem**
- Fullscreen video preview has black margins.

**Solution**
- Fix bottom margin calculation.
