### PR TITLE
[previews] fix loading of backgrounds for 3D models in Task list

### DIFF
--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -737,9 +737,9 @@ export default {
     ...mapGetters([
       'assetMap',
       'currentProduction',
+      'getProductionBackgrounds',
       'isCurrentUserArtist',
       'organisation',
-      'productionBackgrounds',
       'selectedConcepts',
       'user'
     ]),
@@ -995,6 +995,10 @@ export default {
             (this.isDefaultBackground(background) ? ` (${defaultFlag})` : '')
         }))
       ]
+    },
+
+    productionBackgrounds() {
+      return this.getProductionBackgrounds(this.task?.project_id)
     },
 
     currentConcept() {

--- a/src/store/modules/productions.js
+++ b/src/store/modules/productions.js
@@ -167,9 +167,14 @@ const getters = {
     }
   },
 
-  productionBackgrounds: (state, rootState) => {
-    const backgrounds = state.currentProduction?.preview_background_files?.map(
-      id => rootState.backgroundMap.get(id)
+  productionBackgrounds: (state, getters) => {
+    return getters.getProductionBackgrounds(state.currentProduction?.id)
+  },
+
+  getProductionBackgrounds: (state, rootState) => id => {
+    const production = state.productionMap.get(id)
+    const backgrounds = production?.preview_background_files?.map(id =>
+      rootState.backgroundMap.get(id)
     )
     return backgrounds ? sortByName(backgrounds) : []
   },


### PR DESCRIPTION
**Problem**
- In the task list of pages without production selected (e.g., "My Tasks"), the HDR backgrounds are not loaded with 3D model previews.

**Solution**
- Fix loading of backgrounds for 3D models according to the current task.
