### PR TITLE
Fix annotation loading for videos

### DIFF
--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -60,6 +60,10 @@ export const annotationMixin = {
   },
 
   methods: {
+    findAnnotation(list, time) {
+      return list.find(a => a.time < time + 0.0001 && a.time > time - 0.0001)
+    },
+
     // Objects
 
     /*
@@ -259,7 +263,7 @@ export const annotationMixin = {
     addToAdditions(obj) {
       this.markLastAnnotationTime()
       const currentTime = this.getCurrentTime()
-      const additions = this.additions.find(a => a.time === currentTime)
+      const additions = this.findAnnotation(this.additions, currentTime)
       if (additions) {
         additions.drawing.objects.push(obj.serialize())
       } else {
@@ -283,7 +287,7 @@ export const annotationMixin = {
      */
     removeFromAdditions(obj) {
       const currentTime = this.getCurrentTime()
-      const additions = this.additions.find(a => a.time === currentTime)
+      const additions = this.findAnnotation(this.additions, currentTime)
       if (additions) {
         additions.drawing.objects = additions.drawing.objects.filter(
           o => o.id !== obj.id
@@ -297,7 +301,7 @@ export const annotationMixin = {
     addToDeletions(obj) {
       this.markLastAnnotationTime()
       const currentTime = this.getCurrentTime()
-      const deletion = this.deletions.find(d => d.time === currentTime)
+      const deletion = this.findAnnotation(this.deletions, currentTime)
       if (deletion) {
         deletion.objects.push(obj.id)
       } else {
@@ -309,7 +313,6 @@ export const annotationMixin = {
       if (!obj.serialize) {
         this.addSerialization(obj)
       }
-
       this.postAnnotationDeletion(currentTime, obj.serialize())
     },
 
@@ -325,7 +328,7 @@ export const annotationMixin = {
      */
     removeFromDeletions(obj) {
       const currentTime = this.getCurrentTime()
-      const deletions = this.deletions.find(a => a.time === currentTime)
+      const deletions = this.findAnnotation(this.deletions, currentTime)
       if (deletions) {
         deletions.objects = deletions.objects.filter(oId => oId !== obj.id)
       }
@@ -345,7 +348,7 @@ export const annotationMixin = {
     addToUpdatesSerializedObject(obj) {
       this.markLastAnnotationTime()
       const currentTime = this.getCurrentTime()
-      const updates = this.updates.find(a => a.time === currentTime)
+      const updates = this.findAnnotation(this.updates, currentTime)
       if (updates) {
         updates.drawing.objects = updates.drawing.objects.filter(
           o => o.id !== obj.id

--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -872,7 +872,8 @@ export const playerMixin = {
     },
 
     getCurrentTime() {
-      return roundToFrame(this.currentTimeRaw, this.fps) || 0
+      const time = roundToFrame(this.currentTimeRaw, this.fps) || 0
+      return Number(time.toPrecision(4))
     },
 
     setCurrentTimeRaw(time) {

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -2042,15 +2042,6 @@ export default {
 
     fullScreen() {
       this.resetHeight()
-      console.log('fullscreen', this.fullScreen)
-
-      this.$nextTick().then(() => {
-        window.dispatchEvent(new Event('resize'))
-
-        setTimeout(() => {
-          window.dispatchEvent(new Event('resize'))
-        }, 300)
-      })
     },
 
     isComparing() {

--- a/src/components/pages/playlists/RawVideoPlayer.vue
+++ b/src/components/pages/playlists/RawVideoPlayer.vue
@@ -223,12 +223,12 @@ export default {
       }
     },
 
-    resetHeight(height) {
+    resetHeight() {
       this.$nextTick(() => {
         if (this.currentPlayer) this.currentPlayer.style.height = '0px'
         if (this.nextPlayer) this.nextPlayer.style.height = '0px'
         if (this.container) {
-          height = height || this.container.offsetHeight
+          const height = this.container.offsetHeight
           if (this.currentPlayer)
             this.currentPlayer.style.height = `${height}px`
           if (this.nextPlayer) this.nextPlayer.style.height = `${height}px`

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -986,6 +986,7 @@ export default {
     },
 
     setVideoFrameContext(frame) {
+      frame = Math.min(frame, this.nbFrames - 1)
       if (this.currentFrame !== frame) {
         const time = frame * this.frameDuration
         this.currentFrame = frame
@@ -1066,7 +1067,8 @@ export default {
 
     getCurrentTime() {
       if (!this.isMovie) return 0
-      return this.currentTimeRaw
+      const time = roundToFrame(this.currentTimeRaw, this.fps)
+      return Number(time.toPrecision(4))
     },
 
     play() {
@@ -1457,7 +1459,10 @@ export default {
       if (this.isMovie) {
         time = roundToFrame(time, this.fps)
         return this.annotations.find(annotation => {
-          return roundToFrame(annotation.time, this.fps) === time
+          return (
+            roundToFrame(annotation.time, this.fps) < time + 0.0001 &&
+            roundToFrame(annotation.time, this.fps) > time - 0.0001
+          )
         })
       } else if (this.isPicture) {
         return this.annotations.find(annotation => annotation.time === 0)
@@ -1477,6 +1482,7 @@ export default {
       if (this.isMovie) {
         currentTime = this.currentFrame * this.frameDuration
         currentTime = roundToFrame(currentTime, this.fps)
+        currentTime = Number(currentTime.toPrecision(4))
       }
       const annotation = this.getAnnotation(currentTime)
       const annotations = this.getNewAnnotations(currentTime, annotation)

--- a/src/components/previews/VideoViewer.vue
+++ b/src/components/previews/VideoViewer.vue
@@ -399,7 +399,10 @@ export default {
       } else {
         currentTimeRaw = 0
       }
-      return Math.ceil(currentTimeRaw / this.frameDuration) + 1
+      let frame = Math.ceil(currentTimeRaw / this.frameDuration) + 1
+      frame = Number(frame.toPrecision(4))
+      frame = Math.min(frame, this.nbFrames)
+      return frame
     },
 
     play() {


### PR DESCRIPTION
**Problem**

* Annotations can be lost because they are tied to a frame time + 0.0000001.
* The playlist player may become black when resizing or switching to full screen.

**Solution**

* Make annotation loading more loosy.
* Force precision to 4 digits when retrieving the current time.
* Use always the container to compute the height of the player.