### PR TITLE
Add entity chats

### DIFF
--- a/scripts/missinglocales.js
+++ b/scripts/missinglocales.js
@@ -1,4 +1,5 @@
 // import * as en from '../src/locales/en'
+/*
 require = require("esm")(module)
 const en = require('../src/locales/en')
 const fr = require('../src/locales/fr')
@@ -49,5 +50,7 @@ locales.forEach(locale => {
   console.log('Missing main keys for', locale.name, ':', difference)
 })
 
-const fs = require('fs')
+*/
+import fs from 'fs'
+import en from '../src/locales/en.js'
 fs.writeFileSync('en.json', JSON.stringify(en, null, 2))

--- a/src/App.vue
+++ b/src/App.vue
@@ -1948,6 +1948,11 @@ tbody:last-child .empty-line:last-child {
   width: 400px;
 }
 
+.left-side-column {
+  width: 300px;
+  max-width: 300px;
+}
+
 .empty-list {
   margin-top: 2em;
   font-size: 1.5em;

--- a/src/components/layouts/PageLeftSideLayout.vue
+++ b/src/components/layouts/PageLeftSideLayout.vue
@@ -1,0 +1,16 @@
+<template>
+  <div ref="page" class="columns fixed-page">
+    <div class="column left-side-column">
+      <slot name="side" />
+    </div>
+    <div class="column main-column">
+      <slot name="main" />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'page-left-side-layout'
+}
+</script>

--- a/src/components/mixins/entity.js
+++ b/src/components/mixins/entity.js
@@ -9,6 +9,7 @@ import {
   parseDate,
   parseSimpleDate
 } from '@/lib/time'
