### PR TITLE
Fix concept creation

### DIFF
--- a/src/store/modules/concepts.js
+++ b/src/store/modules/concepts.js
@@ -1,4 +1,5 @@
 import async from 'async'
+import { v4 as uuidv4 } from 'uuid'
 
 import conceptsApi from '@/store/api/concepts'
 
@@ -87,7 +88,7 @@ const actions = {
 
     // Create Entity
     const entity = {
-      name: crypto.randomUUID(), // unique and mandatory field
+      name: uuidv4(), // unique and mandatory field
       project_id: production.id
     }
     const concept = await conceptsApi.newConcept(entity)


### PR DESCRIPTION
**Problem**
- An error can block the concept creation process (see #1275 )

**Solution**
- In some cases, the native crypto API is blocked by the browser (e.g. HTTP url, privacy extensions, ...). Use `uuid` npm library instead.
