### PR TITLE
Isolate concept statuses

### DIFF
--- a/src/components/lists/TaskStatusList.vue
+++ b/src/components/lists/TaskStatusList.vue
@@ -28,9 +28,6 @@
             <th scope="col" class="is-feedback-request">
               {{ $t('task_status.fields.is_feedback_request') }}
             </th>
-            <th scope="col" class="is-concept">
-              {{ $t('task_status.fields.for_concept') }}
-            </th>
             <th scope="col" class="actions"></th>
           </tr>
         </thead>
@@ -63,7 +60,6 @@
               class="is-feedback-request"
               :value="entry.is_feedback_request"
             />
-            <boolean-cell class="is-concept" :value="entry.for_concept" />
             <row-actions-cell
               :entry-id="entry.id"
               :hide-delete="entry.is_default === true"
@@ -163,8 +159,7 @@ export default {
 .is-retake,
 .is-artist-allowed,
 .is-client-allowed,
-.is-feedback-request,
-.is-concept {
+.is-feedback-request {
   text-align: center;
   width: 140px;
   min-width: 140px;

--- a/src/components/modals/EditTaskStatusModal.vue
+++ b/src/components/modals/EditTaskStatusModal.vue
@@ -40,6 +40,7 @@
             :label="$t('task_status.fields.is_default')"
             @enter="confirmClicked"
             v-model="form.is_default"
+            :disabled="form.for_concept === 'true'"
           />
           <boolean-field
             :label="$t('task_status.fields.is_done')"
@@ -69,13 +70,14 @@
             v-model="form.is_feedback_request"
             v-if="form.is_default === 'false'"
           />
+          <!--
           <boolean-field
             :label="$t('task_status.fields.for_concept')"
             @enter="confirmClicked"
             v-model="form.for_concept"
             v-if="form.is_default === 'false'"
           />
-
+          -->
           <color-field
             ref="colorField"
             :label="$t('task_status.fields.color')"
@@ -83,7 +85,6 @@
             v-model="form.color"
             v-if="taskStatusToEdit.short_name !== 'todo'"
           />
-
           <combobox-boolean
             :label="$t('main.archived')"
             @enter="confirmClicked"

--- a/src/components/pages/TaskStatus.vue
+++ b/src/components/pages/TaskStatus.vue
@@ -15,14 +15,31 @@
       route-name="task-status"
     />
 
-    <task-status-list
-      :entries="taskStatusList"
-      :is-loading="loading.list"
-      :is-error="errors.list"
-      @edit-clicked="onEditClicked"
-      @delete-clicked="onDeleteClicked"
-      @update-priorities="updatePriorities"
-    />
+    <div class="column">
+      <h2>
+        {{ $t('task_status.title_entities') }}
+        <span class="help-tooltip" :title="$t('task_status.help.entities')">
+          <help-circle-icon class="icon is-small" />
+        </span>
+      </h2>
+      <task-status-list
+        :entries="taskStatusList.filter(taskStatus => !taskStatus.for_concept)"
+        :is-loading="loading.list"
+        :is-error="errors.list"
+        @edit-clicked="onEditClicked"
+        @delete-clicked="onDeleteClicked"
+        @update-priorities="updatePriorities"
+      />
+      <h2>{{ $t('task_status.title_concepts') }}</h2>
+      <task-status-list
+        :entries="taskStatusList.filter(taskStatus => !!taskStatus.for_concept)"
+        :is-loading="loading.list"
+        :is-error="errors.list"
+        @edit-clicked="onEditClicked"
+        @delete-clicked="onDeleteClicked"
+        @update-priorities="updatePriorities"
+      />
+    </div>
 
     <edit-task-status-modal
       :active="modals.edit"
@@ -47,6 +64,7 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
+import { HelpCircleIcon } from 'vue-feather-icons'
 
 import csv from '@/lib/csv'
 import stringHelpers from '@/lib/string'
@@ -63,6 +81,7 @@ export default {
   components: {
     DeleteModal,
     EditTaskStatusModal,
+    HelpCircleIcon,
     ListPageHeader,
     RouteTabs,
     TaskStatusList
@@ -235,3 +254,18 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.help-tooltip {
+  opacity: 0.5;
+  transition: opacity 0.3s ease;
+  margin-left: 0.25rem;
+
+  &:hover {
+    opacity: 1;
+  }
+  .icon.is-small {
+    vertical-align: baseline;
+  }
+}
+</style>

--- a/src/components/widgets/BooleanField.vue
+++ b/src/components/widgets/BooleanField.vue
@@ -113,6 +113,7 @@ export default {
   transition: 0.3s ease all;
 
   &[disabled] {
+    opacity: 0.5;
     pointer-events: none;
   }
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1106,6 +1106,11 @@ export default {
     number: 'task status | task status',
     new_task_status: 'Add a task status',
     title: 'Task Status',
+    title_entities: 'Status for entities',
+    title_concepts: 'Status for concepts',
+    help: {
+      entities: 'Assets, shots, sequences, ...'
+    },
     fields: {
       color: 'Color',
       for_concept: 'For concept',

--- a/src/locales/en_nft.js
+++ b/src/locales/en_nft.js
@@ -65,6 +65,12 @@ export default {
     }
   },
 
+  task_status: {
+    help: {
+      entities: 'Assets, NFTs, Sequences, ...'
+    }
+  },
+
   sequences: {
     delete_text: 'Are you sure you want to remove {name} from your database? All related NFTs and previews will be deleted. Please confirm by typing the sequence name below.',
     delete_error: 'An error occurred while deleting this sequence. There are probably data linked to it. Are you sure this sequence has no NFT linked to it?'

--- a/src/locales/en_video-game.js
+++ b/src/locales/en_video-game.js
@@ -105,6 +105,12 @@ export default {
     }
   },
 
+  task_status: {
+    help: {
+      entities: 'Assets, maps, levels, ...'
+    }
+  },
+
   sequences: {
     all_sequences: 'All levels',
     edit_error: 'An error occurred while saving this level. Are you sure there is no level with a similar name?',


### PR DESCRIPTION
**Problem**
- In the Admin section, concept statuses are mixed with other task statuses. This can be confusing.

**Solution**
- Group the task statuses by type: entities or concepts.
- Disable the action to manually set a task status as a status for concept.
- Disable the action to set a status as default if for concept status.
