### PR TITLE
Improve comments

### DIFF
--- a/src/components/cells/MetadataHeader.vue
+++ b/src/components/cells/MetadataHeader.vue
@@ -22,7 +22,7 @@
         @click="$emit('show-metadata-header-menu', $event)"
         v-if="!noMenu"
       >
-        <chevron-down-icon :size="'12'" />
+        <chevron-down-icon size="12" />
       </span>
     </div>
   </th>

--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -1268,7 +1268,6 @@ export const playerMixin = {
 
   watch: {
     isCommentsHidden() {
-      if (!this.isCommentsHidden) this.$refs['task-info'].loadTaskData()
       if (this.isCurrentPreviewSound) {
         this.soundPlayer.redraw()
       }

--- a/src/components/pages/Edit.vue
+++ b/src/components/pages/Edit.vue
@@ -157,17 +157,14 @@
           </div>
           <task-info
             ref="task-info"
-            :class="{
-              'flexrow-item': true,
-              'task-info-column': true,
-              hidden: isCommentsHidden
-            }"
+            class="flexrow-item task-info-column"
             :task="task"
             :is-preview="false"
             :silent="isCommentsHidden"
             :current-time-raw="currentTimeRaw - frameDuration"
             :current-parent-preview="currentPreview"
             @time-code-clicked="onTimeCodeClicked"
+            v-show="!isCommentsHidden"
           />
         </div>
 

--- a/src/components/pages/Edit.vue
+++ b/src/components/pages/Edit.vue
@@ -421,6 +421,7 @@
           <div class="separator"></div>
           <button-simple
             class="button player-button flexrow-item"
+            :active="!isCommentsHidden"
             :title="$t('playlists.actions.comments')"
             @click="onCommentClicked"
             icon="comment"

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -265,18 +265,14 @@
 
       <task-info
         ref="task-info"
-        :class="{
-          'flexrow-item': true,
-          'task-info-column': true,
-          hidden: isCommentsHidden
-        }"
+        class="flexrow-item task-info-column"
         :task="task"
         :is-preview="false"
         :silent="isCommentsHidden"
         :current-time-raw="currentTimeRaw"
         :current-parent-preview="currentPreview"
-        panel-name="playlist-side-panel"
         @time-code-clicked="onTimeCodeClicked"
+        v-show="!isCommentsHidden"
       />
     </div>
 

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1423,7 +1423,7 @@ export default {
         if (this.$refs['video-container']) {
           this.$refs['video-container'].style.height = `${height}px`
         }
-        if (!this.isCommentsHidden) {
+        if (this.$refs['task-info'] && !this.isCommentsHidden) {
           this.$refs['task-info'].$el.style.height = `${height}px`
         }
         if (this.$refs['picture-preview-wrapper']) {

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -670,6 +670,7 @@
       <div class="separator"></div>
       <button-simple
         class="button playlist-button flexrow-item"
+        :active="!isCommentsHidden"
         :title="$t('playlists.actions.comments')"
         @click="onCommentClicked"
         icon="comment"
@@ -677,6 +678,7 @@
       <button-simple
         class="playlist-button flexrow-item"
         :title="$t('playlists.actions.entity_list')"
+        :active="!isEntitiesHidden"
         @click="onFilmClicked"
         icon="film"
       />

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -93,6 +93,7 @@
           class="flexrow-item task-info-column"
           :task="task"
           :is-preview="false"
+          :silent="isCommentsHidden"
           :current-time-raw="currentTimeRaw"
           :current-parent-preview="currentPreview"
           @comment-added="$emit('comment-added')"

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -89,19 +89,15 @@
         </div>
 
         <task-info
-          name="task-info"
           ref="task-info-player"
-          :class="{
-            'flexrow-item': true,
-            'task-info-column': true,
-            hidden: isCommentsHidden
-          }"
+          class="flexrow-item task-info-column"
           :task="task"
           :is-preview="false"
           :current-time-raw="currentTimeRaw"
           :current-parent-preview="currentPreview"
           @comment-added="$emit('comment-added')"
           @time-code-clicked="timeCodeClicked"
+          v-show="!isCommentsHidden"
         />
       </div>
     </div>
@@ -1591,8 +1587,6 @@ export default {
       this.$nextTick(() => {
         if (!this.isCommentsHidden) {
           this.$refs['task-info-player'].$el.style.height = `${height}px`
-        }
-        if (this.$refs['task-info-player']) {
           this.$refs['task-info-player'].focusCommentTextarea()
         }
         this.previewViewer.resetVideo()

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -348,6 +348,7 @@
             <button-simple
               class="button playlist-button flexrow-item"
               icon="comment"
+              :active="!isCommentsHidden"
               :title="$t('playlists.actions.comments')"
               @click="onCommentClicked"
               v-if="!readOnly && fullScreen"

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -339,10 +339,6 @@ export default {
       type: Boolean,
       default: false
     },
-    panelName: {
-      type: String,
-      default: 'todefine'
-    },
     withActions: {
       type: Boolean,
       default: false
@@ -804,7 +800,7 @@ export default {
     },
 
     focusCommentTextarea() {
-      if (this.$refs['add-comment']) this.$refs['add-comment'].focus()
+      this.$refs['add-comment']?.focus()
     },
 
     getOriginalPath() {

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1568,7 +1568,7 @@ export default {
 
 .side {
   flex: 1;
-  overflow: scroll;
+  overflow: auto;
 }
 
 .extend-bar {

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -404,7 +404,6 @@ export default {
   },
 
   mounted() {
-    this.loadTaskData()
     if (this.$refs['add-comment']) {
       const draft = drafts.getTaskDraft(this.task.id)
       if (draft) {
@@ -1273,6 +1272,14 @@ export default {
       })
       if (!this.silent) {
         this.loadTaskData()
+      }
+    },
+    silent: {
+      immediate: true,
+      handler() {
+        if (!this.silent) {
+          this.loadTaskData()
+        }
       }
     }
   },

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -982,6 +982,7 @@ article.comment {
 .date {
   font-size: 0.8em;
   margin-right: 0.5em;
+  white-space: nowrap;
 }
 
 .preview-info {


### PR DESCRIPTION
**Problem**
- When selecting tasks, loading comments is called twice.
- In preview and playlist players, comments and entity list buttons are not set as active upon activation.

**Solution**
- Fetch data only if comments are visible.
- visually toggle buttons in players. 
