### PR TITLE
[breakdown] Fix header and colum styles

### DIFF
--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -1853,6 +1853,7 @@ export default {
   font-size: 0.9em;
   font-weight: 600;
   letter-spacing: 1px;
+  min-height: 40px;
   overflow-y: hidden;
   padding: 0;
   position: sticky;

--- a/src/components/pages/breakdown/ShotLine.vue
+++ b/src/components/pages/breakdown/ShotLine.vue
@@ -139,7 +139,7 @@
       :style="{
         'min-width': columnWidth[descriptor.id]
           ? columnWidth[descriptor.id] + 'px'
-          : '100px'
+          : '110px'
       }"
       v-for="(descriptor, j) in visibleMetadataDescriptors"
       v-if="isShowInfosBreakdown"


### PR DESCRIPTION
**Problem**

* Breakdown headers didn't display properly
* Breakdown column size didn't match header size

**Solution**

* Set a minimum height to the breakdown headers
* Use same default size for column and headers
