### PR TITLE
Improve previews in fullscreen

### DIFF
--- a/src/components/mixins/fullscreen.js
+++ b/src/components/mixins/fullscreen.js
@@ -46,7 +46,7 @@ export const fullScreenMixin = {
 
     documentSetFullScreen(element) {
       if (element.requestFullscreen) {
-        element.requestFullscreen()
+        return element.requestFullscreen()
       } else if (element.mozRequestFullScreen) {
         element.mozRequestFullScreen()
       } else if (element.webkitRequestFullScreen) {

--- a/src/components/previews/PictureViewer.vue
+++ b/src/components/previews/PictureViewer.vue
@@ -54,6 +54,10 @@ export default {
       type: Number,
       default: 0
     },
+    marginBottom: {
+      type: Number,
+      default: 0
+    },
     fullScreen: {
       type: Boolean,
       default: false
@@ -244,9 +248,7 @@ export default {
         this.pictureWrapper.style['max-height'] = heightValue
         this.pictureSubWrapper.style['max-height'] = heightValue
       }
-      const dimensions = this.getDimensions()
-      const width = dimensions.width
-      const height = dimensions.height
+      let { width, height } = this.getDimensions()
       this.picture.style.width = width + 'px'
       this.picture.style.height = height + 'px'
       this.pictureBig.style.width = width + 'px'
@@ -260,6 +262,10 @@ export default {
       this.pictureGif.width = width
       this.pictureGif.height = height
 
+      if (this.fullScreen) {
+        this.pictureBig.style.maxHeight = `calc(100vh - ${this.marginBottom}px)`
+      }
+
       if (this.isPicture) {
         const pictureElement = this.isGif
           ? this.pictureGif
@@ -270,6 +276,8 @@ export default {
         const containerPosition = this.container.getBoundingClientRect()
         const top = picturePosition.top - containerPosition.top
         const left = picturePosition.left - containerPosition.left
+        width = picturePosition.width
+        height = picturePosition.height
 
         this.resetPanZoom()
 

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1005,9 +1005,16 @@ export default {
 
     setFullScreen() {
       this.endAnnotationSaving()
-      this.documentSetFullScreen(this.container)
+      const promise = this.documentSetFullScreen(this.container)
+      if (promise) {
+        promise.then(() => {
+          this.fullScreen = true
+        })
+      } else {
+        // fallback for legacy browsers
+        this.fullScreen = true
+      }
       this.container.setAttribute('data-fullscreen', !!true)
-      this.fullScreen = true
       this.$nextTick(() => {
         // Needed to avoid fullscreen button to be called with space bar.
         this.clearFocus()

--- a/src/components/previews/PreviewViewer.vue
+++ b/src/components/previews/PreviewViewer.vue
@@ -50,6 +50,7 @@
       ref="picture-viewer"
       :big="big"
       :default-height="defaultHeight"
+      :margin-bottom="marginBottom"
       :full-screen="fullScreen"
       :is-comparing="isComparing"
       :light="light"

--- a/src/components/previews/VideoViewer.vue
+++ b/src/components/previews/VideoViewer.vue
@@ -366,9 +366,7 @@ export default {
     },
 
     resetSize() {
-      const dimensions = this.getDimensions()
-      const width = dimensions.width
-      const height = dimensions.height
+      let { width, height } = this.getDimensions()
       if (height > 0) {
         this.container.style.height = this.defaultHeight + 'px'
         this.video.style.height = height + 'px'
@@ -377,6 +375,8 @@ export default {
         const containerPosition = this.container.getBoundingClientRect()
         const top = videoPosition.top - containerPosition.top
         const left = videoPosition.left - containerPosition.left
+        width = videoPosition.width
+        height = videoPosition.height
         this.$emit('size-changed', { width, height, top, left })
       } else {
         this.$emit('size-changed', { width: 0, height: 0, top: 0, left: 0 })


### PR DESCRIPTION
**Problem**
- in few corner cases, the height of the preview can be wrong in fullscreen mode.

**Solution**
- Improve the height adjustment of previews in fullscreen.
- Use a `promise` to switch on fullscreen (see [support](https://caniuse.com/mdn-api_element_requestfullscreen_returns_promise)).
