### PR TITLE
Improve avatar loading

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
         destructuring: 'all'
       }
     ],
+    'vue/component-name-in-template-casing': ['error', 'kebab-case'],
     'vue/multi-word-component-names': 'off',
     'vue/no-use-v-if-with-v-for': 'off',
     'vue/prop-name-casing': ['error', 'camelCase']

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,8 @@ module.exports = {
       }
     ],
     'vue/multi-word-component-names': 'off',
-    'vue/no-use-v-if-with-v-for': 'off'
+    'vue/no-use-v-if-with-v-for': 'off',
+    'vue/prop-name-casing': ['error', 'camelCase']
   },
   globals: {
     Canny: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "vue-drag-drop": "1.1.4",
         "vue-feather-icons": "5.1.0",
         "vue-i18n": "8.28.2",
-        "vue-lazyload": "1.3.5",
         "vue-meta": "2.4.0",
         "vue-router": "3.6.5",
         "vue-scroll": "2.1.13",
@@ -6117,11 +6116,6 @@
       "version": "8.28.2",
       "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.28.2.tgz",
       "integrity": "sha512-C5GZjs1tYlAqjwymaaCPDjCyGo10ajUphiwA922jKt9n7KPpqR7oM1PCwYzhB/E7+nT3wfdG3oRre5raIT1rKA=="
-    },
-    "node_modules/vue-lazyload": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/vue-lazyload/-/vue-lazyload-1.3.5.tgz",
-      "integrity": "sha512-SCO/LWgCCbjaregHO4wg2buzITBdPBZRlIS104vERGpT88uxXsK26veuzZpgGAXMR8WpkaR+JDqz80OedpaLiA=="
     },
     "node_modules/vue-meta": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "vue-drag-drop": "1.1.4",
     "vue-feather-icons": "5.1.0",
     "vue-i18n": "8.28.2",
-    "vue-lazyload": "1.3.5",
     "vue-meta": "2.4.0",
     "vue-router": "3.6.5",
     "vue-scroll": "2.1.13",

--- a/src/components/cells/TimeSliderCell.vue
+++ b/src/components/cells/TimeSliderCell.vue
@@ -59,7 +59,7 @@ export default {
   },
 
   props: {
-    'task-id': {
+    taskId: {
       type: String,
       default: ''
     },

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -60,30 +60,16 @@
           &nbsp; &nbsp; &nbsp; &nbsp;
         </span>
       </span>
-      <span> </span>
       <span
         class="avatar has-text-centered"
-        :title="personMap.get(personId).full_name"
-        :style="{
-          background: personMap.get(personId).color,
-          width: '20px',
-          height: '20px',
-          'font-size': '10px'
-        }"
-        :key="'avatar-' + personId"
-        v-for="personId in assignees"
+        :title="person.full_name"
+        :style="{ background: person.color }"
+        :key="`avatar-${person.id}`"
+        v-for="person in assignees"
         v-if="isAssignees && !isCurrentUserClient && !disabled"
       >
-        <img
-          v-lazy="avatarPath(personId)"
-          :key="avatarKey(personId)"
-          width="20"
-          height="20"
-          v-if="personMap.get(personId).has_avatar"
-        />
-        <span v-else>
-          {{ personMap.get(personId).initials }}
-        </span>
+        <img v-lazy="person.avatarPath" v-if="person.has_avatar" />
+        <template v-else>{{ person.initials }}</template>
       </span>
       <span class="subscribed" v-if="task && task.is_subscribed">
         <eye-icon size="0.8x" />
@@ -216,11 +202,9 @@ export default {
     ]),
 
     assignees() {
-      if (this.task) {
-        return this.task.assignees
-      } else {
-        return []
-      }
+      return (
+        this.task?.assignees.map(personId => this.personMap.get(personId)) || []
+      )
     },
 
     backgroundColor() {
@@ -346,24 +330,6 @@ export default {
       }
     },
 
