### PR TITLE
Fix response handling for HTTP 50x errors

### DIFF
--- a/src/components/pages/People.vue
+++ b/src/components/pages/People.vue
@@ -461,9 +461,7 @@ export default {
         })
         .catch(err => {
           const isUserLimitReached =
-            err.body &&
-            err.body.message &&
-            err.body.message.indexOf('limit') > 0
+            err.body?.message?.includes('limit') ?? false
           if (isUserLimitReached) {
             this.errors.userLimit = true
           } else {

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -893,10 +893,7 @@ export default {
           console.error(err)
           this.errors.addComment = true
           this.loading.addComment = false
-          const isRetakeError =
-            err.response &&
-            err.response.body.message &&
-            err.response.body.message.indexOf('retake') > 0
+          const isRetakeError = err.body?.message?.includes('retake') ?? false
           this.errors.addComment = !isRetakeError
           this.errors.addCommentMaxRetakes = isRetakeError
         })

--- a/src/components/pages/production/NewProduction.vue
+++ b/src/components/pages/production/NewProduction.vue
@@ -934,12 +934,11 @@ export default {
         }
         await this.loadContext()
         await this.$router.push(this.createProductionRoute(createdProduction))
-      } catch (error) {
-        console.error(error, error.response)
+      } catch (err) {
+        console.error(err)
         this.errors.creatingProduction = true
-        this.errors.creatingProductionError = error.response
-          ? ': ' + error.response.body.message.substring(0, 165)
-          : ''
+        this.errors.creatingProductionError =
+          err.body?.message?.substring(0, 165) ?? ''
       }
       this.loading.createProduction = false
     },

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -814,10 +814,7 @@ export default {
           })
           .catch(err => {
             console.error(err)
-            const isRetakeError =
-              err.response &&
-              err.response.body.message &&
-              err.response.body.message.indexOf('retake') > 0
+            const isRetakeError = err.body?.message?.includes('retake') ?? false
             this.errors.addComment = !isRetakeError
             this.errors.addCommentMaxRetakes = isRetakeError
             this.loading.addComment = false


### PR DESCRIPTION
**Problem**
- On API response with an HTTP 50x error, some error handlers can fail.

**Solution**
- Make sure to handle HTTP 50x errors by using optional chaining to read the response data.