### PR TITLE
Improve kanban board

### DIFF
--- a/src/components/modals/AddPreviewModal.vue
+++ b/src/components/modals/AddPreviewModal.vue
@@ -94,9 +94,11 @@
             @click="$emit('confirm', forms)"
           >
             {{
-              isConcept
-                ? $t('main.confirmation')
-                : $t('tasks.add_revision_confirm')
+              confirmLabel?.length
+                ? confirmLabel
+                : isConcept
+                  ? $t('main.confirmation')
+                  : $t('tasks.add_revision_confirm')
             }}
           </a>
           <button @click="$emit('cancel')" class="button is-link">
@@ -128,6 +130,14 @@ export default {
       type: Boolean,
       default: false
     },
+    confirmLabel: {
+      type: String,
+      default: ''
+    },
+    extensions: {
+      type: String,
+      default: files.ALL_EXTENSIONS_STRING
+    },
     isConcept: {
       type: Boolean,
       default: false
@@ -147,10 +157,6 @@ export default {
     isMultiple: {
       type: Boolean,
       default: true
-    },
-    extensions: {
-      type: String,
-      default: files.ALL_EXTENSIONS_STRING
     },
     message: {
       type: String,

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -72,8 +72,6 @@ export default {
   board: {
     title: 'Board',
     empty: 'Your kanban board is currently empty. It means no task status is configured for your user role in the production settings.',
-    confirm_publish: 'There is no preview files set for publishing. Are you sure you want to change the status of this task?',
-    confirm_publish_button: 'Change status without publishing files',
     settings: {
       title: 'Board Status',
       visible: 'Displayed on kanban board of...',


### PR DESCRIPTION
**Problem**
- On kanban board, a task may require feedback before updating its status (e.g. WFA). In this case, it is more common to publish preview files upon the status change.

**Solution**
-  Add a upload preview modal if a task status requires feedback.
