### PR TITLE
Fix upload multi previews

### DIFF
--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -518,6 +518,7 @@ const actions = {
     { taskId, comment, revision, taskStatusId, form, attachment, checklist }
   ) {
     const data = { taskId, taskStatusId, comment, attachment, checklist }
+    const remainingPreviews = [...state.previewForms].splice(1)
     commit(ADD_PREVIEW_START)
     let newComment
     locks[taskId] = true
@@ -583,7 +584,7 @@ const actions = {
                   return Promise.resolve(preview)
                 })
             }
-            const remainingPreviews = [...state.previewForms].splice(1)
+            // run promise in sequence
             return remainingPreviews.reduce((accumulatorPromise, form) => {
               return accumulatorPromise.then(() => {
                 return addPreview(form)

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -514,7 +514,7 @@ const actions = {
   },
 
   commentTaskWithPreview(
-    { commit, getters, state, dispatch },
+    { commit, state },
     { taskId, comment, revision, taskStatusId, form, attachment, checklist }
   ) {
     const data = { taskId, taskStatusId, comment, attachment, checklist }
@@ -581,23 +581,21 @@ const actions = {
                     commentId: newComment.id,
                     comment: newComment
                   })
-                  return Promise.resolve(preview)
+                  return preview
                 })
             }
             // run promise in sequence
             return remainingPreviews.reduce((accumulatorPromise, form) => {
-              return accumulatorPromise.then(() => {
-                return addPreview(form)
-              })
+              return accumulatorPromise.then(() => addPreview(form))
             }, Promise.resolve())
           } else {
-            return Promise.resolve(preview)
+            return preview
           }
         })
         .then(preview => {
           commit(NEW_TASK_COMMENT_END, { comment: newComment, taskId })
           commit(CLEAR_UPLOAD_PROGRESS)
-          return Promise.resolve({ newComment, preview })
+          return { newComment, preview }
         })
     )
   },


### PR DESCRIPTION
**Problem**
- On task panel, if you upload multi preview files when publishing a new revision, only the first preview is uploaded.

**Solution**
- Init the list of previews to upload before starting the publishing process, to avoid early clearing of the state from realtime update (websocket).
