### PR TITLE
Improve kanban board

### DIFF
--- a/src/components/pages/ProductionSettings.vue
+++ b/src/components/pages/ProductionSettings.vue
@@ -18,6 +18,11 @@
               {{ $t('task_status.title') }}
             </a>
           </li>
+          <li :class="{ 'is-active': isActiveTab('board') }">
+            <a @click="activeTab = 'board'">
+              {{ $t('board.settings.title') }}
+            </a>
+          </li>
           <li :class="{ 'is-active': isActiveTab('taskTypes') }">
             <a @click="activeTab = 'taskTypes'">
               {{ $t('task_types.title') }}
@@ -159,6 +164,10 @@
         </table>
       </div>
 
+      <div class="tab" v-show="isActiveTab('board')">
+        <production-board />
+      </div>
+
       <div class="tab" v-show="isActiveTab('statusAutomations')">
         <production-status-automations />
       </div>
@@ -180,6 +189,7 @@ import BooleanCell from '@/components/cells/BooleanCell'
 import Combobox from '@/components/widgets/Combobox'
 import ComboboxStatus from '@/components/widgets/ComboboxStatus'
 import ProductionBackgrounds from '@/components/pages/production/ProductionBackgrounds'
+import ProductionBoard from '@/components/pages/production/ProductionBoard'
 import ProductionBrief from '@/components/pages/production/ProductionBrief'
 import ProductionParameters from '@/components/pages/production/ProductionParameters'
 import ProductionStatusAutomations from '@/components/pages/production/ProductionStatusAutomations'
