### PR TITLE
Improve UI depending on user rights

### DIFF
--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -16,7 +16,7 @@
           </div>
         </div>
 
-        <template v-if="!person.is_bot">
+        <template v-if="!person.is_bot && isCurrentUserAllowed">
           <div ref="tabs" class="task-tabs tabs">
             <ul>
               <li :class="{ 'is-active': isActiveTab('todos') }">
@@ -147,7 +147,7 @@
             @time-spent-change="onTimeSpentChange"
             @set-day-off="onSetDayOff"
             @unset-day-off="onUnsetDayOff"
-            v-if="isActiveTab('timesheets')"
+            v-if="isActiveTab('timesheets') && isCurrentUserManager"
           />
 
           <div v-if="isActiveTab('schedule')">
@@ -279,6 +279,7 @@ export default {
       'displayedPersonDoneTasks',
       'isCurrentUserAdmin',
       'isCurrentUserManager',
+      'isCurrentUserSupervisor',
       'nbSelectedTasks',
       'personMap',
       'personTasksScrollPosition',
@@ -292,6 +293,19 @@ export default {
       'taskTypeMap',
       'user'
     ]),
+
+    isCurrentUserAllowed() {
+      if (this.isCurrentUserManager || this.user.id === this.person.id) {
+        return true
+      }
+      if (this.isCurrentUserSupervisor) {
+        const isSupervisorInDepartments = this.user.departments.some(
+          department => this.person.departments.includes(department)
+        )
+        return isSupervisorInDepartments
+      }
+      return false
+    },
 
     loggablePersonTasks() {
       return this.displayedPersonTasks.filter(task => {
@@ -542,7 +556,7 @@ export default {
         return
       }
 
-      if (this.person.is_bot) {
+      if (this.person.is_bot || !this.isCurrentUserAllowed) {
         return
       }
 

--- a/src/components/pages/Team.vue
+++ b/src/components/pages/Team.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="people page fixed-page">
-    <div class="flexrow mt2 add-people">
+    <div class="flexrow mt2 add-people" v-if="isCurrentUserManager">
       <people-field
         ref="people-field"
         class="flexrow-item add-people-field"
@@ -10,7 +10,11 @@
         @enter="addPerson"
         v-model="person"
       />
-      <button class="button flexrow-item" @click="addPerson">
+      <button
+        class="button flexrow-item"
+        @click="addPerson"
+        :disabled="!person"
+      >
         {{ $t('main.add') }}
       </button>
     </div>
@@ -29,11 +33,12 @@ import { mapGetters, mapActions } from 'vuex'
 
 import { sortPeople } from '@/lib/sorting'
 
-import ProductionTeamList from '@/components/lists/ProductionTeamList'
 import PeopleField from '@/components/widgets/PeopleField'
+import ProductionTeamList from '@/components/lists/ProductionTeamList'
 
 export default {
   name: 'team',
+
   components: {
     PeopleField,
     ProductionTeamList
@@ -50,10 +55,10 @@ export default {
   computed: {
     ...mapGetters([
       'currentProduction',
-      'productionMap',
+      'isCurrentUserManager',
       'openProductions',
-      'personMap',
-      'people'
+      'people',
+      'personMap'
     ]),
 
     teamPersons() {
@@ -65,9 +70,10 @@ export default {
     },
 
     unlistedPeople() {
-      return this.people.filter(person => {
-        return !this.currentProduction.team.includes(person.id) && person.active
-      })
+      return this.people.filter(
+        person =>
+          !this.currentProduction.team.includes(person.id) && person.active
+      )
     }
   },
 


### PR DESCRIPTION
**Problem**
- On the Team page of a production, a non-manager user (e.g. an Artist) can add a new member to the team. The action will be blocked on the Kitsu API side, but applied on the Kitsu side.
- On the Person page, an artist can see the data tabs of any user. The API will block the data fetching according to the user's rights, but the UI will be stuck as loading.

**Solution**
- Hide the add people field if the current user is not a user manager.
- Check the current user's rights before fetching the person's data. Allowed if user manager, supervisor in the department, or current user. 
