### PR TITLE
Fix comment link on publish revision

### DIFF
--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -459,6 +459,7 @@ export default {
 
   computed: {
     ...mapGetters([
+      'isSavingCommentPreview',
       'currentEpisode',
       'getTaskComment',
       'getTaskComments',
@@ -1375,8 +1376,8 @@ export default {
       'comment:update'(eventData) {
         const commentId = eventData.comment_id
         if (
-          !this.task &&
-          !this.taskComments.some(({ id }) => id === commentId)
+          this.isSavingCommentPreview ||
+          (!this.task && !this.taskComments.some(({ id }) => id === commentId))
         ) {
           return
         }

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -1253,7 +1253,7 @@ const mutations = {
   },
 
   [SET_PREVIEW](state, { taskId, previewId }) {
-    if (state.taskMap.get(taskId)) {
+    if (state.taskMap.get(taskId)?.entity) {
       state.taskMap.get(taskId).entity.preview_file_id = previewId
     }
   },


### PR DESCRIPTION
**Problem**
- In the task side panel, the latest revision link in the comment may be wrong after publishing a preview.

**Solution**
- Fix the latest revision link when publishing a preview. Avoid data conflict due to a real-time update.