### PR TITLE
Fix navigation crash from Concepts to Shots page

### DIFF
--- a/src/components/pages/Concepts.vue
+++ b/src/components/pages/Concepts.vue
@@ -358,7 +358,9 @@ export default {
     async refreshConcepts() {
       this.loading.loadingConcepts = true
       try {
-        this.setCurrentEpisode('all') // mandatory to load all assets
+        if (this.isTVShow) {
+          this.setCurrentEpisode('all') // mandatory to load all assets of a TV show
+        }
         await this.loadAssets(true)
         await this.loadConcepts()
       } catch (err) {


### PR DESCRIPTION
**Problem**
- For productions other than TV shows, the navigation can crash from the Concepts page to the Shots page.
(see #1527)

**Solution**
- Fix navigation crash due to an invalid "current episode" value applied for productions other than TV shows.
