### PR TITLE
[task] enable compare mode on task page

### DIFF
--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -110,6 +110,7 @@
               <div v-if="isPreviews">
                 <preview-player
                   ref="preview-player"
+                  :entity-preview-files="taskEntityPreviews"
                   :extra-wide="true"
                   :last-preview-files="taskPreviews || []"
                   :previews="currentPreview.previews"


### PR DESCRIPTION
**Problem**
- The "compare" button is not visible on the Task page. (related to #1185)

**Solution**
- Add missing preview data in order to activate the compare button.
