### PR TITLE
Fix description cell

### DIFF
--- a/src/lib/string.js
+++ b/src/lib/string.js
@@ -20,11 +20,10 @@ export default {
 
   shortenText(text, maxLength) {
     let result = text || ''
-    if (text !== undefined && text.length > maxLength) {
+    if (text?.length > maxLength) {
       result = text.slice(0, maxLength) + '...'
       result = result.replace(/\n/g, ' ')
     }
-
     return result
   },
 

--- a/tests/unit/lib/string.spec.js
+++ b/tests/unit/lib/string.spec.js
@@ -23,6 +23,7 @@ describe('lib/string', () => {
     expect(stringHelpers.shortenText('long text', 0)).toEqual('...')
     expect(stringHelpers.shortenText('short text', 10)).toEqual('short text')
     expect(stringHelpers.shortenText('long text', 4)).toEqual('long...')
+    expect(stringHelpers.shortenText(null, 4)).toEqual('')
   })
 
   it('slugify', () => {


### PR DESCRIPTION
**Problem**
- Description cell widget fails with a `null` value.

**Solution**
-  Check if the description text is a nullish value.