### PR TITLE
Drag & drop unassigned tasks in Team Schedule

### DIFF
--- a/src/components/lists/KanbanBoard.vue
+++ b/src/components/lists/KanbanBoard.vue
@@ -354,8 +354,8 @@ export default {
     },
 
     onCardDragEnter(event, taskStatus) {
-      this.isAllowed = this.checkUserIsAllowed(taskStatus, this.user)
-      if (this.isAllowed) {
+      const isAllowed = this.checkUserIsAllowed(taskStatus, this.user)
+      if (isAllowed) {
         event.currentTarget.classList.add('droppable')
       }
     },

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -560,6 +560,7 @@ export default {
     home: 'return to home page',
     or: 'or',
     no: 'No',
+    no_results: 'No results',
     less_filters: 'Fewer filters',
     link: 'Link',
     load_more: 'Load more',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1506,6 +1506,7 @@ export default {
     tasks: 'Tasks',
     to_myself: 'To myself',
     use_current_frame: 'Use current frame',
+    unassigned_tasks: 'Unassigned tasks',
     validated: 'Validated',
     validation: 'Validation',
     with_comment: 'With a comment...',

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -434,9 +434,7 @@ const actions = {
 
   updateTask({ commit }, { taskId, data }) {
     commit(EDIT_TASK_DATES, { taskId, data })
-    return tasksApi.updateTask(taskId, data).then(task => {
-      commit(EDIT_TASK_DATES, { taskId, data })
-    })
+    return tasksApi.updateTask(taskId, data)
   },
 
   deleteTask({ commit }, { task, callback }) {

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -51,8 +51,9 @@ $yellow: #FFC107;
   --background-hover: #EFEFEF;
   --background-hover-rgb: 240, 255, 240;
   --background-tag:  #EEE;
-  --background-tag-button: #F9F9F9; 
+  --background-tag-button: #F9F9F9;
   --background-selectable: #E3E6FF;
+  --background-selectable-rgb: 227, 230, 255;
   --background-selected: #CECEFE;
   --background-disabled: #DDD;
   --border: #DBDBDB;
@@ -66,7 +67,7 @@ $yellow: #FFC107;
   --text-selectable: #9FA2FB;
   --text-selected: #8F91EB;
   --poster-color: #000;
-  --purple: #CFD1FF; 
+  --purple: #CFD1FF;
 }
 
 .dark {
@@ -79,8 +80,8 @@ $yellow: #FFC107;
   --background-hover: #4F525A;
   --background-hover-rgb: 94, 97, 105;
   --background-page: #36393F;
-  --background-tag:  #36393F; 
-  --background-tag-button: #4E5159; 
+  --background-tag:  #36393F;
+  --background-tag-button: #4E5159;
   --background-selectable: #7375BC;
   --background-selectable-alt: #878B97;
   --background-selected: #5E60BA;
@@ -95,5 +96,5 @@ $yellow: #FFC107;
   --text-strong: #FEFEFE;
   --text-selectable: #BEC0FA;
   --text-selected: #9EA0FA;
-  --purple: #5E60BA; 
+  --purple: #5E60BA;
 }


### PR DESCRIPTION
**Problem**
- The Team Schedule only allows you to organize tasks already assigned.

**Solution**
- List all unassigned tasks in a side panel with filtering.
- Allow to drag & drop an unassigned task to a team member.
- Check the person's rights before assigning a task: must be a production and department member.


