### PR TITLE
Fix timecode link

### DIFF
--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -10,8 +10,7 @@ const options = {
 }
 marked.use(markedEmoji(options))
 
-export const TIME_CODE_REGEX =
-  /v(\d+) ((\d+):)?(\d+):(\d+)(\.|:)(\d+) \((\d+)\)/g
+export const TIME_CODE_REGEX = /v(\d+) (\d+:)?(\d+):(\d+)(\.|:)(\d+) \((\d+)\)/g
 
 export const sanitize = html => {
   return sanitizeHTML(html, {


### PR DESCRIPTION
**Problem**
- In task comment, the tag `@frame` takes last number in timecode as frame number (related to #1293).

**Solution**
- Fix timecode regex.
