### PR TITLE
Improve automation form

### DIFF
--- a/src/components/modals/EditStatusAutomationModal.vue
+++ b/src/components/modals/EditStatusAutomationModal.vue
@@ -34,7 +34,9 @@
             <combobox-task-type
               class="flexrow-item"
               :label="$t('status_automations.fields.in_task_type')"
-              :task-type-list="form.inEntityTaskTypes"
+              :task-type-list="
+                form.inEntityTaskTypes.filter(({ archived }) => !archived)
+              "
               v-model="form.inTaskTypeId"
               @enter="confirmClicked"
             />
@@ -70,7 +72,9 @@
             <combobox-task-type
               class="flexrow-item"
               :label="$t('status_automations.fields.out_task_type')"
-              :task-type-list="form.outEntityTaskTypes"
+              :task-type-list="
+                form.outEntityTaskTypes.filter(({ archived }) => !archived)
+              "
               :open-top="true"
               @enter="confirmClicked"
               v-model="form.outTaskTypeId"


### PR DESCRIPTION
**Problem**
- Admin can select an archived task type on the creation or edit form of status automation.

**Solution**
- Hide archived task types from available choices in automation form.