### PR TITLE
Chat improvements

### DIFF
--- a/src/components/pages/EntityChats.vue
+++ b/src/components/pages/EntityChats.vue
@@ -62,6 +62,7 @@ import Spinner from '@/components/widgets/Spinner.vue'
 
 export default {
   name: 'entity-chats',
+
   mixins: [formatListMixin],
 
   components: {
@@ -168,7 +169,7 @@ export default {
         }
       },
 
-      async 'chat:left'(eventData) {
+      'chat:left'(eventData) {
         if (
           this.chats.some(c => c.id === eventData.chat_id) &&
           this.user.id === eventData.person_id
@@ -177,7 +178,7 @@ export default {
         }
       },
 
-      async 'chat:new-message'(eventData) {
+      'chat:new-message'(eventData) {
         const chat = this.chats.find(c => c.id === eventData.chat_id)
         if (chat) {
           chat.last_message = eventData.last_message

--- a/src/components/pages/entities/EntityChat.vue
+++ b/src/components/pages/entities/EntityChat.vue
@@ -4,7 +4,7 @@
       <p>
         {{ $t('chats.no_chat') }}
       </p>
-      <div class="has-text-centered">
+      <div class="has-text-centered" v-if="mainConfig.indexer_configured">
         <button-simple
           :text="$t('chats.search_entity')"
           @click="$router.push('entity-search')"
@@ -186,6 +186,7 @@ export default {
     ...mapGetters([
       'currentProduction',
       'departmentMap',
+      'mainConfig',
       'personMap',
       'taskStatusMap',
       'taskTypeMap',

--- a/src/components/pages/entities/EntityChat.vue
+++ b/src/components/pages/entities/EntityChat.vue
@@ -114,15 +114,16 @@ import { XIcon } from 'vue-feather-icons'
 import { sortPeople } from '@/lib/sorting'
 import { domMixin } from '@/components/mixins/dom'
 
-import AddAttachmentModal from '@/components/modals/AddAttachmentModal'
-import ConfirmModal from '@/components/modals/ConfirmModal'
-import ButtonSimple from '@/components/widgets/ButtonSimple'
-import EntityChatDays from '@/components/pages/entities/EntityChatDays'
-import PeopleAvatar from '@/components/widgets/PeopleAvatar'
-import Spinner from '@/components/widgets/Spinner'
+import AddAttachmentModal from '@/components/modals/AddAttachmentModal.vue'
+import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
+import ConfirmModal from '@/components/modals/ConfirmModal.vue'
+import EntityChatDays from '@/components/pages/entities/EntityChatDays.vue'
+import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
+import Spinner from '@/components/widgets/Spinner.vue'
 
 export default {
   name: 'entity-chat',
+
   mixins: [domMixin],
 
   components: {
@@ -333,7 +334,7 @@ export default {
 
   socket: {
     events: {
-      async 'chat:joined'(eventData) {
+      'chat:joined'(eventData) {
         if (
           eventData.chat_id === this.chat.id &&
           !this.participants.includes(eventData.person_id)
@@ -342,7 +343,7 @@ export default {
         }
       },
 
-      async 'chat:left'(eventData) {
+      'chat:left'(eventData) {
         if (
           eventData.chat_id === this.chat.id &&
           this.participants.includes(eventData.person_id)
@@ -367,7 +368,7 @@ export default {
         }
       },
 
-      async 'chat:deleted-message'(eventData) {
+      'chat:deleted-message'(eventData) {
         if (eventData.chat_id === this.chat.id) {
           this.messages = this.messages.filter(
             m => m.id !== eventData.message_id

--- a/src/components/pages/entities/EntityChat.vue
+++ b/src/components/pages/entities/EntityChat.vue
@@ -6,7 +6,7 @@
       </p>
       <div class="has-text-centered">
         <button-simple
-          text="Search for entity"
+          :text="$t('chats.search_entity')"
           @click="$router.push('entity-search')"
         />
       </div>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -130,6 +130,7 @@ export default {
     leave: 'Leave chat',
     no_message_yet: 'No message',
     no_chat: 'You don\'t participate in any entity chat for the moment. Search an entity and join a chat from its page.',
+    search_entity: 'Search for entity',
     title: 'Entity Chats',
   },
 


### PR DESCRIPTION
**Problem**
- The search button on the Entity Chat page is not translated.
- The search button can open an inactive Entity Search page, if not configured on a Kitsu instance.

**Solution**
- Add the missing translation key on the search button.
- Hide the search button if the Entity Search is not enabled on the Kitsu configuration.