### PR TITLE
Fix description cell

### DIFF
--- a/src/components/cells/DescriptionCell.vue
+++ b/src/components/cells/DescriptionCell.vue
@@ -3,14 +3,18 @@
     <template v-if="full">
       <div
         class="description-shorten-text"
-        v-html="compileMarkdown(entry.description || '')"
+        v-html="compileMarkdown(entry.description)"
       ></div>
     </template>
     <template v-else>
       <div class="c-mask" v-if="isOpen"></div>
       <span
         class="description-shorten-text selectable"
-        v-html="compileMarkdown(shortenText(entry.description || '', 20))"
+        v-html="
+          compileMarkdown(shortenText(entry.description, 20), {
+            allowedLinkTag: false
+          })
+        "
       >
       </span>
       <div
@@ -41,11 +45,11 @@
 
 <script>
 import { renderMarkdown } from '@/lib/render'
-import { mapGetters, mapActions } from 'vuex'
 import stringHelpers from '@/lib/string'
 
 export default {
   name: 'description-cell',
+
   data() {
     return {
       isEditing: false,
@@ -53,8 +57,6 @@ export default {
       timeout: null
     }
   },
-
-  components: {},
 
   props: {
     editable: {
@@ -71,19 +73,9 @@ export default {
     }
   },
 
-  computed: {
-    ...mapGetters([]),
-
-    content() {
-      return this.compileMarkdown(this.entry.description)
-    }
-  },
-
   methods: {
-    ...mapActions([]),
-
-    compileMarkdown(input) {
-      return renderMarkdown(input)
+    compileMarkdown(input, options) {
+      return renderMarkdown(input, options)
     },
 
     shortenText: stringHelpers.shortenText,
@@ -169,7 +161,7 @@ td {
   }
 
   textarea {
-    box-shadow: inset 0 0 3px 0px $grey;
+    box-shadow: inset 0 0 3px 0 $grey;
     padding: 0.5em;
     color: inherit;
     font-size: 0.95em;

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -12,9 +12,21 @@ marked.use(markedEmoji(options))
 
 export const TIME_CODE_REGEX = /v(\d+) (\d+:)?(\d+):(\d+)(\.|:)(\d+) \((\d+)\)/g
 
-export const sanitize = html => {
+export const sanitize = (html, options) => {
+  options = {
+    allowedLinkTag: true,
+    allowedImageTag: true,
+    ...options
+  }
+  let allowedTags = sanitizeHTML.defaults.allowedTags
+  if (!options.allowedLinkTag) {
+    allowedTags = allowedTags.filter(tag => tag !== 'a')
+  }
+  if (options.allowedImageTag) {
+    allowedTags = allowedTags.push('img')
+  }
   return sanitizeHTML(html, {
-    allowedTags: sanitizeHTML.defaults.allowedTags.concat(['img']),
+    allowedTags,
     allowedAttributes: {
       a: ['class', 'href'],
       img: ['src']
@@ -69,9 +81,9 @@ export const renderComment = (
   )
 }
 
-export const renderMarkdown = input => {
+export const renderMarkdown = (input, options) => {
   const compiled = marked.parse(input || '')
-  return sanitize(compiled)
+  return sanitize(compiled, options)
 }
 
 export const replaceTimeWithTimecode = (


### PR DESCRIPTION
**Problem**
- On entity lists, a description cell with an HTTP link may target a wrong URL (see #1377)

**Solution**
-  Disable HTTP link on markdown rendering. A shortened description must not contain a link, because it is a clickable area that opens a full description.