-    avatarPath(personId) {
-      const person = this.personMap.get(personId)
-      if (person) {
-        return person.avatarPath + '?unique=' + person.uniqueHash
-      } else {
-        return ''
-      }
-    },
-
-    avatarKey(personId) {
-      const person = this.personMap.get(personId)
-      if (person) {
-        return person.id + '-' + person.uniqueHash
-      } else {
-        return ''
-      }
-    },
-
     changeStyleBasedOnSelected() {
       if (this.selected) {
         const background = this.isDarkTheme ? '#5E60BA' : '#BFC1FF'
@@ -445,10 +411,9 @@ span.person-avatar:nth-child(2) {
   align-items: center;
   justify-content: center;
   margin-right: 2px;
-}
-
-.avatar span {
-  flex: 1;
+  width: 20px;
+  height: 20px;
+  font-size: 10px;
 }
 
 .avatar img {

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -17,7 +17,7 @@
     @click="onClick"
   >
     <div class="wrapper" v-if="!minimized">
-      <span v-if="task">
+      <template v-if="task">
         <span
           class="tag"
           :title="taskStatus.name"
@@ -59,7 +59,7 @@
         >
           &nbsp; &nbsp; &nbsp; &nbsp;
         </span>
-      </span>
+      </template>
       <span
         class="avatar has-text-centered"
         :title="person.full_name"

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -68,7 +68,7 @@
         v-for="person in assignees"
         v-if="isAssignees && !isCurrentUserClient && !disabled"
       >
-        <img v-lazy="person.avatarPath" v-if="person.has_avatar" />
+        <img loading="lazy" :src="person.avatarPath" v-if="person.has_avatar" />
         <template v-else>{{ person.initials }}</template>
       </span>
       <span class="subscribed" v-if="task && task.is_subscribed">

--- a/src/components/modals/EditCommentModal.vue
+++ b/src/components/modals/EditCommentModal.vue
@@ -13,7 +13,7 @@
           {{ $t('comments.edit_title') }}
         </h1>
 
-        <form v-on:submit.prevent>
+        <form @submit.prevent>
           <combo-box-status
             :label="$t('task_status.title')"
             :task-status-list="taskStatusForCurrentUser"
@@ -31,7 +31,6 @@
                     class="flexrow-item"
                     :person="team.item"
                     :size="20"
-                    :no-cache="true"
                   />
                   <span class="flexrow-item">
                     {{ team.item.full_name }}

--- a/src/components/pages/Episode.vue
+++ b/src/components/pages/Episode.vue
@@ -146,7 +146,6 @@
                       :empty-width="103"
                       :empty-height="103"
                       :with-link="false"
-                      :no-cache="true"
                     />
                     <div class="break-word">
                       {{ asset.asset_name }}

--- a/src/components/pages/Logs.vue
+++ b/src/components/pages/Logs.vue
@@ -14,9 +14,8 @@
         </li>
       </ul>
     </div>
-
-    <Events v-if="isActiveTab('events')" />
-    <PreviewFiles v-if="isActiveTab('preview_files')" />
+    <events v-if="isActiveTab('events')" />
+    <preview-files v-if="isActiveTab('preview_files')" />
   </div>
 </template>
 

--- a/src/components/pages/MyChecks.vue
+++ b/src/components/pages/MyChecks.vue
@@ -64,7 +64,7 @@
             {{ nbTasksToCheck }} tasks to check
           </h1>
           <div class="filler"></div>
-          <ButtonSimple
+          <button-simple
             class="flexrow-item"
             @click="isPlaylist = true"
             text="Build playlist from list"

--- a/src/components/pages/People.vue
+++ b/src/components/pages/People.vue
@@ -285,13 +285,8 @@ export default {
     },
 
     deleteText() {
-      const person = this.personToDelete
-      if (person !== undefined) {
-        const personName = `${person.first_name} ${person.last_name}`
-        return this.$t('people.delete_text', { personName })
-      } else {
-        return ''
-      }
+      const personName = this.personToDelete?.full_name
+      return personName ? this.$t('people.delete_text', { personName }) : ''
     },
 
     filteredPeople() {

--- a/src/components/pages/ProductionSettings.vue
+++ b/src/components/pages/ProductionSettings.vue
@@ -41,7 +41,7 @@
       </div>
 
       <div class="tab" v-show="isActiveTab('brief')">
-        <ProductionBrief />
+        <production-brief />
       </div>
 
       <div class="tab" v-show="isActiveTab('assetTypes')">

--- a/src/components/pages/Profile.vue
+++ b/src/components/pages/Profile.vue
@@ -1071,14 +1071,15 @@ export default {
     uploadAvatarFile() {
       this.changeAvatar.isLoading = true
       this.changeAvatar.isError = false
-      this.uploadAvatar(err => {
-        if (err) {
+      this.uploadAvatar()
+        .catch(err => {
+          console.error(err)
           this.changeAvatar.isError = true
-        }
-        this.changeAvatar.isLoading = false
-        this.$refs.avatar.reloadAvatar()
-        this.hideAvatarModal()
-      })
+        })
+        .finally(() => {
+          this.changeAvatar.isLoading = false
+          this.hideAvatarModal()
+        })
     },
 
     hideAvatarModal() {

--- a/src/components/pages/Profile.vue
+++ b/src/components/pages/Profile.vue
@@ -4,8 +4,7 @@
       <div class="has-text-centered profile-header">
         <div class="profile-header-content has-text-centered">
           <people-avatar
-            ref="avatar"
-            :no-cache="true"
+            :is-lazy="false"
             :person="this.user"
             :size="150"
             :font-size="60"

--- a/src/components/pages/Sequence.vue
+++ b/src/components/pages/Sequence.vue
@@ -148,7 +148,6 @@
                       :empty-width="103"
                       :empty-height="103"
                       :with-link="false"
-                      :no-cache="true"
                     />
                     <div class="break-word">
                       {{ asset.asset_name }}

--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -229,7 +229,6 @@
                       :empty-width="103"
                       :empty-height="103"
                       :with-link="false"
-                      :no-cache="true"
                     />
                     <div class="break-word">
                       {{ asset.asset_name }}

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1139,7 +1139,6 @@ export default {
           avatar: true,
           has_avatar: person.has_avatar,
           avatarPath: person.avatarPath,
-          uniqueHash: person.uniqueHash,
           initials: person.initials,
           id: person.id,
           name: person.full_name,

--- a/src/components/pages/breakdown/AssetBlock.vue
+++ b/src/components/pages/breakdown/AssetBlock.vue
@@ -16,12 +16,8 @@
       <div class="asset-add" @click="removeOneAsset" v-if="!readOnly">- 1</div>
       <div class="asset-picture" v-if="asset.preview_file_id">
         <img
-          v-lazy="
-            '/api/pictures/thumbnails-square/preview-files/' +
-            asset.preview_file_id +
-            '.png'
-          "
-          alt=""
+          loading="lazy"
+          :src="`/api/pictures/thumbnails-square/preview-files/${asset.preview_file_id}.png`"
         />
         <span class="nb-occurences" v-if="nbOccurences > 1">
           {{ nbOccurences }}

--- a/src/components/pages/breakdown/AvailableAssetBlock.vue
+++ b/src/components/pages/breakdown/AvailableAssetBlock.vue
@@ -13,12 +13,8 @@
     <div class="asset-add-10" @click="addTenAssets">+ 10</div>
     <div class="asset-picture" v-if="asset.preview_file_id.length > 0">
       <img
-        v-lazy="
-          '/api/pictures/thumbnails-square/preview-files/' +
-          asset.preview_file_id +
-          '.png'
-        "
-        alt=""
+        loading="lazy"
+        :src="`/api/pictures/thumbnails-square/preview-files/${asset.preview_file_id}.png`"
       />
     </div>
     <div class="asset-picture" v-else>

--- a/src/components/pages/playlists/RawVideoPlayer.vue
+++ b/src/components/pages/playlists/RawVideoPlayer.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="container" class="video-wrapper filler flexrow-item">
     <div class="video-loader" v-show="isLoading">
-      <Spinner class="mt2" style="color: white" />
+      <spinner class="mt2" style="color: white" />
     </div>
     <video
       ref="player1"

--- a/src/components/pages/schedule/Schedule.vue
+++ b/src/components/pages/schedule/Schedule.vue
@@ -61,7 +61,6 @@
                   :is-link="false"
                   :font-size="14"
                   :size="28"
-                  :no-cache="true"
                   v-else
                 />
               </span>

--- a/src/components/sides/PeopleQuotaInfo.vue
+++ b/src/components/sides/PeopleQuotaInfo.vue
@@ -7,7 +7,7 @@
     </div>
 
     <div class="flexrow">
-      <people-avatar class="flexrow-item" :person="person" :no-cache="true" />
+      <people-avatar class="flexrow-item" :person="person" :is-lazy="false" />
       <page-title class="flexrow-item" :text="person.full_name" />
     </div>
     <div class="info-date" v-if="isMonthInfo">{{ monthString }} {{ year }}</div>

--- a/src/components/sides/PeopleTimesheetInfo.vue
+++ b/src/components/sides/PeopleTimesheetInfo.vue
@@ -7,7 +7,7 @@
     </div>
 
     <div class="flexrow">
-      <people-avatar class="flexrow-item" :person="person" :no-cache="true" />
+      <people-avatar class="flexrow-item" :person="person" :is-lazy="false" />
       <page-title class="flexrow-item" :text="person.full_name" />
     </div>
 

--- a/src/components/tops/GlobalSearchField.vue
+++ b/src/components/tops/GlobalSearchField.vue
@@ -268,10 +268,9 @@ export default {
         this.searchData({ query: this.searchQuery })
           .then(results => {
             this.assets = results.assets
-            results.persons.forEach(person => {
-              peopleStore.helpers.addAdditionalInformation(person)
-            })
-            this.persons = results.persons
+            this.persons = results.persons.map(
+              peopleStore.helpers.addAdditionalInformation
+            )
             this.shots = results.shots
           })
           .catch(console.error)

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -809,12 +809,6 @@ export default {
         ) {
           this.incrementNotificationCounter()
         }
-      },
-
-      'person:update'(eventData) {
-        if (this.user.id === eventData.person_id) {
-          this.$refs.avatar.reloadAvatar()
-        }
       }
     }
   }

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -3,7 +3,7 @@
     <div
       id="c-mask-user-menu"
       @click="toggleUserMenu()"
-      v-bind:class="{ 'is-active': !isUserMenuHidden }"
+      :class="{ 'is-active': !isUserMenuHidden }"
     ></div>
 
     <nav class="nav">
@@ -121,11 +121,10 @@
           @click="toggleUserMenu"
         >
           <people-avatar
-            ref="avatar"
             class="avatar"
-            :no-cache="true"
-            :person="user"
+            :is-lazy="false"
             :is-link="false"
+            :person="user"
           />
         </div>
       </div>

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -67,7 +67,7 @@
                 :person="team.item"
                 :size="20"
                 :font-size="11"
-                :no-cache="true"
+                :is-lazy="false"
                 :is-link="false"
               />
               <span class="flexrow-item">

--- a/src/components/widgets/AssignationItem.vue
+++ b/src/components/widgets/AssignationItem.vue
@@ -2,7 +2,6 @@
   <div class="flexrow">
     <people-avatar
       :is-link="false"
-      :no-cache="true"
       :person="item"
       :size="30"
       class="flexrow-item"

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -193,7 +193,7 @@
                         :person="team.item"
                         :size="20"
                         :font-size="11"
-                        :no-cache="true"
+                        :is-lazy="false"
                         :is-link="false"
                       />
                       <span class="flexrow-item">

--- a/src/components/widgets/EntityPreview.vue
+++ b/src/components/widgets/EntityPreview.vue
@@ -35,13 +35,14 @@
   >
     <img
       class="thumbnail-picture"
+      loading="lazy"
+      :key="thumbnailKey"
+      :src="thumbnailPath"
       :style="{
         width: 'auto',
-        'max-height': emptyHeight + 'px'
+        'max-height': `${emptyHeight}px`
       }"
       :width="width || ''"
-      v-lazy="thumbnailPath"
-      :key="thumbnailKey"
     />
   </a>
 </template>

--- a/src/components/widgets/EntityThumbnail.vue
+++ b/src/components/widgets/EntityThumbnail.vue
@@ -12,19 +12,21 @@
   >
     <img
       class="thumbnail-picture"
+      loading="lazy"
+      :key="thumbnailKey"
+      :src="thumbnailPath"
       :style="imgStyle"
       :width="width || ''"
-      v-lazy="thumbnailPath"
-      :key="thumbnailKey"
     />
   </a>
 
   <img
     v-else-if="isPreview && !withLink"
-    :key="thumbnailKey"
     class="thumbnail-picture"
+    loading="lazy"
+    :key="thumbnailKey"
+    :src="thumbnailPath"
     :style="imgStyle"
-    v-lazy="thumbnailPath"
   />
 
   <span

--- a/src/components/widgets/LightEntityThumbnail.vue
+++ b/src/components/widgets/LightEntityThumbnail.vue
@@ -1,22 +1,17 @@
 <template functional>
   <img
     class="thumbnail-picture"
+    loading="lazy"
+    :key="props.previewFileId"
+    :src="`/api/pictures/${props.type}/preview-files/${props.previewFileId}.png`"
     :style="{
       width: props.width,
       height: props.height,
       'max-width': props.maxWidth,
       'max-height': props.maxHeight
     }"
-    v-lazy="
-      '/api/pictures/' +
-      props.type +
-      '/preview-files/' +
-      props.previewFileId +
-      '.png'
-    "
-    :key="props.previewFileId"
-    v-if="props.previewFileId"
     v-bind="data.attrs"
+    v-if="props.previewFileId"
   />
   <span
     :class="{

--- a/src/components/widgets/PeopleAvatar.vue
+++ b/src/components/widgets/PeopleAvatar.vue
@@ -20,11 +20,10 @@
       }"
       :title="person.full_name"
     >
-      <img :src="person.avatarPath" v-if="person.has_avatar && noCache" />
       <img
-        loading="lazy"
+        :loading="this.isLazy ? 'lazy' : undefined"
         :src="person.avatarPath"
-        v-else-if="person.has_avatar"
+        v-if="person.has_avatar"
       />
       <template v-else>{{ person.initials }}</template>
     </router-link>
@@ -41,11 +40,10 @@
     }"
     v-else
   >
-    <img :src="person.avatarPath" v-if="person.has_avatar && noCache" />
     <img
-      loading="lazy"
+      :loading="this.isLazy ? 'lazy' : undefined"
       :src="person.avatarPath"
-      v-else-if="person.has_avatar"
+      v-if="person.has_avatar"
     />
     <template v-else>{{ person.initials }}</template>
   </span>
@@ -75,9 +73,9 @@ export default {
       type: Boolean,
       default: true
     },
-    noCache: {
+    isLazy: {
       type: Boolean,
-      default: false
+      default: true
     }
   }
 }

