### PR TITLE
fix search in feature film

### DIFF
--- a/src/components/pages/Edits.vue
+++ b/src/components/pages/Edits.vue
@@ -9,6 +9,7 @@
               :can-save="true"
               :active="isSearchActive"
               @change="onSearchChange"
+              @enter="applySearch(searchField.getValue())"
               @save="saveSearchQuery"
               placeholder="ex: e01 edit=wip"
             />

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -9,6 +9,7 @@
               :can-save="true"
               :active="isSearchActive"
               @change="onSearchChange"
+              @enter="applySearch(searchField.getValue())"
               @save="saveSearchQuery"
               placeholder="ex: e01 s01 anim=wip"
             />


### PR DESCRIPTION
**Problem**
- On the Shots and Edits pages, the search filter doesn't work if you are on a Feature Film type production.

**Solution**
- Process search on press enter.
