### PR TITLE
Various fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
         "eslint-plugin-prettier": "5.1.3",
-        "eslint-plugin-vue": "9.26.0",
+        "eslint-plugin-vue": "9.27.0",
         "esm": "3.2.25",
         "husky": "8.0.3",
         "jsdom": "24.1.0",
@@ -3067,9 +3067,9 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.26.0.tgz",
-      "integrity": "sha512-eTvlxXgd4ijE1cdur850G6KalZqk65k1JKoOI2d1kT3hr8sPD07j1q98FRFdNnpxBELGPWxZmInxeHGF/GxtqQ==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.27.0.tgz",
+      "integrity": "sha512-5Dw3yxEyuBSXTzT5/Ge1X5kIkRTQ3nvBn/VwPwInNiZBSJOO/timWMUaflONnFBzU6NhB68lxnCda7ULV5N7LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3079,7 +3079,7 @@
         "nth-check": "^2.1.1",
         "postcss-selector-parser": "^6.0.15",
         "semver": "^7.6.0",
-        "vue-eslint-parser": "^9.4.2",
+        "vue-eslint-parser": "^9.4.3",
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
@@ -7251,9 +7251,9 @@
       }
     },
     "node_modules/vue-eslint-parser": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.2.tgz",
-      "integrity": "sha512-Ry9oiGmCAK91HrKMtCrKFWmSFWvYkpGglCeFAIqDdr9zdXmMMpJOmUJS7WWsW7fX81h6mwHmUZCQQ1E0PkSwYQ==",
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.4.3.tgz",
+      "integrity": "sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fullcalendar/multimonth": "6.1.14",
         "@fullcalendar/vue": "6.1.14",
         "@google/model-viewer": "3.5.0",
-        "@sentry/vue": "8.11.0",
+        "@sentry/vue": "8.13.0",
         "async": "3.2.5",
         "bowser": "2.11.0",
         "chart.js": "2.9.4",
@@ -72,7 +72,7 @@
         "localStorage": "1.0.4",
         "prettier": "3.3.2",
         "sass": "1.77.6",
-        "vite": "5.3.1",
+        "vite": "5.3.2",
         "vitest": "0.34.6",
         "vitest-localstorage-mock": "0.1.2",
         "vue-template-compiler": "2.7.16"
