### PR TITLE
Add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+liberapay: CGWire


### PR DESCRIPTION
**Problem**
- Missing "Sponsor" section on GitHub.

**Solution**
- Add FUNDING.yml with Liberapay.
