### PR TITLE
Various fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "5.1.3",
-        "eslint-plugin-vue": "9.23.0",
+        "eslint-plugin-vue": "9.24.0",
         "esm": "3.2.25",
         "husky": "8.0.3",
         "jsdom": "24.0.0",
@@ -2511,9 +2511,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.715",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.715.tgz",
-      "integrity": "sha512-XzWNH4ZSa9BwVUQSDorPWAUQ5WGuYz7zJUNpNif40zFCiCl20t8zgylmreNmn26h5kiyw2lg7RfTmeMBsDklqg==",
+      "version": "1.4.717",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.717.tgz",
+      "integrity": "sha512-6Fmg8QkkumNOwuZ/5mIbMU9WI3H2fmn5ajcVya64I5Yr5CcNmO7vcLt0Y7c96DCiMO5/9G+4sI2r6eEvdg1F7A==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2781,12 +2781,13 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.23.0.tgz",
-      "integrity": "sha512-Bqd/b7hGYGrlV+wP/g77tjyFmp81lh5TMw0be9093X02SyelxRRfCI6/IsGq/J7Um0YwB9s0Ry0wlFyjPdmtUw==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.24.0.tgz",
+      "integrity": "sha512-9SkJMvF8NGMT9aQCwFc5rj8Wo1XWSMSHk36i7ZwdI614BU7sIOR28ZjuFPKp8YGymZN12BSEbiSwa7qikp+PBw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
+        "globals": "^13.24.0",
         "natural-compare": "^1.4.0",
         "nth-check": "^2.1.1",
         "postcss-selector-parser": "^6.0.15",
@@ -6102,9 +6103,9 @@
       }
     },
     "node_modules/table": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
