### PR TITLE
Various fixes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -15,6 +15,7 @@ module.exports = {
     'no-empty-pattern': ['error', { allowObjectPatternsAsParameters: true }],
     'no-unused-vars': ['error', { args: 'none' }],
     'no-var': 'error',
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
     'prefer-const': [
       'error',
       {
@@ -25,6 +26,7 @@ module.exports = {
     // additional rules for Vue
     'vue/component-definition-name-casing': ['error', 'kebab-case'],
     'vue/component-name-in-template-casing': ['error', 'kebab-case'],
+    'vue/eqeqeq': ['error', 'always', { null: 'ignore' }],
     'vue/prop-name-casing': ['error', 'camelCase'],
 
     // disabled vue/recommended rules

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -1326,11 +1326,11 @@ export default {
       ]
       if (this.isTVShow) {
         if (this.currentEpisode) {
-          if (this.currentEpisode.id == 'all') {
+          if (this.currentEpisode.id === 'all') {
             nameData.splice(4, 0, 'all')
-          } else if (this.currentEpisode.id == 'main') {
+          } else if (this.currentEpisode.id === 'main') {
             nameData.splice(4, 0, 'main pack')
-            if (this.assetTypeId !== 'all' && this.castingType == 'asset') {
+            if (this.assetTypeId !== 'all' && this.castingType === 'asset') {
               nameData.splice(
                 5,
                 0,
@@ -1339,10 +1339,10 @@ export default {
             }
           } else {
             nameData.splice(4, 0, this.currentEpisode.name)
-            if (this.sequenceId !== 'all' && this.castingType == 'shot') {
+            if (this.sequenceId !== 'all' && this.castingType === 'shot') {
               nameData.splice(5, 0, this.sequenceMap.get(this.sequenceId).name)
             }
-            if (this.assetTypeId !== 'all' && this.castingType == 'asset') {
+            if (this.assetTypeId !== 'all' && this.castingType === 'asset') {
               nameData.splice(
                 5,
                 0,
@@ -1352,10 +1352,10 @@ export default {
           }
         }
       } else {
-        if (this.sequenceId !== 'all' && this.castingType == 'shot') {
+        if (this.sequenceId !== 'all' && this.castingType === 'shot') {
           nameData.splice(5, 0, this.sequenceMap.get(this.sequenceId).name)
         }
-        if (this.assetTypeId !== 'all' && this.castingType == 'asset') {
+        if (this.assetTypeId !== 'all' && this.castingType === 'asset') {
           nameData.splice(5, 0, this.assetTypeMap.get(this.assetTypeId).name)
         }
       }

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -88,7 +88,8 @@
               timeSpent: true
             }"
             :metadata-display-headers.sync="metadataDisplayHeaders"
-            v-if="isShowInfosBreakdown && columnSelectorDisplayed"
+            v-if="isShowInfosBreakdown"
+            v-show="columnSelectorDisplayed"
           />
           <span class="filler"></span>
 

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -113,7 +113,7 @@
             :time-spent-map="personTimeSpentMap"
             :time-spent-total="personTimeSpentTotal"
             :hide-done="personTasksSearchText.length === 0"
-            :hide-day-off="!(isCurrentUserAdmin || user.id == person.id)"
+            :hide-day-off="!(isCurrentUserAdmin || user.id === person.id)"
             @date-changed="onDateChanged"
             @time-spent-change="onTimeSpentChange"
             @set-day-off="onSetDayOff"

--- a/src/components/pages/ProductionNewsFeed.vue
+++ b/src/components/pages/ProductionNewsFeed.vue
@@ -238,7 +238,7 @@
 
                   <div
                     class="has-text-centered"
-                    v-if="previewMode == 'previews'"
+                    v-if="previewMode === 'previews'"
                   >
                     <preview-player
                       :canvas-id="`annotation-canvas-${dayList[0].created_at.substring(

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -482,7 +482,7 @@ export default {
     isValidForm() {
       return Boolean(
         this.mode === 'status' ||
-          (this.mode == 'publish' &&
+          (this.mode === 'publish' &&
             this.previewForms.length &&
             (this.nextRevision === undefined ||
               this.nextRevision > this.revision) &&

--- a/src/components/widgets/ButtonSimple.vue
+++ b/src/components/widgets/ButtonSimple.vue
@@ -46,10 +46,9 @@
     <link-icon class="icon" v-else-if="icon == 'link'" />
     <clock-icon class="icon" v-else-if="icon == 'clock'" />
     <file-digit-icon
-      stroke-width="1.2"
-      size="20"
       class="icon"
-      v-else-if="icon == 'file-digit'"
+      :stroke-width="1.2"
+      v-else-if="icon === 'file-digit'"
     />
     <kitsu-icon
       class="icon"

--- a/src/components/widgets/ButtonSimple.vue
+++ b/src/components/widgets/ButtonSimple.vue
@@ -39,12 +39,12 @@
     <triangle-icon class="icon" v-else-if="icon === 'triangle'" />
     <music-icon class="icon" v-else-if="icon === 'music'" />
     <square-icon class="icon" v-else-if="icon === 'eraser'" />
-    <key-icon class="icon" v-else-if="icon == 'key'" />
-    <zoom-in-icon class="icon" v-else-if="icon == 'loupe'" />
-    <globe-icon class="icon" v-else-if="icon == 'globe'" />
-    <codepen-icon class="icon" v-else-if="icon == 'codepen'" />
-    <link-icon class="icon" v-else-if="icon == 'link'" />
-    <clock-icon class="icon" v-else-if="icon == 'clock'" />
+    <key-icon class="icon" v-else-if="icon === 'key'" />
+    <zoom-in-icon class="icon" v-else-if="icon === 'loupe'" />
+    <globe-icon class="icon" v-else-if="icon === 'globe'" />
+    <codepen-icon class="icon" v-else-if="icon === 'codepen'" />
+    <link-icon class="icon" v-else-if="icon === 'link'" />
+    <clock-icon class="icon" v-else-if="icon === 'clock'" />
     <file-digit-icon
       class="icon"
       :stroke-width="1.2"

--- a/src/store/modules/breakdown.js
+++ b/src/store/modules/breakdown.js
@@ -19,6 +19,7 @@ import {
   CASTING_SET_SEQUENCES,
   CASTING_ADD_TO_CASTING,
   CASTING_REMOVE_FROM_CASTING,
+  LOAD_ASSETS_END,
   LOAD_EPISODES_START,
   LOAD_SHOTS_START,
   LOAD_EPISODE_CASTING_END,
@@ -33,7 +34,6 @@ import {
   SET_IS_SHOW_INFOS_BREAKDOWN,
   RESET_ALL
 } from '@/store/mutation-types'
-import { LOAD_ASSETS_END } from '../mutation-types'
 
 const initialState = {
   breakdownSearchFilterGroups: [],

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -59,7 +59,9 @@ import {
   SET_TODO_LIST_SCROLL_POSITION,
   SAVE_ASSET_SEARCH_END,
   SAVE_SHOT_SEARCH_END,
-  REMOVE_ASSET_SEARCH_END,
+  SAVE_EDIT_SEARCH_END,
+  SAVE_SEQUENCE_SEARCH_END,
+  SAVE_BREAKDOWN_SEARCH_END,
   LOAD_PRODUCTION_STATUS_END,
   LOAD_BACKGROUNDS_END,
   LOAD_DEPARTMENTS_END,
@@ -769,7 +771,50 @@ const mutations = {
     }
   },
 
-  [REMOVE_ASSET_SEARCH_END](state) {},
+  [SAVE_EDIT_SEARCH_END](state, { searchQuery, production }) {
+    if (!state.userFilters.edit) {
+      state.userFilters.edit = {}
+    }
+    if (!state.userFilters.edit[production.id]) {
+      state.userFilters.edit[production.id] = []
+    }
+    if (!state.userFilters.edit[production.id].includes(searchQuery)) {
+      state.userFilters.edit[production.id].push(searchQuery)
+      state.userFilters.edit[production.id] = sortByName(
+        state.userFilters.edit[production.id]
+      )
+    }
+  },
+
+  [SAVE_SEQUENCE_SEARCH_END](state, { searchQuery, production }) {
+    if (!state.userFilters.sequence) {
+      state.userFilters.sequence = {}
+    }
+    if (!state.userFilters.sequence[production.id]) {
+      state.userFilters.sequence[production.id] = []
+    }
+    if (!state.userFilters.sequence[production.id].includes(searchQuery)) {
+      state.userFilters.sequence[production.id].push(searchQuery)
+      state.userFilters.sequence[production.id] = sortByName(
+        state.userFilters.sequence[production.id]
+      )
+    }
+  },
+
+  [SAVE_BREAKDOWN_SEARCH_END](state, { searchQuery, production }) {
+    if (!state.userFilters.breakdown) {
+      state.userFilters.breakdown = {}
+    }
+    if (!state.userFilters.breakdown[production.id]) {
+      state.userFilters.breakdown[production.id] = []
+    }
+    if (!state.userFilters.breakdown[production.id].includes(searchQuery)) {
+      state.userFilters.breakdown[production.id].push(searchQuery)
+      state.userFilters.breakdown[production.id] = sortByName(
+        state.userFilters.breakdown[production.id]
+      )
+    }
+  },
 
   [CLEAR_AVATAR](state, userId) {
     if (state.user.id === userId) {


### PR DESCRIPTION
**Problem**
- Warning message on web console due to invalid options on a Lucide icon component.
- Changing a filter's name does not affect edits, sequences, breakdown pages. A page refresh is required.
- When loading the breakdown, the hidden columns stay visible.

**Solution**
- Fix invalid type on a Lucide icon.
- Fix the filter refresh on update for edits, sequences, and breakdown pages.
- Fix initially hidden metadata columns. A`v-if`directive interrupted the data sync.