### PR TITLE
Fix UI refresh when an entity list is paginated

### DIFF
--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -240,7 +240,11 @@ const helpers = {
     result = sortAssetResult(result, sorting, taskTypeMap, taskMap)
     cache.result = result
 
-    const displayedAssets = result.slice(0, PAGE_SIZE)
+    const limit =
+      state.displayedAssets.length > PAGE_SIZE
+        ? state.displayedAssets.length
+        : PAGE_SIZE
+    const displayedAssets = result.slice(0, limit)
     const maxX = displayedAssets.length
     const maxY = state.nbValidationColumns
 

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -214,7 +214,11 @@ const helpers = {
     result = sortEditResult(result, sorting, taskTypeMap, taskMap)
     cache.result = result
 
-    const displayedEdits = result.slice(0, PAGE_SIZE)
+    const limit =
+      state.displayedEdits.length > PAGE_SIZE
+        ? state.displayedEdits.length
+        : PAGE_SIZE
+    const displayedEdits = result.slice(0, limit)
     const maxX = displayedEdits.length
     const maxY = state.nbValidationColumns
 

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -230,7 +230,11 @@ const helpers = {
     result = sortShotResult(result, sorting, taskTypeMap, taskMap)
     cache.result = result
 
-    const displayedShots = result.slice(0, PAGE_SIZE)
+    const limit =
+      state.displayedShots.length > PAGE_SIZE
+        ? state.displayedShots.length
+        : PAGE_SIZE
+    const displayedShots = result.slice(0, limit)
     const maxX = displayedShots.length
     const maxY = state.nbValidationColumns
 

--- a/tests/unit/store/assets.spec.js
+++ b/tests/unit/store/assets.spec.js
@@ -1498,7 +1498,8 @@ describe('Assets store', () => {
 
     test('SET_ASSET_SEARCH', () => {
       const state = {
-        assetSorting: { 123: 123 }
+        assetSorting: { 123: 123 },
+        displayedAssets: []
       }
       const payload = {
         sorting: 123,
@@ -1864,7 +1865,8 @@ describe('Assets store', () => {
     test('CHANGE_ASSET_SORT', () => {
       const state = {
         assetSorting: { 123: 123 },
-        assetSearchText: 'search'
+        assetSearchText: 'search',
+        displayedAssets: []
       }
       const payload = {
         sorting: { 123: 124 },


### PR DESCRIPTION
**Problem**
- When editing a value, like text metadata, of an entity directly on an entity list, a data refresh is run to apply filtering. If the result is paginated, it generates a UI glitch on the refresh.

**Solution**
- Fix UI refresh when an entity list is paginated, by forcing to reapply the current page size.