### PR TITLE
Fix style of Import CSV modal

### DIFF
--- a/src/components/modals/ImportModal.vue
+++ b/src/components/modals/ImportModal.vue
@@ -8,7 +8,7 @@
     <div class="modal-background" @click="$emit('cancel')"></div>
 
     <div class="modal-content">
-      <div class="box content">
+      <div class="box">
         <h1 class="title">
           {{ $t('main.csv.import_title') }}
         </h1>


### PR DESCRIPTION
**Problem**
- The lists are not styled correctly.

![image](https://github.com/cgwire/kitsu/assets/493223/acc4f3e0-937c-4fb6-8691-13bcddfc2024)

**Solution**
- Remove a useless class on parent which generate a side effect on the style of `<ul>` lists

