### PR TITLE
Assignation field partially clickable on task panel

### DIFF
--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -339,7 +339,7 @@
           </div>
           <div class="flexrow mb05">
             <people-field
-              class="flexrow-item is-wide"
+              class="flexrow-item is-wide assignation-field"
               ref="assignation-field"
               :people="currentTeam"
               :placeholder="$t('tasks.assign_explaination')"
@@ -1838,6 +1838,10 @@ div.assignation {
 
 .change-status-item {
   margin-right: 0.5em;
+}
+
+.assignation-field ::v-deep .v-autocomplete {
+  z-index: 501; // +1 relative to the z-index of canvas-wrapper
 }
 
 .status-item {


### PR DESCRIPTION
**Problem**
- The assignation field is partially clickable on the task panel. The latest usernames are not interactive if they are over the preview player.

**Solution**
- Fix the z-index issue on the assignation field in the task panel.