+import stringHelpers from '@/lib/string'
 
 /*
  * Common functions for shot, asset, edit, sequncen and edit pages.
@@ -16,10 +17,11 @@ import {
 export const entityMixin = {
   data() {
     return {
-      currentSection: 'Casting',
+      currentSection: 'infos',
       zoomLevel: 1,
       entityNavOptions: [
         { label: 'Infos', value: 'infos' },
+        { label: 'Chat', value: 'chat' },
         { label: 'Casting', value: 'casting' },
         { label: 'Schedule', value: 'schedule' },
         { label: 'Preview Files', value: 'preview-files' },
@@ -229,13 +231,31 @@ export const entityMixin = {
   },
 
   watch: {
+    $route() {
+      const entityId = this.route.params[`${this.type}_id`]
+      const currentEntity =
+        this[`current${stringHelpers.capitalize(this.type)}`]
+      if (currentEntity && currentEntity !== entityId) {
+        this.init()
+      }
+      this.currentSection = this.route.query.section || 'infos'
+    },
+
     currentSection() {
-      this.$router.push({
-        query: { section: this.currentSection }
-      })
-      const schedule = this.$refs['schedule-widget']
-      if (this.currentSection === 'schedule' && schedule) {
-        schedule.scrollToToday()
+      if (this.currentSection === 'schedule' && this.scheduleItems.length > 0) {
+        if (this.$refs['schedule-widget']) {
+          this.$refs['schedule-widget'].scrollToDate(
+            this.scheduleItems[0].startDate
+          )
+        }
+      }
+    },
+
+    zoomLevel() {
+      if (this.$refs['schedule-widget']) {
+        this.$refs['schedule-widget'].scrollToDate(
+          this.scheduleItems[0].startDate
+        )
       }
     }
   }

--- a/src/components/modals/AddAttachmentModal.vue
+++ b/src/components/modals/AddAttachmentModal.vue
@@ -104,7 +104,7 @@ import files from '@/lib/files'
 import FileUpload from '@/components/widgets/FileUpload.vue'
 
 export default {
-  name: 'add-comment-image-modal',
+  name: 'add-attachment-modal',
   mixins: [modalMixin],
 
   components: {

--- a/src/components/modals/PreviewModal.vue
+++ b/src/components/modals/PreviewModal.vue
@@ -22,6 +22,8 @@
 import { mapGetters, mapActions } from 'vuex'
 import { modalMixin } from '@/components/modals/base_modal'
 
+import { getDownloadAttachmentPath } from '@/lib/path'
+
 import { ArrowUpRightIcon } from 'vue-feather-icons'
 
 export default {
@@ -40,6 +42,10 @@ export default {
     previewFileId: {
       type: String,
       default: ''
+    },
+    attachment: {
+      type: Object,
+      default: () => {}
     }
   },
 
@@ -53,10 +59,15 @@ export default {
     ...mapGetters([]),
 
     previewPath() {
-      const id = this.previewFileId
-      return this.active && this.previewFileId
-        ? '/api/pictures/originals/preview-files/' + id + '.png'
-        : ''
+      if (this.previewFileId) {
+        const id = this.previewFileId
+        return this.active && this.previewFileId
+          ? '/api/pictures/originals/preview-files/' + id + '.png'
+          : ''
+      } else if (this.attachment) {
+        return getDownloadAttachmentPath(this.attachment)
+      }
+      return ''
     }
   },
 

--- a/src/components/pages/Asset.vue
+++ b/src/components/pages/Asset.vue
@@ -138,6 +138,7 @@
 
         <entity-chat
           :entity="currentAsset"
+          :name="currentAsset?.full_name"
           v-if="currentSection === 'chat'"
         />
 

--- a/src/components/pages/Asset.vue
+++ b/src/components/pages/Asset.vue
@@ -136,6 +136,11 @@
           </div>
         </div>
 
+        <entity-chat
+          :entity="currentAsset"
+          v-if="currentSection === 'chat'"
+        />
+
         <div class="asset-casted-in" v-show="currentSection === 'casting'">
           <div v-if="currentAsset">
             <div
@@ -351,6 +356,7 @@ import ComboboxNumber from '@/components/widgets/ComboboxNumber'
 import ComboboxStatus from '@/components/widgets/ComboboxStatus'
 import DescriptionCell from '@/components/cells/DescriptionCell'
 import EditAssetModal from '@/components/modals/EditAssetModal'
+import EntityChat from '@/components/pages/entities/EntityChat'
 import EntityNews from '@/components/pages/entities/EntityNews'
 import EntityOutputFiles from '@/components/pages/entities/EntityOutputFiles'
 import EntityPreviewFiles from '@/components/pages/entities/EntityPreviewFiles'
@@ -375,6 +381,7 @@ export default {
     ComboboxStatus,
     DescriptionCell,
     EditAssetModal,
+    EntityChat,
     EntityNews,
     EntityOutputFiles,
     EntityPreviewFiles,
@@ -391,6 +398,7 @@ export default {
 
   data() {
     return {
+      type: 'asset',
       currentAsset: null,
       currentTask: null,
       currentConceptStatus: null,
@@ -576,22 +584,6 @@ export default {
               concept.tasks[0].task_status_id === this.currentConceptStatus
           )
         : this.linkedConcepts
-    },
-
-    allTasksEstimation() {
-      return this.formatDuration(
-        this.localTasks.reduce((acc, task) => {
-          return acc + task.estimation
-        }, 0)
-      )
-    },
-
-    allTasksDuration() {
-      return this.formatDuration(
-        this.localTasks.reduce((acc, task) => {
-          return acc + task.duration
-        }, 0)
-      )
     }
   },
 

--- a/src/components/pages/EntityChats.vue
+++ b/src/components/pages/EntityChats.vue
@@ -1,0 +1,239 @@
+<template>
+  <page-left-side-layout>
+
+    <template v-slot:side>
+      <div class="chat-column">
+        <spinner class="mt1" v-if="loading.list" />
+        <div class="chat-list" v-else>
+          <div
+            :key="chat.id"
+            :class="chatClass(chat)"
+            @click="selectChat(chat)"
+            v-for="chat in chatList"
+          >
+            <div class="flexrow">
+              <entity-thumbnail
+                class="flexrow-item mr1"
+                :height="40"
+                :empty-height="40"
+                :empty-width="60"
+                :entity="{
+                  id: chat.object_id,
+                  preview_file_id: chat.preview_file_id
+                }"
+              />
+              <div class="flexcolumn flexrow-item ml1">
+                <div class="chat-item-project-name">
+                  {{ getChatProjectName(chat) }}
+                </div>
+                <div class="chat-item-title">
+                  {{ chat.entity_name }}
+                </div>
+                <div class="chat-item-subtitle">
+                  {{ getChatDate(chat) }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <template v-slot:main>
+      <div class="selected-entity-chat">
+        <entity-chat
+          ref="entityChat"
+          :entity="entity"
+        />
+      </div>
+    </template>
+
+  </page-left-side-layout>
+</template>
+
+<script>
+/*
+ * Page to allow wide search on every entities stored in the open projects.
+ */
+import { mapGetters, mapActions } from 'vuex'
+
+import { formatListMixin } from '@/components/mixins/format'
+
+import EntityChat from '@/components/pages/entities/EntityChat.vue'
+import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
+import PageLeftSideLayout from '@/components/layouts/PageLeftSideLayout.vue'
+import Spinner from '@/components/widgets/Spinner.vue'
+
+export default {
+  name: 'entity-chats',
+  mixins: [formatListMixin],
+
+  components: {
+    EntityChat,
+    EntityThumbnail,
+    PageLeftSideLayout,
+    Spinner
+  },
+
+  data() {
+    return {
+      chats: [],
+      entity: null,
+      loading: {
+        list: false,
+      }
+    }
+  },
+
+  props: {},
+
+  async mounted() {
+    this.loading.list = true
+    this.chats = await this.getEntityChats()
+    this.selectFirstChat()
+    this.loading.list = false
+  },
+
+  computed: {
+    ...mapGetters([
+      'productionMap',
+      'user'
+    ]),
+
+    chatList() {
+      return [...this.chats].sort(
+        (a, b) => {
+          if (!a.last_message) return 1
+          if (!b.last_message) return -1
+          if (a.last_message === b.last_message) {
+            return a.entity_name.localeCompare(b.entity_name)
+          }
+          return a.last_message < b.last_message
+        }
+      )
+    }
+  },
+
+  methods: {
+    ...mapActions(['getEntityChats']),
+
+    selectFirstChat() {
+      if (this.chats.length > 0) {
+        this.entity = { id: this.chats[0].object_id }
+      }
+    },
+
+    selectChat(chat) {
+      this.entity = { id: chat.object_id }
+      this.$nextTick(() => {
+        this.$refs.entityChat.focusMessageBox()
+      })
+    },
+
+    chatClass(chat) {
+      return {
+        'chat-item': true,
+        'selected': this.entity && this.entity.id === chat.object_id
+      }
+    },
+
+    getChatProjectName(chat) {
+      return this.productionMap.get(chat.project_id).name
+    },
+
+    getChatDate(chat) {
+      if (!chat.last_message) return this.$t('chats.no_message_yet')
+      return this.formatDate(chat.last_message)
+    }
+  },
+
+  watch: {
+  },
+
+  socket: {
+    events: {
+      async 'chat:joined' (eventData) {
+        if (
+          !this.chats.some(c => c.id === eventData.chat_id) &&
+          this.user.id === eventData.person_id
+        ) {
+          this.chats = await this.getEntityChats()
+        }
+      },
+
+      async 'chat:left' (eventData) {
+        if (
+          this.chats.some(c => c.id === eventData.chat_id) &&
+          this.user.id === eventData.person_id
+        ) {
+          this.chats = this.chats.filter(c => c.id !== eventData.chat_id)
+        }
+      },
+
+      async 'chat:new-message' (eventData) {
+        this.chats.find(c => c.id === eventData.chat_id)
+        if (chat) {
+          chat.last_message = eventData.last_message
+        }
+      }
+    }
+  },
+
+  metaInfo() {
+    return {
+      title: `${this.$t('chats.title')} - Kitsu`
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+
+.chat-column {
+  border: 1px solid var(--border);
+  height: 100%;
+  overflow-y: auto;
+  padding-top: 60px;
+}
+
+.selected-entity-chat {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-height: 100%;
+  padding: 1em;
+  padding-top: 60px;
+}
+
+.chat-item {
+  border: 2px solid transparent;
+  border-bottom: 2px solid var(--border-alt);
+  color: var(--text);
+  cursor: pointer;
+  padding: 1em;
+
+  &:hover {
+    border-color: var(--background-selectable);
+  }
+
+  &.selected {
+    border-color: var(--background-selected);
+  }
+
+  .chat-item-project-name {
+    color: $grey;
+    font-size: 0.7em;
+    font-weight: bold;
+    text-transform: uppercase;
+  }
+
+  .chat-item-title {
+    font-weight: bold;
+  }
+
+  .chat-item-subtitle {
+    color: $grey;
+    font-size: 0.8em;
+  }
+}
+</style>

--- a/src/components/pages/EntityChats.vue
+++ b/src/components/pages/EntityChats.vue
@@ -51,9 +51,6 @@
 </template>
 
 <script>
-/*
- * Page to allow wide search on every entities stored in the open projects.
- */
 import { mapGetters, mapActions } from 'vuex'
 
 import { formatListMixin } from '@/components/mixins/format'

--- a/src/components/pages/Episode.vue
+++ b/src/components/pages/Episode.vue
@@ -31,7 +31,6 @@
           :tabs="entityNavOptions"
         />
 
-
         <div class="flexrow infos" v-show="currentSection === 'infos'">
           <div class="flexrow-item flexcolumn entity-infos">
             <page-subtitle :text="$t('main.tasks')" />
@@ -205,6 +204,7 @@
 
         <entity-chat
           :entity="currentEpisode"
+          :name="currentEpisode?.name"
           v-if="currentSection === 'chat'"
         />
 
@@ -248,7 +248,6 @@ import { formatListMixin } from '@/components/mixins/format'
 
 import ButtonSimple from '@/components/widgets/ButtonSimple'
 import ComboboxNumber from '@/components/widgets/ComboboxNumber'
-import ComboboxStyled from '@/components/widgets/ComboboxStyled'
 import DescriptionCell from '@/components/cells/DescriptionCell'
 import EditEpisodeModal from '@/components/modals/EditEpisodeModal'
 import EntityChat from '@/components/pages/entities/EntityChat'
@@ -271,7 +270,6 @@ export default {
   components: {
     ButtonSimple,
     ComboboxNumber,
-    ComboboxStyled,
     CornerLeftUpIcon,
     DescriptionCell,
     EditEpisodeModal,
@@ -383,26 +381,26 @@ export default {
 
     init() {
       this.loadCurrentEpisode()
-      .then(episode => {
-        this.currentEpisode = episode
-        this.currentSection = this.route.query.section || 'infos'
-        this.casting.isLoading = true
-        this.casting.isError = false
-        if (this.currentEpisode) {
-          this.loadEpisodeCasting(this.currentEpisode)
-            .then(() => {
-              this.casting.isLoading = false
-            })
-            .catch(err => {
-              this.casting.isLoading = false
-              this.casting.isError = true
-              console.error(err)
-            })
-        } else {
-          this.resetData()
-        }
-      })
-      .catch(console.error)
+        .then(episode => {
+          this.currentEpisode = episode
+          this.currentSection = this.route.query.section || 'infos'
+          this.casting.isLoading = true
+          this.casting.isError = false
+          if (this.currentEpisode) {
+            this.loadEpisodeCasting(this.currentEpisode)
+              .then(() => {
+                this.casting.isLoading = false
+              })
+              .catch(err => {
+                this.casting.isLoading = false
+                this.casting.isError = true
+                console.error(err)
+              })
+          } else {
+            this.resetData()
+          }
+        })
+        .catch(console.error)
     },
 
     loadCurrentEpisode() {
@@ -660,7 +658,6 @@ h2.subtitle {
 .news-column {
   max-height: 85%;
 }
-
 
 @media screen and (max-width: 768px) {
   .task-column {

--- a/src/components/pages/Episode.vue
+++ b/src/components/pages/Episode.vue
@@ -23,66 +23,67 @@
         </div>
       </div>
 
-      <div class="flexrow infos">
-        <div class="flexrow-item block flexcolumn">
-          <page-subtitle :text="$t('episodes.tasks')" />
-          <entity-task-list
-            class="task-list"
-            :entries="currentTasks"
-            :is-loading="!currentEpisode"
-            :is-error="false"
-            @task-selected="onTaskSelected"
-          />
-        </div>
-        <div class="flexrow-item block flexcolumn">
-          <div class="flexrow">
-            <page-subtitle :text="$t('main.info')" />
-            <div class="filler"></div>
-            <div class="flexrow-item has-text-right">
-              <button-simple
-                icon="edit"
-                @click="modals.edit = true"
-                v-if="isCurrentUserManager"
-              />
+      <div class="episode-data block">
+        <route-section-tabs
+          class="section-tabs"
+          :activeTab="currentSection"
+          :route="$route"
+          :tabs="entityNavOptions"
+        />
+
+
+        <div class="flexrow infos" v-show="currentSection === 'infos'">
+          <div class="flexrow-item flexcolumn entity-infos">
+            <page-subtitle :text="$t('main.tasks')" />
+            <entity-task-list
+              class="task-list"
+              :entries="currentTasks"
+              :is-loading="!currentEpisode"
+              :is-error="false"
+              @task-selected="onTaskSelected"
+            />
+            <div class="flexrow">
+              <page-subtitle :text="$t('main.info')" />
+              <div class="filler"></div>
+              <div class="flexrow-item has-text-right">
+                <button-simple
+                  icon="edit"
+                  @click="modals.edit = true"
+                  v-if="isCurrentUserManager"
+                />
+              </div>
+            </div>
+
+            <div class="table-body">
+              <table class="datatable no-header" v-if="currentEpisode">
+                <tbody class="table-body">
+                  <tr class="datatable-row">
+                    <td class="field-label">
+                      {{ $t('shots.fields.description') }}
+                    </td>
+                    <description-cell :entry="currentEpisode" :full="true" />
+                  </tr>
+                  <tr
+                    :key="descriptor.id"
+                    class="datatable-row"
+                    v-for="descriptor in episodeMetadataDescriptors"
+                  >
+                    <td class="field-label">{{ descriptor.name }}</td>
+                    <td>
+                      {{
+                        currentEpisode.data
+                          ? currentEpisode.data[descriptor.field_name]
+                          : ''
+                      }}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
           </div>
-          <div class="table-body">
-            <table class="datatable no-header" v-if="currentEpisode">
-              <tbody class="datatable-body">
-                <tr class="datatable-row">
-                  <td class="field-label">
-                    {{ $t('shots.fields.description') }}
-                  </td>
-                  <description-cell :entry="currentEpisode" :full="true" />
-                </tr>
-
-                <tr
-                  :key="descriptor.id"
-                  class="datatable-row"
-                  v-for="descriptor in episodeMetadataDescriptors"
-                >
-                  <td class="field-label">{{ descriptor.name }}</td>
-                  <td>
-                    {{
-                      currentEpisode && currentEpisode.data
-                        ? currentEpisode.data[descriptor.field_name]
-                        : ''
-                    }}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
         </div>
-      </div>
 
-      <div class="episode-data block">
         <div class="flexrow">
-          <combobox-styled
-            class="section-combo flexrow-item"
-            :options="entityNavOptions"
-            v-model="currentSection"
-          />
           <span v-show="currentSection === 'casting'">
             {{ nbAssets }} {{ $tc('assets.number', nbAssets) }}
           </span>
@@ -202,14 +203,14 @@
           {{ $t('main.empty_schedule') }}
         </div>
 
+        <entity-chat
+          :entity="currentEpisode"
+          v-if="currentSection === 'chat'"
+        />
+
         <entity-preview-files
           :entity="currentEpisode"
           v-if="currentSection === 'preview-files'"
-        />
-
-        <entity-news
-          :entity="currentEpisode"
-          v-if="currentSection === 'activity'"
         />
 
         <entity-time-logs
@@ -219,8 +220,10 @@
       </div>
     </div>
 
-    <div class="column side-column" v-if="currentTask">
-      <task-info :task="currentTask" entity-type="Episode" with-actions />
+    <div class="column side-column" v-show="currentSection === 'infos'">
+      <task-info :task="currentTask" entity-type="Episode" with-actions>
+        <entity-news class="news-column" :entity="currentEpisode" />
+      </task-info>
     </div>
 
     <edit-episode-modal
@@ -248,6 +251,7 @@ import ComboboxNumber from '@/components/widgets/ComboboxNumber'
 import ComboboxStyled from '@/components/widgets/ComboboxStyled'
 import DescriptionCell from '@/components/cells/DescriptionCell'
 import EditEpisodeModal from '@/components/modals/EditEpisodeModal'
+import EntityChat from '@/components/pages/entities/EntityChat'
 import EntityNews from '@/components/pages/entities/EntityNews'
 import EntityPreviewFiles from '@/components/pages/entities/EntityPreviewFiles'
 import EntityTaskList from '@/components/lists/EntityTaskList'
@@ -255,6 +259,7 @@ import EntityTimeLogs from '@/components/pages/entities/EntityTimeLogs'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail'
 import PageTitle from '@/components/widgets/PageTitle'
 import PageSubtitle from '@/components/widgets/PageSubtitle'
+import RouteSectionTabs from '@/components/widgets/RouteSectionTabs'
 import Schedule from '@/components/pages/schedule/Schedule'
 import TableInfo from '@/components/widgets/TableInfo'
 import TaskInfo from '@/components/sides/TaskInfo'
@@ -270,6 +275,7 @@ export default {
     CornerLeftUpIcon,
     DescriptionCell,
     EditEpisodeModal,
+    EntityChat,
     EntityNews,
     EntityPreviewFiles,
     EntityTaskList,
@@ -277,6 +283,7 @@ export default {
     EntityThumbnail,
     PageSubtitle,
     PageTitle,
+    RouteSectionTabs,
     Schedule,
     TableInfo,
     TaskInfo,
@@ -307,27 +314,7 @@ export default {
 
   mounted() {
     this.clearSelectedTasks()
-    this.loadCurrentEpisode()
-      .then(episode => {
-        this.currentEpisode = episode
-        this.currentSection = this.route.query.section || 'casting'
-        this.casting.isLoading = true
-        this.casting.isError = false
-        if (this.currentEpisode) {
-          this.loadEpisodeCasting(this.currentEpisode)
-            .then(() => {
-              this.casting.isLoading = false
-            })
-            .catch(err => {
-              this.casting.isLoading = false
-              this.casting.isError = true
-              console.error(err)
-            })
-        } else {
-          this.resetData()
-        }
-      })
-      .catch(console.error)
+    this.init()
   },
 
   computed: {
@@ -393,6 +380,30 @@ export default {
       'loadEpisodesWithTasks',
       'loadEpisodeCasting'
     ]),
+
+    init() {
+      this.loadCurrentEpisode()
+      .then(episode => {
+        this.currentEpisode = episode
+        this.currentSection = this.route.query.section || 'infos'
+        this.casting.isLoading = true
+        this.casting.isError = false
+        if (this.currentEpisode) {
+          this.loadEpisodeCasting(this.currentEpisode)
+            .then(() => {
+              this.casting.isLoading = false
+            })
+            .catch(err => {
+              this.casting.isLoading = false
+              this.casting.isError = true
+              console.error(err)
+            })
+        } else {
+          this.resetData()
+        }
+      })
+      .catch(console.error)
+    },
 
     loadCurrentEpisode() {
       return new Promise((resolve, reject) => {
@@ -619,13 +630,37 @@ h2.subtitle {
   }
 }
 
-.section-combo {
-  width: 150px;
+.section-tabs {
+  min-height: 36px;
+  margin-bottom: 1em;
+}
 
-  .option-line {
-    width: 150px;
+.infos {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  max-height: 100%;
+  overflow-y: auto;
+
+  .entity-infos {
+    align-self: flex-start;
+    flex: 1.5;
   }
 }
+
+.entity-stats {
+  padding: 1em;
+  font-size: 1.2em;
+
+  .entry-label {
+    display: inline-block;
+    width: 120px;
+  }
+}
+
+.news-column {
+  max-height: 85%;
+}
+
 
 @media screen and (max-width: 768px) {
   .task-column {

--- a/src/components/pages/Notifications.vue
+++ b/src/components/pages/Notifications.vue
@@ -96,18 +96,13 @@
                     class="flexrow-item"
                     :person="personMap.get(notification.author_id)"
                     :size="30"
+                    :is-link="false"
                     v-if="personMap.get(notification.author_id)"
                   />
 
-                  <router-link
-                    class="person-name flexrow-item"
-                    :to="{
-                      name: 'person',
-                      params: { person_id: notification.author_id }
-                    }"
-                  >
+                  <span class="person-name flexrow-item">
                     {{ personName(notification) }}
-                  </router-link>
+                  </span>
 
                   <span
                     class="explaination flexrow-item"
@@ -570,10 +565,11 @@ a {
 }
 
 .unread {
-  border-left: 5px solid $orange;
+  border: 5px solid $orange;
 }
 
 .person-name {
+  font-weight: bold;
   margin-left: 0.5em;
   margin-right: 0.5em;
 }

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -1513,7 +1513,7 @@ export default {
   max-width: 300px;
   background: #f4f5f9;
   overflow-y: auto;
-  padding: 1em 1em 1em 2em;
+  padding: 1em;
   border-right: 1px solid #ddd;
   box-shadow: 0 0 6px #f0f0f0;
   z-index: 201;

--- a/src/components/pages/Sequence.vue
+++ b/src/components/pages/Sequence.vue
@@ -31,10 +31,7 @@
           :tabs="entityNavOptions"
         />
 
-        <div
-          class="flexrow infos"
-          v-show="currentSection === 'infos'"
-        >
+        <div class="flexrow infos" v-show="currentSection === 'infos'">
           <div class="flexrow-item flexcolumn entity-infos">
             <page-subtitle :text="$t('main.tasks')" />
             <entity-task-list
@@ -89,7 +86,10 @@
           <div class="filler"></div>
           <span
             class="flexrow-item mt05"
-            v-show="currentSection === 'schedule' && scheduleItems[0].children.length > 0"
+            v-show="
+              currentSection === 'schedule' &&
+              scheduleItems[0].children.length > 0
+            "
           >
             {{ $t('schedule.zoom_level') }}:
           </span>
@@ -98,7 +98,10 @@
             :options="zoomOptions"
             is-simple
             v-model="zoomLevel"
-            v-show="currentSection === 'schedule' && scheduleItems[0].children.length > 0"
+            v-show="
+              currentSection === 'schedule' &&
+              scheduleItems[0].children.length > 0
+            "
           />
         </div>
 
@@ -211,6 +214,7 @@
 
         <entity-chat
           :entity="currentSequence"
+          :name="currentSequence?.full_name"
           v-if="currentSection === 'chat'"
         />
 
@@ -254,7 +258,6 @@ import { formatListMixin } from '@/components/mixins/format'
 
 import ButtonSimple from '@/components/widgets/ButtonSimple'
 import ComboboxNumber from '@/components/widgets/ComboboxNumber'
-import ComboboxStyled from '@/components/widgets/ComboboxStyled'
 import DescriptionCell from '@/components/cells/DescriptionCell'
 import EditSequenceModal from '@/components/modals/EditSequenceModal'
 import EntityChat from '@/components/pages/entities/EntityChat.vue'
@@ -277,7 +280,6 @@ export default {
   components: {
     ButtonSimple,
     ComboboxNumber,
-    ComboboxStyled,
     CornerLeftUpIcon,
     DescriptionCell,
     EditSequenceModal,
@@ -389,26 +391,26 @@ export default {
 
     init() {
       this.loadCurrentSequence()
-      .then(sequence => {
-        this.currentSequence = sequence
-        this.currentSection = this.route.query.section || 'infos'
-        this.casting.isLoading = true
-        this.casting.isError = false
-        if (this.currentSequence) {
-          this.loadSequenceCasting(this.currentSequence)
-            .then(() => {
-              this.casting.isLoading = false
-            })
-            .catch(err => {
-              this.casting.isLoading = false
-              this.casting.isError = true
-              console.error(err)
-            })
-        } else {
-          this.resetData()
-        }
-      })
-      .catch(console.error)
+        .then(sequence => {
+          this.currentSequence = sequence
+          this.currentSection = this.route.query.section || 'infos'
+          this.casting.isLoading = true
+          this.casting.isError = false
+          if (this.currentSequence) {
+            this.loadSequenceCasting(this.currentSequence)
+              .then(() => {
+                this.casting.isLoading = false
+              })
+              .catch(err => {
+                this.casting.isLoading = false
+                this.casting.isError = true
+                console.error(err)
+              })
+          } else {
+            this.resetData()
+          }
+        })
+        .catch(console.error)
     },
 
     loadCurrentSequence() {

--- a/src/components/pages/Sequence.vue
+++ b/src/components/pages/Sequence.vue
@@ -23,83 +23,73 @@
         </div>
       </div>
 
-      <div class="flexrow infos">
-        <div class="flexrow-item block flexcolumn">
-          <page-subtitle :text="$t('sequences.tasks')" />
-          <entity-task-list
-            class="task-list"
-            :entries="currentTasks"
-            :is-loading="!currentSequence"
-            :is-error="false"
-            @task-selected="onTaskSelected"
-          />
-        </div>
-        <div class="flexrow-item block flexcolumn">
-          <div class="flexrow">
-            <page-subtitle :text="$t('main.info')" />
-            <div class="filler"></div>
-            <div class="flexrow-item has-text-right">
-              <button-simple
-                icon="edit"
-                @click="modals.edit = true"
-                v-if="isCurrentUserManager"
-              />
+      <div class="sequence-data block">
+        <route-section-tabs
+          class="section-tabs"
+          :activeTab="currentSection"
+          :route="$route"
+          :tabs="entityNavOptions"
+        />
+
+        <div
+          class="flexrow infos"
+          v-show="currentSection === 'infos'"
+        >
+          <div class="flexrow-item flexcolumn entity-infos">
+            <page-subtitle :text="$t('main.tasks')" />
+            <entity-task-list
+              class="task-list"
+              :entries="currentTasks"
+              :is-loading="!currentSequence"
+              :is-error="false"
+              @task-selected="onTaskSelected"
+            />
+            <div class="flexrow">
+              <page-subtitle :text="$t('main.info')" />
+              <div class="filler"></div>
+              <div class="flexrow-item has-text-right">
+                <button-simple
+                  icon="edit"
+                  @click="modals.edit = true"
+                  v-if="isCurrentUserManager"
+                />
+              </div>
+            </div>
+
+            <div class="table-body">
+              <table class="datatable no-header" v-if="currentSequence">
+                <tbody class="table-body">
+                  <tr class="datatable-row">
+                    <td class="field-label">
+                      {{ $t('shots.fields.description') }}
+                    </td>
+                    <description-cell :entry="currentSequence" :full="true" />
+                  </tr>
+                  <tr
+                    :key="descriptor.id"
+                    class="datatable-row"
+                    v-for="descriptor in sequenceMetadataDescriptors"
+                  >
+                    <td class="field-label">{{ descriptor.name }}</td>
+                    <td>
+                      {{
+                        currentSequence.data
+                          ? currentSequence.data[descriptor.field_name]
+                          : ''
+                      }}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
           </div>
-          <div class="table-body">
-            <table class="datatable no-header" v-if="currentSequence">
-              <tbody class="datatable-body">
-                <tr class="datatable-row">
-                  <td class="field-label">
-                    {{ $t('shots.fields.description') }}
-                  </td>
-                  <description-cell :entry="currentSequence" :full="true" />
-                </tr>
-
-                <tr
-                  :key="descriptor.id"
-                  class="datatable-row"
-                  v-for="descriptor in sequenceMetadataDescriptors"
-                >
-                  <td class="field-label">{{ descriptor.name }}</td>
-                  <td>
-                    {{
-                      currentSequence && currentSequence.data
-                        ? currentSequence.data[descriptor.field_name]
-                        : ''
-                    }}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
         </div>
-      </div>
 
-      <div class="sequence-data block">
         <div class="flexrow">
-          <combobox-styled
-            class="section-combo flexrow-item"
-            :options="entityNavOptions"
-            v-model="currentSection"
-          />
-          <span v-show="currentSection === 'casting'">
-            {{ nbAssets }} {{ $tc('assets.number', nbAssets) }}
-          </span>
-          <span
-            class="tag tag-standby"
-            v-show="
-              currentSection === 'casting' &&
-              currentSequence &&
-              currentSequence.is_casting_standby
-            "
-          >
-            {{ $t('breakdown.fields.standby') }}
-          </span>
           <div class="filler"></div>
           <span
             class="flexrow-item mt05"
-            v-show="currentSection === 'schedule'"
+            v-show="currentSection === 'schedule' && scheduleItems[0].children.length > 0"
           >
             {{ $t('schedule.zoom_level') }}:
           </span>
@@ -108,11 +98,26 @@
             :options="zoomOptions"
             is-simple
             v-model="zoomLevel"
-            v-show="currentSection === 'schedule'"
+            v-show="currentSection === 'schedule' && scheduleItems[0].children.length > 0"
           />
         </div>
 
         <div class="sequence-casting" v-show="currentSection === 'casting'">
+          <div class="casting-data mt1">
+            <span v-show="currentSection === 'casting' && nbAssets > 0">
+              {{ nbAssets }} {{ $tc('assets.number', nbAssets) }}
+            </span>
+            <span
+              class="tag tag-standby"
+              v-show="
+                currentSection === 'casting' &&
+                currentSequence &&
+                currentSequence.is_casting_standby
+              "
+            >
+              {{ $t('breakdown.fields.standby') }}
+            </span>
+          </div>
           <div v-if="currentSequence">
             <div
               v-if="
@@ -204,14 +209,14 @@
           {{ $t('main.empty_schedule') }}
         </div>
 
+        <entity-chat
+          :entity="currentSequence"
+          v-if="currentSection === 'chat'"
+        />
+
         <entity-preview-files
           :entity="currentSequence"
           v-if="currentSequence && currentSection === 'preview-files'"
-        />
-
-        <entity-news
-          :entity="currentSequence"
-          v-if="currentSequence && currentSection === 'activity'"
         />
 
         <entity-time-logs
@@ -221,8 +226,10 @@
       </div>
     </div>
 
-    <div class="column side-column" v-if="currentTask">
-      <task-info :task="currentTask" entity-type="Sequence" with-actions />
+    <div class="column side-column" v-show="currentSection === 'infos'">
+      <task-info :task="currentTask" entity-type="Sequence" with-actions>
+        <entity-news class="news-column" :entity="currentSequence" />
+      </task-info>
     </div>
 
     <edit-sequence-modal
@@ -250,6 +257,7 @@ import ComboboxNumber from '@/components/widgets/ComboboxNumber'
 import ComboboxStyled from '@/components/widgets/ComboboxStyled'
 import DescriptionCell from '@/components/cells/DescriptionCell'
 import EditSequenceModal from '@/components/modals/EditSequenceModal'
+import EntityChat from '@/components/pages/entities/EntityChat.vue'
 import EntityNews from '@/components/pages/entities/EntityNews'
 import EntityPreviewFiles from '@/components/pages/entities/EntityPreviewFiles'
 import EntityTaskList from '@/components/lists/EntityTaskList'
@@ -257,6 +265,7 @@ import EntityTimeLogs from '@/components/pages/entities/EntityTimeLogs'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail'
 import PageTitle from '@/components/widgets/PageTitle'
 import PageSubtitle from '@/components/widgets/PageSubtitle'
+import RouteSectionTabs from '@/components/widgets/RouteSectionTabs'
 import Schedule from '@/components/pages/schedule/Schedule'
 import TableInfo from '@/components/widgets/TableInfo'
 import TaskInfo from '@/components/sides/TaskInfo'
@@ -272,6 +281,7 @@ export default {
     CornerLeftUpIcon,
     DescriptionCell,
     EditSequenceModal,
+    EntityChat,
     EntityNews,
     EntityPreviewFiles,
     EntityTaskList,
@@ -280,6 +290,7 @@ export default {
     PageSubtitle,
     PageTitle,
     Schedule,
+    RouteSectionTabs,
     TableInfo,
     TaskInfo,
     TaskTypeName
@@ -309,27 +320,7 @@ export default {
 
   mounted() {
     this.clearSelectedTasks()
-    this.loadCurrentSequence()
-      .then(sequence => {
-        this.currentSequence = sequence
-        this.currentSection = this.route.query.section || 'casting'
-        this.casting.isLoading = true
-        this.casting.isError = false
-        if (this.currentSequence) {
-          this.loadSequenceCasting(this.currentSequence)
-            .then(() => {
-              this.casting.isLoading = false
-            })
-            .catch(err => {
-              this.casting.isLoading = false
-              this.casting.isError = true
-              console.error(err)
-            })
-        } else {
-          this.resetData()
-        }
-      })
-      .catch(console.error)
+    this.init()
   },
 
   computed: {
@@ -395,6 +386,30 @@ export default {
       'loadSequencesWithTasks',
       'loadSequenceCasting'
     ]),
+
+    init() {
+      this.loadCurrentSequence()
+      .then(sequence => {
+        this.currentSequence = sequence
+        this.currentSection = this.route.query.section || 'infos'
+        this.casting.isLoading = true
+        this.casting.isError = false
+        if (this.currentSequence) {
+          this.loadSequenceCasting(this.currentSequence)
+            .then(() => {
+              this.casting.isLoading = false
+            })
+            .catch(err => {
+              this.casting.isLoading = false
+              this.casting.isError = true
+              console.error(err)
+            })
+        } else {
+          this.resetData()
+        }
+      })
+      .catch(console.error)
+    },
 
     loadCurrentSequence() {
       return new Promise((resolve, reject) => {
@@ -463,8 +478,6 @@ export default {
       })
     }
   },
-
-  watch: {},
 
   metaInfo() {
     return {
@@ -549,8 +562,8 @@ h2.subtitle {
   text-transform: uppercase;
   font-size: 1.2em;
   color: var(--text);
-  margin-top: 2em;
-  margin-bottom: 0.4em;
+  margin-top: 1em;
+  margin-bottom: 0.6em;
 }
 
 .asset-list {
@@ -653,5 +666,36 @@ h2.subtitle {
   margin-left: 1em;
   cursor: default;
   text-transform: uppercase;
+}
+
+.section-tabs {
+  min-height: 36px;
+  margin-bottom: 0;
+}
+
+.infos {
+  margin-top: 1em;
+  margin-bottom: 1em;
+  max-height: 100%;
+  overflow-y: auto;
+
+  .entity-infos {
+    align-self: flex-start;
+    flex: 1.5;
+  }
+}
+
+.entity-stats {
+  padding: 1em;
+  font-size: 1.2em;
+
+  .entry-label {
+    display: inline-block;
+    width: 120px;
+  }
+}
+
+.news-column {
+  max-height: 85%;
 }
 </style>

--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -195,6 +195,7 @@
 
         <entity-chat
           :entity="currentShot"
+          :name="currentShot ? currentShot.full_name : ''"
           v-if="currentSection === 'chat'"
         />
 

--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -193,6 +193,11 @@
           </div>
         </div>
 
+        <entity-chat
+          :entity="currentShot"
+          v-if="currentSection === 'chat'"
+        />
+
         <div class="shot-casting" v-show="currentSection === 'casting'">
           <div v-if="currentShot">
             <div
@@ -326,6 +331,7 @@ import ButtonSimple from '@/components/widgets/ButtonSimple'
 import ComboboxNumber from '@/components/widgets/ComboboxNumber'
 import DescriptionCell from '@/components/cells/DescriptionCell'
 import EditShotModal from '@/components/modals/EditShotModal'
+import EntityChat from '@/components/pages/entities/EntityChat'
 import EntityNews from '@/components/pages/entities/EntityNews'
 import EntityPreviewFiles from '@/components/pages/entities/EntityPreviewFiles'
 import EntityTaskList from '@/components/lists/EntityTaskList'
@@ -347,6 +353,7 @@ export default {
     CornerLeftUpIcon,
     DescriptionCell,
     EditShotModal,
+    EntityChat,
     EntityNews,
     EntityPreviewFiles,
     EntityTaskList,

--- a/src/components/pages/entities/EntityChat.vue
+++ b/src/components/pages/entities/EntityChat.vue
@@ -1,0 +1,405 @@
+<template>
+  <div class="mt1 entity-chat">
+    <template v-if="!entity">
+      <p>
+        {{ $t('chat.no_chats') }}
+      </p>
+      <div class="has-text-centered">
+        <button-simple text="Search for entity" @click="$router.push('entity-search')"/>
+      </div>
+    </template>
+    <template v-else>
+      <div class="participants flexrow">
+        <people-avatar
+          class="flexrow-item"
+          :key="participant.id"
+          :person="participant"
+          :size="20"
+          :font-size="10"
+          v-for="participant in participantList"
+        />
+        <span class="filler"></span>
+        <button-simple
+          class="flexrow-item"
+          :text="$t('chats.leave')"
+          :is-loading="loading.leave"
+          @click="leaveChat"
+          v-if="isInChat"
+        />
+      </div>
+        <div class="has-text-centered" v-if="loading.chat">
+          <spinner class="mt1" />
+        </div>
+        <entity-chat-days
+          :messages="messages"
+          @delete-message="deleteMessage"
+          v-else
+        />
+        <div class="join-chat" v-if="!isInChat">
+          <button
+            class="button"
+            :is-loading="loading.join"
+            @click="joinChat"
+          >
+            {{ $t('chats.join') }}
+          </button>
+        </div>
+        <div class="message-box" v-else>
+          <textarea
+            ref="messageBox"
+            @keyup.enter="sendMessage"
+            v-focus
+            v-model="currentMessage"
+          >
+          </textarea>
+          <button-simple
+            class="send-button"
+            icon="send"
+            @click="sendMessage"
+          />
+        </div>
+      </template>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+import moment from 'moment'
+import { XIcon } from 'vue-feather-icons'
+
+import { sortPeople } from '@/lib/sorting'
+import { domMixin } from '@/components/mixins/dom'
+
+import ButtonSimple from '@/components/widgets/ButtonSimple'
+import EntityChatDays from '@/components/pages/entities/EntityChatDays'
+import PeopleAvatar from '@/components/widgets/PeopleAvatar'
+import Spinner from '@/components/widgets/Spinner'
+
+export default {
+  name: 'entity-chat',
+  mixins: [domMixin],
+
+  components: {
+    ButtonSimple,
+    EntityChatDays,
+    PeopleAvatar,
+    Spinner,
+    XIcon
+  },
+
+  data() {
+    return {
+      chat: {},
+      loading: {
+        chat: false,
+        join: false,
+        leave: false,
+        send: false
+      },
+      participants: [],
+      currentMessage: '',
+      messages: [],
+      messageMap: new Map()
+    }
+  },
+
+  props: {
+    entity: {
+      type: Object,
+      default: () => {}
+    }
+  },
+
+  mounted() {
+    if (!this.entity) return
+    this.reset()
+  },
+
+  computed: {
+    ...mapGetters([
+      'currentProduction',
+      'departmentMap',
+      'personMap',
+      'taskStatusMap',
+      'taskTypeMap',
+      'user'
+    ]),
+
+    isInChat() {
+      return this.participants.includes(this.user.id)
+    },
+
+    participantList() {
+      return sortPeople(this.participants.map(
+        pid => this.personMap.get(pid)
+      ))
+    },
+
+    messageList() {
+      const messages = [...this.messages]
+        .sort((a, b) => moment(a.created_at).isAfter(moment(b.created_at)))
+      const dayList = []
+      let lastMessage = { data: null }
+      let lastDay = null
+
+      messages.forEach(message => {
+        const messageDate = moment(message.created_at)
+          .tz(this.user.timezone)
+        if (
+          lastDay
+          && messageDate.format('YYYY-MM-DD') === lastDay.date
+        ){
+          if (
+            lastMessage && lastMessage.data &&
+            message.person_id === lastMessage.data.person_id &&
+            moment(message.created_at).diff(lastMessage.data.created_at, 'm') < 60
+          ) {
+            lastMessage.texts.push(message.text)
+          } else {
+            const element = {
+              data: message,
+              texts: [message.text]
+            }
+            lastMessage = element
+            lastDay.messages.push(element)
+          }
+        } else {
+          const element = {
+            data: message,
+            texts: [message.text]
+          }
+          lastDay = {
+            title: messageDate.format('LL'),
+            date: messageDate.format('YYYY-MM-DD'),
+            messages: [element]
+          }
+          lastMessage = element
+          dayList.push(lastDay)
+        }
+      })
+
+      return dayList.reverse()
+    }
+  },
+
+  methods: {
+    ...mapActions([
+      'deleteChatMessage',
+      'getChatMessage',
+      'getEntityChat',
+      'getEntityChatMessages',
+      'joinEntityChat',
+      'leaveEntityChat',
+      'sendChatMessage'
+    ]),
+
+    async reset() {
+      this.loading.chat = true
+      try {
+        this.chat = await this.getEntityChat(this.entity.id)
+        this.messages = await this.getEntityChatMessages(this.entity.id)
+        this.messages.forEach(m => this.messageMap.set(m.id, m))
+        this.participants = this.chat.participants || []
+      } catch (e) {
+        console.error(e)
+      } finally {
+        this.loading.chat = false
+      }
+    },
+
+    async joinChat() {
+      this.loading.join = true
+      try {
+        await this.joinEntityChat(this.entity.id)
+      } catch (e) {
+        console.error(e)
+      } finally {
+        this.loading.join = false
+      }
+    },
+
+    async leaveChat() {
+      this.loading.leave = true
+      try {
+        await this.leaveEntityChat(this.entity.id)
+      } catch (e) {
+        console.error(e)
+      } finally {
+        this.loading.leave = false
+      }
+    },
+
+    async sendMessage(event) {
+      if (event) event.preventDefault()
+      this.pauseEvent(event)
+      this.loading.send = true
+      try {
+        const message = await this.sendChatMessage({
+          entityId: this.entity.id,
+          message: this.currentMessage
+        })
+        this.currentMessage = ''
+        this.messages.push(message)
+        this.messageMap.set(message.id, message)
+      } catch (e) {
+        console.error(e)
+      } finally {
+        this.loading.send = false
+      }
+    },
+
+    async deleteMessage(messageId) {
+      try {
+        this.messages = this.messages.filter(m => m.id !== messageId)
+        await this.deleteChatMessage({
+          entityId: this.entity.id,
+          messageId
+        })
+        this.messageMap.delete(messageId)
+      } catch (e) {
+        console.error(e)
+      }
+    },
+
+    focusMessageBox() {
+      this.$refs.messageBox.focus()
+    }
+  },
+
+  socket: {
+    events: {
+      async 'chat:joined' (eventData) {
+        if (
+          eventData.chat_id === this.chat.id &&
+          !this.participants.includes(eventData.person_id)
+        ) {
+          this.participants.push(eventData.person_id)
+        }
+      },
+
+      async 'chat:left' (eventData) {
+        if (
+          eventData.chat_id === this.chat.id &&
+          this.participants.includes(eventData.person_id)
+        ) {
+          this.participants = this.participants.filter(
+            pId => pId !== eventData.person_id
+          )
+        }
+      },
+
+      async 'chat:new-message' (eventData) {
+        if (
+          eventData.chat_id === this.chat.id
+        ) {
+          const message = await this.getChatMessage({
+            entityId: this.entity.id,
+            messageId: eventData.chat_message_id
+          })
+          if (!this.messageMap.has(eventData.chat_message_id)) {
+            this.messageMap.set(message.id, message)
+            this.messages.push(message)
+          }
+        }
+      },
+
+      async 'chat:deleted-message' (eventData) {
+        if (eventData.chat_id === this.chat.id) {
+          this.messages = this.messages.filter(
+            m => m.id !== eventData.message_id
+          )
+        }
+      }
+    }
+  },
+
+  watch: {
+    entity() {
+      if (this.entity) this.reset()
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+
+.dark {
+  .entity-chat {
+    .participants {
+      background: var(--background);
+    }
+
+    .messages {
+      background-color: var(--background-alt);
+      .message-box {
+        textarea {
+          background: var(--background-alt);
+        }
+      }
+    }
+  }
+}
+
+.entity-chat {
+  border-radius: 16px;
+  border: 1px solid var(--border-alt);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-height: 100%;
+  overflow: hidden;
+
+  p {
+    color: var(--text);
+    padding: 2em;
+    text-align: center;
+  }
+
+  .participants {
+    background: var(--background-alt);
+    border-bottom: 2px solid var(--border-alt);
+    border-top-left-radius: 17px;
+    border-top-right-radius: 17px;
+    display: flex;
+    justify-content: space-between;
+    min-height: 30px;
+    padding: 5px 10px;
+
+    .flexrow-item {
+      margin-right: 3px;
+    }
+  }
+
+  .join-chat {
+    text-align: center;
+    width: 100%;
+
+    .button {
+      width: 100%;
+    }
+  }
+
+  .message-box {
+    position: relative;
+
+    textarea {
+      background: var(--background);
+      box-shadow: inset 0px 0px 5px 0 rgba(0, 0, 0, 0.1);
+      border: 1px solid var(--border-alt);
+      border-bottom-left-radius: 10px;
+      border-bottom-right-radius: 10px;
+      font-size: 14px;
+      margin-bottom: -5px;
+      height: 60px;
+      padding: 10px;
+      width: 100%;
+    }
+
+    .send-button {
+      bottom: 0px;
+      position: absolute;
+      right: 3px;
+    }
+  }
+}
+</style>

--- a/src/components/pages/entities/EntityChatDays.vue
+++ b/src/components/pages/entities/EntityChatDays.vue
@@ -1,0 +1,274 @@
+<template>
+  <div class="messages">
+    <div
+      class="day-messages"
+      v-for="day in messageList"
+    >
+      <div class="day-title">
+        <span>
+          {{ day.title }}
+        </span>
+      </div>
+      <div
+        class="message"
+        :key="chatMessage.id"
+        v-for="chatMessage in day.messages"
+      >
+        <people-avatar
+          class="message-avatar flexrow-item"
+          :person="personMap.get(chatMessage.data.person_id)"
+          :size="30"
+          :font-size="15"
+        />
+        <div class="message-content">
+          <div class="message-header-wrapper flexrow">
+            <div class="message-sender mr05">
+              {{ personMap.get(chatMessage.data.person_id).name }}
+            </div>
+            <div class="message-date">
+              {{ renderDate(chatMessage.data.created_at) }}
+            </div>
+          </div>
+          <div
+            class="message-text"
+            v-for="text in chatMessage.texts"
+          >
+            <div
+              v-html="
+                renderComment(
+                  text,
+                  [],
+                  [],
+                  personMap,
+                  departmentMap,
+                  ''
+                )
+              "
+            >
+            </div>
+            <div
+              class="delete-message-button"
+              @click="$emit('delete-message', chatMessage.data.id)"
+              v-if="chatMessage.data.person_id === user.id"
+            >
+              <x-icon class="" size="0.8x" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+import moment from 'moment-timezone'
+import { XIcon } from 'vue-feather-icons'
+
+import { renderComment } from '@/lib/render'
+import { parseDate } from '@/lib/time'
+import { domMixin } from '@/components/mixins/dom'
+
+import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
+
+
+export default {
+  name: 'entity-chat-days',
+  mixins: [domMixin],
+
+  components: {
+    PeopleAvatar,
+    XIcon
+  },
+
+  data() {
+    return {
+    }
+  },
+
+  props: {
+    messages: {
+      type: Array,
+      default: () => []
+    }
+  },
+
+  mounted() {
+  },
+
+  computed: {
+    ...mapGetters([
+      'departmentMap',
+      'personMap',
+      'user'
+    ]),
+
+    messageList() {
+      const messages = [...this.messages]
+        .sort((a, b) => moment(a.created_at).isAfter(moment(b.created_at)))
+      const dayList = []
+      let lastMessage = { data: null }
+      let lastDay = null
+
+      messages.forEach(message => {
+        const messageDate = moment(message.created_at)
+          .tz(this.user.timezone)
+        if (
+          lastDay
+          && messageDate.format('YYYY-MM-DD') === lastDay.date
+        ){
+          if (
+            lastMessage && lastMessage.data &&
+            message.person_id === lastMessage.data.person_id &&
+            moment(message.created_at).diff(lastMessage.data.created_at, 'm') < 60
+          ) {
+            lastMessage.texts.push(message.text)
+          } else {
+            const element = {
+              data: message,
+              texts: [message.text]
+            }
+            lastMessage = element
+            lastDay.messages.push(element)
+          }
+        } else {
+          const element = {
+            data: message,
+            texts: [message.text]
+          }
+          lastDay = {
+            title: messageDate.format('LL'),
+            date: messageDate.format('YYYY-MM-DD'),
+            messages: [element]
+          }
+          lastMessage = element
+          dayList.push(lastDay)
+        }
+      })
+
+      return dayList.reverse()
+    }
+  },
+
+  methods: {
+    ...mapActions([
+    ]),
+
+    renderComment,
+
+    renderDate(date) {
+      date = moment(parseDate(date)).tz(this.user.timezone)
+      return date.tz(this.user.timezone).format('HH:mm')
+    }
+  },
+
+  watch: {
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.dark {
+  .messages {
+    background-color: var(--background-alt);
+    .message-box {
+      textarea {
+        background: var(--background-alt);
+      }
+    }
+  }
+}
+
+
+.day-messages {
+  width: 100%;
+}
+
+.day-title {
+  border-bottom: 1px solid var(--border-alt);
+  margin-top: 2em;
+  margin-bottom: 2em;
+  position: relative;
+
+  span {
+    background: var(--background-alt);
+    left: 50%;
+    padding: 0 1em;
+    position: absolute;
+    top: -10px;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+}
+
+
+.messages {
+  align-items: flex-end;
+  color: var(--text);
+  display: flex;
+  flex: 1;
+  flex-direction: column-reverse;
+  overflow: auto;
+  padding-bottom: 1em;
+
+  .message {
+    align-items: flex-start;
+    display: flex;
+    background: transparent;
+    margin-bottom: 0.5rem;
+    width: 100%;
+
+    .message-avatar {
+      margin-left: 10px;
+      margin-top: 6px;
+
+      &.flexrow-item {
+        margin-right: .2rem;
+      }
+    }
+
+    .message-header-wrapper {
+      align-items: flex-end;
+      display: flex;
+      margin-left: .5rem;
+      margin-top: .2rem;
+
+      .message-date {
+        font-size: 10px;
+        line-height: 20px;
+      }
+    }
+
+    .message-sender {
+      font-weight: bold;
+    }
+
+    .message-content {
+      margin-left: .2rem;
+      width: 100%;
+    }
+
+    .message-text {
+      border-radius: 4px;
+      margin-right: 10px;
+      padding: .1em .5em;
+      position: relative;
+
+      .delete-message-button {
+        cursor: pointer;
+        display: none;
+        position: absolute;
+        right: 5px;
+        top: 0;
+      }
+
+      &:hover {
+        background-color: var(--background-alt);
+        .delete-message-button {
+          display: block;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/components/sides/Sidebar.vue
+++ b/src/components/sides/Sidebar.vue
@@ -37,6 +37,12 @@
               </router-link>
             </p>
             <p @click="toggleSidebar()">
+              <router-link :to="{ name: 'entity-chats' }">
+                <kitsu-icon class="nav-icon" name="message" />
+                {{ $t('chats.title') }}
+              </router-link>
+            </p>
+            <p @click="toggleSidebar()">
               <router-link :to="{ name: 'open-productions' }">
                 <kitsu-icon class="nav-icon" name="my-productions" />
                 {{ $t('productions.open_productions') }}

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -10,11 +10,10 @@
       <action-panel
         v-if="
           withActions &&
-          (!isConceptTask || selectedConcepts.size > 0) && (
-            nbSelectedEntities > 0 ||
+          (!isConceptTask || selectedConcepts.size > 0) &&
+          (nbSelectedEntities > 0 ||
             nbSelectedTasks > 0 ||
-            nbSelectedValidations > 0
-          )
+            nbSelectedValidations > 0)
         "
         :is-movie-preview="isMoviePreview"
         :is-set-frame-thumbnail-loading="loading.setFrameThumbnail"

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -8,7 +8,14 @@
     ></div>
     <div class="side task-info">
       <action-panel
-        v-if="withActions && (!isConceptTask || selectedConcepts.size > 0)"
+        v-if="
+          withActions &&
+          (!isConceptTask || selectedConcepts.size > 0) && (
+            nbSelectedEntities > 0 ||
+            nbSelectedTasks > 0 ||
+            nbSelectedValidations > 0
+          )
+        "
         :is-movie-preview="isMoviePreview"
         :is-set-frame-thumbnail-loading="loading.setFrameThumbnail"
         @export-task="onExportClick"

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -262,8 +262,8 @@
       </div>
     </div>
 
-    <add-comment-image-modal
-      ref="add-comment-image-modal"
+    <add-attachment-modal
+      ref="add-attachment-modal"
       :active="modals.addCommentAttachment"
       :is-loading="loading.addCommentAttachment"
       :is-error="errors.addCommentAttachment"
@@ -305,7 +305,7 @@ import strings from '@/lib/string'
 import { replaceTimeWithTimecode } from '@/lib/render'
 
 import AtTa from 'vue-at/dist/vue-at-textarea'
-import AddCommentImageModal from '@/components/modals/AddCommentImageModal'
+import AddAttachmentModal from '@/components/modals/AddAttachmentModal'
 import ConfirmModal from '@/components/modals/ConfirmModal'
 import ButtonSimple from '@/components/widgets/ButtonSimple'
 import ComboboxStatus from '@/components/widgets/ComboboxStatus'
@@ -319,7 +319,7 @@ export default {
 
   components: {
     AtTa,
-    AddCommentImageModal,
+    AddAttachmentModal,
     ButtonSimple,
     ConfirmModal,
     Checklist,
@@ -448,7 +448,7 @@ export default {
     ]),
 
     attachmentModal() {
-      return this.$refs['add-comment-image-modal']
+      return this.$refs['add-attachment-modal']
     },
 
     isAddChecklistAllowed() {

--- a/src/components/widgets/KitsuIcon.vue
+++ b/src/components/widgets/KitsuIcon.vue
@@ -20,6 +20,7 @@ import edits from '@/assets/icons/fi-edits.svg'
 import episodeStats from '@/assets/icons/fi-episode-stats.svg'
 import filter from '@/assets/icons/fi-filter.svg'
 import infos from '@/assets/icons/fi-info.svg'
+import message from '@/assets/icons/fi-message-square.svg'
 import myChecks from '@/assets/icons/fi-check-circle.svg'
 import myProductions from '@/assets/icons/fi-my-productions.svg'
 import myTasks from '@/assets/icons/fi-my-tasks.svg'
@@ -65,6 +66,7 @@ import soundOff from '@/assets/icons/fi-sound-off.svg'
 import laser from '@/assets/icons/fi-laser.svg'
 import waveform from '@/assets/icons/fi-waveform.svg'
 
+
 const icons = {
   'add-thumbnail': addThumbnail,
   assets,
@@ -93,6 +95,7 @@ const icons = {
   infos,
   laser,
   logs,
+  message,
   'my-checks': myChecks,
   'my-productions': myProductions,
   'my-tasks': myTasks,

--- a/src/components/widgets/KitsuIcon.vue
+++ b/src/components/widgets/KitsuIcon.vue
@@ -66,7 +66,6 @@ import soundOff from '@/assets/icons/fi-sound-off.svg'
 import laser from '@/assets/icons/fi-laser.svg'
 import waveform from '@/assets/icons/fi-waveform.svg'
 
-
 const icons = {
   'add-thumbnail': addThumbnail,
   assets,

--- a/src/components/widgets/RouteSectionTabs.vue
+++ b/src/components/widgets/RouteSectionTabs.vue
@@ -2,8 +2,10 @@
   <div class="tabs">
     <ul>
       <li
-        :key="`task-type-tab-${tab.name}`"
-        :class="{ 'is-active': tab.name === activeTab }"
+        :key="`task-type-tab-${tab.name || tab.value}`"
+        :class="{
+          'is-active': tab.name === activeTab || tab.value === activeTab
+        }"
         v-for="tab in tabs"
       >
         <router-link :to="getRoute(tab)">
@@ -39,7 +41,7 @@ export default {
         ...this.route,
         query: {
           ...this.route.query,
-          section: tab.name
+          section: tab.name || tab.value
         }
       }
     }

--- a/src/lib/path.js
+++ b/src/lib/path.js
@@ -202,6 +202,7 @@ export const getPersonPath = personId => {
     }
   }
 }
+
 export const getPersonTabPath = (personId, tab) => {
   return {
     name: 'person-tab',
@@ -210,6 +211,14 @@ export const getPersonTabPath = (personId, tab) => {
       tab
     }
   }
+}
+
+export const getDownloadAttachmentPath = attachment => {
+  return `/api/data/attachment-files/${attachment.id}/file/${attachment.name}`
+}
+
+export const getAttachmentThumbnailPath = attachment => {
+  return `/api/pictures/thumbnails/attachment-files/${attachment.id}.png`
 }
 
 export const pluralizeEntityType = (type = '') => {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -123,6 +123,14 @@ export default {
     }
   },
 
+  chats: {
+    join: 'Join chat',
+    leave: 'Leave chat',
+    no_message_yet: 'No message',
+    no_chat: 'You don\'t participate in any entity chat for the moment. Search an entity and join a chat from its page.',
+    title: 'Entity Chats',
+  },
+
   comments: {
     add_attachment: 'Add attachment',
     add_checklist: 'Add checklist',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -124,6 +124,8 @@ export default {
   },
 
   chats: {
+    delete_message: 'Are you sure you want to delete this message?',
+    delete_message_confirm: 'Delete message',
     join: 'Join chat',
     leave: 'Leave chat',
     no_message_yet: 'No message',
@@ -1401,7 +1403,7 @@ export default {
     clear_all_assignations: 'unassign all',
     clear_assignations: 'unassign from selection',
     clear_own_assignations: 'clear your assignments',
-    comment_image: 'Attach files to your comment',
+    comment_image: 'Attach files',
     create_for_selection: 'Create a task for each empty cell',
     create_tasks: 'Add tasks',
     create_tasks_shot: 'Add tasks for current shots',
@@ -1481,7 +1483,7 @@ export default {
     show_infos: 'Show additional information',
     small_thumbnails: 'Show small thumbnails',
     smaller: 'Reduce task panel',
-    select_file: 'Please select the file from your hard drive you want to attach to your comment:',
+    select_file: 'Please select the file from your hard drive you want to attach to your comment or message:',
     show_contact_sheet: 'Display tasks as a contact sheet',
     subscribe_notifications: 'Subscribe to notifications',
     subscribe_to_tasks: 'Subscribe to selected task notifications | Subscribe to the {nbSelectedTasks} selected tasks notifications',

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -30,6 +30,7 @@ const Concepts = () => import('@/components/pages/Concepts.vue')
 const CustomActions = () => import('@/components/pages/CustomActions.vue')
 const Departments = () => import('@/components/pages/Departments.vue')
 const Edit = () => import('@/components/pages/Edit.vue')
+const EntityChats = () => import('@/components/pages/EntityChats.vue')
 const EntitySearch = () => import('@/components/pages/EntitySearch.vue')
 const Episode = () => import('@/components/pages/Episode.vue')
 const Episodes = () => import('@/components/pages/Episodes.vue')
@@ -244,9 +245,15 @@ export const routes = [
       },
 
       {
-        path: '/entity-search',
+        path: 'entity-search',
         component: EntitySearch,
         name: 'entity-search'
+      },
+
+      {
+        path: 'entity-chats',
+        component: EntityChats,
+        name: 'entity-chats'
       },
 
       {

--- a/src/store/api/entities.js
+++ b/src/store/api/entities.js
@@ -26,7 +26,9 @@ export default {
   },
 
   getChatMessage(entityId, messageId) {
-    return client.pget(`/api/data/entities/${entityId}/chat/messages/${messageId}`)
+    return client.pget(
+      `/api/data/entities/${entityId}/chat/messages/${messageId}`
+    )
   },
 
   joinChat(entityId) {
@@ -37,10 +39,16 @@ export default {
     return client.pdel(`/api/actions/user/chats/${entityId}/join`)
   },
 
-  sendMessage(entityId, message) {
-    return client.ppost(`/api/data/entities/${entityId}/chat/messages`, {
-      message
-    })
+  sendMessage(entityId, message, attachments) {
+    let data = { message }
+    if (attachments?.length) {
+      data = new FormData()
+      attachments.forEach((attachment, index) => {
+        data.append(`file-${index}`, attachment.get('file'))
+      })
+      data.set('message', message)
+    }
+    return client.ppost(`/api/data/entities/${entityId}/chat/messages`, data)
   },
 
   deleteMessage(entityId, messageId) {

--- a/src/store/api/entities.js
+++ b/src/store/api/entities.js
@@ -11,5 +11,41 @@ export default {
 
   getEntityTimeLogs(entityId) {
     return client.pget(`/api/data/entities/${entityId}/time-spents`)
+  },
+
+  getEntityChats() {
+    return client.pget(`/api/data/user/chats`)
+  },
+
+  getChat(entityId) {
+    return client.pget(`/api/data/entities/${entityId}/chat`)
+  },
+
+  getChatMessages(entityId) {
+    return client.pget(`/api/data/entities/${entityId}/chat/messages`)
+  },
+
+  getChatMessage(entityId, messageId) {
+    return client.pget(`/api/data/entities/${entityId}/chat/messages/${messageId}`)
+  },
+
+  joinChat(entityId) {
+    return client.ppost(`/api/actions/user/chats/${entityId}/join`, {})
+  },
+
+  leaveChat(entityId) {
+    return client.pdel(`/api/actions/user/chats/${entityId}/join`)
+  },
+
+  sendMessage(entityId, message) {
+    return client.ppost(`/api/data/entities/${entityId}/chat/messages`, {
+      message
+    })
+  },
+
+  deleteMessage(entityId, messageId) {
+    return client.pdel(
+      `/api/data/entities/${entityId}/chat/messages/${messageId}`
+    )
   }
 }

--- a/src/store/modules/backgrounds.js
+++ b/src/store/modules/backgrounds.js
@@ -81,6 +81,7 @@ const mutations = {
   },
 
   [LOAD_BACKGROUNDS_END](state, backgrounds) {
+    if (!backgrounds) return
     backgrounds.forEach(background => {
       background.url = `/api/pictures/preview-background-files/${background.id}.${background.extension}`
       background.thumbnail = `/api/pictures/thumbnails/preview-background-files/${background.id}.png`

--- a/src/store/modules/entities.js
+++ b/src/store/modules/entities.js
@@ -18,6 +18,38 @@ const actions = {
 
   async getEntityTimeLogs({ commit }, entityId) {
     return entitiesApi.getEntityTimeLogs(entityId)
+  },
+
+  async getEntityChats({ commit }) {
+    return entitiesApi.getEntityChats()
+  },
+
+  async getEntityChat({ commit }, entityId) {
+    return entitiesApi.getChat(entityId)
+  },
+
+  async joinEntityChat({ commit }, entityId) {
+    return entitiesApi.joinChat(entityId)
+  },
+
+  async leaveEntityChat({ commit }, entityId) {
+    return entitiesApi.leaveChat(entityId)
+  },
+
+  async sendChatMessage({ commit }, { entityId, message }) {
+    return entitiesApi.sendMessage(entityId, message)
+  },
+
+  async getChatMessage({ commit }, { entityId, messageId }) {
+    return entitiesApi.getChatMessage(entityId, messageId)
+  },
+
+  async deleteChatMessage({ commit }, { entityId, messageId }) {
+    return entitiesApi.deleteMessage(entityId, messageId)
+  },
+
+  async getEntityChatMessages({ commit }, entityId) {
+    return entitiesApi.getChatMessages(entityId)
   }
 }
 

--- a/src/store/modules/entities.js
+++ b/src/store/modules/entities.js
@@ -36,8 +36,8 @@ const actions = {
     return entitiesApi.leaveChat(entityId)
   },
 
-  async sendChatMessage({ commit }, { entityId, message }) {
-    return entitiesApi.sendMessage(entityId, message)
+  async sendChatMessage({ commit }, { entityId, message, attachments }) {
+    return entitiesApi.sendMessage(entityId, message, attachments)
   },
 
   async getChatMessage({ commit }, { entityId, messageId }) {


### PR DESCRIPTION
**Problem**

Discussing an element without making it "official" through task comments is impossible. Casual discussions should happen around an episode, an asset, a short or a sequence.

**Solution**

* Add a section on each entity page to start a conversation. 
* Add a page regrouping all running discussions.
