### PR TITLE
[breakdown] fix refresh of episode casting

### DIFF
--- a/src/store/api/breakdown.js
+++ b/src/store/api/breakdown.js
@@ -8,7 +8,7 @@ export default {
 
   getSequenceCasting(productionId, sequenceId, episodeId) {
     let path = `/api/data/projects/${productionId}/sequences/${sequenceId}/casting`
-    if (episodeId) {
+    if (episodeId && episodeId !== 'all') {
       path = `/api/data/projects/${productionId}/episodes/${episodeId}/sequences/all/casting`
     }
     return client.pget(path)


### PR DESCRIPTION
**Problem**
- When we are on episodes casting, the refresh is broken due to the use of the wrong route. 

**Solution**
- Use correct route to get episodes casting. 
