### PR TITLE
Bump superagent dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "qrcode.vue": "1.7.0",
         "sanitize-html": "2.13.0",
         "socket.io-client": "4.7.5",
-        "superagent": "8.1.2",
+        "superagent": "9.0.1",
         "textarea-caret": "3.1.0",
         "thenby": "1.3.4",
         "three": "0.163.0",
@@ -3356,14 +3356,13 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.2.tgz",
-      "integrity": "sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
+      "integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
       "dependencies": {
         "dezalgo": "^1.0.4",
         "hexoid": "^1.0.0",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
+        "once": "^1.4.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -6112,23 +6111,23 @@
       }
     },
     "node_modules/superagent": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
-      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.1.tgz",
+      "integrity": "sha512-CcRSdb/P2oUVaEpQ87w9Obsl+E9FruRd6b2b7LdiBtJoyMr2DQt7a89anAfiX/EL59j9b2CbRFvf2S91DhuCww==",
       "dependencies": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.4",
         "debug": "^4.3.4",
         "fast-safe-stringify": "^2.1.1",
         "form-data": "^4.0.0",
-        "formidable": "^2.1.2",
+        "formidable": "^3.5.1",
         "methods": "^1.1.2",
         "mime": "2.6.0",
         "qs": "^6.11.0",
         "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=6.4.0 <13 || >=14"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "qrcode.vue": "1.7.0",
     "sanitize-html": "2.13.0",
     "socket.io-client": "4.7.5",
-    "superagent": "8.1.2",
+    "superagent": "9.0.1",
     "textarea-caret": "3.1.0",
     "thenby": "1.3.4",
     "three": "0.163.0",


### PR DESCRIPTION
**Problem**
- the `superagent` npm dependencies have a security advisory on 8.x (due to [`formidable` 2.x as a sub-dependency](https://github.com/cgwire/kitsu/security/dependabot/17))

**Solution**
- Bump `supergent` to 9.x which fixes the CVE.