@@ -1221,125 +1221,125 @@
       ]
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.11.0.tgz",
-      "integrity": "sha512-PCnmzeLm7eTdMleVWa1jbdNcB6M5R17CSX8oQF6A/5a2w9qW6HbjEwK6X4yc9MzsFXFaTNekvPQLMRhIE1MgpA==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.13.0.tgz",
+      "integrity": "sha512-lqq8BYbbs9KTlDuyB5NjdZB6P/llqQs32KUgaCQ/k5DFB4Zf56+BFHXObnMHxwx375X1uixtnEphagWZa+nsLQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "8.11.0",
-        "@sentry/types": "8.11.0",
-        "@sentry/utils": "8.11.0"
+        "@sentry/core": "8.13.0",
+        "@sentry/types": "8.13.0",
+        "@sentry/utils": "8.13.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.11.0.tgz",
-      "integrity": "sha512-cMiFAuHP4jXCqWD7/UA5cvl0ee3hN5klAWTDVCZutnZ30pbUurg+nIggYBcaxdtLlqW6BCwyVs2nb/OB75CCSQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.13.0.tgz",
+      "integrity": "sha512-YyJ6SzpTonixvguAg0H9vkEp7Jq8ZeVY8M4n47ClR0+TtaAUp04ZhcJpHKF7PwBIAzc7DRr2XP112tmWgiVEcg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "8.11.0",
-        "@sentry/types": "8.11.0",
-        "@sentry/utils": "8.11.0"
+        "@sentry/core": "8.13.0",
+        "@sentry/types": "8.13.0",
+        "@sentry/utils": "8.13.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.11.0.tgz",
-      "integrity": "sha512-NyuHW1Ds2GGW6PjN7nnRl/XoM31Y/BUnOhhLbNmbxWj5mgWuUP/7tOlz2PhP0YqZxVteZ99QIssfSRgtYOeQlg==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.13.0.tgz",
+      "integrity": "sha512-DJ1jF/Pab0FH4SeCvSGCnGAu/s0wJvhBWM5VjQp7Jjmcfunp+R3vJibqU8gAVZU1nYRLaqprLdIXrSyP2Km8nQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "8.11.0",
-        "@sentry/core": "8.11.0",
-        "@sentry/types": "8.11.0",
-        "@sentry/utils": "8.11.0"
+        "@sentry-internal/browser-utils": "8.13.0",
+        "@sentry/core": "8.13.0",
+        "@sentry/types": "8.13.0",
+        "@sentry/utils": "8.13.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.11.0.tgz",
-      "integrity": "sha512-SrBFI0vwyeyUjibCbYfxzCNMd07QMDNoi+0SYzhBagp6ALbU8r/pa02JRsnr//qhZt2NOM6S2kks9e2VHr6hYg==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.13.0.tgz",
+      "integrity": "sha512-lPlfWVIHX+gW4S8a/UOVutuqMyQhlkNUAay0W21MVhZJT5Mtj0p21D/Cz7nrOQRDIiLNq90KAGK2tLxx5NkiWA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "8.11.0",
-        "@sentry/core": "8.11.0",
-        "@sentry/types": "8.11.0",
-        "@sentry/utils": "8.11.0"
+        "@sentry-internal/replay": "8.13.0",
+        "@sentry/core": "8.13.0",
+        "@sentry/types": "8.13.0",
+        "@sentry/utils": "8.13.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.11.0.tgz",
-      "integrity": "sha512-++5IrBpzkaAptNjAYnGTnQ2lCjmU6nlu/ABFjUTgi7Vu+ZNiY8qYKEUw65mSxD3EoFLt8IwtjvfAwSMVTB2q8w==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.13.0.tgz",
+      "integrity": "sha512-/tp7HZ5qjwDLtwooPMoexdAi2PG7gMNY0bHeMlwy20hs8mclC8RW8ZiJA6czXHfgnbmvxfrHaY53IJyz//JnlA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "8.11.0",
-        "@sentry-internal/feedback": "8.11.0",
-        "@sentry-internal/replay": "8.11.0",
-        "@sentry-internal/replay-canvas": "8.11.0",
-        "@sentry/core": "8.11.0",
-        "@sentry/types": "8.11.0",
-        "@sentry/utils": "8.11.0"
+        "@sentry-internal/browser-utils": "8.13.0",
+        "@sentry-internal/feedback": "8.13.0",
+        "@sentry-internal/replay": "8.13.0",
+        "@sentry-internal/replay-canvas": "8.13.0",
+        "@sentry/core": "8.13.0",
+        "@sentry/types": "8.13.0",
+        "@sentry/utils": "8.13.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.11.0.tgz",
-      "integrity": "sha512-rZaM55j5Fw0IGb8lNXOTVoq7WR6JmUzm9x5cURGsjL9gzAurGl817oK3iyOvYQ3JZnfijjh0QF0SQr4NZHKbIg==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.13.0.tgz",
+      "integrity": "sha512-N9Qg4ZGxZWp8eb2eUUHVVKgjBLtFIjS805nG92s6yJmkvOpKm6mLtcUaT/iDf3Hta6nG+xRkhbE3r+Z4cbXG8w==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/types": "8.11.0",
-        "@sentry/utils": "8.11.0"
+        "@sentry/types": "8.13.0",
+        "@sentry/utils": "8.13.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.11.0.tgz",
-      "integrity": "sha512-kz9/d2uw7wEXcK8DnCrCuMI75hZnpVAjYr8mq1uatltOx+2JOYPNdaK6ispxXlhb5KXOnVWNgfVDbGlLp0w+Gg==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.13.0.tgz",
+      "integrity": "sha512-r63s/H5gvQnQM9tTGBXz2xErUbxZALh4e2Lg/1aHj4zIvGLBjA2z5qWsh6TEZYbpmgAyGShLDr6+rWeUVf9yBQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.11.0.tgz",
-      "integrity": "sha512-iDt5YVMYNgT151bPYVGo8XlpM0MHWy8DH+czmAiAlFTV7ns7lAeHGF6tsFYo7wOZOPDHxtF6F2CM7AvuYnOZGw==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.13.0.tgz",
+      "integrity": "sha512-PxV0v9VbGWH9zP37P5w2msLUFDr287nYjoY2XVF+RSolyiTs1CQNI5ZMUO3o4MsSac/dpXxjyrZXQd72t/jRYA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/types": "8.11.0"
+        "@sentry/types": "8.13.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry/vue": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-8.11.0.tgz",
-      "integrity": "sha512-KGXhKRdtg2cIAkNCNu0ZacttH3pjogpAD9DC+huCzAdBIcEfhQqqSjDwjaDKkoEdKadWpoa6gmY3WWSkdDMLkQ==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-8.13.0.tgz",
+      "integrity": "sha512-1CTInl9jeh9dDyrL2dOUUiLN9KvvdEibBPXxqz/nGIignT/sVO8ZJzFPctsyh9COF63FN3zfy65xBE4U/Ad6oA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "8.11.0",
-        "@sentry/core": "8.11.0",
-        "@sentry/types": "8.11.0",
-        "@sentry/utils": "8.11.0"
+        "@sentry/browser": "8.13.0",
+        "@sentry/core": "8.13.0",
+        "@sentry/types": "8.13.0",
+        "@sentry/utils": "8.13.0"
       },
       "engines": {
         "node": ">=14.18"
@@ -7038,9 +7038,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.1.tgz",
-      "integrity": "sha512-XBmSKRLXLxiaPYamLv3/hnP/KXDai1NDexN0FpkTaZXTfycHvkRHoenpgl/fvuK/kPbB6xAgoyiryAhQNxYmAQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.2.tgz",
+      "integrity": "sha512-6lA7OBHBlXUxiJxbO5aAY2fsHHzDr1q7DvXYnyZycRs2Dz+dXBWuhpWHvmljTRTpQC2uvGmUFFkSHF2vGo90MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.1.3",
-    "eslint-plugin-vue": "9.26.0",
+    "eslint-plugin-vue": "9.27.0",
     "esm": "3.2.25",
     "husky": "8.0.3",
     "jsdom": "24.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@fullcalendar/multimonth": "6.1.14",
     "@fullcalendar/vue": "6.1.14",
     "@google/model-viewer": "3.5.0",
-    "@sentry/vue": "8.11.0",
+    "@sentry/vue": "8.13.0",
     "async": "3.2.5",
     "bowser": "2.11.0",
     "chart.js": "2.9.4",
@@ -81,7 +81,7 @@
     "localStorage": "1.0.4",
     "prettier": "3.3.2",
     "sass": "1.77.6",
-    "vite": "5.3.1",
+    "vite": "5.3.2",
     "vitest": "0.34.6",
     "vitest-localstorage-mock": "0.1.2",
     "vue-template-compiler": "2.7.16"

--- a/src/components/lists/TaskStatusList.vue
+++ b/src/components/lists/TaskStatusList.vue
@@ -94,10 +94,10 @@ import { HelpCircleIcon } from 'vue-feather-icons'
 
 import { formatListMixin } from '@/components/mixins/format'
 
-import BooleanCell from '@/components/cells/BooleanCell'
-import RowActionsCell from '@/components/cells/RowActionsCell'
-import TableInfo from '@/components/widgets/TableInfo'
-import TaskStatusCell from '@/components/cells/TaskStatusCell'
+import BooleanCell from '@/components/cells/BooleanCell.vue'
+import RowActionsCell from '@/components/cells/RowActionsCell.vue'
+import TableInfo from '@/components/widgets/TableInfo.vue'
+import TaskStatusCell from '@/components/cells/TaskStatusCell.vue'
 
 export default {
   name: 'task-status-list',
@@ -120,9 +120,9 @@ export default {
   },
 
   components: {
-    HelpCircleIcon,
     BooleanCell,
     draggable,
+    HelpCircleIcon,
     RowActionsCell,
     TableInfo,
     TaskStatusCell

--- a/src/components/lists/TaskStatusList.vue
+++ b/src/components/lists/TaskStatusList.vue
@@ -71,7 +71,7 @@
             />
             <row-actions-cell
               :entry-id="entry.id"
-              :hide-delete="entry.is_default === true"
+              :hide-delete="entry.is_default === true || entry.for_concept"
               @edit-clicked="$emit('edit-clicked', entry)"
               @delete-clicked="$emit('delete-clicked', entry)"
             />

--- a/src/components/lists/TaskTypeList.vue
+++ b/src/components/lists/TaskTypeList.vue
@@ -32,7 +32,7 @@
           v-model="assetsItems"
         >
           <tr class="datatable-type-header" slot="header">
-            <th scope="rowgroup" colspan="4">
+            <th scope="rowgroup" colspan="5">
               <span class="datatable-row-header">
                 {{ $t('assets.title') }}
               </span>
@@ -66,7 +66,7 @@
             />
           </tr>
           <tr class="empty" v-if="assetsItems.length === 0">
-            <th scope="rowgroup" colspan="4">
+            <th scope="rowgroup" colspan="5">
               <span class="text">
                 {{ $t('task_types.no_task_types') }}
               </span>
@@ -83,7 +83,7 @@
           @end="updatePriorityShots"
         >
           <tr class="datatable-type-header" slot="header">
-            <th scope="rowgroup" colspan="4">
+            <th scope="rowgroup" colspan="5">
               <span class="datatable-row-header">
                 {{ $t('shots.title') }}
               </span>
@@ -107,6 +107,9 @@
             <td class="allow-timelog">
               <boolean-rep :value="taskType.allow_timelog" />
             </td>
+            <td>
+              {{ taskType.description }}
+            </td>
             <row-actions-cell
               :taskType-id="taskType.id"
               @delete-clicked="$emit('delete-clicked', taskType)"
@@ -114,7 +117,7 @@
             />
           </tr>
           <tr class="empty" v-if="shotsItems.length === 0">
-            <th scope="rowgroup" colspan="4">
+            <th scope="rowgroup" colspan="5">
               <span class="text">
                 {{ $t('task_types.no_task_types') }}
               </span>
@@ -131,7 +134,7 @@
           @end="updatePriorityEdits"
         >
           <tr class="datatable-type-header" slot="header">
-            <th scope="rowgroup" colspan="4">
+            <th scope="rowgroup" colspan="5">
               <span class="datatable-row-header">
                 {{ $t('edits.title') }}
               </span>
@@ -155,6 +158,9 @@
             <td class="allow-timelog">
               <boolean-rep :value="taskType.allow_timelog" />
             </td>
+            <td>
+              {{ taskType.description }}
+            </td>
             <row-actions-cell
               :taskType-id="taskType.id"
               @delete-clicked="$emit('delete-clicked', taskType)"
@@ -162,7 +168,7 @@
             />
           </tr>
           <tr class="empty" v-if="editsItems.length === 0">
-            <th scope="rowgroup" colspan="4">
+            <th scope="rowgroup" colspan="5">
               <span class="text">
                 {{ $t('task_types.no_task_types') }}
               </span>
@@ -179,7 +185,7 @@
           @end="updatePrioritySequences"
         >
           <tr class="datatable-type-header" slot="header">
-            <th scope="rowgroup" colspan="4">
+            <th scope="rowgroup" colspan="5">
               <span class="datatable-row-header">
                 {{ $t('sequences.title') }}
               </span>
@@ -203,6 +209,9 @@
             <td class="allow-timelog">
               <boolean-rep :value="taskType.allow_timelog" />
             </td>
+            <td>
+              {{ taskType.description }}
+            </td>
             <row-actions-cell
               :taskType-id="taskType.id"
               @delete-clicked="$emit('delete-clicked', taskType)"
@@ -210,7 +219,7 @@
             />
           </tr>
           <tr class="empty" v-if="sequencesItems.length === 0">
-            <th scope="rowgroup" colspan="4">
+            <th scope="rowgroup" colspan="5">
               <span class="text">
                 {{ $t('task_types.no_task_types') }}
               </span>
@@ -227,7 +236,7 @@
           @end="updatePriorityEpisodes"
         >
           <tr class="datatable-type-header" slot="header">
-            <th scope="rowgroup" colspan="4">
+            <th scope="rowgroup" colspan="5">
               <span class="datatable-row-header">
                 {{ $t('episodes.title') }}
               </span>
@@ -251,6 +260,9 @@
             <td class="allow-timelog">
               <boolean-rep :value="taskType.allow_timelog" />
             </td>
+            <td>
+              {{ taskType.description }}
+            </td>
             <row-actions-cell
               :taskType-id="taskType.id"
               @delete-clicked="$emit('delete-clicked', taskType)"
@@ -259,7 +271,7 @@
           </tr>
         </draggable>
         <tr class="empty" v-if="episodesItems.length === 0">
-          <th scope="rowgroup" colspan="4">
+          <th scope="rowgroup" colspan="5">
             <span class="text">
               {{ $t('task_types.no_task_types') }}
             </span>

--- a/src/components/modals/EditAssetModal.vue
+++ b/src/components/modals/EditAssetModal.vue
@@ -39,7 +39,6 @@
             ref="descriptionField"
             :label="$t('assets.fields.description')"
             v-model="form.description"
-            v-focus
           />
           <metadata-field
             :key="descriptor.id"

--- a/src/components/modals/EditAssetTypeModal.vue
+++ b/src/components/modals/EditAssetTypeModal.vue
@@ -94,21 +94,23 @@ import { sortByName } from '@/lib/sorting'
 
 import Combobox from '@/components/widgets/Combobox.vue'
 import ComboboxBoolean from '@/components/widgets/ComboboxBoolean.vue'
-import ModalFooter from '@/components/modals/ModalFooter'
-import TextField from '@/components/widgets/TextField'
-import TextareaField from '@/components/widgets/TextareaField'
-import TaskTypeName from '@/components/widgets/TaskTypeName'
+import ModalFooter from '@/components/modals/ModalFooter.vue'
+import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
+import TextareaField from '@/components/widgets/TextareaField.vue'
+import TextField from '@/components/widgets/TextField.vue'
 
 export default {
   name: 'edit-asset-type-modal',
+
   mixins: [modalMixin],
+
   components: {
     Combobox,
     ComboboxBoolean,
-    TaskTypeName,
     ModalFooter,
-    TextField,
-    TextareaField
+    TaskTypeName,
+    TextareaField,
+    TextField
   },
 
   props: {
@@ -135,6 +137,7 @@ export default {
       form: {
         name: '',
         short_name: '',
+        description: '',
         task_types: []
       }
     }
@@ -206,6 +209,7 @@ export default {
         this.form = {
           name: this.assetTypeToEdit.name,
           short_name: this.assetTypeToEdit.short_name,
+          description: this.assetTypeToEdit.description,
           task_types: [...types],
           archived: String(this.assetTypeToEdit.archived === true)
         }
@@ -213,6 +217,7 @@ export default {
         this.form = {
           name: '',
           short_name: '',
+          description: '',
           task_types: [],
           archived: 'false'
         }

--- a/src/components/modals/EditProductionModal.vue
+++ b/src/components/modals/EditProductionModal.vue
@@ -55,7 +55,6 @@
             :step="0.001"
             @enter="runConfirmation"
             v-model="form.fps"
-            v-focus
           />
           <text-field
             v-if="productionToEdit && productionToEdit.id"
@@ -63,7 +62,6 @@
             :label="$t('productions.fields.ratio')"
             v-model="form.ratio"
             @enter="runConfirmation"
-            v-focus
           />
           <text-field
             v-if="productionToEdit && productionToEdit.id"
@@ -71,7 +69,6 @@
             :label="$t('productions.fields.resolution')"
             v-model="form.resolution"
             @enter="runConfirmation"
-            v-focus
           />
 
           <div v-if="productionToEdit && productionToEdit.id">

--- a/src/components/modals/EditShotModal.vue
+++ b/src/components/modals/EditShotModal.vue
@@ -42,7 +42,6 @@
             type="number"
             v-model="form.nb_frames"
             @enter="runConfirmation"
-            v-focus
           />
           <text-field
             ref="frameInField"

--- a/src/components/modals/EditTaskTypeModal.vue
+++ b/src/components/modals/EditTaskTypeModal.vue
@@ -80,21 +80,24 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters } from 'vuex'
+
 import { modalMixin } from '@/components/modals/base_modal'
 
-import BooleanField from '@/components/widgets/BooleanField'
-import ComboboxBoolean from '@/components/widgets/ComboboxBoolean'
-import ComboboxSimple from '@/components/widgets/ComboboxSimple'
-import ComboboxDepartment from '@/components/widgets/ComboboxDepartment'
-import ColorField from '@/components/widgets/ColorField'
-import ModalFooter from '@/components/modals/ModalFooter'
-import TextField from '@/components/widgets/TextField'
-import TextareaField from '@/components/widgets/TextareaField'
+import BooleanField from '@/components/widgets/BooleanField.vue'
+import ComboboxBoolean from '@/components/widgets/ComboboxBoolean.vue'
+import ComboboxSimple from '@/components/widgets/ComboboxSimple.vue'
+import ComboboxDepartment from '@/components/widgets/ComboboxDepartment.vue'
+import ColorField from '@/components/widgets/ColorField.vue'
+import ModalFooter from '@/components/modals/ModalFooter.vue'
+import TextField from '@/components/widgets/TextField.vue'
+import TextareaField from '@/components/widgets/TextareaField.vue'
 
 export default {
   name: 'edit-task-type-modal',
+
   mixins: [modalMixin],
+
   components: {
     BooleanField,
     ComboboxBoolean,
@@ -131,6 +134,7 @@ export default {
         this.form = {
           name: this.taskTypeToEdit.name,
           short_name: this.taskTypeToEdit.short_name,
+          description: this.taskTypeToEdit.description,
           color: this.taskTypeToEdit.color,
           for_entity: this.taskTypeToEdit.for_entity || 'Asset',
           allow_timelog: String(this.taskTypeToEdit.allow_timelog === true),
@@ -146,6 +150,7 @@ export default {
       form: {
         name: '',
         short_name: '',
+        description: '',
         color: '$grey',
         for_entity: 'Asset',
         allow_timelog: 'false',
@@ -170,8 +175,6 @@ export default {
   },
 
   methods: {
-    ...mapActions([]),
-
     newPriority(forEntity) {
       return (
         this.taskTypes.filter(taskType => taskType.for_entity === forEntity)

--- a/src/components/pages/TaskStatus.vue
+++ b/src/components/pages/TaskStatus.vue
@@ -23,7 +23,7 @@
         </span>
       </h2>
       <task-status-list
-        :entries="taskStatusList.filter(taskStatus => !taskStatus.for_concept)"
+        :entries="taskStatusList"
         :is-loading="loading.list"
         :is-error="errors.list"
         @edit-clicked="onEditClicked"
@@ -32,7 +32,7 @@
       />
       <h2>{{ $t('task_status.title_concepts') }}</h2>
       <task-status-list
-        :entries="taskStatusList.filter(taskStatus => !!taskStatus.for_concept)"
+        :entries="conceptStatusList"
         :is-loading="loading.list"
         :is-error="errors.list"
         @edit-clicked="onEditClicked"
@@ -69,11 +69,11 @@ import { HelpCircleIcon } from 'vue-feather-icons'
 import csv from '@/lib/csv'
 import stringHelpers from '@/lib/string'
 
-import DeleteModal from '@/components/modals/DeleteModal'
-import EditTaskStatusModal from '@/components/modals/EditTaskStatusModal'
-import ListPageHeader from '@/components/widgets/ListPageHeader'
-import RouteTabs from '@/components/widgets/RouteTabs'
-import TaskStatusList from '@/components/lists/TaskStatusList'
+import DeleteModal from '@/components/modals/DeleteModal.vue'
+import EditTaskStatusModal from '@/components/modals/EditTaskStatusModal.vue'
+import ListPageHeader from '@/components/widgets/ListPageHeader.vue'
+import RouteTabs from '@/components/widgets/RouteTabs.vue'
+import TaskStatusList from '@/components/lists/TaskStatusList.vue'
 
 export default {
   name: 'task-status',
@@ -130,11 +130,20 @@ export default {
       return this.activeTab === 'active'
     },
 
+    activeTaskStatuses() {
+      return this.isActiveTab ? this.taskStatus : this.archivedTaskStatus
+    },
+
     taskStatusList() {
-      const taskStatusList = this.isActiveTab
-        ? this.taskStatus
-        : this.archivedTaskStatus
-      return [...taskStatusList].sort((a, b) => a.priority - b.priority)
+      return this.activeTaskStatuses
+        .filter(taskStatus => !taskStatus.for_concept)
+        .sort((a, b) => a.priority - b.priority)
+    },
+
+    conceptStatusList() {
+      return this.activeTaskStatuses
+        .filter(taskStatus => taskStatus.for_concept)
+        .sort((a, b) => a.priority - b.priority)
     }
   },
 

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -873,17 +873,6 @@ const mutations = {
       state.taskMap.set(task.id, task)
     } else {
       Object.assign(state.taskMap.get(task.id), task)
-      if (
-        state.taskComments[task.id] &&
-        state.taskComments[task.id].length > 0 &&
-        !locks[task.id]
-      ) {
-        const comment = state.taskComments[task.id].find(c => !c.pinned)
-        Object.assign(comment, {
-          task_status_id: task.task_status_id,
-          task_status: state.taskStatusMap.get(task.task_status_id)
-        })
-      }
     }
   },
 


### PR DESCRIPTION
**Problem**
- Some outdated npm dependencies.
- On changing the status of a task, the real-time update may apply the wrong type.
- A task status for concepts can be deleted.
- On admin pages, some description fields are not visible or not editable.

**Solution**
- Bump npm dependencies: sentry, vite
- Fix a side effect on the real-time update of task status.
- Disallow to delete task status for concepts.
- Fix list and form with description field on admin pages: task statuses, task types
