### PR TITLE
Fix task comments

### DIFF
--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -986,12 +986,11 @@ export default {
         })
     },
 
-    async saveComment(comment, checklist) {
+    async saveComment(comment) {
       try {
         await this.editTaskComment({
           taskId: this.task.id,
-          comment,
-          checklist
+          comment
         })
       } catch (err) {
         console.error(err)

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -207,14 +207,19 @@
                     :comment="comment"
                     :fps="parseInt(currentFps)"
                     :frame="currentFrame"
+                    :is-checkable="
+                      user.id === comment.person?.id ||
+                      (isCurrentUserArtist && isAssigned) ||
+                      isDepartmentSupervisor ||
+                      isCurrentUserManager
+                    "
                     :is-editable="
-                      (comment.person && user.id === comment.person.id) ||
-                      isCurrentUserAdmin
+                      user.id === comment.person?.id || isCurrentUserAdmin
                     "
                     :is-first="index === 0"
                     :is-last="index === pinnedCount"
                     :is-pinnable="
-                      isCurrentUserManager || isCurrentUserSupervisor
+                      isDepartmentSupervisor || isCurrentUserManager
                     "
                     :is-change="isStatusChange(index)"
                     :revision="currentRevision"
@@ -433,9 +438,10 @@ export default {
       'getTaskPreviews',
       'getTaskComment',
       'isCurrentUserAdmin',
-      'isCurrentUserSupervisor',
+      'isCurrentUserArtist',
       'isCurrentUserClient',
       'isCurrentUserManager',
+      'isCurrentUserSupervisor',
       'isSingleEpisode',
       'isTVShow',
       'personMap',
@@ -484,11 +490,7 @@ export default {
           if (this.user.departments.length === 0) {
             return false
           } else {
-            const taskType = this.taskTypeMap.get(this.task.task_type_id)
-            return !(
-              taskType.department_id &&
-              this.user.departments.includes(taskType.department_id)
-            )
+            return !this.user.departments.includes(this.taskType?.department_id)
           }
         }
       }
@@ -524,14 +526,6 @@ export default {
 
     currentRevision() {
       return this.currentPreview?.revision || 0
-    },
-
-    isCommentingAllowed() {
-      return (
-        this.isCurrentUserManager ||
-        this.isCurrentUserClient ||
-        this.task.assignees.some(personId => personId === this.user.id)
-      )
     },
 
     taskTypeBorder() {
@@ -712,19 +706,33 @@ export default {
     },
 
     isAssigned() {
-      if (this.task) {
-        return this.task.assignees.some(personId => personId === this.user.id)
-      } else {
+      return (
+        this.task?.assignees.some(personId => personId === this.user.id) ??
+        false
+      )
+    },
+
+    isCommentingAllowed() {
+      return (
+        this.isAssigned ||
+        this.isCurrentUserClient ||
+        this.isDepartmentSupervisor ||
+        this.isCurrentUserManager
+      )
+    },
+
+    isDepartmentSupervisor() {
+      if (!this.isCurrentUserSupervisor) {
         return false
       }
+      if (this.user.departments.length === 0) {
+        return true
+      }
+      return this.user.departments.includes(this.taskType?.department_id)
     },
 
     taskType() {
-      if (this.task) {
-        return this.taskTypeMap.get(this.task.task_type_id)
-      } else {
-        return null
-      }
+      return this.taskTypeMap.get(this.task?.task_type_id)
     },
 
     currentTeam() {

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1047,12 +1047,11 @@ export default {
       this.modals.deleteComment = false
     },
 
-    async saveComment(comment, checklist) {
+    async saveComment(comment) {
       try {
         await this.editTaskComment({
           taskId: this.task.id,
-          comment,
-          checklist
+          comment
         })
       } catch (err) {
         console.error(err)

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -93,7 +93,7 @@
               class="checklist"
               :checklist="checklist"
               :disabled="true"
-              :is-editable="isEditable"
+              :is-editable="isCheckable"
               @remove-task="removeTask"
               @keyup.native="emitChangeEvent"
               @emit-change="emitChangeEvent"
@@ -419,6 +419,10 @@ export default {
       default: 25
     },
     isChange: {
+      type: Boolean,
+      default: false
+    },
+    isCheckable: {
       type: Boolean,
       default: false
     },

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -95,8 +95,8 @@
               :disabled="true"
               :is-editable="isCheckable"
               @remove-task="removeTask"
-              @keyup.native="emitChangeEvent"
-              @emit-change="emitChangeEvent"
+              @keyup.native="onChecklistChanged"
+              @emit-change="onChecklistChanged"
               @time-code-clicked="onChecklistTimecodeClicked"
               v-if="checklist.length > 0"
             />
@@ -697,16 +697,16 @@ export default {
       this.checklist = remove(this.checklist, entry)
     },
 
-    emitChangeEvent() {
+    onChecklistChanged() {
       const now = new Date().getTime()
       this.lastCall = this.lastCall || 0
       if (now - this.lastCall > 1000) {
         this.lastCall = now
-        this.$emit(
-          'checklist-updated',
-          this.comment,
-          this.checklist.filter(item => item.text && item.text.length > 0)
-        )
+        const comment = {
+          id: this.comment.id,
+          checklist: this.checklist.filter(item => item.text?.length)
+        }
+        this.$emit('checklist-updated', comment)
       }
     },
 
@@ -809,7 +809,7 @@ export default {
 
     checklist() {
       if (!this.$options.silent) {
-        this.emitChangeEvent()
+        this.onChecklistChanged()
       }
     },
 

--- a/src/store/api/tasks.js
+++ b/src/store/api/tasks.js
@@ -89,13 +89,13 @@ export default {
     return client.pget(`/api/data/comments/${data.id}`)
   },
 
-  editTaskComment(comment, callback) {
-    const commentData = {
+  editTaskComment(comment) {
+    const data = {
       text: comment.text,
       task_status_id: comment.task_status_id,
       checklist: comment.checklist
     }
-    return client.pput(`/api/data/comments/${comment.id}`, commentData)
+    return client.pput(`/api/data/comments/${comment.id}`, data)
   },
 
   deleteTaskComment(taskId, commentId, callback) {

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -470,11 +470,10 @@ const actions = {
     })
   },
 
-  editTaskComment({ commit }, { taskId, comment, checklist }) {
-    checklist = checklist || comment.checklist
+  editTaskComment({ commit }, { taskId, comment }) {
     return tasksApi.editTaskComment(comment).then(comment => {
-      commit(EDIT_COMMENT_END, { taskId, comment, checklist })
-      return Promise.resolve(comment)
+      commit(EDIT_COMMENT_END, { taskId, comment })
+      return comment
     })
   },
 
@@ -1047,13 +1046,13 @@ const mutations = {
     }
   },
 
-  [EDIT_COMMENT_END](state, { taskId, comment, checklist }) {
+  [EDIT_COMMENT_END](state, { taskId, comment }) {
     const oldComment = state.taskComments[taskId].find(c => c.id === comment.id)
     Object.assign(oldComment, {
       text: comment.text,
       task_status_id: comment.task_status_id,
       task_status: state.taskStatusMap.get(comment.task_status_id),
-      checklist: checklist || []
+      checklist: comment.checklist || []
     })
   },
 


### PR DESCRIPTION
**Problem**
- An artist can no longer check the checklist items for a comment that is not theirs, even if the task is assigned to them.
- On checklist update, too much data are sent to the server.

**Solution**
- Fix action rules on a comment depending on user rights.
- Reduce the payload on the update of a comment checklist.