--- a/src/components/widgets/PeopleAvatar.vue
+++ b/src/components/widgets/PeopleAvatar.vue
@@ -68,10 +68,22 @@ export default {
         color: '#FFF'
       })
     },
-    size: { type: Number, default: 40 },
-    'font-size': { type: Number, default: 18 },
-    'is-link': { type: Boolean, default: true },
-    'no-cache': { type: Boolean, default: false }
+    size: {
+      type: Number,
+      default: 40
+    },
+    fontSize: {
+      type: Number,
+      default: 18
+    },
+    isLink: {
+      type: Boolean,
+      default: true
+    },
+    noCache: {
+      type: Boolean,
+      default: false
+    }
   },
 
   created() {

--- a/src/components/widgets/PeopleAvatar.vue
+++ b/src/components/widgets/PeopleAvatar.vue
@@ -19,13 +19,10 @@
         }
       }"
       :title="person.full_name"
-      class="avatar-link"
     >
-      <img :src="avatarPath" v-if="person.has_avatar && noCache" />
-      <img v-lazy="avatarPath" :key="avatarKey" v-else-if="person.has_avatar" />
-      <span v-if="!person.has_avatar">
-        {{ initials }}
-      </span>
+      <img :src="person.avatarPath" v-if="person.has_avatar && noCache" />
+      <img v-lazy="person.avatarPath" v-else-if="person.has_avatar" />
+      <template v-else>{{ person.initials }}</template>
     </router-link>
   </span>
 
