### PR TITLE
Fix new person form

### DIFF
--- a/src/components/modals/EditPersonModal.vue
+++ b/src/components/modals/EditPersonModal.vue
@@ -342,6 +342,7 @@ export default {
       }
       const form = {
         ...this.form,
+        last_name: this.form.last_name || '',
         active: this.form.active === 'true' || this.form.active === true
       }
       this.$emit('confirm', form)

--- a/src/components/modals/EditPersonModal.vue
+++ b/src/components/modals/EditPersonModal.vue
@@ -256,7 +256,7 @@ export default {
         email: '',
         phone: '',
         role: 'user',
-        contract_type: 'permanent',
+        contract_type: 'open-ended',
         active: 'true',
         departments: [],
         expiration_date: null,
@@ -376,7 +376,7 @@ export default {
       } else {
         this.form = {
           role: 'user',
-          contract_type: 'permanent',
+          contract_type: 'open-ended',
           active: 'true',
           departments: [],
           expiration_date: null,


### PR DESCRIPTION
**Problem**
- The creation of a user can fail if the contract type is not changed or the last name is empty.

**Solution**
- Fix default values for the new person form.
