### PR TITLE
Various fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "localStorage": "1.0.4",
         "prettier": "3.2.5",
         "sass": "1.71.0",
-        "vite": "5.0.12",
+        "vite": "5.1.3",
         "vitest": "0.34.6",
         "vitest-localstorage-mock": "0.0.1",
         "vue-template-compiler": "2.7.16"
@@ -927,9 +927,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.11.0.tgz",
-      "integrity": "sha512-BV+u2QSfK3i1o6FucqJh5IK9cjAU6icjFFhvknzFgu472jzl0bBojfDAkJLBEsHFMo+YZg6rthBvBBt8z12IBQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
+      "integrity": "sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==",
       "cpu": [
         "arm"
       ],
@@ -940,9 +940,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.11.0.tgz",
-      "integrity": "sha512-0ij3iw7sT5jbcdXofWO2NqDNjSVVsf6itcAkV2I6Xsq4+6wjW1A8rViVB67TfBEan7PV2kbLzT8rhOVWLI2YXw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.0.tgz",
+      "integrity": "sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==",
       "cpu": [
         "arm64"
       ],
@@ -953,9 +953,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.11.0.tgz",
-      "integrity": "sha512-yPLs6RbbBMupArf6qv1UDk6dzZvlH66z6NLYEwqTU0VHtss1wkI4UYeeMS7TVj5QRVvaNAWYKP0TD/MOeZ76Zg==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.0.tgz",
+      "integrity": "sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==",
       "cpu": [
         "arm64"
       ],
@@ -966,9 +966,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.11.0.tgz",
-      "integrity": "sha512-OvqIgwaGAwnASzXaZEeoJY3RltOFg+WUbdkdfoluh2iqatd090UeOG3A/h0wNZmE93dDew9tAtXgm3/+U/B6bw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.0.tgz",
+      "integrity": "sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==",
       "cpu": [
         "x64"
       ],
@@ -979,9 +979,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.11.0.tgz",
-      "integrity": "sha512-X17s4hZK3QbRmdAuLd2EE+qwwxL8JxyVupEqAkxKPa/IgX49ZO+vf0ka69gIKsaYeo6c1CuwY3k8trfDtZ9dFg==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.0.tgz",
+      "integrity": "sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==",
       "cpu": [
         "arm"
       ],
@@ -992,9 +992,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.11.0.tgz",
-      "integrity": "sha512-673Lu9EJwxVB9NfYeA4AdNu0FOHz7g9t6N1DmT7bZPn1u6bTF+oZjj+fuxUcrfxWXE0r2jxl5QYMa9cUOj9NFg==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.0.tgz",
+      "integrity": "sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==",
       "cpu": [
         "arm64"
       ],
@@ -1005,9 +1005,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.11.0.tgz",
-      "integrity": "sha512-yFW2msTAQNpPJaMmh2NpRalr1KXI7ZUjlN6dY/FhWlOclMrZezm5GIhy3cP4Ts2rIAC+IPLAjNibjp1BsxCVGg==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.0.tgz",
+      "integrity": "sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==",
       "cpu": [
         "arm64"
       ],
@@ -1018,9 +1018,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.11.0.tgz",
-      "integrity": "sha512-kKT9XIuhbvYgiA3cPAGntvrBgzhWkGpBMzuk1V12Xuoqg7CI41chye4HU0vLJnGf9MiZzfNh4I7StPeOzOWJfA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.0.tgz",
+      "integrity": "sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==",
       "cpu": [
         "riscv64"
       ],
@@ -1031,9 +1031,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.11.0.tgz",
-      "integrity": "sha512-6q4ESWlyTO+erp1PSCmASac+ixaDv11dBk1fqyIuvIUc/CmRAX2Zk+2qK1FGo5q7kyDcjHCFVwgGFCGIZGVwCA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
+      "integrity": "sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==",
       "cpu": [
         "x64"
       ],
@@ -1044,9 +1044,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.11.0.tgz",
-      "integrity": "sha512-vIAQUmXeMLmaDN78HSE4Kh6xqof2e3TJUKr+LPqXWU4NYNON0MDN9h2+t4KHrPAQNmU3w1GxBQ/n01PaWFwa5w==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.0.tgz",
+      "integrity": "sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==",
       "cpu": [
         "x64"
       ],
@@ -1057,9 +1057,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.11.0.tgz",
-      "integrity": "sha512-LVXo9dDTGPr0nezMdqa1hK4JeoMZ02nstUxGYY/sMIDtTYlli1ZxTXBYAz3vzuuvKO4X6NBETciIh7N9+abT1g==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.0.tgz",
+      "integrity": "sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==",
       "cpu": [
         "arm64"
       ],
