### PR TITLE
[shots] Allow to set frames from previews

### DIFF
--- a/src/components/modals/SetFramesFromTaskTypePreviewsModal.vue
+++ b/src/components/modals/SetFramesFromTaskTypePreviewsModal.vue
@@ -1,0 +1,119 @@
+<template>
+  <div
+    :class="{
+      modal: true,
+      'is-active': active
+    }"
+  >
+    <div class="modal-background" @click="$emit('cancel')"></div>
+
+    <div class="modal-content">
+      <div class="box content">
+        <h1 class="title">
+          {{ $t('shots.get_frames_from_previews') }}
+        </h1>
+
+        <p class="description">
+          {{ $t('shots.get_frames_from_previews_description') }}
+        </p>
+
+        <combobox-task-type
+          :task-type-list="productionShotTaskTypes"
+          :placeholder="$t('task_types.select_task_type')"
+          add-placeholder
+          v-model="taskTypeId"
+        />
+
+        <modal-footer
+          :error-text="$t('shots.get_frames_from_previews_error')"
+          :is-error="isError"
+          :is-loading="isLoading"
+          :is-disabled="!isFormFilled"
+          @confirm="confirm"
+          @cancel="$emit('cancel')"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from 'vuex'
+import { modalMixin } from '@/components/modals/base_modal'
+
+import ComboboxTaskType from '@/components/widgets/ComboboxTaskType'
+import ModalFooter from '@/components/modals/ModalFooter'
+
+export default {
+  name: 'set-frames-from-task-type-previews-modal',
+  mixins: [modalMixin],
+
+  components: {
+    ComboboxTaskType,
+    ModalFooter
+  },
+
+  props: {
+    active: {
+      type: Boolean,
+      default: false
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
+    },
+    isError: {
+      type: Boolean,
+      default: false
+    },
+    errorText: {
+      type: String,
+      default: ''
+    }
+  },
+
+  data() {
+    return {
+      taskTypeId: null
+    }
+  },
+
+  mounted() {
+    this.reset()
+  },
+
+  computed: {
+    ...mapGetters(['productionShotTaskTypes']),
+
+    isFormFilled() {
+      return this.taskTypeId !== null && this.taskTypeId !== ''
+    }
+  },
+
+  methods: {
+    ...mapActions([]),
+
+    confirm() {
+      return this.$emit('confirm', this.taskTypeId)
+    },
+
+    reset() {
+      this.taskType = null
+    }
+  },
+
+  watch: {
+    active() {
+      if (this.active) {
+        this.reset()
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+p.description {
+  font-size: 1.2rem;
+}
+</style>

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -47,6 +47,13 @@
               />
               <button-simple
                 class="flexrow-item"
+                icon="film"
+                :title="$t('shots.get_frames_from_previews')"
+                @click="() => (modals.isSetFramesDisplayed = true)"
+                v-if="isCurrentUserManager"
+              />
+              <button-simple
+                class="flexrow-item"
                 :title="$t('main.edl.import_file')"
                 icon="import-edl"
                 @click="showEDLImportModal"
@@ -257,6 +264,14 @@
       @confirm="confirmAddMetadata"
     />
 
+    <set-frames-from-task-type-previews-modal
+      :active="modals.isSetFramesDisplayed"
+      :is-loading="loading.getFrames"
+      :is-error="errors.getFrames"
+      @cancel="modals.isSetFramesDisplayed = false"
+      @confirm="confirmSetFrames"
+    />
+
     <add-thumbnails-modal
       ref="add-thumbnails-modal"
       entity-type="Shot"
@@ -312,6 +327,7 @@ import HardDeleteModal from '@/components/modals/HardDeleteModal'
 import ManageShotsModal from '@/components/modals/ManageShotsModal'
 import SearchField from '@/components/widgets/SearchField'
 import SearchQueryList from '@/components/widgets/SearchQueryList'
+import SetFramesFromTaskTypePreviewsModal from '@/components/modals/SetFramesFromTaskTypePreviewsModal'
 import SortingInfo from '@/components/widgets/SortingInfo'
 import ShowAssignationsButton from '@/components/widgets/ShowAssignationsButton'
 import ShowInfosButton from '@/components/widgets/ShowInfosButton'
@@ -341,6 +357,7 @@ export default {
     InfoQuestionMark,
     SearchField,
     SearchQueryList,
+    SetFramesFromTaskTypePreviewsModal,
     SortingInfo,
     ShotHistoryModal,
     ShowAssignationsButton,
@@ -384,6 +401,7 @@ export default {
         isDeleteDisplayed: false,
         isDeleteMetadataDisplayed: false,
         isDeleteAllTasksDisplayed: false,
+        isSetFramesDisplayed: false,
         isImportRenderDisplayed: false,
         isImportDisplayed: false,
         isEDLImportDisplayed: false,
@@ -401,6 +419,7 @@ export default {
         deleteMetadata: false,
         edit: false,
         del: false,
+        getFrames: false,
         importing: false,
         restore: false,
         savingSearch: false,
@@ -412,6 +431,7 @@ export default {
         deleteMetadata: false,
         creatingTasks: false,
         deleteAllTasks: false,
+        getFrames: false,
         importing: false,
         importingError: null
       }
@@ -564,6 +584,7 @@ export default {
       'hideAssignations',
       'loadEpisodes',
       'loadShots',
+      'setNbFramesFromTaskTypePreviews',
       'newEpisode',
       'newSequence',
       'newShot',
@@ -1097,6 +1118,23 @@ export default {
         .finally(() => {
           this.loading.importing = false
         })
+    },
+
+    async confirmSetFrames(taskTypeId) {
+      this.loading.getFrames = true
+      try {
+        await this.setNbFramesFromTaskTypePreviews({
+          taskTypeId,
+          productionId: this.currentProduction.id,
+          episodeId: this.currentEpisode ? this.currentEpisode.id : null
+        })
+        this.modals.isSetFramesDisplayed = false
+      } catch (err) {
+        console.error(err)
+        this.errors.getFrames = true
+      } finally {
+        this.loading.getFrames = false
+      }
     }
   },
 

--- a/src/components/widgets/ComboboxTaskType.vue
+++ b/src/components/widgets/ComboboxTaskType.vue
@@ -80,6 +80,12 @@ export default {
       default: false,
       type: Boolean
     },
+    placeholder: {
+      default: function () {
+        return this.$t('task_types.add_task_type_placeholder')
+      },
+      type: String
+    },
     openTop: {
       default: false,
       type: Boolean
@@ -95,7 +101,7 @@ export default {
       if (this.value) {
         return this.taskTypeMap.get(this.value)
       } else if (this.addPlaceholder) {
-        return { name: '+ Task Type', color: '#E5E5E5', id: '' }
+        return { name: this.placeholder, color: '#E5E5E5', id: '' }
       } else {
         return this.taskTypeList[0]
       }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1232,6 +1232,7 @@ export default {
   },
 
   task_types: {
+    add_task_type_placeholder: '+ Task type',
     delete_text: 'Are you sure you want to remove {name} from your database?',
     delete_error: 'An error occurred while deleting this task type. There are probably data linked to it. Are you sure this task type has no task linked to it?',
     edit_title: 'Edit task type',
@@ -1239,6 +1240,7 @@ export default {
     new_task_type: 'Add a task type',
     no_task_types: 'There is no task type for this entity type',
     number: 'task type | task types',
+    select_task_type: 'Select a task type...',
     title: 'Task Types',
     fields: {
       dedicated_to: 'For',
@@ -1366,6 +1368,9 @@ export default {
     empty_list: 'There is no shot in the production. What about creating some?',
     empty_list_client: 'There is no shot in this production.',
     episodes: 'Episodes',
+    get_frames_from_previews: 'Set frame numbers from previews',
+    get_frames_from_previews_description: 'Select a task type to extract the frame numbers from the latest published movie previews.',
+    get_frames_from_previews_error: 'There was an error while extracting the frame numbers from the task type previews. Please contact our support team.',
     history: 'Shot values history',
     multiple_delete_error: 'An error occurred while deleting a shot. There is probably some data linked to a shot. Are you sure there is no task linked to a selected shot?',
     new_shot: 'Add a shot',

--- a/src/store/api/shots.js
+++ b/src/store/api/shots.js
@@ -191,5 +191,13 @@ export default {
       `/api/data/projects/${productionId}/quotas/` +
         `${taskTypeId}?detail=${detailLevel}&weighted=${weighted}`
     )
+  },
+
+  setNbFramesFromTaskTypePreviews(taskTypeId, productionId, episodeId) {
+    let path =
+      `/api/actions/projects/${productionId}/task-types/` +
+      `${taskTypeId}/set-shot-nb-frames`
+    if (episodeId) path += `?episode_id=${episodeId}`
+    return client.ppost(path)
   }
 }

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -759,6 +759,21 @@ const actions = {
         }
       )
     })
+  },
+
+  async setNbFramesFromTaskTypePreviews(
+    { commit, rootGetters },
+    { taskTypeId, productionId, episodeId }
+  ) {
+    const shotNbFrames = await shotsApi.setNbFramesFromTaskTypePreviews(
+      taskTypeId,
+      productionId,
+      episodeId
+    )
+    shotNbFrames.forEach(shot => {
+      commit(UPDATE_SHOT, shot)
+    })
+    return shotNbFrames
   }
 }
 


### PR DESCRIPTION
**Problem**

There is no way to compute frames from previews information.

**Solution**

Add a modal in the Shots page that allows to compute the number of frames from the previews of a given task type.
