### PR TITLE
Fix milestones on Schedule

### DIFF
--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -164,6 +164,7 @@
             :height="scheduleHeight"
             :is-loading="isTasksLoading"
             :is-estimation-linked="true"
+            :with-milestones="false"
             v-if="scheduleItems.length > 0"
           />
           <div class="has-text-centered" v-else>

--- a/src/components/pages/schedule/Schedule.vue
+++ b/src/components/pages/schedule/Schedule.vue
@@ -1548,8 +1548,10 @@ export default {
       if (this.isCurrentUserManager) {
         this.modals.edit = true
         if (milestone) {
-          milestone.date = parseDate(milestone.date)
-          this.milestoneToEdit = milestone
+          this.milestoneToEdit = {
+            ...milestone,
+            date: parseDate(milestone.date)
+          }
         } else {
           this.milestoneToEdit = { date: day }
         }

--- a/src/store/modules/schedule.js
+++ b/src/store/modules/schedule.js
@@ -144,7 +144,7 @@ const actions = {
   deleteMilestone({ commit, rootState }, milestone) {
     return scheduleApi
       .deleteMilestone(milestone)
-      .then(milestone => {
+      .then(() => {
         commit(REMOVE_MILESTONE, milestone)
       })
       .catch(console.error)

--- a/src/store/modules/schedule.js
+++ b/src/store/modules/schedule.js
@@ -154,6 +154,7 @@ const actions = {
 const mutations = {
   [ADD_MILESTONE](state, milestone) {
     state.milestones[milestone.date] = milestone
+    state.milestones = { ...state.milestones } // for reactivity
   },
 
   [ADD_MILESTONES](state, milestones) {
@@ -165,6 +166,7 @@ const mutations = {
 
   [REMOVE_MILESTONE](state, milestone) {
     delete state.milestones[milestone.date.format('YYYY-MM-DD')]
+    state.milestones = { ...state.milestones } // for reactivity
   },
 
   [SET_CURRENT_SCHEDULE_ITEMS](state, items) {


### PR DESCRIPTION
**Problem**
- A user cannot delete a milestone for a production (related to https://github.com/cgwire/kitsu/issues/1013).
- On Person page, the schedule fails to load or create milestones. Current production can be an empty value.

**Solution**
- Fix data store reactivity when adding/delete a milestone.
- Disable milestone on schedule of Person page. The Schedule will display multiple productions, but the milestones only relate to one production.
