### PR TITLE
Various fixes and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,3 @@ tests/test-bundle.js
 # Custom
 TODO
 QA
-
-# Cache
-.eslintcache

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ tests/test-bundle.js
 # IDE
 .idea/
 .vscode/
+.eslintcache
 
 # Custom
 TODO

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -63,7 +63,12 @@
         v-for="person in assignees"
         v-if="isAssignees && !isCurrentUserClient && !disabled"
       >
-        <img loading="lazy" :src="person.avatarPath" v-if="person.has_avatar" />
+        <img
+          loading="lazy"
+          alt=""
+          :src="person.avatarPath"
+          v-if="person.has_avatar"
+        />
         <template v-else>{{ person.initials }}</template>
       </span>
       <span class="subscribed" v-if="task && task.is_subscribed">

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -36,12 +36,7 @@
             emergency: task.priority === 3
           }"
           :title="formatPriority(task.priority)"
-          v-if="
-            !isCurrentUserClient &&
-            !disabled &&
-            task.priority > 0 &&
-            !this.taskStatus.is_done
-          "
+          v-if="!isCurrentUserClient && !disabled && task.priority > 0"
         >
           {{ priority }}
         </span>
@@ -233,7 +228,7 @@ export default {
     },
 
     priority() {
-      if (this.task.priority && !this.taskStatus.is_done) {
+      if (this.task.priority) {
         if (this.task.priority === 3) {
           return '!!!'
         } else if (this.task.priority === 2) {

--- a/src/components/modals/BuildFilterModal.vue
+++ b/src/components/modals/BuildFilterModal.vue
@@ -807,7 +807,6 @@ export default {
     },
 
     setFiltersFromAssignedToQuery(filter) {
-      console.log(filter)
       this.assignation.value = filter.excluding ? '-assignedto' : 'assignedto'
       this.assignation.person = this.people.find(p => p.id === filter.personId)
       this.assignation.taskTypeId = filter.taskType?.id

--- a/src/components/modals/BuildFilterModal.vue
+++ b/src/components/modals/BuildFilterModal.vue
@@ -161,7 +161,7 @@
           {{ $t('entities.build_filter.assignation') }}
         </h3>
 
-        <div class="flexrow" v-if="!isCurrentUserVendor">
+        <div class="flexrow assignation-filter" v-if="!isCurrentUserVendor">
           <combobox
             class="flexrow-item"
             :options="assignation.options"
@@ -169,19 +169,30 @@
             v-model="assignation.value"
           />
 
-          <combobox-task-type
-            class="flexrow-item"
-            :task-type-list="taskTypeList"
-            v-model="assignation.taskTypeId"
-            v-if="['assigned', 'unassigned'].includes(assignation.value)"
-          />
+          <div class="flexcolumn">
+            <people-field
+              class="flexrow-item assignation-person"
+              :people="team"
+              big
+              v-model="assignation.person"
+              v-if="['assignedto', '-assignedto'].includes(assignation.value)"
+            />
+            <span class="flexrow-item"> on </span>
 
-          <people-field
-            class="flexrow-item"
-            :people="team"
-            v-model="assignation.person"
-            v-if="['assignedto', '-assignedto'].includes(assignation.value)"
-          />
+            <combobox-task-type
+              class="flexrow-item"
+              :task-type-list="taskTypeList"
+              v-model="assignation.taskTypeId"
+              v-if="
+                [
+                  'assigned',
+                  'unassigned',
+                  'assignedto',
+                  '-assignedto'
+                ].includes(assignation.value)
+              "
+            />
+          </div>
         </div>
 
         <h3 class="subtitle">
@@ -538,8 +549,9 @@ export default {
       if (this.assignation.value !== 'nofilter') {
         if (this.assignation.person) {
           let value = this.assignation.person.name
+          const taskType = this.taskTypeMap.get(this.assignation.taskTypeId)
           if (this.assignation.value === '-assignedto') value = `-${value}`
-          query += ` assignedto=[${value}]`
+          query += ` assignedto[${taskType.name}]=[${value}]`
         } else if (this.assignation.taskTypeId) {
           const taskType = this.taskTypeMap.get(this.assignation.taskTypeId)
           const value =
@@ -795,8 +807,10 @@ export default {
     },
 
     setFiltersFromAssignedToQuery(filter) {
+      console.log(filter)
       this.assignation.value = filter.excluding ? '-assignedto' : 'assignedto'
       this.assignation.person = this.people.find(p => p.id === filter.personId)
+      this.assignation.taskTypeId = filter.taskType?.id
     },
 
     setFiltersFromThumbnailQuery(filter) {
@@ -904,5 +918,17 @@ export default {
 .value-column {
   flex-direction: column;
   align-items: flex-start;
+}
+
+.assignation-filter {
+  align-items: flex-start;
+
+  input {
+    line-height: 30px;
+  }
+}
+
+.assignation-person {
+  margin-bottom: 0.5em;
 }
 </style>

--- a/src/components/modals/EditAssetTypeModal.vue
+++ b/src/components/modals/EditAssetTypeModal.vue
@@ -26,6 +26,13 @@
             v-focus
           />
 
+          <combobox-boolean
+            :label="$t('main.archived')"
+            @enter="runConfirmation"
+            v-model="form.archived"
+            v-if="isEditing"
+          />
+
           <label class="label">
             {{ $t('asset_types.fields.task_types') }}
           </label>
@@ -75,6 +82,7 @@ import { modalMixin } from '@/components/modals/base_modal'
 import { sortByName } from '@/lib/sorting'
 
 import Combobox from '@/components/widgets/Combobox.vue'
+import ComboboxBoolean from '@/components/widgets/ComboboxBoolean.vue'
 import ModalFooter from '@/components/modals/ModalFooter'
 import TextField from '@/components/widgets/TextField'
 import TaskTypeName from '@/components/widgets/TaskTypeName'
@@ -84,6 +92,7 @@ export default {
   mixins: [modalMixin],
   components: {
     Combobox,
+    ComboboxBoolean,
     TaskTypeName,
     ModalFooter,
     TextField
@@ -124,6 +133,10 @@ export default {
       'assetTypes',
       'assetTypeStatusOptions'
     ]),
+
+    isEditing() {
+      return this.assetTypeToEdit && this.assetTypeToEdit.id
+    },
 
     availableTaskTypes() {
       const taskTypes = sortByName(
@@ -178,12 +191,14 @@ export default {
         const types = this.assetTypeToEdit.task_types || []
         this.form = {
           name: this.assetTypeToEdit.name,
-          task_types: [...types]
+          task_types: [...types],
+          archived: String(this.assetTypeToEdit.archived === true)
         }
       } else {
         this.form = {
           name: '',
-          task_types: []
+          task_types: [],
+          archived: 'false'
         }
       }
     }

--- a/src/components/modals/EditDepartmentsModal.vue
+++ b/src/components/modals/EditDepartmentsModal.vue
@@ -27,6 +27,12 @@
             :label="$t('departments.fields.color')"
             v-model="form.color"
           />
+          <combobox-boolean
+            :label="$t('main.archived')"
+            @enter="runConfirmation"
+            v-model="form.archived"
+            v-if="isEditing"
+          />
         </form>
         <modal-footer
           :error-text="$t('departments.create_error')"
@@ -44,15 +50,17 @@
 import { mapGetters, mapActions } from 'vuex'
 import { modalMixin } from '@/components/modals/base_modal'
 
+import ColorField from '@/components/widgets/ColorField'
+import ComboboxBoolean from '@/components/widgets/ComboboxBoolean'
 import ModalFooter from '@/components/modals/ModalFooter'
 import TextField from '@/components/widgets/TextField'
-import ColorField from '@/components/widgets/ColorField'
 
 export default {
   name: 'edit-departments-modal',
   mixins: [modalMixin],
   components: {
     ColorField,
+    ComboboxBoolean,
     ModalFooter,
     TextField
   },
@@ -87,7 +95,11 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['assetTypes', 'assetTypeStatusOptions'])
+    ...mapGetters(['assetTypes', 'assetTypeStatusOptions']),
+
+    isEditing() {
+      return this.departmentToEdit && this.departmentToEdit.id
+    }
   },
 
   methods: {
@@ -108,10 +120,18 @@ export default {
     },
 
     departmentToEdit() {
-      if (this.departmentToEdit) {
+      if (this.isEditing) {
         this.form.name = this.departmentToEdit.name
         this.form.color = this.departmentToEdit.color
         this.form.id = this.departmentToEdit.id
+        this.form.archived = this.departmentToEdit.archive
+      } else {
+        this.form = {
+          name: '',
+          color: '',
+          id: null,
+          archived: String(this.departmentToEdit.archive === true)
+        }
       }
     }
   }

--- a/src/components/pages/AssetTypes.vue
+++ b/src/components/pages/AssetTypes.vue
@@ -6,9 +6,16 @@
       @new-clicked="onNewClicked"
     />
 
-    <asset-type-list
+    <route-tabs
       class="mt2"
-      :entries="assetTypes"
+      :active-tab="activeTab"
+      :tabs="tabs"
+      route-name="asset-types"
+    />
+
+    <asset-type-list
+      class="asset-type-list"
+      :entries="assetTypesList"
       :is-loading="loading.list"
       :is-error="errors.list"
       @edit-clicked="onEditClicked"
@@ -42,6 +49,7 @@ import AssetTypeList from '@/components/lists/AssetTypeList'
 import DeleteModal from '@/components/modals/DeleteModal'
 import EditAssetTypeModal from '@/components/modals/EditAssetTypeModal'
 import ListPageHeader from '@/components/widgets/ListPageHeader'
+import RouteTabs from '@/components/widgets/RouteTabs'
 
 export default {
   name: 'asset-types',
@@ -50,11 +58,13 @@ export default {
     AssetTypeList,
     DeleteModal,
     EditAssetTypeModal,
-    ListPageHeader
+    ListPageHeader,
+    RouteTabs
   },
 
   data() {
     return {
+      activeTab: 'active',
       assetTypeToDelete: null,
       assetTypeToEdit: {},
       choices: [],
@@ -71,12 +81,32 @@ export default {
         del: false,
         edit: false,
         list: false
-      }
+      },
+      tabs: [
+        {
+          name: 'active',
+          label: this.$t('main.active')
+        },
+        {
+          name: 'archived',
+          label: this.$t('main.archived')
+        }
+      ]
     }
   },
 
+  mounted() {
+    this.activeTab = this.$route.query.tab || 'active'
+  },
+
   computed: {
-    ...mapGetters(['assetTypes', 'getAssetType']),
+    ...mapGetters(['assetTypes', 'archivedAssetTypes', 'getAssetType']),
+
+    assetTypesList() {
+      return this.activeTab === 'active'
+        ? this.assetTypes
+        : this.archivedAssetTypes
+    },
 
     deleteText() {
       const assetType = this.assetTypeToDelete
@@ -151,7 +181,11 @@ export default {
     }
   },
 
-  watch: {},
+  watch: {
+    $route() {
+      this.activeTab = this.$route.query.tab
+    }
+  },
 
   metaInfo() {
     return {
@@ -161,4 +195,8 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.asset-type-list {
+  margin-top: 0rem;
+}
+</style>

--- a/src/components/pages/Departments.vue
+++ b/src/components/pages/Departments.vue
@@ -6,8 +6,16 @@
       @new-clicked="onNewClicked"
     />
 
+    <route-tabs
+      class="mt2"
+      :active-tab="activeTab"
+      :tabs="tabs"
+      route-name="departments"
+    />
+
     <department-list
-      :entries="departments"
+      class="department-list"
+      :entries="departmentList"
       :is-loading="loading.departments"
       :is-error="errors.departments"
       @edit-clicked="onEditClicked"
@@ -37,10 +45,11 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import DepartmentList from '@/components/lists/DepartmentList.vue'
-import ListPageHeader from '@/components/widgets/ListPageHeader'
-import EditDepartmentsModal from '@/components/modals/EditDepartmentsModal'
 import DeleteModal from '@/components/modals/DeleteModal'
+import DepartmentList from '@/components/lists/DepartmentList.vue'
+import EditDepartmentsModal from '@/components/modals/EditDepartmentsModal'
+import ListPageHeader from '@/components/widgets/ListPageHeader'
+import RouteTabs from '@/components/widgets/RouteTabs'
 
 export default {
   name: 'departments',
@@ -48,13 +57,17 @@ export default {
     DeleteModal,
     DepartmentList,
     EditDepartmentsModal,
-    ListPageHeader
+    ListPageHeader,
+    RouteTabs
   },
 
   props: {},
 
   data() {
     return {
+      activeTab: 'active',
+      departmentToEdit: null,
+      departmentToDelete: null,
       errors: {
         departments: false,
         edit: false,
@@ -69,25 +82,21 @@ export default {
         del: false,
         edit: false
       },
-      departmentToEdit: null,
-      departmentToDelete: null
-    }
-  },
-
-  computed: {
-    ...mapGetters(['departments']),
-    deleteText() {
-      if (this.departmentToDelete) {
-        return this.$t('departments.delete_text', {
-          name: this.departmentToDelete.name
-        })
-      } else {
-        return ''
-      }
+      tabs: [
+        {
+          name: 'active',
+          label: this.$t('main.active')
+        },
+        {
+          name: 'archived',
+          label: this.$t('main.archived')
+        }
+      ]
     }
   },
 
   mounted() {
+    this.activeTab = this.$route.query.tab || 'active'
     this.loading.departments = true
     this.errors.departments = false
     this.loadDepartments()
@@ -99,6 +108,28 @@ export default {
         this.loading.departments = false
         this.errors.departments = true
       })
+  },
+
+  computed: {
+    ...mapGetters(['departments', 'archivedDepartments']),
+
+    departmentList() {
+      if (this.activeTab === 'active') {
+        return this.departments
+      } else {
+        return this.archivedDepartments
+      }
+    },
+
+    deleteText() {
+      if (this.departmentToDelete) {
+        return this.$t('departments.delete_text', {
+          name: this.departmentToDelete.name
+        })
+      } else {
+        return ''
+      }
+    }
   },
 
   methods: {
@@ -152,8 +183,18 @@ export default {
         this.errors.del = true
       }
     }
+  },
+
+  watch: {
+    $route() {
+      this.activeTab = this.$route.query.tab
+    }
   }
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.department-list {
+  margin-top: 0rem;
+}
+</style>

--- a/src/components/pages/EntitySearch.vue
+++ b/src/components/pages/EntitySearch.vue
@@ -104,9 +104,24 @@
               </router-link>
             </div>
           </div>
+          <p
+            class="has-text-centered mt2"
+            v-if="
+              results.assets.length !== 0 && results.assets.length % 12 === 0
+            "
+          >
+            <button
+              class="button is-link"
+              @click="loadMoreResults('assets')"
+              v-if="!isLoadingMoreAssets"
+            >
+              {{ $t('main.load_more') }}
+            </button>
+            <spinner v-else />
+          </p>
         </div>
         <div class="pb1" v-if="this.searchFilter.shots">
-          <h2 class="mt0">
+          <h2 class="mt1">
             {{ $t('shots.title') }} ({{ this.results.shots?.length || 0 }})
           </h2>
           <div class="has-text-centered" v-if="!this.results.shots?.length">
@@ -153,49 +168,20 @@
               </router-link>
             </div>
           </div>
-        </div>
-        <!--
-        <div class="pb1" v-if="this.searchFilter.persons">
-          <h2 class="mt0">
-            {{ $t('people.title') }} ({{ this.results.persons?.length || 0 }})
-          </h2>
-          <div class="has-text-centered" v-if="!this.results.persons.length">
-            {{ $t('main.search.no_result') }}
-          </div>
-          <div class="result-list" v-else>
-            <div
-              class="result flexcolumn"
-              :class="{
-                'selected-result': flattenResults[selectedIndex] === person
-              }"
-              :key="person.id"
-              @mouseover="selectResultById(person.id)"
-              v-for="person in this.results.persons"
+          <p
+            class="has-text-centered mt2"
+            v-if="results.shots.length !== 0 && results.shots.length % 12 === 0"
+          >
+            <button
+              class="button is-link"
+              @click="loadMoreResults('shots')"
+              v-if="!isLoadingMoreShots"
             >
-              <router-link
-                :id="`result-link-${person.id}`"
-                :to="personPath(person)"
-              >
-                <div class="flexcolumn has-text-centered">
-                  <people-avatar
-                    class="mauto"
-                    :is-link="false"
-                    :person="person"
-                    :size="200"
-                  />
-                  <div class="result-description">
-                    <div class="person-name">{{ person.name }}</div>
-                    <div class="person-email">{{ person.email }}</div>
-                    <div class="person-role">
-                      {{ $t(`people.role.${person.role}`) }}
-                    </div>
-                  </div>
-                </div>
-              </router-link>
-            </div>
-          </div>
+              {{ $t('main.load_more') }}
+            </button>
+            <spinner v-else />
+          </p>
         </div>
-        -->
       </div>
     </div>
   </div>
@@ -209,14 +195,12 @@ import { mapGetters, mapActions } from 'vuex'
 import { getEntityPath, getPersonPath } from '@/lib/path'
 
 import { SearchIcon } from 'vue-feather-icons'
-
-// import peopleStore from '@/store/modules/people'
+import stringHelpers from '@/lib/string'
 
 import Checkbox from '@/components/widgets/Checkbox'
 import Combobox from '@/components/widgets/Combobox'
 import ComboboxProduction from '@/components/widgets/ComboboxProduction'
 import EntityPreview from '@/components/widgets/EntityPreview'
-// import PeopleAvatar from '@/components/widgets/PeopleAvatar'
 import Spinner from '@/components/widgets/Spinner'
 
 const AVAILABLE_LIMITS = [12, 24, 48]
@@ -230,7 +214,6 @@ export default {
     Combobox,
     ComboboxProduction,
     EntityPreview,
-    // PeopleAvatar,
     SearchIcon,
     Spinner
   },
@@ -238,6 +221,8 @@ export default {
   data() {
     return {
       isLoading: false,
+      isLoadingMoreAssets: false,
+      isLoadingMoreShots: false,
       limit: AVAILABLE_LIMITS[0],
       limitOptions: AVAILABLE_LIMITS.map(value => ({ label: value, value })),
       productionId: '',
@@ -336,6 +321,29 @@ export default {
         .catch(console.error)
         .finally(() => {
           this.isLoading = false
+        })
+    },
+
+    loadMoreResults(indexName) {
+      const index_names = [indexName]
+      const loadingField = `isLoadingMore${stringHelpers.capitalize(indexName)}`
+      this[loadingField] = true
+
+      this.searchData({
+        query: this.searchQuery,
+        limit: this.limit,
+        offset: this.results[indexName].length,
+        productionId: this.productionId,
+        index_names
+      })
+        .then(results => {
+          this.results[indexName] = this.results[indexName].concat(
+            results[indexName]
+          )
+        })
+        .catch(console.error)
+        .finally(() => {
+          this[loadingField] = false
         })
     },
 

--- a/src/components/pages/StatusAutomations.vue
+++ b/src/components/pages/StatusAutomations.vue
@@ -6,8 +6,16 @@
       @new-clicked="onNewClicked"
     />
 
+    <route-tabs
+      class="mt2"
+      :active-tab="activeTab"
+      :tabs="tabs"
+      route-name="status-automations"
+    />
+
     <status-automation-list
-      :entries="statusAutomations"
+      class="status-automation-list"
+      :entries="statusAutomationsList"
       :is-editable="true"
       :is-loading="loading.list"
       :is-error="errors.list"
@@ -38,10 +46,11 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import StatusAutomationList from '@/components/lists/StatusAutomationList'
 import DeleteModal from '@/components/modals/DeleteModal'
 import EditStatusAutomationModal from '@/components/modals/EditStatusAutomationModal'
 import ListPageHeader from '@/components/widgets/ListPageHeader'
+import RouteTabs from '@/components/widgets/RouteTabs'
+import StatusAutomationList from '@/components/lists/StatusAutomationList'
 
 export default {
   name: 'status-automations',
@@ -50,11 +59,13 @@ export default {
     DeleteModal,
     EditStatusAutomationModal,
     ListPageHeader,
+    RouteTabs,
     StatusAutomationList
   },
 
   data() {
     return {
+      activeTab: 'active',
       modals: {
         edit: false,
         del: false
@@ -69,13 +80,31 @@ export default {
         del: false,
         list: false
       },
+      tabs: [
+        {
+          name: 'active',
+          label: this.$t('main.active')
+        },
+        {
+          name: 'archived',
+          label: this.$t('main.archived')
+        }
+      ],
       statusAutomationToDelete: null,
       statusAutomationToEdit: null
     }
   },
 
   computed: {
-    ...mapGetters(['statusAutomations']),
+    ...mapGetters(['statusAutomations', 'archivedStatusAutomations']),
+
+    statusAutomationsList() {
+      if (this.activeTab === 'active') {
+        return this.statusAutomations
+      } else {
+        return this.archivedStatusAutomations
+      }
+    },
 
     deleteText() {
       const statusAutomation = this.statusAutomationToDelete
@@ -90,6 +119,7 @@ export default {
   },
 
   created() {
+    this.activeTab = this.$route.query.tab || 'active'
     this.loading.list = true
     this.errors.list = false
     this.loadStatusAutomations(err => {
@@ -167,6 +197,7 @@ export default {
   watch: {
     $route() {
       this.handleModalsDisplay()
+      this.activeTab = this.$route.query.tab
     }
   },
 
@@ -178,4 +209,8 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.status-automation-list {
+  margin-top: 0rem;
+}
+</style>

--- a/src/components/pages/breakdown/AssetBlock.vue
+++ b/src/components/pages/breakdown/AssetBlock.vue
@@ -17,6 +17,7 @@
       <div class="asset-picture" v-if="asset.preview_file_id">
         <img
           loading="lazy"
+          alt=""
           :src="`/api/pictures/thumbnails-square/preview-files/${asset.preview_file_id}.png`"
         />
         <span class="nb-occurences" v-if="nbOccurences > 1">

--- a/src/components/pages/breakdown/AvailableAssetBlock.vue
+++ b/src/components/pages/breakdown/AvailableAssetBlock.vue
@@ -14,6 +14,7 @@
     <div class="asset-picture" v-if="asset.preview_file_id.length > 0">
       <img
         loading="lazy"
+        alt=""
         :src="`/api/pictures/thumbnails-square/preview-files/${asset.preview_file_id}.png`"
       />
     </div>

--- a/src/components/previews/PictureViewer.vue
+++ b/src/components/previews/PictureViewer.vue
@@ -361,6 +361,18 @@ export default {
         panzoom.moveTo(0, 0)
         panzoom.zoomAbs(0, 0, 1)
       })
+    },
+
+    pausePanZoom() {
+      if (this.panzoomInstance) {
+        this.panzoomInstance.pause()
+      }
+    },
+
+    resumePanZoom() {
+      if (this.panzoomInstance) {
+        this.panzoomInstance.resume()
+      }
     }
   },
 

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1203,6 +1203,7 @@ export default {
 
     setFullScreen() {
       this.endAnnotationSaving()
+      this.previewViewer.pauseZoom()
       const promise = this.documentSetFullScreen(this.container)
       if (promise) {
         promise.then(() => {
@@ -1212,6 +1213,9 @@ export default {
         // fallback for legacy browsers
         this.fullScreen = true
       }
+      setTimeout(() => {
+        this.previewViewer.resumeZoom()
+      }, 2000)
       this.$nextTick(() => {
         // Needed to avoid fullscreen button to be called with space bar.
         this.clearFocus()
@@ -1220,6 +1224,7 @@ export default {
 
     exitFullScreen() {
       this.endAnnotationSaving()
+      this.previewViewer.pauseZoom()
       const promise = this.documentExitFullScreen()
       if (promise) {
         promise.then(() => {
@@ -1233,6 +1238,9 @@ export default {
         // fallback for legacy browsers
         this.fullScreen = false
       }
+      setTimeout(() => {
+        this.previewViewer.resumeZoom()
+      }, 2000)
       this.isComparing = false
       this.isCommentsHidden = true
       this.$nextTick(() => {

--- a/src/components/previews/PreviewViewer.vue
+++ b/src/components/previews/PreviewViewer.vue
@@ -447,6 +447,24 @@ export default {
       if (this.videoViewer) {
         this.videoViewer.resetPanZoom()
       }
+    },
+
+    pauseZoom() {
+      if (this.pictureViewer) {
+        this.pictureViewer.pausePanZoom()
+      }
+      if (this.videoViewer) {
+        this.videoViewer.pausePanZoom()
+      }
+    },
+
+    resumeZoom() {
+      if (this.pictureViewer) {
+        this.pictureViewer.resumePanZoom()
+      }
+      if (this.videoViewer) {
+        this.videoViewer.resumePanZoom()
+      }
     }
   },
 

--- a/src/components/previews/VideoViewer.vue
+++ b/src/components/previews/VideoViewer.vue
@@ -474,6 +474,18 @@ export default {
         this.panzoomInstance.moveTo(0, 0)
         this.panzoomInstance.zoomAbs(0, 0, 1)
       }
+    },
+
+    pausePanZoom() {
+      if (this.panzoomInstance) {
+        this.panzoomInstance.pause()
+      }
+    },
+
+    resumePanZoom() {
+      if (this.panzoomInstance) {
+        this.panzoomInstance.resume()
+      }
     }
   },
 

--- a/src/components/widgets/EntityPreview.vue
+++ b/src/components/widgets/EntityPreview.vue
@@ -43,6 +43,7 @@
         'max-height': `${emptyHeight}px`
       }"
       :width="width || ''"
+      alt=""
     />
   </a>
 </template>

--- a/src/components/widgets/EntityThumbnail.vue
+++ b/src/components/widgets/EntityThumbnail.vue
@@ -17,6 +17,7 @@
       :src="thumbnailPath"
       :style="imgStyle"
       :width="width || ''"
+      alt=""
     />
   </a>
 
@@ -27,6 +28,7 @@
     :key="thumbnailKey"
     :src="thumbnailPath"
     :style="imgStyle"
+    alt=""
   />
 
   <span

--- a/src/components/widgets/LightEntityThumbnail.vue
+++ b/src/components/widgets/LightEntityThumbnail.vue
@@ -2,6 +2,7 @@
   <img
     class="thumbnail-picture"
     loading="lazy"
+    alt=""
     :key="props.previewFileId"
     :src="`/api/pictures/${props.type}/preview-files/${props.previewFileId}.png`"
     :style="{

--- a/src/components/widgets/PeopleAvatar.vue
+++ b/src/components/widgets/PeopleAvatar.vue
@@ -22,6 +22,7 @@
     >
       <img
         :loading="this.isLazy ? 'lazy' : undefined"
+        alt=""
         :src="person.avatarPath"
         v-if="person.has_avatar"
       />
@@ -42,6 +43,7 @@
   >
     <img
       :loading="this.isLazy ? 'lazy' : undefined"
+      alt=""
       :src="person.avatarPath"
       v-if="person.has_avatar"
     />

--- a/src/components/widgets/PeopleAvatarWithMenu.vue
+++ b/src/components/widgets/PeopleAvatarWithMenu.vue
@@ -12,6 +12,7 @@
     >
       <img
         :loading="this.isLazy ? 'lazy' : undefined"
+        alt=""
         :src="person.avatarPath"
         v-if="person.has_avatar"
       />

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -458,6 +458,7 @@ export default {
     or: 'or',
     no: 'No',
     less_filters: 'Fewer filters',
+    load_more: 'Load more',
     loading: 'Loading...',
     loading_data: 'Loading data',
     loading_error: 'An error occurred while loading data.',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -458,7 +458,7 @@ export default {
     or: 'or',
     no: 'No',
     less_filters: 'Fewer filters',
-    load_more: 'Load more',
+    load_more: 'Load more',
     loading: 'Loading...',
     loading_data: 'Loading data',
     loading_error: 'An error occurred while loading data.',

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -26,8 +26,7 @@ const AssetTypes = () => import('@/components/pages/AssetTypes.vue')
 const Backgrounds = () => import('@/components/pages/Backgrounds.vue')
 const Breakdown = () => import('@/components/pages/Breakdown.vue')
 const CustomActions = () => import('@/components/pages/CustomActions.vue')
-const Departments = () =>
-  import('@/components/pages/departments/Departments.vue')
+const Departments = () => import('@/components/pages/Departments.vue')
 const Edit = () => import('@/components/pages/Edit.vue')
 const EntitySearch = () => import('@/components/pages/EntitySearch.vue')
 const Episode = () => import('@/components/pages/Episode.vue')
@@ -181,20 +180,8 @@ export const routes = [
 
       {
         path: 'asset-types',
-        component: AssetTypes,
-        children: [
-          { path: 'new', component: AssetTypes },
-          {
-            name: 'edit-asset-type',
-            path: 'edit/:asset_type_id',
-            component: AssetTypes
-          },
-          {
-            name: 'delete-asset-type',
-            path: 'delete/:asset_type_id',
-            component: AssetTypes
-          }
-        ]
+        name: 'asset-types',
+        component: AssetTypes
       },
 
       {
@@ -205,54 +192,20 @@ export const routes = [
 
       {
         path: 'departments',
-        component: Departments,
-        name: 'departments'
+        name: 'departments',
+        component: Departments
       },
 
       {
         name: 'custom-actions',
         path: 'custom-actions',
-        component: CustomActions,
-        children: [
-          {
-            name: 'custom-actions-new',
-            path: 'new',
-            component: CustomActions
-          },
-          {
-            name: 'edit-custom-action',
-            path: 'edit/:custom_action_id',
-            component: CustomActions
-          },
-          {
-            name: 'delete-custom-action',
-            path: 'delete/:custom_action_id',
-            component: CustomActions
-          }
-        ]
+        component: CustomActions
       },
 
       {
         name: 'status-automations',
         path: 'status-automations',
-        component: StatusAutomations,
-        children: [
-          {
-            name: 'status-automations-new',
-            path: 'new',
-            component: StatusAutomations
-          },
-          {
-            name: 'edit-status-automation',
-            path: 'edit/:status_automation_id',
-            component: StatusAutomations
-          },
-          {
-            name: 'delete-status-automation',
-            path: 'delete/:status_automation_id',
-            component: StatusAutomations
-          }
-        ]
+        component: StatusAutomations
       },
 
       {
@@ -282,20 +235,7 @@ export const routes = [
       {
         path: 'people',
         component: People,
-        name: 'people',
-        children: [
-          { path: 'new', component: People, name: 'new-people' },
-          {
-            path: 'edit/:person_id',
-            component: People,
-            name: 'edit-person'
-          },
-          {
-            name: 'delete-person',
-            path: 'delete/:person_id',
-            component: People
-          }
-        ]
+        name: 'people'
       },
 
       {
@@ -399,45 +339,14 @@ export const routes = [
       {
         name: 'task-types',
         path: 'task-types',
-        component: TaskTypes,
-        children: [
-          { path: 'new', component: TaskTypes },
-          {
-            name: 'edit-task-type',
-            path: 'edit/:task_type_id',
-            component: TaskTypes
-          },
-          {
-            name: 'delete-task-type',
-            path: 'delete/:task_type_id',
-            component: TaskTypes
-          }
-        ]
+        component: TaskTypes
       },
 
       {
         name: 'task-status',
         path: 'task-status',
-        component: TaskStatus,
-        children: [
-          {
-            name: 'new-task-status',
-            path: 'new',
-            component: TaskStatus
-          },
-          {
-            name: 'edit-task-status',
-            path: 'edit/:task_status_id',
-            component: TaskStatus
-          },
-          {
-            name: 'delete-task-status',
-            path: 'delete/:task_status_id',
-            component: TaskStatus
-          }
-        ]
+        component: TaskStatus
       },
-
       {
         path: 'my-tasks',
         component: Todos,

--- a/src/store/api/assettypes.js
+++ b/src/store/api/assettypes.js
@@ -20,7 +20,8 @@ export default {
   updateAssetType(assetType) {
     const data = {
       name: assetType.name,
-      task_types: assetType.task_types
+      task_types: assetType.task_types,
+      archived: assetType.archived === 'true'
     }
     return client.pput(`/api/data/entity-types/${assetType.id}`, data)
   },

--- a/src/store/api/client.js
+++ b/src/store/api/client.js
@@ -134,9 +134,9 @@ const client = {
     return client.pget(path)
   },
 
-  searchData(query, limit, index_names, productionId) {
+  searchData(query, limit, offset, index_names, productionId) {
     const path = '/api/data/search'
-    const data = { query, limit, index_names }
+    const data = { query, limit, offset, index_names }
     if (productionId !== 'all') data.project_id = productionId
     return client.ppost(path, data)
   }

--- a/src/store/api/departments.js
+++ b/src/store/api/departments.js
@@ -5,18 +5,26 @@ export default {
     client.get('/api/data/departments', callback)
   },
 
-  newDepartement(newDepartement) {
-    return client.ppost('/api/data/departments', newDepartement)
+  newDepartement(department) {
+    const data = {
+      name: department.name,
+      color: department.color,
+      archived: department.archived === 'true'
+    }
+    return client.ppost('/api/data/departments', data)
   },
 
-  editDepartement(editedDepartement) {
-    return client.pput(
-      `/api/data/departments/${editedDepartement.id}`,
-      editedDepartement
-    )
+  editDepartement(department) {
+    const data = {
+      name: department.name,
+      color: department.color,
+      archived: department.archived === 'true'
+    }
+    console.log(data)
+    return client.pput(`/api/data/departments/${department.id}`, data)
   },
 
-  deleteDepartment(departementToDelete) {
-    return client.pdel(`/api/data/departments/${departementToDelete.id}`)
+  deleteDepartment(department) {
+    return client.pdel(`/api/data/departments/${department.id}`)
   }
 }

--- a/src/store/api/departments.js
+++ b/src/store/api/departments.js
@@ -20,7 +20,6 @@ export default {
       color: department.color,
       archived: department.archived === 'true'
     }
-    console.log(data)
     return client.pput(`/api/data/departments/${department.id}`, data)
   },
 

--- a/src/store/api/statusautomation.js
+++ b/src/store/api/statusautomation.js
@@ -31,7 +31,8 @@ export default {
       in_task_status_id: statusAutomation.inTaskStatusId,
       out_field_type: statusAutomation.outFieldType,
       out_task_type_id: statusAutomation.outTaskTypeId,
-      out_task_status_id: statusAutomation.outTaskStatusId
+      out_task_status_id: statusAutomation.outTaskStatusId,
+      archived: statusAutomation.archived === 'true'
     }
     return client.pput(
       `/api/data/status-automations/${statusAutomation.id}`,

--- a/src/store/modules/assettypes.js
+++ b/src/store/modules/assettypes.js
@@ -17,7 +17,8 @@ const initialState = {
 const state = { ...initialState }
 
 const getters = {
-  assetTypes: state => state.assetTypes,
+  assetTypes: state => state.assetTypes.filter(type => !type.archived),
+  archivedAssetTypes: state => state.assetTypes.filter(type => type.archived),
   assetTypeMap: state => state.assetTypeMap,
 
   getAssetType: (state, getters) => id => {

--- a/src/store/modules/departments.js
+++ b/src/store/modules/departments.js
@@ -20,7 +20,8 @@ const initialState = {
 const state = { ...initialState }
 
 const getters = {
-  departments: state => state.departments,
+  departments: state => state.departments.filter(d => !d.archived),
+  archivedDepartments: state => state.departments.filter(d => d.archived),
   departmentMap: state => state.departmentMap,
 
   getDepartments: state => id => {

--- a/src/store/modules/main.js
+++ b/src/store/modules/main.js
@@ -75,11 +75,8 @@ const actions = {
     })
   },
 
-  searchData(_, { query, limit, productionId, index_names }) {
-    if (!limit) {
-      limit = 3
-    }
-    return client.searchData(query, limit, index_names, productionId)
+  searchData(_, { query, limit = 3, offset = 0, productionId, index_names }) {
+    return client.searchData(query, limit, offset, index_names, productionId)
   }
 }
 

--- a/src/store/modules/statusautomation.js
+++ b/src/store/modules/statusautomation.js
@@ -28,7 +28,9 @@ const initialState = {
 const state = { ...initialState }
 
 const getters = {
-  statusAutomations: state => state.statusAutomations,
+  statusAutomations: state => state.statusAutomations.filter(s => !s.archived),
+  archivedStatusAutomations: state =>
+    state.statusAutomations.filter(s => s.archived),
   statusAutomationMap: state => state.statusAutomationMap,
 
   // Used to know if the automation will apply in the current production.

--- a/src/store/modules/taskstatus.js
+++ b/src/store/modules/taskstatus.js
@@ -18,7 +18,10 @@ const initialState = {
 const state = initialState
 
 const getters = {
-  taskStatus: state =>
+  taskStatus: (
+    state // Wrong naming, keep it for compatibility
+  ) => state.taskStatus.filter(taskStatus => !taskStatus.archived),
+  taskStatuses: state =>
     state.taskStatus.filter(taskStatus => !taskStatus.archived),
   archivedTaskStatus: state =>
     state.taskStatus.filter(taskStatus => taskStatus.archived),

--- a/tests/unit/lib/filtering.spec.js
+++ b/tests/unit/lib/filtering.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 import {
   applyFilters,
   getKeyWords,
@@ -16,9 +18,7 @@ describe('lib/filtering', () => {
     })
 
     it('no keyword query', () => {
-      const keyWords = getKeyWords(
-        'modeling=wip -bunnyfat'
-      )
+      const keyWords = getKeyWords('modeling=wip -bunnyfat')
       expect(keyWords).toEqual([])
     })
 
@@ -30,20 +30,14 @@ describe('lib/filtering', () => {
 
   describe('getMultipleKeyWords', () => {
     it('multiple query', () => {
-      let keyWords = getMultipleKeyWords(
-        '[chars,bunny,with space]'
-      )
+      let keyWords = getMultipleKeyWords('[chars,bunny,with space]')
       expect(keyWords).toEqual(['chars', 'bunny', 'with space'])
-      keyWords = getMultipleKeyWords(
-        '[chars]'
-      )
+      keyWords = getMultipleKeyWords('[chars]')
       expect(keyWords).toEqual(['chars'])
     })
 
     it('no keyword query', () => {
-      const keyWords = getKeyWords(
-        'modeling=wip -bunnyfat'
-      )
+      const keyWords = getKeyWords('modeling=wip -bunnyfat')
       expect(keyWords).toEqual([])
     })
 
@@ -52,7 +46,6 @@ describe('lib/filtering', () => {
       expect(keyWords).toEqual([])
     })
   })
-
 
   describe('getExcludingKeyWords', () => {
     it('classic query', () => {
@@ -63,9 +56,7 @@ describe('lib/filtering', () => {
     })
 
     it('no excluding keyword query', () => {
-      const keyWords = getExcludingKeyWords(
-        'chars bunny'
-      )
+      const keyWords = getExcludingKeyWords('chars bunny')
       expect(keyWords).toEqual([])
     })
 
@@ -104,7 +95,6 @@ describe('lib/filtering', () => {
         name: 'BG',
         id: 'task-type-5'
       }
-
     ]
     const descriptors = [
       {
@@ -117,7 +107,6 @@ describe('lib/filtering', () => {
         name: 'Modeling infos',
         field_name: 'modeling_infos'
       }
-
     ]
     const persons = [
       {
@@ -412,7 +401,7 @@ describe('lib/filtering', () => {
       expect(filters[0].excluding).toEqual(true)
     })
 
-    it('assignedto=[John Doe] in query case', () => {
+    it('assignedto[Modeling]=[John Doe] in query case', () => {
       const filters = getFilters({
         entryIndex,
         assetTypes,
@@ -420,11 +409,12 @@ describe('lib/filtering', () => {
         taskStatuses,
         descriptors,
         persons,
-        query: 'assignedto=[John Doe]'
+        query: 'assignedto[Modeling]=[John Doe]'
       })
       expect(filters).toHaveLength(1)
       expect(filters[0].type).toEqual('assignedto')
       expect(filters[0].personId).toEqual('person-1')
+      expect(filters[0].taskType.id).toEqual('task-type-2')
       expect(filters[0].excluding).toEqual(false)
     })
 
@@ -557,56 +547,60 @@ describe('lib/filtering', () => {
         episode_name: 'E02',
         id: 'shot-5',
         data: { color: 'red' },
-        validations: new Map(
-          [['task-type-1', 'task-5'], ['task-type-3', 'task-6'], ['task-type-4', 'task-7']]
-        ),
+        validations: new Map([
+          ['task-type-1', 'task-5'],
+          ['task-type-3', 'task-6'],
+          ['task-type-4', 'task-7']
+        ]),
         tasks: ['task-5', 'task-6']
       }
     ]
-    const taskMap = new Map(Object.entries({
-      'task-1': {
-        id: 'task-1',
-        assignees: [],
-        task_status_id: 'task-status-1',
-        priority: 0
-      },
-      'task-2': {
-        id: 'task-2',
-        assignees: ['person-1'],
-        task_status_id: 'task-status-1',
-        priority: 0
-      },
-      'task-3': {
-        id: 'task-3',
-        assignees: ['person-1', 'person-2'],
-        task_status_id: 'task-status-1',
-        priority: 3
-      },
-      'task-4': {
-        id: 'task-4',
-        assignees: [],
-        task_status_id: 'task-status-2',
-        priority: 0
-      },
-      'task-5': {
-        id: 'task-5',
-        assignees: [],
-        task_status_id: 'task-status-2',
-        priority: 0
-      },
-      'task-6': {
-        id: 'task-6',
-        assignees: [],
-        task_status_id: 'task-status-1',
-        priority: 0
-      },
-      'task-7': {
-        id: 'task-7',
-        assignees: [],
-        task_status_id: 'task-status-2',
-        priority: 0
-      }
-    }))
+    const taskMap = new Map(
+      Object.entries({
+        'task-1': {
+          id: 'task-1',
+          assignees: [],
+          task_status_id: 'task-status-1',
+          priority: 0
+        },
+        'task-2': {
+          id: 'task-2',
+          assignees: ['person-1'],
+          task_status_id: 'task-status-1',
+          priority: 0
+        },
+        'task-3': {
+          id: 'task-3',
+          assignees: ['person-1', 'person-2'],
+          task_status_id: 'task-status-1',
+          priority: 3
+        },
+        'task-4': {
+          id: 'task-4',
+          assignees: [],
+          task_status_id: 'task-status-2',
+          priority: 0
+        },
+        'task-5': {
+          id: 'task-5',
+          assignees: [],
+          task_status_id: 'task-status-2',
+          priority: 0
+        },
+        'task-6': {
+          id: 'task-6',
+          assignees: [],
+          task_status_id: 'task-status-1',
+          priority: 0
+        },
+        'task-7': {
+          id: 'task-7',
+          assignees: [],
+          task_status_id: 'task-status-2',
+          priority: 0
+        }
+      })
+    )
     const descriptors = [
       {
         id: 'descriptor-1',
@@ -623,11 +617,7 @@ describe('lib/filtering', () => {
           type: 'status'
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(3)
     })
 
@@ -639,21 +629,13 @@ describe('lib/filtering', () => {
           type: 'status'
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(1)
     })
 
     it('empty filter', () => {
       const filters = []
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(5)
     })
 
@@ -670,11 +652,7 @@ describe('lib/filtering', () => {
           type: 'status'
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(1)
     })
 
@@ -692,12 +670,7 @@ describe('lib/filtering', () => {
         }
       ]
       filters.union = true
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap,
-        true
-      )
+      const results = applyFilters(entries, filters, taskMap, true)
       expect(results).toHaveLength(2)
     })
 
@@ -709,11 +682,7 @@ describe('lib/filtering', () => {
           type: 'status'
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(5)
     })
 
@@ -725,11 +694,7 @@ describe('lib/filtering', () => {
           type: 'assignation'
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(3)
     })
 
@@ -741,11 +706,7 @@ describe('lib/filtering', () => {
           type: 'assignation'
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(2)
     })
 
@@ -758,11 +719,7 @@ describe('lib/filtering', () => {
           type: 'exclusion'
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(4)
     })
 
@@ -774,11 +731,7 @@ describe('lib/filtering', () => {
           type: 'descriptor'
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(3)
     })
 
@@ -790,11 +743,7 @@ describe('lib/filtering', () => {
           type: 'descriptor'
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(1)
     })
 
@@ -806,11 +755,7 @@ describe('lib/filtering', () => {
           type: 'descriptor'
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(4)
     })
 
@@ -821,11 +766,7 @@ describe('lib/filtering', () => {
           type: 'thumbnail'
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(2)
     })
 
@@ -836,11 +777,7 @@ describe('lib/filtering', () => {
           type: 'thumbnail'
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(3)
     })
 
@@ -852,11 +789,7 @@ describe('lib/filtering', () => {
           excluding: false
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(2)
     })
 
@@ -865,14 +798,10 @@ describe('lib/filtering', () => {
         {
           type: 'priority',
           taskTypeId: 'task-type-1',
-          value: 3,
+          value: 3
         }
       ]
-      const results = applyFilters(
-        entries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(entries, filters, taskMap)
       expect(results).toHaveLength(1)
     })
 
@@ -881,7 +810,7 @@ describe('lib/filtering', () => {
         {
           name: 'Bunny',
           id: 'asset-1',
-          data: { },
+          data: {},
           validations: new Map([['task-type-1', 'task-1']]),
           tasks: ['task-1'],
           ready_for: 'task-type-1'
@@ -889,7 +818,7 @@ describe('lib/filtering', () => {
         {
           name: 'Lama',
           id: 'asset-1',
-          data: { },
+          data: {},
           validations: new Map([['task-type-1', 'task-1']]),
           tasks: ['task-1'],
           ready_for: 'task-type-2'
@@ -901,11 +830,7 @@ describe('lib/filtering', () => {
           value: 'task-type-1'
         }
       ]
-      const results = applyFilters(
-        assetEntries,
-        filters,
-        taskMap
-      )
+      const results = applyFilters(assetEntries, filters, taskMap)
       expect(results).toHaveLength(1)
     })
   })

--- a/tests/unit/lib/indexing.spec.js
+++ b/tests/unit/lib/indexing.spec.js
@@ -1,4 +1,4 @@
-import test from '../../../src/lib/string'
+/* eslint-disable no-undef */
 import {
   buildNameIndex,
   buildAssetIndex,
@@ -50,7 +50,12 @@ describe('lib/indexing', () => {
       { name: 'SH01', sequence_name: 'S02', episode_name: 'E01', id: 3 },
       { name: 'SH01', sequence_name: 'S01', episode_name: 'E02', id: 4 },
       { name: 'SH02', sequence_name: 'S01', episode_name: 'E02', id: 5 },
-      { name: 'constructor', sequence_name: 'SEQ01', episode_name: 'EP02', id: 6 }
+      {
+        name: 'constructor',
+        sequence_name: 'SEQ01',
+        episode_name: 'EP02',
+        id: 6
+      }
     ]
     const index = buildShotIndex(entries)
     expect(index.e01).toHaveLength(3)

--- a/tests/unit/modals/buildfiltermodal.spec.js
+++ b/tests/unit/modals/buildfiltermodal.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 import { shallowMount, createLocalVue } from '@vue/test-utils'
 import Vuex from 'vuex'
 import VueRouter from 'vue-router'
@@ -24,17 +26,22 @@ describe('BuildFilterModal', () => {
       getters: {
         assetMetadataDescriptors: () => [
           {
-            id: 'descriptor-1', name: 'Difficulty', choices: ['easy', 'hard']
+            id: 'descriptor-1',
+            name: 'Difficulty',
+            choices: ['easy', 'hard']
           },
           { id: 'descriptor-2', name: 'Size' }
         ],
-        assetSearchText: (state) => state.assetSearchText,
+        assetSearchText: state => state.assetSearchText,
         assetValidationColumns: () => ['task-type-1', 'task-type-2'],
-        assetTypeMap: () => new Map(Object.entries({
-          'asset-type-1': { id: 'asset-type-1', name: 'chars' },
-          'asset-type-2': { id: 'asset-type-2', name: 'sets' },
-          'asset-type-3': { id: 'asset-type-3', name: 'props' }
-        })),
+        assetTypeMap: () =>
+          new Map(
+            Object.entries({
+              'asset-type-1': { id: 'asset-type-1', name: 'chars' },
+              'asset-type-2': { id: 'asset-type-2', name: 'sets' },
+              'asset-type-3': { id: 'asset-type-3', name: 'props' }
+            })
+          ),
         assetTypes: () => [
           { id: 'asset-type-1', name: 'chars' },
           { id: 'asset-type-2', name: 'sets' },
@@ -42,10 +49,12 @@ describe('BuildFilterModal', () => {
         ]
       },
       mutations: {
-        CHANGE_SEARCH: (state, query) => { state.assetSearchText = query }
+        CHANGE_SEARCH: (state, query) => {
+          state.assetSearchText = query
+        }
       },
       actions: {
-        changeSearch ({ commit, state }, query) {
+        changeSearch({ commit, state }, query) {
           commit('CHANGE_SEARCH', query)
         }
       }
@@ -69,11 +78,14 @@ describe('BuildFilterModal', () => {
           { id: 'person-2', name: 'James', active: true },
           { id: 'person-3', name: 'Ema', active: true }
         ],
-        personMap: () => new Map(Object.entries({
-          'person-1': { id: 'person-1', name: 'John', active: true },
-          'person-2': { id: 'person-2', name: 'James', active: true },
-          'person-3': { id: 'person-3', name: 'Ema', active: true }
-        }))
+        personMap: () =>
+          new Map(
+            Object.entries({
+              'person-1': { id: 'person-1', name: 'John', active: true },
+              'person-2': { id: 'person-2', name: 'James', active: true },
+              'person-3': { id: 'person-3', name: 'Ema', active: true }
+            })
+          )
       },
       actions: {}
     }
@@ -90,17 +102,23 @@ describe('BuildFilterModal', () => {
           { id: 'task-status-2', short_name: 'WIP' },
           { id: 'task-status-3', short_name: 'Retake' }
         ],
-        taskTypeMap: () => new Map(Object.entries({
-          'task-type-1': { id: 'task-type-1', name: 'Modeling' },
-          'task-type-2': { id: 'task-type-2', name: 'Rigging' },
-          'task-type-3': { id: 'task-type-3', name: 'Layout' },
-          'task-type-4': { id: 'task-type-4', name: 'Animation' }
-        })),
-        taskStatusMap: () => new Map(Object.entries({
-          'task-status-1': { id: 'task-status-1', short_name: 'WFA' },
-          'task-status-2': { id: 'task-status-2', short_name: 'WIP' },
-          'task-status-3': { id: 'task-status-3', short_name: 'Retake' }
-        }))
+        taskTypeMap: () =>
+          new Map(
+            Object.entries({
+              'task-type-1': { id: 'task-type-1', name: 'Modeling' },
+              'task-type-2': { id: 'task-type-2', name: 'Rigging' },
+              'task-type-3': { id: 'task-type-3', name: 'Layout' },
+              'task-type-4': { id: 'task-type-4', name: 'Animation' }
+            })
+          ),
+        taskStatusMap: () =>
+          new Map(
+            Object.entries({
+              'task-status-1': { id: 'task-status-1', short_name: 'WFA' },
+              'task-status-2': { id: 'task-status-2', short_name: 'WIP' },
+              'task-status-3': { id: 'task-status-3', short_name: 'Retake' }
+            })
+          )
       },
       actions: {}
     }
@@ -132,43 +150,45 @@ describe('BuildFilterModal', () => {
       wrapper.findComponent(BuildFilterModal)
     })
     describe('mount with query', () => {
-      it('task types', () => new Promise(done => {
-        expect(wrapper.find('.task-type-filter').exists()).toBeFalsy()
-        wrapper.setData({
-          taskTypeFilters: {
-            values: [
-              {
-                id: 'task-type-1',
-                operator: '=',
-                values: ['task-status-2']
-              }
-            ]
-          }
-        })
-        wrapper.vm.$nextTick().then(() => {
-          expect(wrapper.find('.task-type-filter').exists()).toBeTruthy()
-          done()
-        })
-      }))
-      it('descriptors', () => new Promise(done => {
-        expect(wrapper.find('.descriptor-filter').exists()).toBeFalsy()
-        wrapper.setData({
-          metadataDescriptorFilters: {
-            values: [
-              {
-                id: 'descriptor-1',
-                operator: '=',
-                values: ['easy'],
-                is_checklist: false
-              }
-            ]
-          }
-        })
-        wrapper.vm.$nextTick().then(() => {
-          expect(wrapper.find('.descriptor-filter').exists()).toBeTruthy()
-          done()
-        })
-      }))
+      it('task types', () =>
+        new Promise(done => {
+          expect(wrapper.find('.task-type-filter').exists()).toBeFalsy()
+          wrapper.setData({
+            taskTypeFilters: {
+              values: [
+                {
+                  id: 'task-type-1',
+                  operator: '=',
+                  values: ['task-status-2']
+                }
+              ]
+            }
+          })
+          wrapper.vm.$nextTick().then(() => {
+            expect(wrapper.find('.task-type-filter').exists()).toBeTruthy()
+            done()
+          })
+        }))
+      it('descriptors', () =>
+        new Promise(done => {
+          expect(wrapper.find('.descriptor-filter').exists()).toBeFalsy()
+          wrapper.setData({
+            metadataDescriptorFilters: {
+              values: [
+                {
+                  id: 'descriptor-1',
+                  operator: '=',
+                  values: ['easy'],
+                  is_checklist: false
+                }
+              ]
+            }
+          })
+          wrapper.vm.$nextTick().then(() => {
+            expect(wrapper.find('.descriptor-filter').exists()).toBeTruthy()
+            done()
+          })
+        }))
     })
   })
 
@@ -352,21 +372,26 @@ describe('BuildFilterModal', () => {
             wrapper.setData({
               assignation: {
                 value: 'assignedto',
-                person: { id: 'person-1', name: 'John' }
+                taskTypeId: 'task-type-1',
+                person: {
+                  id: 'person-1',
+                  name: 'John'
+                }
               }
             })
             const query = wrapper.vm.buildFilter()
-            expect(query).toBe('assignedto=[John]')
+            expect(query).toBe('assignedto[Modeling]=[John]')
           })
           it('not assigned to', () => {
             wrapper.setData({
               assignation: {
                 value: '-assignedto',
+                taskTypeId: 'task-type-1',
                 person: { id: 'person-1', name: 'John' }
               }
             })
             const query = wrapper.vm.buildFilter()
-            expect(query).toBe('assignedto=[-John]')
+            expect(query).toBe('assignedto[Modeling]=[-John]')
           })
         })
         describe('thumbnail', () => {
@@ -394,22 +419,26 @@ describe('BuildFilterModal', () => {
             wrapper.setData({
               assignation: {
                 value: 'assignedto',
+                taskTypeId: 'task-type-1',
                 person: { id: 'person-1', name: 'John' }
               },
               union: 'or'
             })
             const query = wrapper.vm.buildFilter()
-            expect(query).toBe('+(assignedto=[John])')
+            expect(query).toBe('+(assignedto[Modeling]=[John])')
           })
         })
       })
 
       describe('Set values from query', () => {
-        const changeSearch = (query) => {
-          assetStore.actions.changeSearch({
-            commit: store.commit,
-            state: store.state
-          }, query)
+        const changeSearch = query => {
+          assetStore.actions.changeSearch(
+            {
+              commit: store.commit,
+              state: store.state
+            },
+            query
+          )
         }
 
         describe('task types', () => {
@@ -499,15 +528,16 @@ describe('BuildFilterModal', () => {
             expect(wrapper.vm.assignation.taskTypeId).toBe('task-type-1')
           })
           it('assigned to', () => {
-            changeSearch('assignedto=[John]')
+            changeSearch('assignedto[Modeling]=[John]')
             wrapper.vm.setFiltersFromCurrentQuery()
             expect(wrapper.vm.assignation.value).toBe('assignedto')
             expect(wrapper.vm.assignation.person.id).toBe('person-1')
           })
           it('not assigned to', () => {
-            changeSearch('assignedto=[-John]')
+            changeSearch('assignedto[Modeling]=[-John]')
             wrapper.vm.setFiltersFromCurrentQuery()
             expect(wrapper.vm.assignation.value).toBe('-assignedto')
+            expect(wrapper.vm.assignation.taskTypeId).toBe('task-type-1')
             expect(wrapper.vm.assignation.person.id).toBe('person-1')
           })
         })
@@ -541,11 +571,13 @@ describe('BuildFilterModal', () => {
         it('add', () => {
           expect(wrapper.vm.taskTypeFilters.values).toHaveLength(0)
           wrapper.vm.addTaskTypeFilter()
-          expect(wrapper.vm.taskTypeFilters.values).toStrictEqual([{
-            id: 'task-type-1',
-            operator: '=',
-            values: ['task-status-1']
-          }])
+          expect(wrapper.vm.taskTypeFilters.values).toStrictEqual([
+            {
+              id: 'task-type-1',
+              operator: '=',
+              values: ['task-status-1']
+            }
+          ])
           wrapper.vm.addTaskTypeFilter()
           expect(wrapper.vm.taskTypeFilters.values).toHaveLength(2)
         })
@@ -562,12 +594,14 @@ describe('BuildFilterModal', () => {
         it('add', () => {
           expect(wrapper.vm.taskTypeFilters.values).toHaveLength(0)
           wrapper.vm.addDescriptorFilter()
-          expect(wrapper.vm.metadataDescriptorFilters.values).toStrictEqual([{
-            id: 'descriptor-1',
-            operator: '=',
-            values: ['easy'],
-            is_checklist: false
-          }])
+          expect(wrapper.vm.metadataDescriptorFilters.values).toStrictEqual([
+            {
+              id: 'descriptor-1',
+              operator: '=',
+              values: ['easy'],
+              is_checklist: false
+            }
+          ])
           wrapper.vm.addDescriptorFilter()
           expect(wrapper.vm.metadataDescriptorFilters.values).toHaveLength(2)
         })


### PR DESCRIPTION
**Problem**

The Miyu and Monelo studios reported a bunch of issues:

- The Pan/Zoom is active, while it shouldn't be when switching to fullscreen (it breaks the annotation canvas resizing).
- The priority is not displayed on done tasks, which makes things confusing when filtering and sorting.
- Departments, automations, and asset types are not archivable.
- Assignation filters do not apply to an asset type, which makes it hard to use.
- It's not possible to load more results on the search page.

**Solution**

- Disable pan / zoom for 2s when switching to full screen.
- Always display the priority in task cells.
- Add the capability to archive departments, automation, and asset types.
- Add a task type parameter to the assignation filter
- Add a load more button on the search page
