### PR TITLE
Improve production schedule

### DIFF
--- a/src/components/modals/EditMilestoneModal.vue
+++ b/src/components/modals/EditMilestoneModal.vue
@@ -20,17 +20,17 @@
         <text-field
           ref="nameField"
           :label="$t('schedule.milestone.name')"
-          v-model="form.name"
+          :maxlength="40"
+          v-model.trim="form.name"
           @enter="confirm"
           v-focus
         />
         <button-simple
           class="button is-link error"
-          text="Delete milestone"
+          :text="$t('schedule.milestone.delete_milestone')"
           @click="$emit('remove-milestone', milestoneToEdit)"
           v-if="isEdit"
         />
-
         <modal-footer
           :error-text="$t('schedule.milestone.error')"
           :is-error="isError"
@@ -48,7 +48,7 @@
 /*
  * Modal used to edit and create milestones.
  */
-import { mapGetters, mapActions } from 'vuex'
+import { mapActions } from 'vuex'
 import { modalMixin } from '@/components/modals/base_modal'
 
 import ButtonSimple from '@/components/widgets/ButtonSimple'
@@ -97,8 +97,6 @@ export default {
   },
 
   computed: {
-    ...mapGetters([]),
-
     isEdit() {
       return this.milestoneToEdit.id !== undefined
     },
@@ -118,7 +116,7 @@ export default {
     reset() {
       this.form = {
         id: this.milestoneToEdit.id || undefined,
-        name: `${this.milestoneToEdit.name || ''}`,
+        name: this.milestoneToEdit.name || '',
         date: this.milestoneToEdit.date
       }
     }

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -8,7 +8,7 @@
           </label>
           <datepicker
             wrapper-class="datepicker"
-            input-class="date-input input"
+            input-class="date-input input short"
             :language="locale"
             :disabled-dates="{ days: [6, 0] }"
             :monday-first="true"
@@ -22,7 +22,7 @@
           </label>
           <datepicker
             wrapper-class="datepicker"
-            input-class="date-input input"
+            input-class="date-input input short"
             :language="locale"
             :disabled-dates="{ days: [6, 0] }"
             :monday-first="true"

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -30,14 +30,15 @@
             v-model="selectedEndDate"
           />
         </div>
+        <!--
         <text-field
           class="flexrow-item overall-man-days"
           type="number"
           v-model="overallManDays"
           :label="$t('schedule.overall_man_days')"
           :disabled="!isCurrentUserAdmin"
-          v-show="false"
         />
+        -->
         <combobox-number
           class="flexrow-item zoom-level"
           :label="$t('schedule.zoom_level')"
@@ -85,7 +86,6 @@ import { daysToMinutes, parseDate } from '@/lib/time'
 
 import ComboboxNumber from '@/components/widgets/ComboboxNumber'
 import TaskInfo from '@/components/sides/TaskInfo'
-import TextField from '@/components/widgets/TextField'
 import Schedule from '@/components/pages/schedule/Schedule'
 
 export default {
@@ -94,14 +94,13 @@ export default {
     ComboboxNumber,
     Datepicker,
     Schedule,
-    TaskInfo,
-    TextField
+    TaskInfo
   },
 
   data() {
     return {
       currentTask: null,
-      overallManDays: 0,
+      // overallManDays: 0,
       endDate: moment().add(6, 'months').endOf('day'),
       scheduleItems: [],
       startDate: moment().startOf('day'),
@@ -236,7 +235,7 @@ export default {
       if (this.currentProduction.end_date) {
         this.endDate = parseDate(this.currentProduction.end_date)
       }
-      this.overallManDays = this.currentProduction.man_days
+      // this.overallManDays = this.currentProduction.man_days
       this.selectedStartDate = this.startDate.toDate()
       this.selectedEndDate = this.endDate.toDate()
       this.loadData()
@@ -397,14 +396,14 @@ export default {
       })
     },
 
-    overallManDays() {
-      if (this.overallManDays !== this.currentProduction.man_days) {
-        this.editProduction({
-          ...this.currentProduction,
-          man_days: this.overallManDays
-        })
-      }
-    },
+    // overallManDays() {
+    //   if (this.overallManDays !== this.currentProduction.man_days) {
+    //     this.editProduction({
+    //       ...this.currentProduction,
+    //       man_days: this.overallManDays
+    //     })
+    //   }
+    // },
 
     currentProduction() {
       this.reset()

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -382,18 +382,30 @@ export default {
   watch: {
     selectedStartDate() {
       this.startDate = parseDate(this.selectedStartDate)
-      this.editProduction({
-        ...this.currentProduction,
-        start_date: this.startDate.format('YYYY-MM-DD')
-      })
+      const start_date = this.startDate.format('YYYY-MM-DD')
+      if (
+        this.currentProduction.start_date &&
+        this.currentProduction.start_date !== start_date
+      ) {
+        this.editProduction({
+          ...this.currentProduction,
+          start_date
+        })
+      }
     },
 
     selectedEndDate() {
       this.endDate = parseDate(this.selectedEndDate)
-      this.editProduction({
-        ...this.currentProduction,
-        end_date: this.endDate.format('YYYY-MM-DD')
-      })
+      const end_date = this.endDate.format('YYYY-MM-DD')
+      if (
+        this.currentProduction.end_date &&
+        this.currentProduction.end_date !== end_date
+      ) {
+        this.editProduction({
+          ...this.currentProduction,
+          end_date
+        })
+      }
     },
 
     // overallManDays() {

--- a/src/components/pages/schedule/Schedule.vue
+++ b/src/components/pages/schedule/Schedule.vue
@@ -453,7 +453,6 @@
     </div>
 
     <edit-milestone-modal
-      ref="edit-milestone-modal"
       :active="modals.edit"
       :is-loading="loading.edit"
       :is-error="errors.edit"
@@ -1566,12 +1565,13 @@ export default {
       this.saveMilestone(milestone)
         .then(() => {
           this.modals.edit = false
-          this.loading.edit = false
         })
         .catch(err => {
           console.error(err)
-          this.loading.edit = false
           this.errors.edit = true
+        })
+        .finally(() => {
+          this.loading.edit = false
         })
     },
 
@@ -1580,12 +1580,13 @@ export default {
       this.deleteMilestone(milestone)
         .then(() => {
           this.modals.edit = false
-          this.loading.edit = false
         })
         .catch(err => {
           console.error(err)
-          this.loading.edit = false
           this.errors.edit = true
+        })
+        .finally(() => {
+          this.loading.edit = false
         })
     },
 
@@ -1612,8 +1613,6 @@ export default {
       )
     }
   },
-
-  socket: {},
 
   watch: {
     startDate() {

--- a/src/components/pages/schedule/Schedule.vue
+++ b/src/components/pages/schedule/Schedule.vue
@@ -185,8 +185,10 @@
         >
           <div
             class="day"
+            :class="{
+              'without-milestones': !withMilestones
+            }"
             :key="'header-' + day.text + '-' + index"
-            :style="dayStyle(day)"
             v-for="(day, index) in daysAvailable"
           >
             <div
@@ -194,19 +196,13 @@
               @click="showEditMilestoneModal(day, currentMilestones[day.text])"
               v-if="currentMilestones[day.text] && withMilestones"
             >
-              <div class="milestone-tooltip" :style="milestoneTooltipStyle">
-                <span>
-                  {{ currentMilestones[day.text].name }}
-                </span>
+              <div class="milestone-tooltip">
+                {{ currentMilestones[day.text].name }}
               </div>
-              <div>
-                <span class="bull">&bull;</span>
-              </div>
+              <div class="bull pointer">&bull;</div>
             </div>
             <div class="milestone" v-else-if="withMilestones">
-              <div>
-                <span class="bull">&nbsp;</span>
-              </div>
+              <div class="bull">&nbsp;</div>
             </div>
 
             <div
@@ -221,8 +217,12 @@
                 @click="
                   showEditMilestoneModal(day, currentMilestones[day.text])
                 "
+                v-if="withMilestones && isCurrentUserManager"
               >
-                <span>+</span>
+                <span class="button">
+                  <edit-icon size="10" v-if="currentMilestones[day.text]" />
+                  <plus-icon size="12" stroke-width="3" v-else />
+                </span>
               </div>
               <div class="date-name">
                 <span class="month-name" v-if="day.newMonth">
@@ -248,20 +248,16 @@
         >
           <div
             class="day"
+            :class="{
+              'without-milestones': !withMilestones
+            }"
             :key="'header-' + week.weekText + '-' + index"
             :title="week.label"
-            :style="dayStyle(week)"
             v-for="(week, index) in weeksAvailable"
           >
-            <div class="milestone">
-              <div>
-                <span class="bull">&nbsp;</span>
-              </div>
-            </div>
             <div
               :class="{
-                'with-milestones': false,
-                'date-widget': true
+                'hidden-milestones': withMilestones
               }"
             >
               <div class="date-name">
@@ -482,7 +478,12 @@ import {
   parseDate
 } from '@/lib/time'
 
-import { ChevronRightIcon, ChevronDownIcon } from 'vue-feather-icons'
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  EditIcon,
+  PlusIcon
+} from 'vue-feather-icons'
 import EditMilestoneModal from '@/components/modals/EditMilestoneModal'
 import PeopleAvatar from '@/components/widgets/PeopleAvatar'
 import ProductionName from '@/components/widgets/ProductionName'
@@ -494,6 +495,8 @@ export default {
   components: {
     ChevronDownIcon,
     ChevronRightIcon,
+    EditIcon,
+    PlusIcon,
     EditMilestoneModal,
     PeopleAvatar,
     ProductionName,
@@ -845,11 +848,6 @@ export default {
         right: 0,
         width: `${this.cellWidth * diff}px`
       }
-    },
-
-    milestoneTooltipStyle() {
-      // arbitrary calculus
-      return { left: -40 - 10 * (3 - this.zoomLevel) + 'px' }
     },
 
     dayAfterEndDate() {
@@ -1406,13 +1404,6 @@ export default {
       }
     },
 
-    dayStyle() {
-      return {
-        'min-width': this.cellWidth + 'px',
-        'max-width': this.cellWidth + 'px'
-      }
-    },
-
     entityLineStyle(timeElement, root = false, header = false) {
       const style = {}
       let color = timeElement.color
@@ -1737,6 +1728,7 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
         }
 
         .month-name {
+          background-color: $dark-grey-2;
           border-left: 2px solid white;
           color: white;
         }
@@ -1784,10 +1776,7 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
       border: 1px solid $dark-grey;
       box-shadow: 0 2px 2px 0 $dark-grey-strong;
     }
-    .milestone-tooltip:after {
-      border-color: transparent;
-      border-top-color: $dark-grey-lighter;
-    }
+    .milestone-tooltip:after,
     .milestone-tooltip:before {
       border-color: transparent;
       border-top-color: $dark-grey-lighter;
@@ -1875,7 +1864,7 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
   .timeline-header {
     white-space: nowrap;
     position: relative;
-    margin-left: 1px;
+    margin-left: 2px;
     padding-bottom: 0;
     overflow: hidden;
     padding-top: 24px;
@@ -1883,22 +1872,23 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
     .day {
       display: inline-block;
       font-size: 0.8em;
-      padding-bottom: 0;
-      height: 30px;
+
+      &.without-milestones {
+        margin-top: 10px;
+      }
 
       .day-name {
-        border-left: 2px solid transparent;
         color: $grey;
-        padding-bottom: 0em;
-        margin-bottom: 0em;
-        padding-left: 0;
+        padding-left: 1px;
         text-align: center;
-        padding-top: 0em;
         text-transform: uppercase;
 
-        &.new-month,
         &.new-week {
           border-left: 2px solid black;
+
+          .zoom-level-1 & {
+            border-left: none;
+          }
         }
       }
 
@@ -1908,15 +1898,17 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
       }
 
       .month-name {
+        background-color: white;
         border-left: 2px solid black;
         bottom: 0;
         color: black;
         font-size: 0.9em;
         padding-bottom: 24px;
-        padding-left: 1em;
+        padding-left: 0.5em;
         top: 10px;
         text-transform: uppercase;
         position: absolute;
+        z-index: -1;
       }
     }
   }
@@ -1951,10 +1943,10 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
         left: 0;
         top: 0;
         bottom: 0;
-        background: rgba(200, 255, 200, 0.3);
-        z-index: 100;
         width: 1px;
         border-left: 1px dashed black;
+        margin-left: -0.5px;
+        z-index: 100;
       }
 
       .entity-line {
@@ -2031,31 +2023,23 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
   .timeline-content {
     background-image: url('../../../assets/background/schedule-white-1.png');
   }
+  .day {
+    width: 20px;
+  }
+  .milestone-tooltip {
+    left: 10px;
+  }
 }
 
 .zoom-level-1 {
   .timeline-content {
     background-image: url('../../../assets/background/schedule-white-1-weekend.png');
   }
-
-  .timeline {
-    .timeline-header {
-      .day {
-        font-size: 0.8em;
-        padding-left: 0;
-
-        .day-name {
-          padding-left: 2px;
-          &.new-week {
-            border-left: solid 2px transparent;
-          }
-          &.new-month {
-            padding-left: 4px;
-            border-left: solid 2px white;
-          }
-        }
-      }
-    }
+  .day {
+    width: 20px;
+  }
+  .milestone-tooltip {
+    left: 10px;
   }
 }
 
@@ -2063,11 +2047,23 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
   .timeline-content {
     background-image: url('../../../assets/background/schedule-white-2-weekend.png');
   }
+  .day {
+    width: 40px;
+  }
+  .milestone-tooltip {
+    left: 20px;
+  }
 }
 
 .schedule.zoom-level-3 {
   .timeline-content {
     background-image: url('../../../assets/background/schedule-white-3-weekend.png');
+  }
+  .day {
+    width: 60px;
+  }
+  .milestone-tooltip {
+    left: 30px;
   }
 }
 
@@ -2160,11 +2156,10 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
 }
 
 .milestone {
-  cursor: pointer;
   margin-bottom: 0;
+  min-height: 40px;
   position: relative;
   text-align: center;
-  min-height: 35px;
 
   .flexrow-item {
     margin-left: 5px;
@@ -2177,25 +2172,27 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
   }
 
   .milestone-tooltip {
+    visibility: hidden;
+    display: inline-block;
     border: 1px solid #eee;
     border-radius: 5px;
     box-shadow: 0 2px 2px 0 #eee;
     font-size: 0.8em;
     font-weight: bold;
-    opacity: 0;
-    padding: 2px;
+    padding: 2px 5px;
     position: relative;
-    border: 1px solid #eeeeee;
-    width: 140px;
+    border: 1px solid #eee;
+    min-width: 100px;
     text-align: center;
     top: -5px;
     background: white;
     z-index: 100;
+    transform: translateX(-50%);
   }
 
   &:hover {
     .milestone-tooltip {
-      opacity: 1;
+      visibility: visible;
     }
   }
 
@@ -2236,35 +2233,40 @@ const setItemPositions = (items, attributeName, unitOfTime = 'days') => {
 }
 
 .date-widget {
-  padding-top: 8px;
+  height: 20px;
+  padding-top: 3px;
 
   .add-milestone {
     display: none;
     cursor: pointer;
     text-align: center;
 
-    span {
+    .button {
       background: black;
+      border: none;
       color: white;
-      border-radius: 50%;
-      font-size: 1.4em;
-      line-height: 0.6em;
-      font-weight: bold;
-      padding: 0 6px 2px 6px;
+      height: 20px;
+      margin-top: -2px;
+      padding: 0;
+      width: 20px;
     }
   }
 
-  &:hover.with-milestones {
+  &.with-milestones:hover {
     background: $light-green-light;
-    height: 100%;
+
     .add-milestone {
       display: block;
     }
 
-    .date-name {
+    .day-name {
       display: none;
     }
   }
+}
+
+.hidden-milestones {
+  margin-top: 43px;
 }
 
 .timebar-wrapper {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1101,6 +1101,7 @@ export default {
     zoom_level: 'Zoom level',
     milestone: {
       add_milestone: 'Add milestone for',
+      delete_milestone: 'Delete milestone',
       edit_milestone: 'Edit milestone for',
       name: 'Name',
       error: 'An error occurred while adding or editing the milestone. Please try again.'

--- a/src/store/modules/schedule.js
+++ b/src/store/modules/schedule.js
@@ -115,12 +115,9 @@ const actions = {
 
   loadMilestones({ commit, rootState }) {
     const production = rootState.productions.currentProduction
-    return scheduleApi
-      .getMilestones(production)
-      .then(milestones => {
-        commit(ADD_MILESTONES, milestones)
-      })
-      .catch(console.error)
+    return scheduleApi.getMilestones(production).then(milestones => {
+      commit(ADD_MILESTONES, milestones)
+    })
   },
 
   saveMilestone({ commit, rootState }, milestone) {
@@ -132,22 +129,16 @@ const actions = {
           commit(ADD_MILESTONE, milestone)
         })
     } else {
-      return scheduleApi
-        .updateMilestone(milestone)
-        .then(milestone => {
-          commit(ADD_MILESTONE, milestone)
-        })
-        .catch(console.error)
+      return scheduleApi.updateMilestone(milestone).then(milestone => {
+        commit(ADD_MILESTONE, milestone)
+      })
     }
   },
 
-  deleteMilestone({ commit, rootState }, milestone) {
-    return scheduleApi
-      .deleteMilestone(milestone)
-      .then(() => {
-        commit(REMOVE_MILESTONE, milestone)
-      })
-      .catch(console.error)
+  deleteMilestone({ commit }, milestone) {
+    return scheduleApi.deleteMilestone(milestone).then(() => {
+      commit(REMOVE_MILESTONE, milestone)
+    })
   }
 }
 


### PR DESCRIPTION
**Problem**
- When loading Production Schedule loading, two backup calls are executed without changing data.
- In the modal to edit a milestone, a too long name will crash in silent, without error message.
- UX glitches on add/edit milestone buttons positioned at the start of the month.


**Solution**
- Avoid useless save call on init Production Schedule.
- Add a max length to the milestone name field, and handle error in modal on failure.
- Rework css of milestone.
