### PR TITLE
[qa][shots] fix clicking on clear search query

### DIFF
--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -903,11 +903,11 @@ export default {
     onSearchChange() {
       if (!this.searchField) return
       this.isSearchActive = false
-      const searchQuery = this.searchField.getValue()
-      if (searchQuery && searchQuery.length !== 1 && !this.isLongShotList) {
+      const searchQuery = this.searchField.getValue() || ''
+      if (searchQuery.length !== 1 && !this.isLongShotList) {
         this.applySearch(searchQuery)
       }
-      if (searchQuery && searchQuery.length === 0 && this.isLongShotList) {
+      if (searchQuery.length === 0 && this.isLongShotList) {
         this.applySearch('')
       }
     },


### PR DESCRIPTION
**Problem**
- On shots page when clicking on the cross that clear the search query it doesn't update the search.

**Solution**
- Fix that problem
