### PR TITLE
Improve keyboard shortcuts on macOS

### DIFF
--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -786,7 +786,7 @@ export const playerMixin = {
           event.stopPropagation()
           // ctrl + shift + left
           if (
-            event.ctrlKey &&
+            (event.ctrlKey || event.metaKey) &&
             event.shiftKey &&
             this.moveSelectedEntityToLeft
           ) {
@@ -799,7 +799,7 @@ export const playerMixin = {
           event.stopPropagation()
           // ctrl + shift + right
           if (
-            event.ctrlKey &&
+            (event.ctrlKey || event.metaKey) &&
             event.shiftKey &&
             this.moveSelectedEntityToLeft
           ) {
@@ -821,15 +821,19 @@ export const playerMixin = {
           event.preventDefault()
           event.stopPropagation()
           this.onPlayNextEntityClicked()
-        } else if (event.ctrlKey && event.keyCode === 67) {
+        } else if ((event.ctrlKey || event.metaKey) && event.keyCode === 67) {
           // ctrl + c
           this.copyAnnotations()
-        } else if (event.ctrlKey && event.keyCode === 86) {
+        } else if ((event.ctrlKey || event.metaKey) && event.keyCode === 86) {
           // ctrl + v
           this.pasteAnnotations()
-        } else if (event.ctrlKey && event.altKey && event.keyCode === 68) {
+        } else if (
+          (event.ctrlKey || event.metaKey) &&
+          event.altKey &&
+          event.keyCode === 68
+        ) {
           this.onAnnotateClicked()
-        } else if (event.ctrlKey && event.keyCode === 90) {
+        } else if ((event.ctrlKey || event.metaKey) && event.keyCode === 90) {
           this.undoLastAction()
         } else if (event.altKey && event.keyCode === 82) {
           this.redoLastAction()

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -1102,10 +1102,10 @@ export default {
 
     onKeyDown(event) {
       if (!['INPUT', 'TEXTAREA'].includes(event.target.tagName)) {
-        if (event.ctrlKey && event.keyCode === 67) {
+        if ((event.ctrlKey || event.metaKey) && event.keyCode === 67) {
           // ctrl + c
           this.copyCasting()
-        } else if (event.ctrlKey && event.keyCode === 86) {
+        } else if ((event.ctrlKey || event.metaKey) && event.keyCode === 86) {
           // ctrl + v
           this.pasteCasting()
         }

--- a/src/components/pages/EntitySearch.vue
+++ b/src/components/pages/EntitySearch.vue
@@ -245,7 +245,11 @@ export default {
 
   mounted() {
     window.addEventListener('keydown', event => {
-      if (event.ctrlKey && event.altKey && event.keyCode === 70) {
+      if (
+        (event.ctrlKey || event.metaKey) &&
+        event.altKey &&
+        event.keyCode === 70
+      ) {
         this.searchField.focus()
       } else if (event.keyCode === 40) {
         this.selectNext()

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1738,7 +1738,7 @@ export default {
           this.container.focus()
           this.pauseEvent(event)
           this.onPencilAnnotateClicked()
-        } else if (event.ctrlKey && event.keyCode === 90) {
+        } else if ((event.ctrlKey || event.metaKey) && event.keyCode === 90) {
           // ctrl + z
           this.undoLastAction()
         } else if (event.altKey && event.keyCode === 82) {
@@ -1750,10 +1750,10 @@ export default {
         } else if (event.altKey && event.keyCode === 75) {
           // alt+k
           this.onNextClicked()
-        } else if (event.ctrlKey && event.keyCode === 67) {
+        } else if ((event.ctrlKey || event.metaKey) && event.keyCode === 67) {
           // ctrl + c
           this.copyAnnotations()
-        } else if (event.ctrlKey && event.keyCode === 86) {
+        } else if ((event.ctrlKey || event.metaKey) && event.keyCode === 86) {
           // ctrl + v
           this.pasteAnnotations()
         } else if (event.keyCode === 27) {

--- a/src/components/tops/GlobalSearchField.vue
+++ b/src/components/tops/GlobalSearchField.vue
@@ -190,7 +190,11 @@ export default {
 
   mounted() {
     window.addEventListener('keydown', event => {
-      if (event.ctrlKey && event.altKey && event.keyCode === 70) {
+      if (
+        (event.ctrlKey || event.metaKey) &&
+        event.altKey &&
+        event.keyCode === 70
+      ) {
         if (this.$refs['global-search-field']) {
           this.$refs['global-search-field'].focus()
         }


### PR DESCRIPTION
**Problem**
- on Apple macOS, some keyboard shortcuts don't work as expected. For example, in the preview player, you cannot copy/paste an annotation with the macOs conventional shortcut `Cmd + c` / `Cmd + v`, but it works with Windows/Linux conventional `Ctlr + c` / `Ctlr + v`.

**Solution**
- On key press, support the `Command` key (macOS) as a `Control` key (Windows/Linux)