@@ -1070,9 +1070,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.11.0.tgz",
-      "integrity": "sha512-xZVt6K70Gr3I7nUhug2dN6VRR1ibot3rXqXS3wo+8JP64t7djc3lBFyqO4GiVrhNaAIhUCJtwQ/20dr0h0thmQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.0.tgz",
+      "integrity": "sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==",
       "cpu": [
         "ia32"
       ],
@@ -1083,9 +1083,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.11.0.tgz",
-      "integrity": "sha512-f3I7h9oTg79UitEco9/2bzwdciYkWr8pITs3meSDSlr1TdvQ7IxkQaaYN2YqZXX5uZhiYL+VuYDmHwNzhx+HOg==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.0.tgz",
+      "integrity": "sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==",
       "cpu": [
         "x64"
       ],
@@ -1839,9 +1839,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001587",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001587.tgz",
-      "integrity": "sha512-HMFNotUmLXn71BQxg8cijvqxnIAofforZOwGsxyXJ0qugTdspUF4sPSJ2vhgprHCB996tIDzEq1ubumPDV8ULA==",
+      "version": "1.0.30001588",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001588.tgz",
+      "integrity": "sha512-+hVY9jE44uKLkH0SrUTqxjxqNTOWHsbnQDIKjwkZ3lNTzUUVdBLBGXtj/q5Mp5u98r3droaZAewQuEDzjQdZlQ==",
       "dev": true,
       "funding": [
         {
@@ -2512,9 +2512,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.672",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.672.tgz",
-      "integrity": "sha512-YYCy+goe3UqZqa3MOQCI5Mx/6HdBLzXL/mkbGCEWL3sP3Z1BP9zqAzeD3YEmLZlespYGFtyM8tRp5i2vfaUGCA==",
+      "version": "1.4.673",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.673.tgz",
+      "integrity": "sha512-zjqzx4N7xGdl5468G+vcgzDhaHkaYgVcf9MqgexcTqsl2UHSCmOj/Bi3HAprg4BZCpC7HyD8a6nZl6QAZf72gw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -4026,9 +4026,9 @@
       }
     },
     "node_modules/js-beautify": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.0.tgz",
-      "integrity": "sha512-U1f+LPtn13M0OS0ChNMpM7wA7J47ECqwIcvayrZu+o0FLLt9FckoT6XOO1grhBS2vZjSt79K+vkUuP0o+BIdsA==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.1.tgz",
+      "integrity": "sha512-ESjNzSlt/sWE8sciZH8kBF8BPlwXPwhR6pWKAw8bw4Bwj+iZcnKW6ONWUutJ7eObuBZQpiIb8S7OYspWrKt7rA==",
       "dev": true,
       "dependencies": {
         "config-chain": "^1.1.13",
@@ -5524,9 +5524,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.11.0.tgz",
-      "integrity": "sha512-2xIbaXDXjf3u2tajvA5xROpib7eegJ9Y/uPlSFhXLNpK9ampCczXAhLEb5yLzJyG3LAdI1NWtNjDXiLyniNdjQ==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.0.tgz",
+      "integrity": "sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -5539,19 +5539,19 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.11.0",
-        "@rollup/rollup-android-arm64": "4.11.0",
-        "@rollup/rollup-darwin-arm64": "4.11.0",
-        "@rollup/rollup-darwin-x64": "4.11.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.11.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.11.0",
-        "@rollup/rollup-linux-arm64-musl": "4.11.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.11.0",
-        "@rollup/rollup-linux-x64-gnu": "4.11.0",
-        "@rollup/rollup-linux-x64-musl": "4.11.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.11.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.11.0",
-        "@rollup/rollup-win32-x64-msvc": "4.11.0",
+        "@rollup/rollup-android-arm-eabi": "4.12.0",
+        "@rollup/rollup-android-arm64": "4.12.0",
+        "@rollup/rollup-darwin-arm64": "4.12.0",
+        "@rollup/rollup-darwin-x64": "4.12.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.12.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.12.0",
+        "@rollup/rollup-linux-arm64-musl": "4.12.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.12.0",
+        "@rollup/rollup-linux-x64-gnu": "4.12.0",
+        "@rollup/rollup-linux-x64-musl": "4.12.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.12.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.12.0",
+        "@rollup/rollup-win32-x64-msvc": "4.12.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -6422,13 +6422,13 @@
       "integrity": "sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw=="
     },
     "node_modules/vite": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
