### PR TITLE
Fix chat on Shot page

### DIFF
--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -370,6 +370,7 @@ export default {
 
   data() {
     return {
+      type: 'shot',
       currentShot: null,
       currentTask: null,
       casting: {


### PR DESCRIPTION
**Problem**
- An error is raised on the browser console when opening the Chat section on the Shot page.

**Solution**
- Add missing entity type on the Shot page.
