### PR TITLE
Various fixes

### DIFF
--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -289,7 +289,7 @@
       <task-info
         ref="task-info"
         class="flexrow-item task-info-column"
-        :current-frame="parseInt(currentFrame)"
+        :current-frame="parseInt(currentFrame) - 1"
         :current-parent-preview="currentPreview"
         :fps="fps"
         :is-preview="false"

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -645,7 +645,7 @@ export default {
       fullScreen: false,
       color: '#ff3860',
       currentBackground: null,
-      currentTime: '00:00.000',
+      currentTime: '00:00:00.00',
       currentTimeRaw: 0,
       isObjectBackground: false,
       isAnnotationsDisplayed: true,
@@ -1101,7 +1101,7 @@ export default {
           this.videoDuration - this.frameDuration
         )
       } else {
-        this.maxDuration = '00:00.000'
+        this.maxDuration = '00:00:00.00'
         this.videoDuration = 0
       }
     },

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1276,6 +1276,7 @@ export default {
         this.loadTaskData()
       }
     },
+
     silent: {
       immediate: true,
       handler() {
@@ -1283,6 +1284,10 @@ export default {
           this.loadTaskData()
         }
       }
+    },
+
+    currentFrame() {
+      this.currentFrameRaw = this.currentFrame
     }
   },
 

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -701,9 +701,7 @@ export default {
 
     timeCodeClicked(event) {
       const data = { ...event.target.dataset }
-      const isChromium = !!window.chrome
-      const change = isChromium ? 2 : 1
-      data.frame = data.frame - change
+      data.frame = data.frame - 1
       this.pauseEvent(event)
       this.$emit('time-code-clicked', data)
     },

--- a/src/lib/video.js
+++ b/src/lib/video.js
@@ -40,13 +40,13 @@ export const frameToSeconds = (nbFrames, production, shot) => {
  */
 export const formatTime = seconds => {
   if (seconds < 0) seconds = 0
-  let milliseconds = `${Math.round((seconds % 1) * 1000)}`.padStart(3, '0')
-  milliseconds = '.' + milliseconds
+  let centiseconds = `${Math.round((seconds % 1) * 100)}`.padStart(2, '0')
+  centiseconds = '.' + centiseconds
   try {
-    return new Date(1000 * seconds).toISOString().substr(14, 5) + milliseconds
+    return new Date(1000 * seconds).toISOString().substr(11, 8) + centiseconds
   } catch (err) {
     console.error(err)
-    return '00:00.000'
+    return '00:00:00.00'
   }
 }
 

--- a/tests/unit/lib/video.spec.js
+++ b/tests/unit/lib/video.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 import {
   formatFrame,
   formatTime,
@@ -43,14 +45,14 @@ describe('video', () => {
   })
 
   it('formatTime', () => {
-    expect(formatTime(0.091)).toBe('00:00.091')
-    expect(formatTime(0.001)).toBe('00:00.001')
-    expect(formatTime(0.900)).toBe('00:00.900')
-    expect(formatTime(0.960)).toBe('00:00.960')
-    expect(formatTime(0.966)).toBe('00:00.966')
-    expect(formatTime(2.416)).toBe('00:02.416')
-    expect(formatTime(2.016)).toBe('00:02.016')
-    expect(formatTime(60.018)).toBe('01:00.018')
-    expect(formatTime(362.018)).toBe('06:02.018')
+    expect(formatTime(0.091)).toBe('00:00:00.09')
+    expect(formatTime(0.001)).toBe('00:00:00.00')
+    expect(formatTime(0.9)).toBe('00:00:00.90')
+    expect(formatTime(0.96)).toBe('00:00:00.96')
+    expect(formatTime(0.966)).toBe('00:00:00.97')
+    expect(formatTime(2.416)).toBe('00:00:02.42')
+    expect(formatTime(2.016)).toBe('00:00:02.02')
+    expect(formatTime(60.018)).toBe('00:01:00.02')
+    expect(formatTime(362.018)).toBe('00:06:02.02')
   })
 })


### PR DESCRIPTION
**Problem**

* The timestamp displayed doesn't conform to the SMPTE standards.
* The frame tagging adds an extra frame.

**Solution**

* Apply the standard rendering to the preview player
* Use the right frame computation during the frame tagging
