### PR TITLE
[shots] fix metadata type for frame in/out

### DIFF
--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -425,7 +425,7 @@
                   event =>
                     onMetadataFieldChanged(
                       shot,
-                      { field_name: 'frame_in' },
+                      { field_name: 'frame_in', data_type: 'number' },
                       event
                     )
                 "
@@ -459,7 +459,7 @@
                   event =>
                     onMetadataFieldChanged(
                       shot,
-                      { field_name: 'frame_out' },
+                      { field_name: 'frame_out', data_type: 'number' },
                       event
                     )
                 "
@@ -488,7 +488,11 @@
                 @keydown="onNumberFieldKeyDown"
                 @input="
                   event =>
-                    onMetadataFieldChanged(shot, { field_name: 'fps' }, event)
+                    onMetadataFieldChanged(
+                      shot,
+                      { field_name: 'fps', data_type: 'number' },
+                      event
+                    )
                 "
                 @keyup.ctrl="
                   event =>
@@ -519,7 +523,7 @@
                   event =>
                     onMetadataFieldChanged(
                       shot,
-                      { field_name: 'max_retakes' },
+                      { field_name: 'max_retakes', data_type: 'number' },
                       event
                     )
                 "

--- a/src/components/pages/breakdown/ShotLine.vue
+++ b/src/components/pages/breakdown/ShotLine.vue
@@ -91,7 +91,11 @@
         :value="getMetadataFieldValue({ field_name: 'frame_in' }, entity)"
         @input="
           event =>
-            onMetadataFieldChanged(entity, { field_name: 'frame_in' }, event)
+            onMetadataFieldChanged(
+              entity,
+              { field_name: 'frame_in', data_type: 'number' },
+              event
+            )
         "
         v-if="isCurrentUserManager"
       />
@@ -113,7 +117,11 @@
         :value="getMetadataFieldValue({ field_name: 'frame_out' }, entity)"
         @input="
           event =>
-            onMetadataFieldChanged(entity, { field_name: 'frame_out' }, event)
+            onMetadataFieldChanged(
+              entity,
+              { field_name: 'frame_out', data_type: 'number' },
+              event
+            )
         "
         v-if="isCurrentUserManager"
       />


### PR DESCRIPTION
**Problem**
- For Shot entities, the frame in / out data still saved as a string instead of a number when editing list. But no issue when editing from modal (related #1022 ).

**Solution**
- Add the missing data type to the numeric metadata in list components.
