### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, current]
     steps:
       - uses: actions/checkout@v4
       - name: Setup node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'


### PR DESCRIPTION
**Problem**
- Node 16 actions are deprecated on GitHub Actions (see [changlog](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/))
- The `current` release of Nodeis not covered by matrix testing.

**Solution**
- Bump setup-node action to v4 (run on Node 20, see [release note](https://github.com/actions/setup-node/releases/tag/v4.0.0)).
- Add the "current" Node version to matrix testing (currently Node 21, see [releases](https://nodejs.org/en/about/previous-releases)).
