### PR TITLE
Improve search on task type page

### DIFF
--- a/src/lib/indexing.js
+++ b/src/lib/indexing.js
@@ -85,7 +85,7 @@ export const buildSupervisorTaskIndex = (tasks, personMap, taskStatusMap) => {
     const words = stringToIndex
       .toLowerCase()
       .split(' ')
-      .concat([taskStatus.short_name])
+      .concat([task.entity_name, taskStatus.short_name])
     task.assignees.forEach(personId => {
       const person = personMap.get(personId)
       if (person) words.push(person.first_name, person.last_name)


### PR DESCRIPTION
**Problem**
- On a Task Type page, the result is always empty when searching an entity name with `-` or `_`.  
(E.g. a sequence with the name `SEQ_01` and a search equal to `seq_`)

**Solution**
- Add to the search index the original name of entities to allow a search with special chars