-      "integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.3.tgz",
+      "integrity": "sha512-UfmUD36DKkqhi/F75RrxvPpry+9+tTkrXfMNZD+SboZqBCMsxKtO52XeGzzuh7ioz+Eo/SYDBbdb0Z7vgcDJew==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",
-        "postcss": "^8.4.32",
+        "postcss": "^8.4.35",
         "rollup": "^4.2.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "localStorage": "1.0.4",
     "prettier": "3.2.5",
     "sass": "1.71.0",
-    "vite": "5.0.12",
+    "vite": "5.1.3",
     "vitest": "0.34.6",
     "vitest-localstorage-mock": "0.0.1",
     "vue-template-compiler": "2.7.16"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1029,12 +1029,25 @@ input.input:focus {
   border-radius: 2em;
 }
 
-.datepicker .input.is-small {
-  font-size: 1em;
-  padding: 0.5em;
-  height: 2.3em;
-  width: 100px;
-  border-radius: 10px;
+.datepicker {
+  .input {
+    border-radius: 10px;
+
+    &::placeholder {
+      color: $light-grey;
+    }
+
+    &.is-small {
+      font-size: 1em;
+      padding: 0.5em;
+      height: 2.3em;
+      width: 100px;
+    }
+
+    &.invalid {
+      border-color: $red;
+    }
+  }
 }
 
 .button:focus {
@@ -2012,15 +2025,6 @@ th.validation-cell {
   ul {
     margin-bottom: 1em;
   }
-}
-
-.input.date-input {
-  border-radius: 10px;
-}
-
-.date-input::placeholder {
-  border-radius: 10px;
-  color: $light-grey;
 }
 
 .project-dates .date-input {

--- a/src/components/modals/NewTokenModal.vue
+++ b/src/components/modals/NewTokenModal.vue
@@ -14,13 +14,15 @@
             }}
           </p>
           <date-field
-            :label="$t('bots.fields.expiration_date')"
             :disabled-dates="{ to: new Date() }"
+            :invalid="!isValidExpirationDate"
+            :label="$t('bots.fields.expiration_date')"
             v-model="form.expiration_date"
           />
           <div class="flexrow right">
             <button
               class="button flexrow-item is-primary"
+              :disabled="!isValidExpirationDate"
               @click="generateToken"
             >
               {{ $t('bots.generate') }}
@@ -117,6 +119,15 @@ export default {
       },
       message: null,
       visible: false
+    }
+  },
+
+  computed: {
+    isValidExpirationDate() {
+      return (
+        !this.form.expiration_date ||
+        new Date(this.form.expiration_date) > new Date()
+      )
     }
   },
 

--- a/src/components/pages/OpenProductions.vue
+++ b/src/components/pages/OpenProductions.vue
@@ -106,13 +106,13 @@
           <router-link :to="getPath(production)">
             <div
               class="avatar has-text-centered"
-              v-bind:style="{
+              :style="{
                 background: getAvatarColor(production)
               }"
             >
-              <span v-if="!production.has_avatar">
+              <template v-if="!production.has_avatar">
                 {{ generateAvatar(production) }}
-              </span>
+              </template>
               <img :src="getThumbnailPath(production)" v-else />
             </div>
             <div class="production-name">
@@ -159,13 +159,13 @@
 </template>
 
 <script>
+import { XIcon } from 'vue-feather-icons'
 import { mapGetters, mapActions } from 'vuex'
 
-import { XIcon } from 'vue-feather-icons'
 import { buildNameIndex } from '@/lib/indexing'
+import colors from '@/lib/colors'
 import preferences from '@/lib/preferences'
 
-import colors from '@/lib/colors'
 import EditProductionModal from '@/components/modals/EditProductionModal'
 import SearchField from '@/components/widgets/SearchField'
 import Spinner from '@/components/widgets/Spinner'
@@ -250,6 +250,16 @@ export default {
         } else {
           route.params.episode_id = 'all'
         }
