### PR TITLE
[csv] add missing sanitize for some csv import + stop removing ';' an…

### DIFF
--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -925,8 +925,8 @@ export default {
     uploadImportFile(data) {
       const formData = new FormData()
       const filename = 'import.csv'
-      const csvcontent = csv.turnEntriesToCsvString(data)
-      const file = new File([csvcontent], filename, { type: 'text/csv' })
+      const csvContent = csv.turnEntriesToCsvString(data)
+      const file = new File([csvContent], filename, { type: 'text/csv' })
 
       formData.append('file', file)
 

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -925,7 +925,8 @@ export default {
     uploadImportFile(data) {
       const formData = new FormData()
       const filename = 'import.csv'
-      const file = new File([data.join('\n')], filename, { type: 'text/csv' })
+      const csvcontent = csv.turnEntriesToCsvString(data)
+      const file = new File([csvcontent], filename, { type: 'text/csv' })
 
       formData.append('file', file)
 

--- a/src/components/pages/People.vue
+++ b/src/components/pages/People.vue
@@ -337,7 +337,8 @@ export default {
     uploadImportFile(data, toUpdate) {
       const formData = new FormData()
       const filename = 'import.csv'
-      const file = new File([data.join('\n')], filename, { type: 'text/csv' })
+      const csvContent = csv.turnEntriesToCsvString(data)
+      const file = new File([csvContent], filename, { type: 'text/csv' })
 
       formData.append('file', file)
       this.loading.importing = true

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1330,7 +1330,8 @@ export default {
     uploadImportFile(data) {
       const formData = new FormData()
       const filename = 'import.csv'
-      const file = new File([data.join('\n')], filename, { type: 'text/csv' })
+      const csvContent = csv.turnEntriesToCsvString(data)
+      const file = new File([csvContent], filename, { type: 'text/csv' })
 
       formData.append('file', file)
 

--- a/src/lib/csv.js
+++ b/src/lib/csv.js
@@ -113,9 +113,7 @@ const csv = {
     entries.forEach(infoArray => {
       const sanitizedCells = infoArray.map(cell => {
         const cellString = `${cell || ''}`
-        if (cellString.search('"') !== -1) {
-          return `${cellString.replace(/;/g, '')}`
-        } else return `"${cellString}"`
+        return `"${cellString.replace(/"/g, '""')}"`
       })
       const line = sanitizedCells.join(';')
       if (line.length > 2) lineArray.push(line)


### PR DESCRIPTION
…d add always double quotes

**Problem**
- Some csv imports aren't sanitized before sending them to Zou.
- We remove delimiter ";" and don't double double quotes so it's not properly recognized by Zou (and it can leads to wrong behavior) 

**Solution**
- Sanitize every csv import before sending it to Zou. 
- Only double double quotes and always put the cell between double quote. 
