### PR TITLE
Set Monday as first day of the week on the  user calendar

### DIFF
--- a/src/components/widgets/UserCalendar.vue
+++ b/src/components/widgets/UserCalendar.vue
@@ -60,7 +60,8 @@ export default {
           center: 'title',
           right: 'dayGridMonth,dayGridWeek,multiMonthYear'
         },
-        initialView: 'dayGridMonth'
+        initialView: 'dayGridMonth',
+        firstDay: 1
       }
     }
   },


### PR DESCRIPTION
**Problem**
-  In "My Tasks" section, the first day of the week on the calendar is currently Sunday.

**Solution**
- Set Monday as the first day of the week, to be consistent with other calendars in Kitsu.
