### PR TITLE
Various fixes

### DIFF
--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -428,8 +428,13 @@ export const playerMixin = {
       this.showCanvas()
       if (this.isCurrentPreviewMovie) {
         const comparisonPlayer = this.$refs['raw-player-comparison']
+        const currentTime = roundToFrame(this.rawPlayer.getCurrentTimeRaw(), this.fps)
         if (this.rawPlayer) this.rawPlayer.pause()
         if (comparisonPlayer) comparisonPlayer.pause()
+        if (comparisonPlayer) {
+          this.rawPlayer.setCurrentTimeRaw(currentTime)
+          comparisonPlayer.setCurrentTimeRaw(currentTime)
+        }
       } else if (this.isCurrentPreviewSound) {
         this.soundPlayer.pause()
       }
@@ -481,7 +486,7 @@ export const playerMixin = {
         this.rawPlayerComparison.currentPlayer
       ) {
         const currentTimeRaw = this.rawPlayer.getCurrentTimeRaw()
-        this.rawPlayerComparison.currentPlayer.currentTime = currentTimeRaw
+        this.rawPlayerComparison.setCurrentTimeRaw(currentTimeRaw)
       }
     },
 

--- a/src/components/pages/ProductionSettings.vue
+++ b/src/components/pages/ProductionSettings.vue
@@ -3,14 +3,14 @@
     <div class="wrapper">
       <div class="tabs">
         <ul>
-          <li :class="{ 'is-active': isActiveTab('brief') }">
-            <a @click="activeTab = 'brief'">
-              {{ $t('productions.brief.title') }}
-            </a>
-          </li>
           <li :class="{ 'is-active': isActiveTab('parameters') }">
             <a @click="activeTab = 'parameters'">
               {{ $t('productions.parameters.title') }}
