### PR TITLE
[qa] Remove Canny

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,6 +26,5 @@ module.exports = {
     'vue/prop-name-casing': ['error', 'camelCase']
   },
   globals: {
-    Canny: true
   }
 }

--- a/index.html
+++ b/index.html
@@ -17,5 +17,4 @@
     <!-- built files will be auto injected -->
   </body>
 
-<script>!function(w,d,i,s){function l(){if(!d.getElementById(i)){var f=d.getElementsByTagName(s)[0],e=d.createElement(s);e.type="text/javascript",e.async=!0,e.src="https://canny.io/sdk.js",f.parentNode.insertBefore(e,f)}}if("function"!=typeof w.Canny){var c=function(){c.q.push(arguments)};c.q=[],w.Canny=c,"complete"===d.readyState?l():w.attachEvent?w.attachEvent("onload",l):w.addEventListener("load",l,!1)}}(window,document,"canny-jssdk","script");</script>
 </html>

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -105,9 +105,13 @@
           v-if="mainConfig.indexer_configured"
         />
         <div class="nav-item">
-          <button data-canny-changelog class="changelog-button">
+          <a
+            class="changelog-button"
+            target="_blank"
+            href="https://cgwire.canny.io/changelog"
+          >
             <zap-icon />
-          </button>
+          </a>
         </div>
         <notification-bell />
         <div class="nav-item">
@@ -263,11 +267,6 @@ export default {
   },
 
   mounted() {
-    Canny('initChangelog', {
-      appID: '5db968118d1a9c132c168d54',
-      position: 'bottom',
-      align: 'right'
-    })
     this.currentProjectSection = this.getCurrentSectionFromRoute()
     this.setProductionFromRoute()
   },


### PR DESCRIPTION

**Problem**

There is no guarantee that it is GDPR compliant and it adds a non-essential tracker to the application.


**Solution**

Remove the Canny widget and shows a link to our changelog instead.
