### PR TITLE
Fix automation creation

### DIFF
--- a/src/components/modals/EditStatusAutomationModal.vue
+++ b/src/components/modals/EditStatusAutomationModal.vue
@@ -91,7 +91,6 @@
             :label="$t('status_automations.fields.import_last_revision')"
             @enter="confirmClicked"
             v-model="form.importLastRevision"
-            v-if="isEditing"
           />
 
           <combobox-boolean

--- a/src/store/api/statusautomation.js
+++ b/src/store/api/statusautomation.js
@@ -19,7 +19,7 @@ export default {
       out_field_type: statusAutomation.outFieldType,
       out_task_type_id: statusAutomation.outTaskTypeId,
       out_task_status_id: statusAutomation.outTaskStatusId,
-      import_last_revision: statusAutomation.importLastRevision
+      import_last_revision: statusAutomation.importLastRevision === 'true'
     }
     return client.ppost('/api/data/status-automations/', data)
   },


### PR DESCRIPTION
**Problem**
- The creation of a new automation failed due to a missing new option.

**Solution**
- Add the missing option "Import Last Revision" in the creation form of automation.
