### PR TITLE
[previews] set a skybox as background of 3D model

### DIFF
--- a/src/components/previews/ObjectViewer.vue
+++ b/src/components/previews/ObjectViewer.vue
@@ -95,6 +95,7 @@ export default {
 #model-viewer {
   height: 100%;
   width: 100%;
+  background-color: #333;
   --progress-bar-color: #999;
 }
 </style>

--- a/src/components/previews/ObjectViewer.vue
+++ b/src/components/previews/ObjectViewer.vue
@@ -1,47 +1,33 @@
 <template>
   <div
-    id="model-container"
+    class="model-container"
+    :class="{
+      light: light && !readOnly
+    }"
     :style="{
       height: defaultHeight ? defaultHeight + 'px' : '100%',
       width: '100%'
     }"
-    :class="{
-      light: light && !readOnly
-    }"
   >
     <model-viewer
-      id="model-viewer"
-      loading="eager"
-      camera-controls
-      :src="previewUrl"
       autoplay
-    >
-    </model-viewer>
+      camera-controls
+      class="model-viewer"
+      loading="eager"
+      :skybox-image="skyboxUrl"
+      :src="previewUrl"
+    />
   </div>
 </template>
 
 <script>
-import {} from 'vue-feather-icons'
-
 import('@google/model-viewer')
 
 export default {
   name: 'object-viewer',
 
-  components: {},
-
-  data() {
-    return {
-      isLoading: false
-    }
-  },
-
   props: {
     previewUrl: {
-      default: '',
-      type: String
-    },
-    previewDlPath: {
       default: '',
       type: String
     },
@@ -53,49 +39,26 @@ export default {
       default: false,
       type: Boolean
     },
-    empty: {
-      default: false,
-      type: Boolean
-    },
     defaultHeight: {
-      type: Number,
-      default: 0
+      default: 0,
+      type: Number
     },
-    fullScreen: {
-      default: false,
-      type: Boolean
+    skyboxUrl: {
+      type: String
     }
-  },
-
-  mounted() {},
-
-  computed: {
-    container() {
-      return this.$refs.container
-    }
-  },
-
-  methods: {},
-
-  watch: {
-    defaultHeight() {},
-
-    previewUrl() {},
-
-    light() {}
   }
 }
 </script>
 
 <style lang="scss" scoped>
-#model-viewer.light {
-  height: 200px;
-}
-
-#model-viewer {
+.model-viewer {
   height: 100%;
   width: 100%;
   background-color: #333;
   --progress-bar-color: #999;
+
+  &.light {
+    height: 200px;
+  }
 }
 </style>

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -24,6 +24,8 @@
               :default-height="defaultHeight"
               :margin-bottom="marginBottom"
               :full-screen="fullScreen"
+              :is-object-background="isObjectBackground"
+              :object-background-url="objectBackgroundUrl"
               :is-comparing="isComparing && isComparisonEnabled"
               :is-hd="isHd"
               :is-muted="isMuted"
@@ -311,6 +313,23 @@
             />
           </div>
 
+          <div class="flexrow" v-if="is3DModel">
+            <button-simple
+              class="flexrow-item"
+              icon="globe"
+              :active="isObjectBackground"
+              :title="$t('playlists.actions.object_background')"
+              @click="onGlobeClicked"
+            />
+            <input
+              ref="object-background-input-file"
+              accept=".hdr"
+              class="visuallyhidden"
+              type="file"
+              @change="onObjectBackgroundSelected"
+            />
+          </div>
+
           <div
             class="separator"
             v-if="!readOnly && fullScreen && isPicture"
@@ -522,6 +541,8 @@ export default {
       color: '#ff3860',
       currentTime: '00:00.000',
       currentTimeRaw: 0,
+      isObjectBackground: false,
+      objectBackgroundUrl: null,
       isAnnotationsDisplayed: true,
       isCommentsHidden: true,
       isComparing: false,
@@ -1132,6 +1153,23 @@ export default {
         this.isZoomPan = false
         this.isAnnotationsDisplayed = true
       }
+    },
+
+    onGlobeClicked() {
+      if (this.isObjectBackground) {
+        this.isObjectBackground = false
+        this.$refs['object-background-input-file'].value = ''
+        URL.revokeObjectURL(this.objectBackgroundUrl.replace('#.hdr', ''))
+      } else {
+        this.$refs['object-background-input-file'].click()
+      }
+    },
+
+    onObjectBackgroundSelected(event) {
+      const file = event.target.files[0]
+      const blobURL = URL.createObjectURL(file)
+      this.objectBackgroundUrl = `${blobURL}#.hdr`
+      this.isObjectBackground = true
     },
 
     // Annotations

--- a/src/components/previews/PreviewViewer.vue
+++ b/src/components/previews/PreviewViewer.vue
@@ -66,6 +66,7 @@
       :light="light"
       :empty="!is3DModel"
       :full-screen="fullScreen"
+      :skybox-url="isObjectBackground ? objectBackgroundUrl : undefined"
       v-if="is3DModel"
     />
 
@@ -145,6 +146,13 @@ export default {
     marginBottom: {
       type: Number,
       default: 0
+    },
+    isObjectBackground: {
+      type: Boolean,
+      default: false
+    },
+    objectBackgroundUrl: {
+      type: String
     },
     isComparing: {
       type: Boolean,

--- a/src/components/widgets/ButtonSimple.vue
+++ b/src/components/widgets/ButtonSimple.vue
@@ -52,6 +52,7 @@
     <square-icon :class="iconClass" v-if="icon === 'eraser'" />
     <key-icon :class="iconClass" v-if="icon == 'key'" />
     <zoom-in-icon :class="iconClass" v-if="icon == 'loupe'" />
+    <globe-icon :class="iconClass" v-if="icon == 'globe'" />
     <span :class="iconClass" v-if="icon === 'laser'"> ⦿ </span>
     <span
       :class="{
@@ -76,6 +77,7 @@ import {
   DownloadIcon,
   EditIcon,
   Edit2Icon,
+  GlobeIcon,
   GridIcon,
   FilmIcon,
   FilterIcon,
@@ -124,6 +126,7 @@ export default {
     Edit2Icon,
     FilmIcon,
     FilterIcon,
+    GlobeIcon,
     GridIcon,
     ImageIcon,
     KeyIcon,

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -722,6 +722,7 @@ export default {
       files_previous: 'Previous file for this revision',
       frames_per_picture: 'Frames per picture',
       fullscreen: 'See file in full screen',
+      object_background: 'Set a background to the 3D model',
       looping: 'Loop on current video',
       mute: 'Mute',
       overlay: 'Overlay',


### PR DESCRIPTION
**Problem**
- The 3D model previews only have a black background by default.

**Solution**
- Allow to upload a skybox file (.hdr) as the background of a 3D model preview.
- Update default background color to gray, to be consistent with DCCs (blender, maya, ...)
