### PR TITLE
Various fixes

### DIFF
--- a/src/components/cells/ProductionNameCell.vue
+++ b/src/components/cells/ProductionNameCell.vue
@@ -38,6 +38,8 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
+
 import colors from '@/lib/colors.js'
 
 export default {
@@ -75,6 +77,8 @@ export default {
   },
 
   computed: {
+    ...mapGetters(['isCurrentUserClient']),
+
     generatedAvatar() {
       const firstLetter = this.entry.name?.[0] || 'P'
       return firstLetter.toUpperCase()
@@ -121,7 +125,9 @@ export default {
 
   methods: {
     sectionPath(production, section) {
-      const routeName = production.homepage || section
+      const routeName = this.isCurrentUserClient
+        ? 'playlists'
+        : production.homepage || section
       const route = {
         name: routeName,
         params: {

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -888,6 +888,10 @@ export default {
       this.updateOffsets()
     },
 
+    isBigThumbnails() {
+      this.updateOffsets()
+    },
+
     currentProduction() {
       // Map used for performance reasons, to avoid array traversals
       this.isSelectableMap = {}

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -793,6 +793,10 @@ export default {
 
     isLoading() {
       this.updateOffsets()
+    },
+
+    isBigThumbnails() {
+      this.updateOffsets()
     }
   },
 

--- a/src/components/lists/EpisodeList.vue
+++ b/src/components/lists/EpisodeList.vue
@@ -661,6 +661,10 @@ export default {
 
     isLoading() {
       this.updateOffsets()
+    },
+
+    isBigThumbnails() {
+      this.updateOffsets()
     }
   }
 }

--- a/src/components/lists/SequenceList.vue
+++ b/src/components/lists/SequenceList.vue
@@ -617,6 +617,10 @@ export default {
 
     isLoading() {
       this.updateOffsets()
+    },
+
+    isBigThumbnails() {
+      this.updateOffsets()
     }
   }
 }

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -1093,6 +1093,10 @@ export default {
 
     isLoading() {
       this.updateOffsets()
+    },
+
+    isBigThumbnails() {
+      this.updateOffsets()
     }
   },
 

--- a/src/components/pages/MyChecks.vue
+++ b/src/components/pages/MyChecks.vue
@@ -164,6 +164,7 @@ export default {
 
   mounted() {
     this.isLoading = true
+    this.clearSelectedTasks()
     this.loadTasksToCheck()
       .then(tasks => {
         if (tasks) {
@@ -313,6 +314,7 @@ export default {
 
   methods: {
     ...mapActions([
+      'clearSelectedTasks',
       'loadTasksToCheck',
       'removeTodoSearch',
       'saveTodoSearch',

--- a/src/components/pages/OpenProductions.vue
+++ b/src/components/pages/OpenProductions.vue
@@ -235,7 +235,9 @@ export default {
     },
 
     sectionPath(production, section) {
-      const routeName = production.homepage || section
+      const routeName = this.isCurrentUserClient
+        ? 'playlists'
+        : production.homepage || section
       const route = {
         name: routeName,
         params: {

--- a/src/lib/path.js
+++ b/src/lib/path.js
@@ -112,12 +112,22 @@ const getProductionRoute = (name, productionId) => {
 
 export const getProductionPath = (
   production,
-  section = 'assets',
+  section = production.homepage || 'assets',
   episodeId
 ) => {
   if (section === 'assetTypes') section = 'production-asset-types'
   if (section === 'newsFeed') section = 'news-feed'
   let route = getProductionRoute(section, production.id)
+
+  if (production.production_type === 'shots' && route.name === 'assets') {
+    route.name = 'shots'
+  } else if (
+    production.production_type === 'assets' &&
+    ['shots', 'sequences'].includes(route.name)
+  ) {
+    route.name = 'assets'
+  }
+
   if (
     production.production_type === 'tvshow' &&
     ![
@@ -134,7 +144,11 @@ export const getProductionPath = (
     route = episodifyRoute(route, episodeId || 'all')
   }
 
-  if (['assets', 'shots', 'edits', 'breakdown'].includes(section)) {
+  if (
+    ['assets', 'shots', 'edits', 'sequences', 'episodes', 'breakdown'].includes(
+      section
+    )
+  ) {
     route.query = { search: '' }
   }
 


### PR DESCRIPTION
**Problem**
- As a Client user, when opening a production, I should be redirected to the Playlists section.
- On My Checks page, an old selected task can be displayed on the side panel and I cannot close it.
- On an entity list, the position of a sticky column is not refreshed on toggle small/big thumbnails.
- On changing production from the top bar, if I select an "Only shots" production, the default section is always "Assets".

**Solution**
- Set the default section to Playlists if it's a Client user, instead of the configured homepage.
- Reset the previous task selection when opening My Checks to hide the task panel.
- Refresh columns' position on toggle small/big thumbnails.
- Fix the default section depending on the homepage settings and the production type.
