### PR TITLE
[docs] update CI badge in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Kitsu is a web application to share the progress of your productions and
 validate your deliveries. It improves the communication between all stakeholders. 
 Which leads to better pictures, shipped faster. 
 
-[![Build
-badge](https://app.travis-ci.com/cgwire/kitsu.svg?branch=master)](https://app.travis-ci.com/cgwire/kitsu)
+[![CI badge](https://github.com/cgwire/kitsu/actions/workflows/ci.yml/badge.svg)](https://github.com/cgwire/kitsu/actions/workflows/ci.yml)
 [![Discord](https://badgen.net/badge/icon/discord?icon=discord&label)](https://discord.com/invite/VbCxtKN)
 
 


### PR DESCRIPTION
**Problem**
- In README, the current badge is for Travis CI.

**Solution**
- Replace it with a Github Actions badge.
