### PR TITLE
Allow to set entity thumbnails automatically

### DIFF
--- a/src/components/modals/AddPreviewModal.vue
+++ b/src/components/modals/AddPreviewModal.vue
@@ -24,6 +24,7 @@
 
         <file-upload
           ref="preview-field"
+          class="preview-files-field"
           :accept="extensions"
           :is-primary="false"
           :label="$t('main.select_file')"
@@ -43,7 +44,7 @@
         <h3 class="subtitle has-text-centered" v-if="forms.length > 0">
           Selected Files
         </h3>
-        <p class="upload-previews mt2" v-if="forms.length > 0">
+        <p class="upload-previews" v-if="forms.length > 0">
           <template v-for="(form, i) in forms">
             <p class="preview-name" :key="'name-' + i">
               {{ form.get('file').name }}
@@ -280,9 +281,11 @@ export default {
   text-transform: uppercase;
 }
 
-h1.title {
+.modal-content .box h1.title {
   font-weight: 350;
+  font-size: 2.2em;
   line-height: 1.2em;
+  margin-bottom: 0.5em;
 }
 
 h3 {
@@ -293,7 +296,7 @@ h3 {
 }
 
 h3.subtitle {
-  margin-top: 2em;
+  margin-top: 1em;
   font-weight: 400;
 }
 
@@ -304,5 +307,9 @@ h3.subtitle {
 
 .message-body {
   border-width: 0 0 0 4px;
+}
+
+.preview-files-field {
+  margin: auto;
 }
 </style>

--- a/src/components/pages/production/ProductionParameters.vue
+++ b/src/components/pages/production/ProductionParameters.vue
@@ -52,7 +52,7 @@
           v-if="currentProduction && currentProduction.id"
         />
 
-        <text-field
+        <!--text-field
           ref="nbEpisodesField"
           type="number"
           :step="1"
@@ -60,7 +60,7 @@
           @enter="runConfirmation"
           v-model="form.nb_episodes"
           v-if="currentProduction && currentProduction.id && isLocalTVShow"
-        />
+        /-->
         <!--text-field
           ref="episodesSpanField"
           :label="$t('productions.fields.episode_span')"
@@ -106,6 +106,13 @@
           :label="$t('productions.fields.is_preview_download_allowed')"
           @enter="runConfirmation"
           v-model="form.is_preview_download_allowed"
+          v-if="currentProduction && currentProduction.id"
+        />
+        <combobox-boolean
+          ref="isSetPreviewAutomated"
+          :label="$t('productions.fields.is_set_preview_automated')"
+          @enter="runConfirmation"
+          v-model="form.is_set_preview_automated"
           v-if="currentProduction && currentProduction.id"
         />
         <text-field
@@ -185,6 +192,7 @@ export default {
         max_retakes: 0,
         is_clients_isolated: 'false',
         is_preview_download_allowed: 'false',
+        is_set_preview_automated: 'false',
         ratio: '',
         resolution: '',
         production_type: 'short'
@@ -266,6 +274,10 @@ export default {
             .is_preview_download_allowed
             ? 'true'
             : 'false',
+          is_set_preview_automated: this.currentProduction
+            .is_set_preview_automated
+            ? 'true'
+            : 'false',
           ratio: this.currentProduction.ratio,
           resolution: this.currentProduction.resolution,
           homepage: this.currentProduction.homepage
@@ -281,6 +293,7 @@ export default {
           max_retakes: 0,
           is_clients_isolated: 'false',
           is_preview_download_allowed: 'false',
+          is_set_preview_automated: 'false',
           fps: '',
           ratio: '',
           resolution: '',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -919,6 +919,7 @@ export default {
       fps: 'FPS',
       is_clients_isolated: 'Isolate client comments (not visible to each others)',
       is_preview_download_allowed: 'Allow artists to download previews',
+      is_set_preview_automated: 'Set new preview as entity thumbnail automatically',
       max_retakes: 'Maximum number of retakes',
       name: 'Name',
       nb_episodes: 'Number of episodes',
@@ -1085,7 +1086,7 @@ export default {
       discord_token: 'Discord Token (Optional)',
       timesheets_locked: 'Lock artist timesheets older than 1 week',
       use_original_name: 'Use original file name for downloads',
-      show_hd_default: 'Show picture with HD quality by default'
+      show_hd_default: 'Show movies with HD quality by default (slower)'
     },
     production: {
       empty_list: 'The list is currently empty. It means that all data from the main settings are available to users. Add some entries to limit choices for this production.',

--- a/src/store/api/productions.js
+++ b/src/store/api/productions.js
@@ -40,6 +40,7 @@ export default {
       is_clients_isolated: production.is_clients_isolated === 'true',
       is_preview_download_allowed:
         production.is_preview_download_allowed === 'true',
+      is_set_preview_automated: production.is_set_preview_automated === 'true',
       homepage: production.homepage
     }
     return client.pput(`/api/data/projects/${production.id}`, data)

--- a/src/store/modules/productions.js
+++ b/src/store/modules/productions.js
@@ -657,9 +657,11 @@ const mutations = {
     // update states
     if (previousProduction) {
       Object.assign(previousProduction, production)
+      Object.assign(production, previousProduction)
     }
     if (openProduction) {
       Object.assign(openProduction, production)
+      Object.assign(production, openProduction)
     }
     if (isStatusChanged) {
       if (production.project_status_name === 'Open') {


### PR DESCRIPTION
**Problem**

https://cgwire.canny.io/asset-and-shot-tables/p/automatically-set-the-thumbnail-from-the-latest-preview-upload

**Solution**

Add a setting at the project level to allow to set automatically the latest upload as the entity thumbnail.
