### PR TITLE
Various fixes

### DIFF
--- a/src/components/modals/EditStatusAutomationModal.vue
+++ b/src/components/modals/EditStatusAutomationModal.vue
@@ -17,7 +17,7 @@
         </h1>
 
         <form v-on:submit.prevent>
-          <h2 class="subtitle">{{ $t('status_automations.entity_title') }}</h2>
+          <h3 class="subtitle">{{ $t('status_automations.entity_title') }}</h3>
           <combobox
             :label="$t('status_automations.fields.entity_type')"
             :options="entityTypeOptions"
@@ -26,7 +26,7 @@
             locale-key-prefix="status_automations.entity_types."
             @enter="confirmClicked"
           />
-          <span v-else> {{ form.entityType }} </span>
+          <span class="entity-type-name" v-else> {{ form.entityType }} </span>
 
           <h2 class="subtitle">{{ $t('status_automations.in_title') }}</h2>
 
@@ -197,7 +197,11 @@ export default {
     setTaskTypes(fieldType) {
       if (fieldType === 'asset') {
         this.form.inEntityTaskTypes = this.assetTaskTypes
-        this.form.outEntityTaskTypes = this.assetTaskTypes
+        if (this.mode === 'status') {
+          this.form.outEntityTaskTypes = this.assetTaskTypes
+        } else {
+          this.form.outEntityTaskTypes = this.shotTaskTypes
+        }
       } else if (fieldType === 'shot') {
         this.form.inEntityTaskTypes = this.shotTaskTypes
         this.form.outEntityTaskTypes = this.shotTaskTypes
@@ -272,7 +276,12 @@ export default {
 }
 .subtitle {
   font-size: 1.4em;
-  margin-top: 1.5em;
+  margin-top: 2em;
   margin-bottom: 0.5em;
+  text-transform: none;
+}
+.entity-type-name {
+  font-size: 1.2em;
+  text-transform: capitalize;
 }
 </style>

--- a/src/components/pages/Asset.vue
+++ b/src/components/pages/Asset.vue
@@ -176,7 +176,7 @@
                       :with-link="false"
                     />
                     <div>
-                      <span>{{ shot.shot_name }}</span>
+                      <span class="break-word">{{ shot.shot_name }}</span>
                       <span v-if="shot.nb_occurences > 1">
                         ({{ shot.nb_occurences }})
                       </span>
@@ -244,7 +244,7 @@
                       :with-link="false"
                     />
                     <div>
-                      <span>{{ asset.asset_name }}</span>
+                      <span class="break-word">{{ asset.asset_name }}</span>
                       <span v-if="asset.nb_occurences > 1">
                         ({{ asset.nb_occurences }})
                       </span>

--- a/src/components/pages/Episode.vue
+++ b/src/components/pages/Episode.vue
@@ -148,7 +148,7 @@
                       :with-link="false"
                       :no-cache="true"
                     />
-                    <div>
+                    <div class="break-word">
                       {{ asset.asset_name }}
                       <span v-if="asset.nb_occurences > 1">
                         ({{ asset.nb_occurences }})

--- a/src/components/pages/Sequence.vue
+++ b/src/components/pages/Sequence.vue
@@ -150,7 +150,7 @@
                       :with-link="false"
                       :no-cache="true"
                     />
-                    <div>
+                    <div class="break-word">
                       {{ asset.asset_name }}
                       <span v-if="asset.nb_occurences > 1">
                         ({{ asset.nb_occurences }})

--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -231,7 +231,7 @@
                       :with-link="false"
                       :no-cache="true"
                     />
-                    <div>
+                    <div class="break-word">
                       {{ asset.asset_name }}
                       <span v-if="asset.nb_occurences > 1">
                         ({{ asset.nb_occurences }})

--- a/src/components/pages/breakdown/AssetBlock.vue
+++ b/src/components/pages/breakdown/AssetBlock.vue
@@ -279,4 +279,8 @@ export default {
 .modify-asset {
   min-width: 20px;
 }
+
+.asset-text-name {
+  word-wrap: anywhere;
+}
 </style>

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -798,6 +798,7 @@
           @play-click="entityListClicked"
           @remove-entity="removeEntity"
           @preview-changed="onPreviewChanged"
+          @entity-to-add="$emit('entity-to-add', $event)"
           @entity-dropped="onEntityDropped"
         />
       </div>
@@ -1350,19 +1351,30 @@ export default {
       this.updateTaskPanel()
     },
 
+    /*
+     * Called when an entity is dropped in the playlist. The entity is moved
+     * to the new position and the order of the entities is updated.
+     * @param {Object} info - {
+     *   before: where entity is dropped (id of the entity before),
+     *   after: the id of the entity dropped.
+     * }
+     */
     onEntityDropped(info) {
       const playlistEl = this.$refs['playlisted-entities']
       const scrollLeft = playlistEl.scrollLeft
-
       const entityToMove = this.entityList.find(s => s.id === info.after)
-      const toMoveIndex = this.entityList.findIndex(s => s.id === info.after)
-      let targetIndex = this.entityList.findIndex(s => s.id === info.before)
-      if (toMoveIndex > targetIndex) targetIndex += 1
-      this.moveSelectedEntity(entityToMove, toMoveIndex, targetIndex)
-      this.$nextTick(() => {
-        playlistEl.scrollLeft = scrollLeft
-      })
-      this.$emit('order-change', info)
+      if (!entityToMove) {
+        this.$emit('new-entity-dropped', info)
+      } else {
+        const toMoveIndex = this.entityList.findIndex(s => s.id === info.after)
+        let targetIndex = this.entityList.findIndex(s => s.id === info.before)
+        if (toMoveIndex > targetIndex) targetIndex += 1
+        this.moveSelectedEntity(entityToMove, toMoveIndex, targetIndex)
+        this.$nextTick(() => {
+          playlistEl.scrollLeft = scrollLeft
+        })
+        this.$emit('order-change', info)
+      }
     },
 
     moveSelectedEntityToLeft() {

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -108,7 +108,7 @@
       <div class="post-area">
         <checklist
           :checklist="checklist"
-          :frame="frame"
+          :frame="frame + 1"
           :revision="revision"
           :is-movie-preview="isMovie"
           @add-item="onAddChecklistItem"


### PR DESCRIPTION
**Problem**

* Long names with underscores are not well displayed on the breakdown page.
* It's not possible to add a new element in the middle of a playlist
* In the automation edition, the ready for selector is broken.
* When clicking on a frame tag in a checklist, the selected frame is wrong.

**Solution**

* Use the right break-word attribute value.
* Handle drop from the entity selector.
* Use the shot task status list instead of the asset status list.
* Add one frame to the frame selected to get the right element.