@@ -194,6 +204,7 @@ export default {
     ComboboxStatus,
     draggable,
     ProductionBackgrounds,
+    ProductionBoard,
     ProductionBrief,
     ProductionParameters,
     ProductionStatusAutomations,
@@ -321,9 +332,10 @@ export default {
 
     async updateTaskStatusPriorities(taskStatuses) {
       const taskStatusLinks = taskStatuses.map((taskStatus, index) => ({
-        projectId: this.currentProduction.id,
-        taskStatusId: taskStatus.id,
-        priority: index + 1
+        ...this.currentProduction.task_statuses_link[taskStatus.id],
+        priority: index + 1,
+        project_id: this.currentProduction.id,
+        task_status_id: taskStatus.id
       }))
       for (const taskStatusLink of taskStatusLinks) {
         await this.editTaskStatusLink(taskStatusLink)

--- a/src/components/pages/Todos.vue
+++ b/src/components/pages/Todos.vue
@@ -275,10 +275,17 @@ export default {
     },
 
     boardStatuses() {
-      const statuses = this.getProductionTaskStatuses(this.productionId).filter(
-        status => !status.for_concept
-      )
       const production = this.productionMap.get(this.productionId)
+      const statuses = this.getProductionTaskStatuses(this.productionId).filter(
+        status => {
+          if (status.for_concept) {
+            return false
+          }
+          const roles_for_board =
+            production.task_statuses_link?.[status.id]?.roles_for_board
+          return roles_for_board?.includes(this.user.role)
+        }
+      )
       return sortTaskStatuses(statuses, production)
     },
 

--- a/src/components/pages/production/ProductionBoard.vue
+++ b/src/components/pages/production/ProductionBoard.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="production-board">
+    <div class="box" v-if="!currentProduction.task_statuses?.length">
+      {{ $t('settings.production.empty_list') }}
+    </div>
+    <table class="datatable" v-else>
+      <thead>
+        <tr>
+          <th class="th-name">{{ $t('task_status.fields.name') }}</th>
+          <th class="th-short-name">
+            {{ $t('task_status.fields.short_name') }}
+          </th>
+          <th class="th-roles">
+            {{ $t('board.settings.visible') }}
+          </th>
+        </tr>
+      </thead>
+      <tbody class="datatable-body">
+        <template v-for="taskStatus in sortedProductionTaskStatuses">
+          <tr
+            class="datatable-row task-status"
+            :key="taskStatus.id"
+            v-if="taskStatus"
+          >
+            <td>{{ taskStatus.name }}</td>
+            <td class="name">
+              <validation-tag
+                :is-static="true"
+                :task="{ task_status_id: taskStatus.id }"
+              />
+            </td>
+            <td class="role">
+              <boolean-field
+                class="role-field"
+                :key="`${taskStatus.id}-${role}`"
+                :label="$t(`people.role.${role}`)"
+                :value="String(isActiveRole(taskStatus, role))"
+                @click="updateRolesForBoard(taskStatus, role)"
+                v-for="role in availableRoles"
+              />
+            </td>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+
+import { sortTaskStatuses } from '@/lib/sorting'
+
+import BooleanField from '@/components/widgets/BooleanField'
+import ValidationTag from '@/components/widgets/ValidationTag'
+
+export default {
+  name: 'production-board',
+
+  components: {
+    BooleanField,
+    ValidationTag
+  },
+
+  data() {
+    return {
+      availableRoles: ['user', 'vendor', 'supervisor', 'manager', 'admin']
+    }
+  },
+
+  computed: {
+    ...mapGetters(['currentProduction', 'productionTaskStatuses']),
+
+    sortedProductionTaskStatuses() {
+      return sortTaskStatuses(
+        this.productionTaskStatuses,
+        this.currentProduction
+      )
+    }
+  },
+
+  methods: {
+    ...mapActions(['editTaskStatusLink', 'loadContext']),
+
+    getActiveRoles(taskStatus) {
+      return (
+        this.currentProduction.task_statuses_link[taskStatus.id]
+          ?.roles_for_board || []
+      )
+    },
+
+    isActiveRole(taskStatus, role) {
+      return this.getActiveRoles(taskStatus).includes(role)
+    },
+
+    async updateRolesForBoard(taskStatus, role) {
+      const roles = this.getActiveRoles(taskStatus)
+      if (this.isActiveRole(taskStatus, role)) {
+        roles.splice(roles.indexOf(role), 1)
+      } else {
+        roles.push(role)
+      }
+
+      const taskStatusLink = {
+        ...this.currentProduction.task_statuses_link[taskStatus.id],
+        roles_for_board: roles,
+        project_id: this.currentProduction.id,
+        task_status_id: taskStatus.id
+      }
+      await this.editTaskStatusLink(taskStatusLink)
+      await this.loadContext()
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.datatable th {
+  color: var(--text);
+  padding-left: 10px;
+  padding-bottom: 5px;
+}
+
+.th-name {
+  width: 200px;
+}
+
+.th-short-name {
+  width: 120px;
+}
+
+.role {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+
+  .role-field {
+    margin: 0;
+  }
+}
+</style>

--- a/src/components/pages/production/ProductionBoard.vue
+++ b/src/components/pages/production/ProductionBoard.vue
@@ -73,7 +73,7 @@ export default {
 
     sortedProductionTaskStatuses() {
       return sortTaskStatuses(
-        this.productionTaskStatuses,
+        [...this.productionTaskStatuses],
         this.currentProduction
       )
     }
@@ -94,7 +94,7 @@ export default {
     },
 
     async updateRolesForBoard(taskStatus, role) {
-      const roles = this.getActiveRoles(taskStatus)
+      const roles = [...this.getActiveRoles(taskStatus)]
       if (this.isActiveRole(taskStatus, role)) {
         roles.splice(roles.indexOf(role), 1)
       } else {

--- a/src/lib/productions.js
+++ b/src/lib/productions.js
@@ -56,6 +56,7 @@ export function getTaskStatusPriorityOfProd(taskStatus, production) {
   if (!taskStatus) {
     return 1
   }
-  const productionPriority = production?.task_statuses_priority?.[taskStatus.id]
+  const productionPriority =
+    production?.task_statuses_link?.[taskStatus.id]?.priority
   return productionPriority || taskStatus.priority
 }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -70,7 +70,11 @@ export default {
   },
 
   board: {
-    title: 'Board'
+    title: 'Board',
+    settings: {
+      title: 'Board Status',
+      visible: 'Displayed on kanban board of...'
+    }
   },
 
   breakdown: {

--- a/src/store/api/taskstatus.js
+++ b/src/store/api/taskstatus.js
@@ -43,9 +43,10 @@ export default {
 
   async updateTaskStatusLink(taskStatusLink) {
     const data = {
-      project_id: taskStatusLink.projectId,
-      task_status_id: taskStatusLink.taskStatusId,
-      priority: taskStatusLink.priority
+      project_id: taskStatusLink.project_id,
+      task_status_id: taskStatusLink.task_status_id,
+      priority: taskStatusLink.priority,
+      roles_for_board: taskStatusLink.roles_for_board
     }
     return await client.ppost('/api/data/task-status-links', data)
   },


### PR DESCRIPTION
**Problem**
- The kanban board may display too many columns.
- The horizontal scroll with a mouse is limited to the scroll bar.

**Solution**
- Add a board settings section on the production settings page to select which statuses to display based on user role.
- Allow horizontal scrolling by grabbing.