### PR TITLE
[ci] fix "Push changes" step on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: true
           branch: build
+          force: true


### PR DESCRIPTION
**Problem**
The workflow failed to push the release tag because it already exists.

**Solution**
Enable the `force` option due to version bump of `actions/checkout@v4`, to avoid the tag "already exists" error.

(see https://github.com/ad-m/github-push-action/tree/master/#troubleshooting)
