### PR TITLE
Revert "[qa] remove computed value already defined as a prop"

### DIFF
--- a/src/components/modals/EditTaskTypeModal.vue
+++ b/src/components/modals/EditTaskTypeModal.vue
@@ -148,8 +148,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['taskTypeStatusOptions', 'departments']),
-
+    ...mapGetters(['taskTypes', 'taskTypeStatusOptions', 'departments']),
     isEditing() {
       return this.taskTypeToEdit && this.taskTypeToEdit.id
     }


### PR DESCRIPTION
This reverts commit c185d2d916ceef6d90a97dae9135eb4e54fc169d.

**Problem**
- taskTypes list is missing

**Solution**
- restore taskTypes getter