@@ -40,25 +37,15 @@
     }"
     v-else
   >
-    <img :src="avatarPath" v-if="person.has_avatar && noCache" />
-    <img v-lazy="avatarPath" :key="avatarKey" v-else-if="person.has_avatar" />
-    <span v-else>
-      {{ initials }}
-    </span>
+    <img :src="person.avatarPath" v-if="person.has_avatar && noCache" />
+    <img v-lazy="person.avatarPath" v-else-if="person.has_avatar" />
+    <template v-else>{{ person.initials }}</template>
   </span>
 </template>
 
 <script>
 export default {
-  name: 'person-avatar',
-
-  data() {
-    return {
-      avatarPath: '',
-      avatarKey: '',
-      initials: ''
-    }
-  },
+  name: 'people-avatar',
 
   props: {
     person: {
@@ -84,32 +71,6 @@ export default {
       type: Boolean,
       default: false
     }
-  },
-
-  created() {
-    this.reloadAvatar()
-  },
-
-  methods: {
-    reloadAvatar() {
-      this.avatarPath =
-        this.person.avatarPath + '?unique=' + this.person.uniqueHash
-      this.avatarKey = this.person.id + '-' + this.person.uniqueHash
-    }
-  },
-
-  mounted() {
-    this.initials = this.person.initials
-  },
-
-  watch: {
-    person() {
-      this.reloadAvatar()
-    },
-
-    'person.uniqueHash'() {
-      this.reloadAvatar()
-    }
   }
 }
 </script>
@@ -127,10 +88,6 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.avatar span {
-  flex: 1;
 }
 
 .avatar a {

--- a/src/components/widgets/PeopleAvatar.vue
+++ b/src/components/widgets/PeopleAvatar.vue
@@ -21,7 +21,11 @@
       :title="person.full_name"
     >
       <img :src="person.avatarPath" v-if="person.has_avatar && noCache" />
-      <img v-lazy="person.avatarPath" v-else-if="person.has_avatar" />
+      <img
+        loading="lazy"
+        :src="person.avatarPath"
+        v-else-if="person.has_avatar"
+      />
       <template v-else>{{ person.initials }}</template>
     </router-link>
   </span>
@@ -38,7 +42,11 @@
     v-else
   >
     <img :src="person.avatarPath" v-if="person.has_avatar && noCache" />
-    <img v-lazy="person.avatarPath" v-else-if="person.has_avatar" />
+    <img
+      loading="lazy"
+      :src="person.avatarPath"
+      v-else-if="person.has_avatar"
+    />
     <template v-else>{{ person.initials }}</template>
   </span>
 </template>

--- a/src/components/widgets/PeopleAvatarWithMenu.vue
+++ b/src/components/widgets/PeopleAvatarWithMenu.vue
@@ -10,20 +10,9 @@
         'font-size': fontSize + 'px'
       }"
     >
-      <img
-        class="avatar-image"
-        :src="avatarPath"
-        v-if="person.has_avatar && noCache"
-      />
-      <img
-        class="avatar-image"
-        v-lazy="avatarPath"
-        :key="avatarKey"
-        v-else-if="person.has_avatar"
-      />
-      <span v-else>
-        {{ initials }}
-      </span>
+      <img :src="person.avatarPath" v-if="person.has_avatar && noCache" />
+      <img v-lazy="person.avatarPath" v-else-if="person.has_avatar" />
+      <template v-else>{{ person.initials }}</template>
     </span>
 
     <div class="avatar-menu">
@@ -46,19 +35,11 @@
 import { UserIcon, UserMinusIcon } from 'vue-feather-icons'
 
 export default {
-  name: 'person-avatar',
+  name: 'people-avatar-with-menu',
 
   components: {
     UserIcon,
     UserMinusIcon
-  },
-
-  data() {
-    return {
-      avatarPath: '',
-      avatarKey: '',
-      initials: ''
-    }
   },
 
   props: {
@@ -89,32 +70,6 @@ export default {
       type: Boolean,
       default: false
     }
-  },
-
-  created() {
-    this.reloadAvatar()
-  },
-
-  methods: {
-    reloadAvatar() {
-      this.avatarPath =
-        this.person.avatarPath + '?unique=' + this.person.uniqueHash
-      this.avatarKey = this.person.id + '-' + this.person.uniqueHash
-    }
-  },
-
-  mounted() {
-    this.initials = this.person.initials
-  },
-
-  watch: {
-    person() {
-      this.reloadAvatar()
-    },
-
-    'person.uniqueHash'() {
-      this.reloadAvatar()
-    }
   }
 }
 </script>
@@ -133,10 +88,6 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.avatar span {
-  flex: 1;
 }
 
 .avatar a {

--- a/src/components/widgets/PeopleAvatarWithMenu.vue
+++ b/src/components/widgets/PeopleAvatarWithMenu.vue
@@ -11,7 +11,11 @@
       }"
     >
       <img :src="person.avatarPath" v-if="person.has_avatar && noCache" />
-      <img v-lazy="person.avatarPath" v-else-if="person.has_avatar" />
+      <img
+        loading="lazy"
+        :src="person.avatarPath"
+        v-else-if="person.has_avatar"
+      />
       <template v-else>{{ person.initials }}</template>
     </span>
 

--- a/src/components/widgets/PeopleAvatarWithMenu.vue
+++ b/src/components/widgets/PeopleAvatarWithMenu.vue
@@ -69,11 +69,26 @@ export default {
         color: '#FFF'
       })
     },
