### PR TITLE
Various fixes

### DIFF
--- a/src/components/modals/EditStatusAutomationModal.vue
+++ b/src/components/modals/EditStatusAutomationModal.vue
@@ -246,7 +246,7 @@ export default {
             : entityTaskTypes[0].id,
           inTaskStatusId: this.isEditing
             ? this.statusAutomationToEdit.in_task_status_id
-            : this.taskStatuses[0].id,
+            : this.taskStatusList[0].id,
           outFieldType: this.isEditing
             ? this.statusAutomationToEdit.out_field_type
             : 'status',
@@ -255,7 +255,7 @@ export default {
             : entityTaskTypes[1].id,
           outTaskStatusId: this.isEditing
             ? this.statusAutomationToEdit.out_task_status_id
-            : this.taskStatuses[1].id,
+            : this.taskStatusList[1].id,
           archived: this.isEditing
             ? String(this.statusAutomationToEdit.archived === true)
             : 'false'
@@ -268,9 +268,9 @@ export default {
       this.setTaskTypes(entityType)
       if (!this.isEditing) {
         this.form.inTaskTypeId = this.form.inEntityTaskTypes[0].id
-        this.form.inTaskStatusId = this.taskStatuses[0].id
+        this.form.inTaskStatusId = this.taskStatusList[0].id
         this.form.outTaskTypeId = this.form.outEntityTaskTypes[1].id
-        this.form.outTaskStatusId = this.taskStatuses[1].id
+        this.form.outTaskStatusId = this.taskStatusList[1].id
       }
     },
 

--- a/src/components/pages/People.vue
+++ b/src/components/pages/People.vue
@@ -188,7 +188,7 @@ export default {
   data() {
     return {
       csvColumns: ['First Name', 'Last Name'],
-      optionalCsvColumns: ['Phone', 'Role'],
+      optionalCsvColumns: ['Phone', 'Role', 'Contract Type', 'Active'],
       dataMatchers: ['Email'],
       role: 'all',
       roleOptions: [

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -209,7 +209,7 @@
             <kitsu-icon
               name="trash"
               :active="selectedBar === 'delete-tasks'"
-              :title="$t('menu.create_tasks')"
+              :title="$t('menu.delete_tasks')"
             />
           </div>
 


### PR DESCRIPTION
**Problem**
- On the Add Status Automation form, the default status can be wrong.
- On the People page, the CSV import doesn't support all columns.
- On the New Production form, we can select the only "shots" type and still upload assets files.

**Solution**
- Use the filtered status list (without concept status).
- Add support of new person fields "Contract Type" and "Active" on CSV import.
- Improve the new production form by hiding sections if they are only assets or only shots, and by adapting the step numbers.