### PR TITLE
Improve CI with matrix testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,17 @@ on:
 
 jobs:
   ci:
+    name: Test with Node ${{ matrix.node }}
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        node: [ 18, 20 ]
     steps:
       - uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
       - name: Run tests
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+          cache: "npm"
       - name: Run tests
         env:
           NODE_OPTIONS: "--max_old_space_size=8192"


### PR DESCRIPTION
**Problem**
- CI pipeline runs tests only for one version of Node.js

**Solution**
- Run the CI on major Node.js versions (v18 LTS + v20) with matrix testing.
- Caching dependencies to speed up workflows.