-    size: { type: Number, default: 40 },
-    'font-size': { type: Number, default: 18 },
-    'is-link': { type: Boolean, default: true },
-    'no-cache': { type: Boolean, default: false },
-    isMenu: { type: Boolean, default: false }
+    size: {
+      type: Number,
+      default: 40
+    },
+    fontsize: {
+      type: Number,
+      default: 18
+    },
+    isLink: {
+      type: Boolean,
+      default: true
+    },
+    noCache: {
+      type: Boolean,
+      default: false
+    },
+    isMenu: {
+      type: Boolean,
+      default: false
+    }
   },
 
   created() {

--- a/src/components/widgets/PeopleAvatarWithMenu.vue
+++ b/src/components/widgets/PeopleAvatarWithMenu.vue
@@ -10,11 +10,10 @@
         'font-size': fontSize + 'px'
       }"
     >
-      <img :src="person.avatarPath" v-if="person.has_avatar && noCache" />
       <img
-        loading="lazy"
+        :loading="this.isLazy ? 'lazy' : undefined"
         :src="person.avatarPath"
-        v-else-if="person.has_avatar"
+        v-if="person.has_avatar"
       />
       <template v-else>{{ person.initials }}</template>
     </span>
@@ -66,9 +65,9 @@ export default {
       type: Boolean,
       default: true
     },
