### PR TITLE
[previews] Remove clumsy annotation reloading

### DIFF
--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -888,14 +888,10 @@ export const playerMixin = {
 
     reloadAnnotations(current = true) {
       if (!this.annotations) return
-      const annotations = this.annotations.map(a => ({ ...a }))
-      this.annotations = []
-      setTimeout(() => {
-        this.annotations = annotations
-        if (current) {
-          this.reloadCurrentAnnotation()
-        }
-      }, 200)
+      this.annotations = this.annotations.map(a => ({ ...a }))
+      if (current) {
+        this.reloadCurrentAnnotation()
+      }
     },
 
     onFilmClicked() {
@@ -903,7 +899,6 @@ export const playerMixin = {
       window.dispatchEvent(new Event('resize'))
       this.$nextTick(() => {
         this.resetHeight()
-        this.reloadAnnotations()
         this.scrollToEntity(this.playingEntityIndex)
       })
     },
@@ -944,7 +939,6 @@ export const playerMixin = {
       this.$nextTick(() => {
         this.$refs['task-info'].focusCommentTextarea()
         this.resetHeight()
-        this.reloadAnnotations()
       })
     },
 

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -49,7 +49,8 @@
       <div class="filler"></div>
       <button-simple
         class="playlist-button topbar-button flexrow-item"
-        :title="$t('playlists.actions.next_shot')"
+        :text="$t('playlists.actions.exit_play_full')"
+        :title="$t('playlists.actions.exit_play_full')"
         @click="isFullMode = false"
         v-if="isFullMode"
       />
@@ -312,7 +313,7 @@
       :frame-duration="frameDuration"
       :is-playlist="true"
       :is-full-mode="isFullMode"
-      :is-full-screen="fullScreen"
+      :is-full-screen="fullScreen || isEntitiesHidden"
       :movie-dimensions="movieDimensions"
       :nb-frames="nbFrames"
       :handle-in="playlist.for_entity === 'shot' ? handleIn : -1"
@@ -1827,7 +1828,10 @@ export default {
     configureFullPlayer() {
       if (!this.fullPlayer) return
       this.fullPlayer.addEventListener('loadedmetadata', () => {
-        this.playlistDuration = this.fullPlayer.duration
+        this.playlistDuration = this.entityList.reduce(
+          (acc, entity) => acc + entity.preview_file_duration,
+          0
+        )
       })
       this.fullPlayer.addEventListener('ended', () => {
         this.pause()
@@ -2070,7 +2074,6 @@ export default {
         this.resetPictureCanvas()
         this.resetCanvas()
         this.syncComparisonPlayer()
-        this.reloadAnnotations()
       })
     },
 

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1745,7 +1745,6 @@ export default {
       this.$nextTick(() => {
         this.previewViewer.resize()
         this.comparisonViewer.resize()
-        this.reloadAnnotations()
         this.loadAnnotation()
       })
     },


### PR DESCRIPTION
**Problem**

In playlist annotations disappear when the UI is moved.

**Solution**

Remove unused annotation reloading.
