### PR TITLE
Improve thumbnail in video progress bar

### DIFF
--- a/src/components/pages/Edit.vue
+++ b/src/components/pages/Edit.vue
@@ -72,9 +72,10 @@
               :current-preview-index="currentPreviewIndex"
               :muted="isMuted"
               @max-duration-update="onMaxDurationUpdate"
+              @frame-update="onFrameUpdate"
               @metadata-loaded="onMetadataLoaded"
               @repeat="onVideoRepeated"
-              @frame-update="onFrameUpdate"
+              @video-loaded="onVideoLoaded"
               v-show="isCurrentPreviewMovie && !isLoading"
             />
 
@@ -173,9 +174,11 @@
           class="video-progress pull-bottom"
           :annotations="annotations"
           :frame-duration="frameDuration"
+          :movie-dimensions="movieDimensions"
           :nb-frames="nbFrames"
           :handle-in="-1"
           :handle-out="-1"
+          :preview-id="currentPreview ? currentPreview.id : ''"
           @start-scrub="onScrubStart"
           @end-scrub="onScrubEnd"
           @progress-changed="onProgressChanged"
@@ -655,6 +658,7 @@ export default {
       currentSection: 'infos',
       isLoading: true,
       isError: false,
+      movieDimensions: { width: 0, height: 0 },
       previewRoomRef: 'edits-preview-room',
       previewFileMap: new Map(),
       tempMode: false,
@@ -884,6 +888,13 @@ export default {
         deletions,
         updates
       })
+    },
+
+    onVideoLoaded() {
+      this.movieDimensions = {
+        width: this.currentPreview.width,
+        height: this.currentPreview.height
+      }
     },
 
     scrollToEntity() {

--- a/src/components/previews/VideoProgress.vue
+++ b/src/components/previews/VideoProgress.vue
@@ -384,13 +384,16 @@ export default {
       this.updateProgressBar(0)
     },
 
-    previewId() {
-      if (this.movieDimensions.width && this.previewId) {
-        this.isTileLoading = true
-        const img = new Image()
-        img.src = this.tilePath
-        img.onload = () => {
-          this.isTileLoading = false
+    previewId: {
+      immediate: true,
+      handler() {
+        if (this.previewId) {
+          this.isTileLoading = true
+          const img = new Image()
+          img.src = this.tilePath
+          img.onload = () => {
+            this.isTileLoading = false
+          }
         }
       }
     }


### PR DESCRIPTION
**Problem**
- On Edit page, there is no thumbnail on video progress bar.
- Too much styling calculation on mouseover progress bar.
- The tile image is not preloading of first init of component.

**Solution**
- Fix missing tile on video progress for Edit page.
- Refactor frame tile style in order to reduce compute.
- Improve tile preloading on init component.