+      } else if (
+        production.production_type === 'shots' &&
+        routeName === 'assets'
+      ) {
+        route.name = 'shots'
+      } else if (
+        production.production_type === 'assets' &&
+        ['shots', 'sequences'].includes(routeName)
+      ) {
+        route.name = 'assets'
       }
       const isEntityPage = [
         'assets',

--- a/src/components/pages/ProductionNewsFeed.vue
+++ b/src/components/pages/ProductionNewsFeed.vue
@@ -18,7 +18,7 @@
               :label="$t('shots.fields.episode')"
               :options="runningEpisodeOptions"
               v-model="episodeId"
-              v-show="isTVShow"
+              v-if="isTVShow"
             />
             <combobox-status
               class="flexrow-item selector"
@@ -32,15 +32,20 @@
               :task-type-list="taskTypeList"
               v-model="taskTypeId"
             />
-            <div class="field flexrow-item selector small">
+            <div class="flexrow-item selector">
               <label class="label person-label">
                 {{ $t('main.person') }}
               </label>
-              <people-field :people="team" :big="true" v-model="person" />
+              <people-field
+                class="person-field small"
+                big
+                :people="team"
+                v-model="person"
+              />
             </div>
           </div>
 
-          <div class="filters flexrow mt1" v-show="isFiltersDisplayed">
+          <div class="filters flexrow mt1" v-if="isFiltersDisplayed">
             <date-field
               class="flexrow-item"
               :disabled-dates="{ from: today }"
@@ -968,6 +973,10 @@ export default {
 .person-label {
   margin-top: 5px;
   margin-bottom: 4px;
+}
+
+.person-field ::v-deep .v-autocomplete {
+  z-index: 501; // +1 relative to the z-index of canvas-wrapper
 }
 
 .filter-button {

--- a/src/components/pages/production/NewProduction.vue
+++ b/src/components/pages/production/NewProduction.vue
@@ -883,6 +883,8 @@ export default {
       if (this.isTVShow) {
         params.episode_id = 'all'
         routeName = 'episode-assets'
+      } else if (this.productionToCreate.settings.type === 'shots') {
+        routeName = 'shots'
       }
       return {
         name: routeName,

--- a/src/components/pages/production/NewProduction.vue
+++ b/src/components/pages/production/NewProduction.vue
@@ -121,7 +121,7 @@
             <div class="date-picker-wrapper">
               <datepicker
                 wrapper-class="datepicker"
-                input-class=" is-small date-input input"
+                input-class="is-small date-input input"
                 label="Start date"
                 :placeholder="startDatePlaceholder"
                 :language="locale"

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -16,7 +16,8 @@
                 isInDepartment ||
                 isCurrentViewTodos) &&
               !isEntitySelection &&
-              isTaskSelection
+              isTaskSelection &&
+              nbSelectedTasks > 1
             "
           >
             {{ $t('main.status') }}

--- a/src/components/widgets/ConceptCard.vue
+++ b/src/components/widgets/ConceptCard.vue
@@ -110,7 +110,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .concept-item {
   border-radius: 1em;
   box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.1);

--- a/src/components/widgets/DateField.vue
+++ b/src/components/widgets/DateField.vue
@@ -7,6 +7,7 @@
         :input-class="{
           'date-input': true,
           input: true,
+          invalid,
           short: shortDate
         }"
         :language="locale"
@@ -56,6 +57,10 @@ export default {
     disabledDates: {
       default: () => {},
       type: Object
+    },
+    invalid: {
+      default: false,
+      type: Boolean
     },
     label: {
       default: '',

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -7,7 +7,7 @@ import init from '@/lib/init'
 
 import userStore from '@/store/modules/user'
 import taskTypeStore from '@/store/modules/tasktypes'
-import store from '@/store/'
+import store from '@/store'
 
 import Assets from '@/components/pages/Assets'
 import Login from '@/components/pages/Login'

--- a/src/testrouter/routes.js
+++ b/src/testrouter/routes.js
@@ -7,7 +7,7 @@ import init from '@/lib/init'
 
 import userStore from '@/store/modules/user'
 import taskTypeStore from '@/store/modules/tasktypes'
-import store from '@/store/'
+import store from '@/store'
 
 import Assets from '@/components/pages/Assets'
 import Login from '@/components/pages/Login'


### PR DESCRIPTION
**Problem**
- In the Task panel, the change status button is always visible.
- In the Bots section, we can regenerate an expired token without changing the expiration date.
- In the Person page, display task details are useless if the user is a bot. A bot cannot be assigned to a task.
- After creating a new production of type "Shots only", a user will be redirected to the unwanted "Assets" page, instead of the "Shots" section.
- On the News feed, the people field glitches over a preview player.

**Solution**
- Restore the condition to show the change-status action (at least two tasks selected)
- Check the expiration date validity before generating a new token.
- Hide the task details if the user bot, and redirect if it's an unknown user.
- Fix the default section depending on the production type for "Only assets" and "Only shots".
- Use a z-index relative to the canvas-wrapper.

In addition, bump Vite dependency.