+      "integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
       "dependencies": {
         "ajv": "^8.0.1",
         "lodash.truncate": "^4.4.2",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.1.3",
-    "eslint-plugin-vue": "9.23.0",
+    "eslint-plugin-vue": "9.24.0",
     "esm": "3.2.25",
     "husky": "8.0.3",
     "jsdom": "24.0.0",

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -658,7 +658,7 @@ export default {
       try {
         await this.setDayOff({
           ...dayOff,
-          personId: this.user.id
+          personId: this.person.id
         })
         this.$refs['timesheet-list']?.closeSetDayOffModal()
       } catch (error) {

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -205,20 +205,21 @@
                   <comment
                     :key="comment.id"
                     :comment="comment"
-                    :current-user="user"
+                    :fps="parseInt(currentFps)"
                     :frame="currentFrame"
-                    :editable="
+                    :is-editable="
                       (comment.person && user.id === comment.person.id) ||
                       isCurrentUserAdmin
                     "
-                    :fps="parseInt(currentFps)"
-                    :highlighted="false"
                     :is-first="index === 0"
                     :is-last="index === pinnedCount"
+                    :is-pinnable="
+                      isCurrentUserManager || isCurrentUserSupervisor
+                    "
                     :is-change="isStatusChange(index)"
                     :revision="currentRevision"
-                    :team="currentTeam"
                     :task="task"
+                    :team="currentTeam"
                     @ack-comment="ackComment"
                     @duplicate-comment="onDuplicateComment"
                     @pin-comment="onPinComment"
@@ -312,33 +313,36 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
 import { ImageIcon } from 'vue-feather-icons'
+import { mapGetters, mapActions } from 'vuex'
 
-import { getTaskEntityPath } from '@/lib/path'
 import drafts from '@/lib/drafts'
+import { getTaskEntityPath } from '@/lib/path'
 import { sortPeople } from '@/lib/sorting'
+
 import { formatListMixin } from '@/components/mixins/format'
 import { taskMixin } from '@/components/mixins/task'
 
-import AddComment from '@/components/widgets/AddComment'
-import AddPreviewModal from '@/components/modals/AddPreviewModal'
-import Comment from '@/components/widgets/Comment'
+import AddComment from '@/components/widgets/AddComment.vue'
+import AddPreviewModal from '@/components/modals/AddPreviewModal.vue'
+import Comment from '@/components/widgets/Comment.vue'
 import ComboboxStyled from '@/components/widgets/ComboboxStyled.vue'
-import DeleteModal from '@/components/modals/DeleteModal'
-import EditCommentModal from '@/components/modals/EditCommentModal'
-import EntityThumbnail from '@/components/widgets/EntityThumbnail'
-import PageSubtitle from '@/components/widgets/PageSubtitle'
-import PeopleAvatar from '@/components/widgets/PeopleAvatar'
-import Spinner from '@/components/widgets/Spinner'
-import SubscribeButton from '@/components/widgets/SubscribeButton'
-import TaskTypeName from '@/components/widgets/TaskTypeName'
-import ValidationTag from '@/components/widgets/ValidationTag'
-import PreviewPlayer from '@/components/previews/PreviewPlayer'
+import DeleteModal from '@/components/modals/DeleteModal.vue'
+import EditCommentModal from '@/components/modals/EditCommentModal.vue'
+import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
+import PageSubtitle from '@/components/widgets/PageSubtitle.vue'
+import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
+import Spinner from '@/components/widgets/Spinner.vue'
+import SubscribeButton from '@/components/widgets/SubscribeButton.vue'
+import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
+import ValidationTag from '@/components/widgets/ValidationTag.vue'
+import PreviewPlayer from '@/components/previews/PreviewPlayer.vue'
 
 export default {
   name: 'task',
+
   mixins: [formatListMixin, taskMixin],
+
   components: {
     AddComment,
     AddPreviewModal,

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -162,26 +162,27 @@
                     <comment
                       :key="'comment' + comment.id"
                       :comment="comment"
-                      :task="task"
-                      :team="currentTeam"
-                      :light="true"
-                      :add-preview="onAddPreviewClicked"
-                      :is-first="index === 0"
-                      :is-last="index === pinnedCount"
+                      :fps="parseInt(currentFps)"
+                      :frame="currentFrame || currentFrameRaw"
                       :is-change="isStatusChange(index)"
-                      :editable="
+                      :is-editable="
                         (comment.person && user.id === comment.person.id) ||
                         isCurrentUserAdmin
                       "
-                      :fps="parseInt(currentFps)"
-                      :frame="currentFrame || currentFrameRaw"
+                      :is-first="index === 0"
+                      :is-last="index === pinnedCount"
+                      :is-pinnable="
+                        isCurrentUserManager || isCurrentUserSupervisor
+                      "
                       :revision="currentRevision"
+                      :task="task"
+                      :team="currentTeam"
+                      @ack-comment="onAckComment"
                       @duplicate-comment="onDuplicateComment"
                       @pin-comment="onPinComment"
                       @edit-comment="onEditComment"
                       @delete-comment="onDeleteComment"
                       @checklist-updated="saveComment"
-                      @ack-comment="onAckComment"
                       @time-code-clicked="timeCodeClicked"
                       v-for="(comment, index) in taskComments"
                     />
@@ -286,8 +287,9 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
 import moment from 'moment'
+import { CornerRightUpIcon } from 'vue-feather-icons'
+import { mapGetters, mapActions } from 'vuex'
 
 import csv from '@/lib/csv'
 import drafts from '@/lib/drafts'
@@ -301,23 +303,22 @@ import { formatDate } from '@/lib/time'
 import { taskMixin } from '@/components/mixins/task'
 import { domMixin } from '@/components/mixins/dom'
 
-import { CornerRightUpIcon } from 'vue-feather-icons'
-
-import ActionPanel from '@/components/tops/ActionPanel'
-import AddComment from '@/components/widgets/AddComment'
-import AddPreviewModal from '@/components/modals/AddPreviewModal'
-import Comment from '@/components/widgets/Comment'
-import ComboboxStyled from '@/components/widgets/ComboboxStyled'
-import DeleteModal from '@/components/modals/DeleteModal'
-import EditCommentModal from '@/components/modals/EditCommentModal'
-import Spinner from '@/components/widgets/Spinner'
-import TaskTypeName from '@/components/widgets/TaskTypeName'
-import PreviewPlayer from '@/components/previews/PreviewPlayer'
+import ActionPanel from '@/components/tops/ActionPanel.vue'
+import AddComment from '@/components/widgets/AddComment.vue'
+import AddPreviewModal from '@/components/modals/AddPreviewModal.vue'
+import Comment from '@/components/widgets/Comment.vue'
+import ComboboxStyled from '@/components/widgets/ComboboxStyled.vue'
+import DeleteModal from '@/components/modals/DeleteModal.vue'
+import EditCommentModal from '@/components/modals/EditCommentModal.vue'
+import Spinner from '@/components/widgets/Spinner.vue'
+import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
+import PreviewPlayer from '@/components/previews/PreviewPlayer.vue'
 
 const DEFAULT_PANEL_WIDTH = 400
 
 export default {
   name: 'task-info',
+
   mixins: [domMixin, taskMixin],
 
   components: {

--- a/src/components/widgets/CommentMenu.vue
+++ b/src/components/widgets/CommentMenu.vue
@@ -1,10 +1,7 @@
 <template>
-  <div class="comment-menu hidden" ref="main">
-    <div @click="onPinClicked" v-show="!isEmpty">
-      <span v-if="isPinned">
-        {{ $t('comments.unpin') }}
-      </span>
-      <span v-else>{{ $t('comments.pin') }}</span>
+  <div class="comment-menu">
+    <div @click="$emit('pin-clicked')" v-if="isPinnable && !isEmpty">
+      {{ isPinned ? $t('comments.unpin') : $t('comments.pin') }}
     </div>
     <div @click="$emit('edit-clicked')" v-if="isEditable">
       {{ $t('main.edit') }}
@@ -16,20 +13,10 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
-
 export default {
   name: 'comment-menu',
 
   props: {
-    isPinned: {
-      type: Boolean,
-      default: false
-    },
-    isCurrentUserAdmin: {
-      type: Boolean,
-      default: false
-    },
     isEditable: {
       type: Boolean,
       default: true
@@ -37,32 +24,14 @@ export default {
     isEmpty: {
       type: Boolean,
       default: false
-    }
-  },
-
-  data() {
-    return {}
-  },
-
-  computed: {
-    ...mapGetters([])
-  },
-
-  methods: {
-    ...mapActions([]),
-
-    toggle() {
-      const mainEl = this.$refs.main
-      if (mainEl.className === 'comment-menu') {
-        mainEl.className = 'comment-menu hidden'
-      } else {
-        mainEl.className = 'comment-menu'
-      }
     },
-
-    onPinClicked() {
-      this.$emit('pin-clicked')
-      this.toggle()
+    isPinnable: {
+      type: Boolean,
+      default: true
+    },
+    isPinned: {
+      type: Boolean,
+      default: false
     }
   }
 }
@@ -71,7 +40,7 @@ export default {
 <style lang="scss" scoped>
 .dark .comment-menu {
   background-color: $dark-grey-light;
-  box-shadow: 0px 2px 6px $dark-grey-light;
+  box-shadow: 0 2px 6px $dark-grey-light;
   color: $light-grey-light;
 }
 
@@ -80,21 +49,19 @@ export default {
   position: absolute;
   background: white;
   width: 118px;
-  box-shadow: 0px 2px 6px $light-grey;
+  box-shadow: 0 2px 6px $light-grey;
   top: 20px;
   left: -90px;
   z-index: 100;
-}
+  overflow: hidden;
 
-.comment-menu div {
-  cursor: pointer;
+  div {
+    cursor: pointer;
+    padding: 0.5em;
 
-  &:hover {
-    background-color: var(--background-alt);
+    &:hover {
+      background-color: var(--background-alt);
+    }
   }
-}
-
-.comment-menu div {
-  padding: 0.5em;
 }
 </style>

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -171,19 +171,19 @@ const applyFiltersFunctions = {
   },
 
   assetsready(entry, filter, taskMap) {
-    let isOk = false
-    if (entry.tasks) {
-      entry.tasks.forEach(taskId => {
-        const task = taskMap.get(taskId)
-        if (task.task_type_id === filter.value) {
-          isOk =
-            entry.nb_entities_out > 0 &&
-            entry.nb_entities_out === task.nb_assets_ready
-        }
-      })
+    if (entry.nb_entities_out <= 0) {
+      return filter.excluding
     }
-    if (filter.excluding) isOk = !isOk
-    return isOk
+    const isOk =
+      entry.tasks?.some(taskId => {
+        const task = taskMap.get(taskId)
+        return (
+          task &&
+          task.task_type_id === filter.value &&
+          entry.nb_entities_out === task.nb_assets_ready
+        )
+      }) ?? false
+    return filter.excluding ? !isOk : isOk
   }
 }
 


### PR DESCRIPTION
**Problem**
- The "asset ready for" filtering can crash under corner cases.
- On the task panel, as an Artist user, the comment pin action seems applied but lost after a page refresh (related to https://github.com/cgwire/kitsu/issues/1391)
- On the Person page, an Admin can set days off for another user in the Timesheets section, but the final action applies the settings to itself.

**Solution**
- Check if the task exists before applying the filter.
- An artist is not allowed to pin a comment. Show actions according to user rights in the comment menu.
- Fix the setting of days off as admin on behalf of another user with the correct user ID.
