### PR TITLE
[comments] Temporary fix for preview drag'n'drop

### DIFF
--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -656,8 +656,10 @@ export default {
 
     onDrop(event) {
       if (event.target.id === 'drop-mask') return
+      /*
       if (event.target.parentElement?.className?.indexOf('box')) return
       if (event.target.parentElement?.className?.indexOf('buttons')) return
+      */
       const forms = []
       for (let i = 0; i < event.dataTransfer.files.length; i++) {
         const form = new FormData()


### PR DESCRIPTION
**Problem**

The preview drag'n'drop in the comment section is broken.

**Solution**

Temporary fix: remove hacks done to make the dnd works in the add attachment modal.

