### PR TITLE
various improvements 

### DIFF
--- a/src/components/previews/VideoProgress.vue
+++ b/src/components/previews/VideoProgress.vue
@@ -524,8 +524,8 @@ export default {
       } else {
         frame = frame - 1
       }
-      if (this.nbFrames >= 1920) {
-        frame = Math.ceil(frame / Math.ceil(this.nbFrames / 1920))
+      if (this.nbFrames >= 3840) {
+        frame = Math.ceil(frame / Math.ceil(this.nbFrames / 3840))
       }
       const frameX = frame % 8
       const frameY = Math.floor(frame / 8)

--- a/src/components/previews/VideoProgress.vue
+++ b/src/components/previews/VideoProgress.vue
@@ -524,6 +524,9 @@ export default {
       } else {
         frame = frame - 1
       }
+      if (this.nbFrames >= 1920) {
+        frame = Math.ceil(frame / Math.ceil(this.nbFrames / 1920))
+      }
       const frameX = frame % 8
       const frameY = Math.floor(frame / 8)
       const frameHeight = 100

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -31,7 +31,8 @@ const ALL_EXTENSIONS = [
   'mp3',
   'webm',
   'avi',
-  'clip'
+  'clip',
+  'mkv'
 ]
 const ALL_EXTENSIONS_STRING = ALL_EXTENSIONS.map(e => `.${e}`).join(',')
 


### PR DESCRIPTION
**Problem**
- When searching for a file when uploading a preview .mkv files are not in the file explorer filter. 
- We can't properly display tiles for videos longer than 1920 frames. 

**Solution**
- Add .mkv files in the file explorer filter. 
- For videos longer than 3840 frames use a ratio to guess which frame to show.

This PR is dependent to this one for Zou : https://github.com/cgwire/zou/pull/802