### PR TITLE
Create task on empty cells of entity list

### DIFF
--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -8,7 +8,7 @@
     ></div>
     <div class="side task-info">
       <action-panel
-        v-if="withActions && (nbSelectedTasks > 0 || nbSelectedEntities > 0)"
+        v-if="withActions && (!isConceptTask || selectedConcepts.size > 0)"
         :is-set-frame-thumbnail-loading="loading.setFrameThumbnail"
         @export-task="onExportClick"
         @set-frame-thumbnail="onSetCurrentFrameAsThumbnail"


### PR DESCRIPTION
**Problem**
- On entity lists, you can no longer create a task by selecting one or more empty cells.

**Solution**
- Update the condition to show the action panel if you are in an entity list or in the concept page with a selected concept.
