### PR TITLE
Rollback to Vue 2.7.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "three": "0.160.1",
         "uuid": "9.0.1",
         "v-autocomplete": "1.8.2",
-        "vue": "2.7.16",
+        "vue": "2.7.15",
         "vue-at": "2.5.1",
         "vue-chartkick": "0.6.1",
         "vue-drag-drop": "1.1.4",
@@ -56,7 +56,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue2": "2.3.1",
-        "@vue/compiler-sfc": "2.7.16",
+        "@vue/compiler-sfc": "2.7.15",
         "@vue/test-utils": "1.3.6",
         "autoprefixer": "10.4.17",
         "eslint": "8.56.0",
@@ -73,7 +73,7 @@
         "vite": "5.0.12",
         "vitest": "0.34.6",
         "vitest-localstorage-mock": "0.0.1",
-        "vue-template-compiler": "2.7.16"
+        "vue-template-compiler": "2.7.15"
       },
       "engines": {
         "node": ">=18.12"
@@ -1264,31 +1264,13 @@
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
-      "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.15.tgz",
+      "integrity": "sha512-FCvIEevPmgCgqFBH7wD+3B97y7u7oj/Wr69zADBf403Tui377bThTjBvekaZvlRr4IwUAu3M6hYZeULZFJbdYg==",
       "dependencies": {
-        "@babel/parser": "^7.23.5",
+        "@babel/parser": "^7.18.4",
         "postcss": "^8.4.14",
         "source-map": "^0.6.1"
-      },
-      "optionalDependencies": {
-        "prettier": "^1.18.2 || ^2.0.0"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "optional": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@vue/test-utils": {
@@ -6422,12 +6404,12 @@
       }
     },
     "node_modules/vue": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
-      "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.15.tgz",
+      "integrity": "sha512-a29fsXd2G0KMRqIFTpRgpSbWaNBK3lpCTOLuGLEDnlHWdjB8fwl6zyYZ8xCrqkJdatwZb4mGHiEfJjnw0Q6AwQ==",
       "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
       "dependencies": {
-        "@vue/compiler-sfc": "2.7.16",
+        "@vue/compiler-sfc": "2.7.15",
         "csstype": "^3.1.0"
       }
     },
@@ -6532,9 +6514,9 @@
       "integrity": "sha512-06gDoheKMU8TdqjoofIJaYfXw3uuWOXF2I14d/F5yW/8iOxnoI4Ks9WSXy8RWY+gs62GBE6tQXHDSX/H6IOaAw=="
     },
     "node_modules/vue-template-compiler": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-      "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz",
+      "integrity": "sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==",
       "dev": true,
       "dependencies": {
         "de-indent": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "three": "0.160.1",
     "uuid": "9.0.1",
     "v-autocomplete": "1.8.2",
-    "vue": "2.7.16",
+    "vue": "2.7.15",
     "vue-at": "2.5.1",
     "vue-chartkick": "0.6.1",
     "vue-drag-drop": "1.1.4",
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue2": "2.3.1",
-    "@vue/compiler-sfc": "2.7.16",
+    "@vue/compiler-sfc": "2.7.15",
     "@vue/test-utils": "1.3.6",
     "autoprefixer": "10.4.17",
     "eslint": "8.56.0",
@@ -82,7 +82,7 @@
     "vite": "5.0.12",
     "vitest": "0.34.6",
     "vitest-localstorage-mock": "0.0.1",
-    "vue-template-compiler": "2.7.16"
+    "vue-template-compiler": "2.7.15"
   },
   "engines": {
     "node": ">=18.12"


### PR DESCRIPTION
**Problem**
- on the entity list, the selected item doesn't have the right style applied.

**Solution**
- The release 2.7.16 of Vue has a side effect on dynamic style + reference update. Rollback to the previous release.