+            </a>
+          </li>
+          <li :class="{ 'is-active': isActiveTab('brief') }">
+            <a @click="activeTab = 'brief'">
+              {{ $t('productions.brief.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('taskStatus') }">
@@ -36,12 +36,12 @@
         </ul>
       </div>
 
-      <div class="tab" v-show="isActiveTab('brief')">
-        <ProductionBrief />
-      </div>
-
       <div class="tab" v-show="isActiveTab('parameters')">
         <production-parameters />
+      </div>
+
+      <div class="tab" v-show="isActiveTab('brief')">
+        <ProductionBrief />
       </div>
 
       <div class="tab" v-show="isActiveTab('assetTypes')">
@@ -178,7 +178,7 @@ export default {
 
   data() {
     return {
-      activeTab: 'brief',
+      activeTab: 'parameters',
       assetTypeId: '',
       taskStatusId: ''
     }

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -111,7 +111,7 @@
                 <preview-player
                   ref="preview-player"
                   :extra-wide="true"
-                  :last-preview-files="lastFivePreviews"
+                  :last-preview-files="taskPreviews || []"
                   :previews="currentPreview.previews"
                   :read-only="isPreviewPlayerReadOnly"
                   :task="task"
@@ -559,14 +559,6 @@ export default {
         return {
           name: 'open-productions'
         }
-      }
-    },
-
-    lastFivePreviews() {
-      if (this.taskPreviews) {
-        return this.taskPreviews.slice(0, 5)
-      } else {
-        return []
       }
     },
 

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1761,6 +1761,7 @@ export default {
       this.$nextTick().then(() => {
         this.resetPictureCanvas()
         this.resetCanvas()
+        this.syncComparisonPlayer()
         this.reloadAnnotations()
       })
     },

--- a/src/components/pages/playlists/RawVideoPlayer.vue
+++ b/src/components/pages/playlists/RawVideoPlayer.vue
@@ -373,6 +373,13 @@ export default {
       }
     },
 
+    getCurrentFrame()  {
+      let time = this.getCurrentTime()
+      time = floorToFrame(time, this.fps)
+      const frameNumber = time / this.frameDuration
+      return frameNumber
+    },
+
     getLastPushedCurrentTime() {
       const length = this.$options.currentTimeCalls.length
       if (length > 0) {
@@ -382,8 +389,8 @@ export default {
       }
     },
 
-    getCurrentTimeRaw(currentTime) {
-      return this.currentPlayer.currentTime
+    getCurrentTimeRaw() {
+      return this.currentPlayer ? this.currentPlayer.currentTime : 0
     },
 
     setCurrentTimeRaw(currentTime) {

--- a/src/components/pages/production/ProductionParameters.vue
+++ b/src/components/pages/production/ProductionParameters.vue
@@ -91,6 +91,14 @@
           v-model="form.is_clients_isolated"
           v-if="currentProduction && currentProduction.id"
         />
+        <combobox-boolean
+          ref="isPreviewDownloadAllowed"
+          :label="$t('productions.fields.is_preview_download_allowed')"
+          @enter="runConfirmation"
+          v-focus
+          v-model="form.is_preview_download_allowed"
+          v-if="currentProduction && currentProduction.id"
+        />
         <text-field
           ref="maxRetakesField"
           type="number"
@@ -168,6 +176,7 @@ export default {
         fps: '',
         max_retakes: 0,
         is_clients_isolated: 'false',
+        is_preview_download_allowed: 'false',
         ratio: '',
         resolution: '',
         production_type: 'short'
@@ -245,6 +254,10 @@ export default {
           is_clients_isolated: this.currentProduction.is_clients_isolated
             ? 'true'
             : 'false',
+          is_preview_download_allowed: this.currentProduction
+            .is_preview_download_allowed
+            ? 'true'
+            : 'false',
           ratio: this.currentProduction.ratio,
           resolution: this.currentProduction.resolution
         }
@@ -258,6 +271,7 @@ export default {
           episode_span: 0,
           max_retakes: 0,
           is_clients_isolated: 'false',
+          is_preview_download_allowed: 'false',
           fps: '',
           ratio: '',
           resolution: ''

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -352,18 +352,14 @@
 
           <div class="flexrow">
             <div class="flexrow" v-if="fullScreen">
-              <span
-                :class="{
-                  'previous-preview-file': true,
-                  'current-preview-file': isCurrentRevision(previewFile)
-                }"
-                :key="`last-preview-${previewFile.id}`"
-                :title="getRevisionTitle(previewFile)"
-                @click="changeCurrentPreview(previewFile)"
-                v-for="previewFile in lastPreviewFiles"
-              >
-                {{ previewFile.revision }}
-              </span>
+              <combobox-styled
+                class="preview-combo flexrow-item"
+                :options="lastPreviewFileOptions"
+                is-reversed
+                is-preview
+                thin
+                @input="changeCurrentPreviewFile"
+              />
             </div>
           </div>
 
@@ -441,6 +437,7 @@ import ButtonSimple from '@/components/widgets/ButtonSimple'
 import BrowsingBar from '@/components/previews/BrowsingBar'
 import ColorPicker from '@/components/widgets/ColorPicker'
 import Combobox from '@/components/widgets/Combobox'
+import ComboboxStyled from '@/components/widgets/ComboboxStyled'
 import PencilPicker from '@/components/widgets/PencilPicker'
 import PreviewViewer from '@/components/previews/PreviewViewer'
 import RevisionPreview from '@/components/previews/RevisionPreview'
@@ -460,6 +457,7 @@ export default {
     BrowsingBar,
     ColorPicker,
     Combobox,
+    ComboboxStyled,
     DownloadIcon,
     PencilPicker,
     PreviewViewer,
@@ -735,6 +733,16 @@ export default {
             value: taskType.id
           }
         })
+    },
+
+    lastPreviewFileOptions() {
+      if (!this.lastPreviewFiles) return []
+      return this.lastPreviewFiles.map(previewFile => {
+        return {
+          label: `v${previewFile.revision}`,
+          value: previewFile.id
+        }
+      })
     },
 
     previewFileOptions() {
@@ -1453,6 +1461,13 @@ export default {
     },
 
     // Browsing
+
+    changeCurrentPreviewFile(previewFileId) {
+      const previewFile = this.lastPreviewFiles.find(
+        (previewFile) => previewFile.id === previewFileId
+      )
+      this.changeCurrentPreview(previewFile)
+    },
 
     changeCurrentPreview(previewFile) {
       this.$emit('change-current-preview', previewFile)

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -376,7 +376,8 @@
             class="button flexrow-item"
             :href="originalDlPath"
             :title="$t('playlists.actions.download_file')"
-            v-if="!isCurrentUserArtist"
+            v-if="!isCurrentUserArtist ||
+              this.currentProduction.is_preview_download_allowed"
           >
             <download-icon class="icon is-small" />
           </a>

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -882,7 +882,9 @@ export default {
         this.isPlaying = false
         if (this.previewViewer) this.previewViewer.pause()
         if (this.comparisonViewer) this.comparisonViewer.pause()
-        this.syncComparisonViewer()
+        this.$nextTick(() => {
+          this.syncComparisonViewer()
+        })
       }
     },
 
@@ -902,7 +904,7 @@ export default {
       if (this.comparisonViewer && this.isComparing) {
         // Dirty fix: add a missing frame to the comparison video
         this.comparisonViewer.setCurrentTimeRaw(
-          this.previewViewer.getCurrentTimeRaw() + this.frameDuration
+          this.previewViewer.getCurrentTimeRaw()
         )
       }
     },

--- a/src/components/previews/VideoProgress.vue
+++ b/src/components/previews/VideoProgress.vue
@@ -347,10 +347,13 @@ progress {
   background: $black;
   border: 1px solid $white;
   border-radius: 5px;
-  position: relative;
-  padding: 0.3em;
-  top: 8px;
   color: $white;
+  height: 28px;
+  position: absolute;
+  padding: 0.3em;
+  text-align: center;
+  top: 30px;
+  width: 40px;
   z-index: 800;
 }
 

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -64,30 +64,17 @@
           <div class="task-column preview-column" v-if="isPreview">
             <div class="preview-column-content">
               <div class="flexrow">
+                <div class="preview-list flexrow w100" v-if="previewOptions.length > 0">
+                  <combobox-styled
+                    class="preview-combo flexrow-item"
+                    :options="previewOptions"
+                    is-preview
+                    thin
+                    @input="onPreviewChanged"
+                  />
+                </div>
                 <div class="filler"></div>
-                <div class="preview-list flexrow w100" v-if="isPreview">
-                  <div
-                    :class="{
-                      'flexrow-item': true,
-                      'revision-thumbnail': true,
-                      selected: currentPreviewIndex === index
-                    }"
-                    :key="'preview-' + preview.id"
-                    @click="onPreviewChanged(index)"
-                    v-for="(preview, index) in lastFivePreviews"
-                  >
-                    <entity-thumbnail
-                      :preview-file-id="preview.id"
-                      :width="50"
-                      :height="30"
-                      :empty-width="50"
-                      :empty-height="30"
-                      no-preview
-                    />
-                    <span>
-                      {{ preview.revision }}
-                    </span>
-                  </div>
+                <div>
                   <router-link
                     class="history-button flexrow-item"
                     :to="taskPath"
@@ -103,7 +90,7 @@
                     :entity-preview-files="taskEntityPreviews"
                     :extra-wide="isExtraWide"
                     :is-assigned="isAssigned"
-                    :last-preview-files="lastFivePreviews"
+                    :last-preview-files="taskPreviews"
                     :light="!isWide"
                     :previews="currentPreview ? currentPreview.previews : []"
                     :read-only="isPreviewPlayerReadOnly"
@@ -297,6 +284,7 @@ import ActionPanel from '@/components/tops/ActionPanel'
 import AddComment from '@/components/widgets/AddComment'
 import AddPreviewModal from '@/components/modals/AddPreviewModal'
 import Comment from '@/components/widgets/Comment'
+import ComboboxStyled from '@/components/widgets/ComboboxStyled'
 import DeleteModal from '@/components/modals/DeleteModal'
 import EditCommentModal from '@/components/modals/EditCommentModal'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail'
@@ -314,6 +302,7 @@ export default {
     ActionPanel,
     AddComment,
     AddPreviewModal,
+    ComboboxStyled,
     Comment,
     CornerRightUpIcon,
     DeleteModal,
@@ -674,6 +663,16 @@ export default {
       return getTaskEntityPath(this.task, episodeId)
     },
 
+    previewOptions() {
+      if (!this.taskPreviews) return []
+      return this.taskPreviews.map((preview, index) => {
+        return {
+          value: preview.id,
+          label: 'v' + preview.revision
+        }
+      })
+    },
+
     lastFivePreviews() {
       if (this.taskPreviews) {
         return this.taskPreviews.slice(0, 5)
@@ -956,8 +955,10 @@ export default {
       this.modals.addExtraPreview = false
     },
 
-    onPreviewChanged(index) {
-      this.currentPreviewIndex = index
+    onPreviewChanged(previewId) {
+      this.currentPreviewIndex = this.taskPreviews.findIndex(
+        p => p.id === previewId
+      )
       this.currentPreviewPath = this.getOriginalPath()
       this.currentPreviewDlPath = this.getOriginalDlPath()
     },

--- a/src/components/widgets/ComboboxStyled.vue
+++ b/src/components/widgets/ComboboxStyled.vue
@@ -6,8 +6,11 @@
     <div
       :class="{
         combo: true,
+        thin: thin,
+        reversed: isReversed,
         open: showList
       }"
+      ref="select"
       @click="toggleList"
     >
       <div class="flexrow">
@@ -16,13 +19,13 @@
         </div>
         <chevron-down-icon class="down-icon flexrow-item" />
       </div>
-      <div class="select-input" ref="select" v-if="showList">
+      <div class="select-input" v-if="showList">
         <div
+          :key="option.id"
           class="option-line flexrow"
-          v-for="option in options"
           @click="selectOption(option)"
           @click.middle="openRoute(option)"
-          :key="option.id"
+          v-for="option in optionList"
         >
           <entity-thumbnail
             class="revision-thumbnail"
@@ -91,6 +94,14 @@ export default {
     isPreview: {
       default: false,
       type: Boolean
+    },
+    isReversed: {
+      default: false,
+      type: Boolean
+    },
+    thin: {
+      default: false,
+      type: Boolean
     }
   },
 
@@ -101,12 +112,21 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['isDarkTheme'])
+    ...mapGetters(['isDarkTheme']),
+
+    optionList() {
+      if (this.isReversed) {
+        return [...this.options].reverse()
+      } else {
+        return this.options
+      }
+    }
   },
 
   methods: {
     selectOption(option) {
       this.$emit('input', option.value)
+      this.$emit('change', option.value)
       this.selectedOption = option
     },
 
@@ -146,6 +166,20 @@ export default {
         } else {
           this.selectedOption = this.options[0]
         }
+      }
+    },
+
+    showList() {
+      if (this.showList) {
+        this.$nextTick(() => {
+          let list = null
+          for (const child of this.$refs.select.children) {
+            if (child.className !== 'flexrow') {
+              list = child
+            }
+          }
+          list.scrollTo({top: this.optionList.length * 60})
+        })
       }
     },
 
@@ -252,5 +286,34 @@ export default {
 
 .revision-thumbnail {
   margin-right: 0.5em;
+}
+
+.thin {
+  height: 30px;
+  padding: 3px 0 3px 10px;
+  margin-bottom: 3px;
+
+  .select-input {
+    top: 29px;
+  }
+}
+
+.reversed {
+
+  &.open {
+    border-top-left-radius: 0em;
+    border-top-right-radius: 0em;
+    border-bottom-left-radius: 1em;
+    border-bottom-right-radius: 1em;
+  }
+
+  .select-input {
+    border-top-left-radius: 1em;
+    border-top-right-radius: 1em;
+    border-bottom-left-radius: 0em;
+    border-bottom-right-radius: 0em;
+    height: 180px;
+    top: -180px;
+  }
 }
 </style>

--- a/src/components/widgets/ComboboxTaskType.vue
+++ b/src/components/widgets/ComboboxTaskType.vue
@@ -166,13 +166,13 @@ export default {
 
 .select-input {
   background: $white;
-  width: 195px;
-  position: absolute;
   border: 1px solid var(--border);
-  z-index: 300;
   margin-left: -1px;
   max-height: 200px;
   overflow-y: auto;
+  position: absolute;
+  width: 195px;
+  z-index: 300;
 
   &.open-top {
     bottom: 41px;

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -817,6 +817,7 @@ export default {
       episode_span: 'Episode spacing',
       fps: 'FPS',
       is_clients_isolated: 'Isolate client comments (not visible to each others)',
+      is_preview_dowload_allowed: 'Allow artists to download previews',
       max_retakes: 'Maximum number of retakes',
       name: 'Name',
       nb_episodes: 'Number of episodes',

--- a/src/store/api/productions.js
+++ b/src/store/api/productions.js
@@ -37,7 +37,9 @@ export default {
       max_retakes: production.max_retakes,
       nb_episodes: production.nb_episodes,
       episode_span: production.episode_span,
-      is_clients_isolated: production.is_clients_isolated === 'true'
+      is_clients_isolated: production.is_clients_isolated === 'true',
+      is_preview_download_allowed:
+        production.is_preview_download_allowed === 'true',
     }
     return client.pput(`/api/data/projects/${production.id}`, data)
   },


### PR DESCRIPTION
**Problem**

* Artists can't download videos anymore.
* Thumbnail previews in the side panel are not stylish.
* The comparison synchronization is not accurate in terms of frames.
* The video progress in the news feed is broken.

**Solution**

* Add a settings at the project level to allow video downloads.
* Put all preview shortcuts in a combobox.
* Force time position after a pause in the player.
* Use absolute positioning instead of relative for the frame tag.
