### PR TITLE
Fix team schedule

### DIFF
--- a/src/components/pages/TeamSchedule.vue
+++ b/src/components/pages/TeamSchedule.vue
@@ -60,6 +60,7 @@
       </div>
 
       <schedule
+        ref="schedule"
         :end-date="endDate"
         :hide-man-days="true"
         :hierarchy="scheduleItems"


### PR DESCRIPTION
**Problem**
- On the Team Schedule page, the button "today" doesn't work.

**Solution**
- Add the missing $ref.
