### PR TITLE
Improve kanban board

### DIFF
--- a/src/components/lists/KanbanBoard.vue
+++ b/src/components/lists/KanbanBoard.vue
@@ -267,10 +267,10 @@ export default {
     },
 
     onBoardScrolling(event) {
-      event.preventDefault()
       if (!this.isScrollingX) {
         return
       }
+      event.preventDefault()
       const clientX = this.getClientX(event)
       const diffX = clientX - this.initialClientX
       event.currentTarget.scrollLeft -= diffX

--- a/src/components/lists/KanbanBoard.vue
+++ b/src/components/lists/KanbanBoard.vue
@@ -318,6 +318,10 @@ export default {
   flex-direction: column;
   display: flex;
   overflow-y: auto;
+
+  > .box {
+    margin: 2px; // avoid the overflow from hiding the box-shadow
+  }
 }
 
 .board-columns,

--- a/src/components/pages/Todos.vue
+++ b/src/components/pages/Todos.vue
@@ -100,6 +100,7 @@
           :is-error="isTodosLoadingError"
           :statuses="boardStatuses"
           :tasks="boardTasks"
+          :user="user"
           v-if="isTabActive('board')"
         />
 

--- a/src/components/pages/production/ProductionBoard.vue
+++ b/src/components/pages/production/ProductionBoard.vue
@@ -29,15 +29,32 @@
                 :task="{ task_status_id: taskStatus.id }"
               />
             </td>
-            <td class="role">
+            <td class="roles">
               <boolean-field
                 class="role-field"
                 :key="`${taskStatus.id}-${role}`"
                 :label="$t(`people.role.${role}`)"
                 :value="String(isActiveRole(taskStatus, role))"
-                @click="updateRolesForBoard(taskStatus, role)"
+                @click="
+                  value =>
+                    updateRolesForBoard(taskStatus, [role], value === 'true')
+                "
                 v-for="role in availableRoles"
               />
+              <button
+                class="button"
+                @click="updateRolesForBoard(taskStatus, availableRoles)"
+                v-if="getActiveRoles(taskStatus).length < availableRoles.length"
+              >
+                {{ $t('board.settings.select_all') }}
+              </button>
+              <button
+                class="button"
+                @click="updateRolesForBoard(taskStatus, availableRoles, false)"
+                v-else
+              >
+                {{ $t('board.settings.unselect_all') }}
+              </button>
             </td>
           </tr>
         </template>
@@ -93,13 +110,16 @@ export default {
       return this.getActiveRoles(taskStatus).includes(role)
     },
 
-    async updateRolesForBoard(taskStatus, role) {
+    async updateRolesForBoard(taskStatus, rolesToUpdate, addition = true) {
       const roles = [...this.getActiveRoles(taskStatus)]
-      if (this.isActiveRole(taskStatus, role)) {
-        roles.splice(roles.indexOf(role), 1)
-      } else {
-        roles.push(role)
-      }
+
+      rolesToUpdate.forEach(role => {
+        if (addition && !this.isActiveRole(taskStatus, role)) {
+          roles.push(role)
+        } else if (!addition && this.isActiveRole(taskStatus, role)) {
+          roles.splice(roles.indexOf(role), 1)
+        }
+      })
 
       const taskStatusLink = {
         ...this.currentProduction.task_statuses_link[taskStatus.id],
@@ -129,13 +149,31 @@ export default {
   width: 120px;
 }
 
-.role {
+.roles {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5em;
+  align-items: center;
 
   .role-field {
     margin: 0;
+  }
+
+  .button {
+    border: 2px dashed transparent;
+    border-radius: 25px;
+    color: $grey;
+    background: none;
+    font-size: 0.9em;
+    font-weight: 500;
+    height: 100%;
+    padding: 0.5em 1.2em;
+    transition: 0.3s ease all;
+
+    &:hover {
+      color: $light-green;
+      border-color: $light-green;
+    }
   }
 }
 </style>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -76,7 +76,9 @@ export default {
     confirm_publish_button: 'Change status without publishing files',
     settings: {
       title: 'Board Status',
-      visible: 'Displayed on kanban board of...'
+      visible: 'Displayed on kanban board of...',
+      select_all: "Select all",
+      unselect_all: "Unselect all"
     }
   },
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -72,6 +72,8 @@ export default {
   board: {
     title: 'Board',
     empty: 'Your kanban board is currently empty. It means no task status is configured for your user role in the production settings.',
+    confirm_publish: 'There is no preview files set for publishing. Are you sure you want to change the status of this task?',
+    confirm_publish_button: 'Change status without publishing files',
     settings: {
       title: 'Board Status',
       visible: 'Displayed on kanban board of...'


### PR DESCRIPTION
**Problem**
- On kanban board, a user can update a task to any status without checking their rights.
- On kanban board, some task can require feedback before updating its status (e.g. WFA).
- On production settings, in the board section, selecting the roles to modify one by one is boring.
- With browsers based on Chromium, the cards are not draggable in the kanban board.

**Solution**
- Check that a user is authorized to update the status of a task.
- Add a confirmation modal if a task requires feedback.
- Add a button to select/unselect all roles on board settings.
- Fix event of card dragging for Chromium browser.