### PR TITLE
Fix metadata sorting

### DIFF
--- a/src/lib/sorting.js
+++ b/src/lib/sorting.js
@@ -361,9 +361,9 @@ export const sortEditResult = (result, sorting, taskTypeMap, taskMap) => {
   return result
 }
 
-const getMetadataValues = (sortInfo, a, b) => {
-  const dataA = a.data && a.data[sortInfo.column] ? a.data[sortInfo.column] : ''
-  const dataB = b.data && b.data[sortInfo.column] ? b.data[sortInfo.column] : ''
+const getMetadataValues = (sortInfo, a, b, defaultValue = '') => {
+  const dataA = a.data?.[sortInfo.column] ?? defaultValue
+  const dataB = b.data?.[sortInfo.column] ?? defaultValue
   return { dataA, dataB }
 }
 
@@ -371,20 +371,21 @@ const sortByMetadata = sortInfo => {
   if (sortInfo.data_type === 'number') {
     return (a, b) => {
       const { dataA, dataB } = getMetadataValues(sortInfo, a, b)
-      if (!dataB) return -1
-      if (!dataA) return 1
-      return dataA > dataB
+      if (dataA === dataB) return 0
+      if (dataB === '') return -1
+      if (dataA === '') return 1
+      return Number(dataA) - Number(dataB)
     }
   } else if (sortInfo.data_type === 'boolean') {
     return (a, b) => {
-      const { dataA, dataB } = getMetadataValues(sortInfo, a, b)
-      if (!dataB) return -1
-      if (!dataA) return 1
-      return dataA ? 1 : -1
+      const { dataA, dataB } = getMetadataValues(sortInfo, a, b, 'false')
+      if (dataA === dataB) return 0
+      return dataA === 'true' ? 1 : -1
     }
   } else if (sortInfo.data_type === 'checklist') {
     return (a, b) => {
       const { dataA, dataB } = getMetadataValues(sortInfo, a, b)
+      if (dataA === dataB) return 0
       if (!dataB) return -1
       if (!dataA) return 1
       const checklistA = JSON.parse(dataA)
@@ -402,6 +403,7 @@ const sortByMetadata = sortInfo => {
   } else if (sortInfo.data_type === 'taglist') {
     return (a, b) => {
       const { dataA, dataB } = getMetadataValues(sortInfo, a, b)
+      if (dataA === dataB) return 0
       if (!dataB) return -1
       if (!dataA) return 1
       return dataA.localeCompare(dataB, undefined, { numeric: true })
@@ -409,6 +411,7 @@ const sortByMetadata = sortInfo => {
   } else {
     return (a, b) => {
       const { dataA, dataB } = getMetadataValues(sortInfo, a, b)
+      if (dataA === dataB) return 0
       if (!dataB) return -1
       if (!dataA) return 1
       return dataA.localeCompare(dataB, undefined, { numeric: true })

--- a/src/lib/sorting.js
+++ b/src/lib/sorting.js
@@ -362,8 +362,12 @@ export const sortEditResult = (result, sorting, taskTypeMap, taskMap) => {
 }
 
 const getMetadataValues = (sortInfo, a, b, defaultValue = '') => {
-  const dataA = a.data?.[sortInfo.column] ?? defaultValue
-  const dataB = b.data?.[sortInfo.column] ?? defaultValue
+  let dataA = a.data?.[sortInfo.column] ?? defaultValue
+  let dataB = b.data?.[sortInfo.column] ?? defaultValue
+
+  if (typeof dataA === 'number') dataA = String(dataA)
+  if (typeof dataB === 'number') dataB = String(dataB)
+
   return { dataA, dataB }
 }
 
@@ -374,7 +378,7 @@ const sortByMetadata = sortInfo => {
       if (dataA === dataB) return 0
       if (dataB === '') return -1
       if (dataA === '') return 1
-      return Number(dataA) - Number(dataB)
+      return dataA.localeCompare(dataB, undefined, { numeric: true })
     }
   } else if (sortInfo.data_type === 'boolean') {
     return (a, b) => {


### PR DESCRIPTION
**Problem**
- On the entity list, sorting a column by a number or boolean metadata returns a wrong result.
- Updating the type of metadata (eg. from Text to Number) can crash sorting.

**Solution**
- Number metadata can be a string or number value. Fix comparison if empty string and not 0.
- Boolean metadata is a string value. Fix the "true" test case and force a "false" default value if empty.
- Handle equality when comparing values.
- Support updating the type of metadata (string <-> number).