### PR TITLE
Fix selectable dates in timesheets

### DIFF
--- a/src/components/lists/TimesheetList.vue
+++ b/src/components/lists/TimesheetList.vue
@@ -309,14 +309,13 @@ export default {
       this.$refs['th-prod'].offsetWidth +
       this.$refs['th-type'].offsetWidth +
       'px'
-    const beginningOfTheWeek = moment().startOf('isoWeek').toDate()
     this.disabledDates = {
       to:
         this.isCurrentUserArtist &&
         this.organisation.timesheets_locked === 'true'
-          ? beginningOfTheWeek
+          ? moment().subtract(1, 'weeks').toDate() // Disable dates older than one week
           : undefined,
-      from: moment().toDate() // Disable dates after today.
+      from: moment().toDate() // Disable dates after today
     }
   },
 


### PR DESCRIPTION
**Problem**
- In the timesheets, a user with artist rights is unable to select dates from the previous week.

**Solution**
- Fix selectable dates when timesheets are locked to allow artists to choose dates until one week before.