### PR TITLE
Disable Git hooks on CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           cache: 'npm'
       - name: Run tests
         env:
+          HUSKY: 0
           NODE_OPTIONS: '--max_old_space_size=8192'
         run: |
           echo "Node.js $(node -v)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
           fetch-depth: 0
       - name: Build release
         env:
+          HUSKY: 0
           NODE_OPTIONS: '--max_old_space_size=8192'
         run: |
           echo "Node.js $(node -v)"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Update Kitsu on staging server
         uses: appleboy/ssh-action@v0.1.4
+        env:
+          HUSKY: 0
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
@@ -30,4 +32,3 @@ jobs:
             echo "${KITSU_VERSION}" > dist/.version.txt
             echo "${GIT_COMMIT}"    > dist/.commit.txt
             echo "${GIT_TAG}"       > dist/.tag.txt
-


### PR DESCRIPTION
**Problem**
- There is no need to install Git hooks on CI workflows.

**Solution**
- Configure workflows to prevent the installation of Git Hooks with Husky on CI servers.
