### PR TITLE
Fix available task statuses on Concepts

### DIFF
--- a/src/components/modals/EditCommentModal.vue
+++ b/src/components/modals/EditCommentModal.vue
@@ -225,15 +225,16 @@ export default {
   computed: {
     ...mapGetters([
       'departmentMap',
+      'getTaskStatusForCurrentUser',
       'isCurrentUserClient',
       'productionDepartmentIds',
       'taskStatusForCurrentUser'
     ]),
 
     taskStatuses() {
-      return this.taskStatusForCurrentUser.filter(
-        status => Boolean(status.for_concept) === this.isConceptTask
-      )
+      return this.isConceptTask
+        ? this.getTaskStatusForCurrentUser(null, true)
+        : this.taskStatusForCurrentUser.filter(status => !status.for_concept)
     },
 
     isConceptTask() {

--- a/src/components/pages/ProductionSettings.vue
+++ b/src/components/pages/ProductionSettings.vue
@@ -231,7 +231,9 @@ export default {
 
     remainingTaskStatuses() {
       return this.taskStatus.filter(
-        s => !this.currentProduction.task_statuses.includes(s.id)
+        status =>
+          !this.currentProduction.task_statuses.includes(status.id) &&
+          !status.for_concept
       )
     }
   },

--- a/src/components/pages/production/NewProduction.vue
+++ b/src/components/pages/production/NewProduction.vue
@@ -738,7 +738,8 @@ export default {
       return this.taskStatus.filter(
         status =>
           this.productionToCreate.taskStatuses.indexOf(status) === -1 &&
-          !status.is_default
+          !status.is_default &&
+          !status.for_concept
       )
     },
 

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -649,11 +649,9 @@ export default {
     },
 
     taskStatuses() {
-      const taskStatuses = this.getTaskStatusForCurrentUser(
-        this.task.project_id
-      )
-      return taskStatuses.filter(
-        status => Boolean(status.for_concept) === this.isConceptTask
+      return this.getTaskStatusForCurrentUser(
+        this.task.project_id,
+        this.isConceptTask
       )
     },
 

--- a/src/store/modules/taskstatus.js
+++ b/src/store/modules/taskstatus.js
@@ -48,21 +48,23 @@ const getters = {
   },
 
   getTaskStatusForCurrentUser:
-    (state, getters, rootState, rootGetters) => projectId => {
-      const statuses = rootGetters.getProductionTaskStatuses(projectId)
+    (state, getters, rootState, rootGetters) =>
+    (projectId, forConcept = false) => {
+      let statuses = forConcept
+        ? getters.taskStatuses
+        : rootGetters.getProductionTaskStatuses(projectId)
+      statuses = statuses.filter(
+        status => Boolean(status.for_concept) === forConcept
+      )
       if (
         rootGetters.isCurrentUserManager ||
         rootGetters.isCurrentUserSupervisor
       ) {
         return statuses
       } else if (rootGetters.isCurrentUserClient) {
-        return statuses.filter(taskStatus => {
-          return taskStatus.is_client_allowed
-        })
+        return statuses.filter(taskStatus => taskStatus.is_client_allowed)
       } else {
-        return statuses.filter(taskStatus => {
-          return taskStatus.is_artist_allowed
-        })
+        return statuses.filter(taskStatus => taskStatus.is_artist_allowed)
       }
     }
 }


### PR DESCRIPTION
**Problem**
- Available task status combo boxes display unwanted statuses related to Concepts (e.g., on the Create Production form)
- The Concepts' task statuses are not always visible depending on the project configuration.

**Solution**
- Fix available task statuses on forms.
