### PR TITLE
Various fixes

### DIFF
--- a/src/components/widgets/Checklist.vue
+++ b/src/components/widgets/Checklist.vue
@@ -6,8 +6,8 @@
         flexrow: true,
         checked: entry.checked
       }"
-      :key="'comment-checklist-' + '-' + index"
-      v-for="(entry, index) in checklist"
+      :key="`comment-checklist-${index}`"
+      v-for="(entry, index) in filteredChecklist"
     >
       <span class="flexrow-item" @click="toggleEntryChecked(entry)">
         <check-square-icon class="icon" v-if="entry.checked" />
@@ -21,15 +21,11 @@
             revision: entry.revision
           })
         "
-        v-show="entry.frame >= 0"
+        v-if="entry.frame >= 0"
       >
         v{{ entry.revision }} - {{ formatFrame(entry.frame) }}
       </span>
-      <span
-        class="flexrow-item"
-        @click="setFrame(entry)"
-        v-show="isMoviePreview"
-      >
+      <span class="flexrow-item" @click="setFrame(entry)" v-if="isMoviePreview">
         <clock-icon class="icon clock" />
       </span>
       <textarea-autosize
@@ -82,6 +78,12 @@ export default {
     revision: {
       default: -1,
       type: Number
+    }
+  },
+
+  computed: {
+    filteredChecklist() {
+      return this.checklist.filter(Boolean) // remove empty entries
     }
   },
 

--- a/src/components/widgets/PeopleField.vue
+++ b/src/components/widgets/PeopleField.vue
@@ -187,6 +187,11 @@ export default {
 .v-autocomplete {
   z-index: 205; // +1 relative to the z-index of c-mask
   position: relative;
+
+  // Hide native clear button for Webkit browsers (Chrome, Safari)
+  input[type='search']::-webkit-search-cancel-button {
+    display: none;
+  }
 }
 
 .v-autocomplete .v-autocomplete-list-item {


### PR DESCRIPTION
**Problem**
- On Chrome browser, the People Field displays 2 clear buttons.
- Error is raised on the Comment component if invalid data are in the Checklist.

**Solution**
- Hide native clear button for Webkit browsers (Chrome, Safari)
- Filter empty data on the checklist rendering.
