### PR TITLE
Various fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -136,7 +136,6 @@ export default {
       handler() {
         const userLocale = this.user?.locale.substring(0, 2)
         const variant = this.currentProduction?.production_style
-        console.log(userLocale, variant, this.$i18n.locale)
         if (userLocale !== 'en') {
           return
         }

--- a/src/components/lists/KanbanBoard.vue
+++ b/src/components/lists/KanbanBoard.vue
@@ -311,6 +311,7 @@ export default {
 .board {
   user-select: none;
   flex: 1;
+  flex-direction: column;
   display: flex;
   max-height: 80%;
 }

--- a/src/components/lists/KanbanBoard.vue
+++ b/src/components/lists/KanbanBoard.vue
@@ -41,7 +41,7 @@
             draggable
             :key="task.id"
             @click="onSelectTask(task, $event.ctrlKey || $event.metaKey)"
-            @dragstart="onCardDragStart($event, task)"
+            @dragstart="onCardDragStart($event, task, column.status)"
             @drag="onCardDrag"
             @dragend="onCardDragEnd"
             @mouseenter="onCardMouseEnter"
@@ -252,12 +252,13 @@ export default {
       this.isScrollingX = false
     },
 
-    onCardDragStart(event, task) {
+    onCardDragStart(event, task, taskStatus) {
       event.stopPropagation()
       event.target.classList.add('drag')
       event.dataTransfer.dropEffect = 'move'
       event.dataTransfer.effectAllowed = 'move'
       event.dataTransfer.setData('taskId', task.id)
+      event.dataTransfer.setData('taskStatusId', taskStatus.id)
     },
 
     onCardDrag(event) {
@@ -284,6 +285,10 @@ export default {
 
     onCardDrop(event, taskStatusId) {
       event.currentTarget.classList.remove('droppable')
+      const previousTaskStatusId = event.dataTransfer.getData('taskStatusId')
+      if (previousTaskStatusId === taskStatusId) {
+        return
+      }
       const taskId = event.dataTransfer.getData('taskId')
       this.commentTask({
         taskId,


### PR DESCRIPTION
**Problem**
- Unwanted `console.log()`
- on Kanban board, the task status of a task can be updated unnecessarily if dropped on the original column.
- on Kanban board, the loader is incorrectly positioned.

**Solution**
- Remove log.
- Update the task status only if the card dropped in a new status.
- Fix loader position.