-    noCache: {
+    isLazy: {
       type: Boolean,
-      default: false
+      default: true
     },
     isMenu: {
       type: Boolean,

--- a/src/components/widgets/PeopleName.vue
+++ b/src/components/widgets/PeopleName.vue
@@ -10,17 +10,16 @@
     :title="person.full_name"
     v-if="withLink"
   >
-    {{ person.first_name + ' ' + person.last_name }}
+    {{ person.full_name }}
   </router-link>
   <span class="person-name" v-else>
-    {{ person.first_name + ' ' + person.last_name }}
+    {{ person.full_name }}
   </span>
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
 export default {
-  name: 'person-name',
+  name: 'people-name',
   props: {
     person: {
       type: Object,
@@ -30,12 +29,6 @@ export default {
       type: Boolean,
       default: false
     }
-  },
-  computed: {
-    ...mapGetters([])
-  },
-  methods: {
-    ...mapActions([])
   }
 }
 </script>

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,6 @@ import Chart from 'chart.js'
 import Meta from 'vue-meta'
 import VueChartkick from 'vue-chartkick'
 import VueDragDrop from 'vue-drag-drop'
-import VueLazyload from 'vue-lazyload'
 import vuescroll from 'vue-scroll'
 import VueTextareaAutosize from 'vue-textarea-autosize'
 import VueWebsocket from 'vue-websocket-next'
@@ -25,7 +24,6 @@ Vue.use(Autocomplete)
 Vue.use(Meta)
 Vue.use(resizableColumn)
 Vue.use(VueChartkick, { adapter: Chart })
-Vue.use(VueLazyload)
 Vue.use(vuescroll)
 Vue.use(VueDragDrop)
 Vue.use(VueTextareaAutosize)

--- a/src/store/api/people.js
+++ b/src/store/api/people.js
@@ -49,8 +49,8 @@ export default {
     client.get('/api/data/persons?relations=true', callback)
   },
 
-  getPerson(personId, callback) {
-    client.get(`/api/data/persons/${personId}`, callback)
+  getPerson(personId) {
+    return client.pget(`/api/data/persons/${personId}`)
   },
 
   createPerson(person) {
@@ -122,12 +122,8 @@ export default {
     return client.ppost(path, formData)
   },
 
-  postAvatar(userId, formData, callback) {
-    client.post(
-      `/api/pictures/thumbnails/persons/${userId}`,
-      formData,
-      callback
-    )
+  postAvatar(userId, formData) {
+    return client.ppost(`/api/pictures/thumbnails/persons/${userId}`, formData)
   },
 
   changePassword(form, callback) {

--- a/src/store/modules/people.js
+++ b/src/store/modules/people.js
@@ -203,7 +203,7 @@ const getters = {
   getPersonOptions: state =>
     state.people.map(person => {
       return {
-        label: `${person.first_name} ${person.last_name}`,
+        label: person.full_name,
         value: person.id
       }
     }),

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -926,9 +926,7 @@ const mutations = {
 
   [LOAD_TASK_COMMENTS_END](state, { taskId, comments }) {
     comments.forEach(comment => {
-      comment.person = personStore.helpers.addAdditionalInformation(
-        comment.person
-      )
+      comment.person = personStore.state.personMap.get(comment.person_id)
     })
     state.taskComments[taskId] = sortComments(comments)
     Vue.set(

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -1,4 +1,3 @@
-import Vue from 'vue/dist/vue'
 import peopleApi from '@/store/api/people'
 import peopleStore from '@/store/modules/people'
 import taskStatusStore from '@/store/modules/taskstatus'
@@ -323,16 +322,14 @@ const actions = {
     })
   },
 
-  uploadAvatar({ commit, state }, callback) {
-    peopleApi.postAvatar(state.user.id, state.avatarFormData, err => {
-      if (!err) commit(UPLOAD_AVATAR_END, state.user.id)
-      if (callback) callback(err)
-    })
+  async uploadAvatar({ commit, state }) {
+    await peopleApi.postAvatar(state.user.id, state.avatarFormData)
+    commit(UPLOAD_AVATAR_END, state.user.id)
   },
 
-  clearAvatar({ commit, state }) {
-    commit(CLEAR_AVATAR)
-    return peopleApi.clearAvatar()
+  async clearAvatar({ commit, state }) {
+    await peopleApi.clearAvatar()
+    commit(CLEAR_AVATAR, state.user.id)
   },
 
   setTodosSearch({ commit, state }, searchText) {
@@ -614,10 +611,9 @@ const mutations = {
 
   [UPLOAD_AVATAR_END](state) {
     if (state.user) {
-      const randomHash = Math.random().toString(36).substring(7)
+      const timestamp = Date.now()
+      state.user.avatarPath = `/api/pictures/thumbnails/persons/${state.user.id}.png?t=${timestamp}`
       state.user.has_avatar = true
-      Vue.set(state.user, 'uniqueHash', randomHash)
-      state.user.avatarPath = `/api/pictures/thumbnails/persons/${state.user.id}.png`
     }
   },
 


### PR DESCRIPTION
**Problem**
User avatar images are loaded too many times because they are not effectively cached.
This unnecessarily increases the network load.

**Solution**
- Refactor how to cache images and sync people in the UI, based on each person's last update date.
- Replace v-lazy library by native lazy loading.
- Add an option to disable lazy loading when necessary.
