### PR TITLE
Fix link to the Episodes section

### DIFF
--- a/src/components/cells/ProductionNameCell.vue
+++ b/src/components/cells/ProductionNameCell.vue
@@ -136,8 +136,13 @@ export default {
         query: {}
       }
       if (production.production_type === 'tvshow') {
-        route.name = `episode-${routeName}`
-        if (section !== 'edits' && production.first_episode_id) {
+        if (routeName !== 'episodes') {
+          route.name = `episode-${routeName}`
+        }
+        if (
+          !['edits', 'episodes'].includes(routeName) &&
+          production.first_episode_id
+        ) {
           route.params.episode_id = production.first_episode_id
         } else {
           route.params.episode_id = 'all'

--- a/src/components/pages/OpenProductions.vue
+++ b/src/components/pages/OpenProductions.vue
@@ -246,8 +246,13 @@ export default {
         query: {}
       }
       if (production.production_type === 'tvshow') {
-        route.name = `episode-${routeName}`
-        if (section !== 'edits' && production.first_episode_id) {
+        if (routeName !== 'episodes') {
+          route.name = `episode-${routeName}`
+        }
+        if (
+          !['edits', 'episodes'].includes(routeName) &&
+          production.first_episode_id
+        ) {
           route.params.episode_id = production.first_episode_id
         } else {
           route.params.episode_id = 'all'

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -410,10 +410,10 @@ export default {
         if (section !== 'episodes') {
           route.name = `episode-${section}`
         }
-        if (section !== 'edits' && production.first_episode_id) {
-          if (section === 'episodes') {
-            route.name = 'episode'
-          }
+        if (
+          !['edits', 'episodes'].includes(section) &&
+          production.first_episode_id
+        ) {
           route.params.episode_id = production.first_episode_id
         } else {
           route.params.episode_id = 'all'


### PR DESCRIPTION
**Problem**
- From the topbar menu,  the backlink to the production pages will always open the 1st episode instead of the episode list if the previous section was Episodes.

**Solution**
- Do not set a default episode for a link to the Episodes section.
