### PR TITLE
Fix the reordering of the archived task types

### DIFF
--- a/src/store/api/tasktypes.js
+++ b/src/store/api/tasktypes.js
@@ -21,14 +21,16 @@ export default {
     const data = {
       name: taskType.name,
       color: taskType.color,
-      department_id: taskType.department_id,
-      archived: taskType.archived === 'true'
+      department_id: taskType.department_id
     }
     if (taskType.priority && taskType.priority > 0) {
       data.priority = Number(taskType.priority)
     }
     if (taskType.allow_timelog !== undefined) {
-      data.allow_timelog = Boolean(taskType.allow_timelog === 'true')
+      data.allow_timelog = taskType.allow_timelog === 'true'
+    }
+    if (taskType.archived !== undefined) {
+      data.archived = taskType.archived === 'true'
     }
     return client.pput(`/api/data/task-types/${taskType.id}`, data)
   },


### PR DESCRIPTION
**Problem**
As an administrator on the task types section, if we change the order of any archived item in the archived list, all archived items will be unarchived.

**Solution**
- Check the data to update to avoid resetting the Archived value accidentally.
