### PR TITLE
Improve 3D model preview

### DIFF
--- a/src/components/previews/ObjectViewer.vue
+++ b/src/components/previews/ObjectViewer.vue
@@ -83,7 +83,9 @@ export default {
         const materials = texture[materialsSymbol]
         materials.forEach(material => {
           material.wireframe = true
-          material.emissive.setHex(0xc0c0c0)
+          material.color.setHex(0xc0c0c0)
+          material.emissive?.setHex(0xc0c0c0)
+          material.emissiveMap = null
           material.envMapIntensity = 0
         })
       }

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -5,6 +5,7 @@ const ALL_EXTENSIONS = [
   'mov',
   'obj',
   'glb',
+  'gltf',
   'pdf',
   'ma',
   'mb',


### PR DESCRIPTION
**Problem**
- On preview panel, "glTF" files are supported by Kitsu as 3D model, but not available as upload extension.
- The color of the wireframe rendering cannot always be applied to materials.

**Solution**
- Allow to upload *.gltf as preview.
- improve settings on wireframe materials.
