### PR TITLE
Fix status selection on ToDo list

### DIFF
--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -7,7 +7,7 @@
       validation: selectable
     }"
     :style="cellStyle"
-    @click="onSelect"
+    @click="onClick"
   >
     <div class="wrapper" v-if="!minimized">
       <template v-if="task">
@@ -231,8 +231,14 @@ export default {
   },
 
   methods: {
-    onSelect(event) {
-      if (!this.clickable || !this.selectable) {
+    onClick(event) {
+      if (this.clickable) {
+        this.select(event)
+      }
+    },
+
+    select(event) {
+      if (!this.selectable) {
         return
       }
       this.$emit(!this.selected ? 'select' : 'unselect', {


### PR DESCRIPTION
**Problem**
- In the ToDo list of My Tasks page, I cannot select a status as expected.

**Solution**
- Fix status selection by allowing the selection of a validation cell defined as non-clickable.
