### PR TITLE
[metadata] save number metadata as a numeric instead of a string

### DIFF
--- a/src/components/mixins/descriptors.js
+++ b/src/components/mixins/descriptors.js
@@ -48,6 +48,10 @@ export const descriptorMixin = {
         return
       } else if (descriptor.data_type === 'boolean') {
         value = event.target.checked ? 'true' : 'false'
+      } else if (descriptor.data_type === 'number') {
+        value = !isNaN(event.target.valueAsNumber)
+          ? event.target.valueAsNumber
+          : null
       } else {
         value = event.target.value
       }

--- a/src/components/widgets/MetadataField.vue
+++ b/src/components/widgets/MetadataField.vue
@@ -103,9 +103,8 @@ export default {
       required: true
     },
     value: {
-      type: String,
-      default: '',
-      required: true
+      type: [Number, String],
+      default: ''
     }
   },
 

--- a/src/components/widgets/TextField.vue
+++ b/src/components/widgets/TextField.vue
@@ -40,8 +40,6 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
-
 export default {
   name: 'text-field',
   props: {
@@ -106,18 +104,23 @@ export default {
   },
 
   computed: {
-    ...mapGetters([])
+    inputValue() {
+      const input = this.$refs.input
+      if (this.type === 'number') {
+        return !isNaN(input.valueAsNumber) ? input.valueAsNumber : null
+      } else {
+        return input.value
+      }
+    }
   },
 
   methods: {
-    ...mapActions([]),
-
     emitEnter() {
-      this.$emit('enter', this.$refs.input.value)
+      this.$emit('enter', this.inputValue)
     },
 
     updateValue() {
-      this.$emit('input', this.$refs.input.value)
+      this.$emit('input', this.inputValue)
     },
 
     focus() {


### PR DESCRIPTION
**Problem**
- Number metadata can be initialized as numeric value in Zou (via API or Gazu), but Kitsu then modifies it as a string (related to #1022).

**Solution**
- Always save Number metadata as numeric value on Kitsu.
