### PR TITLE
[assets] Improve library ux

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -234,6 +234,7 @@
             }"
             scope="row"
             :key="`row${asset.id}`"
+            :title="asset.shared ? $t('library.from_library') : undefined"
             v-for="(asset, i) in group"
           >
             <th

--- a/src/components/pages/AssetLibrary.vue
+++ b/src/components/pages/AssetLibrary.vue
@@ -1,17 +1,9 @@
 <template>
-  <page-layout :side="openedSidePanel || hasSelectedAssets">
+  <page-layout>
     <template #main>
       <div class="asset-library">
         <header class="flexrow">
           <page-title class="mt1 filler" :text="$t('library.asset_library')" />
-          <button-simple
-            class="button"
-            :disabled="hasSelectedAssets"
-            icon="plus"
-            :is-on="openedSidePanel"
-            :text="$t('library.manage')"
-            @click="openedSidePanel = !openedSidePanel"
-          />
         </header>
 
         <div class="filters flexrow">
@@ -78,14 +70,16 @@
                       :entity="entity"
                       is-rounded-top-border
                     />
-                    <div class="item-description">
-                      <div class="entity-name mt05">
+                    <div class="item-description flexrow">
+                      <production-name
+                        class="flexrow-item"
+                        :production="entity.production"
+                        :size="30"
+                        only-avatar
+                      />
+                      <div class="entity-name ml1 flexrow-item">
                         {{ entity.full_name }}
                       </div>
-                      <production-name
-                        class="mt05"
-                        :production="entity.production"
-                      />
                     </div>
                   </div>
                 </li>
@@ -105,7 +99,6 @@
 import firstBy from 'thenby'
 import { mapGetters, mapActions } from 'vuex'
 
-import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import Combobox from '@/components/widgets/Combobox.vue'
 import ComboboxProduction from '@/components/widgets/ComboboxProduction.vue'
 import EntityPreview from '@/components/widgets/EntityPreview.vue'
@@ -120,7 +113,6 @@ export default {
   name: 'asset-library',
 
   components: {
-    ButtonSimple,
     Combobox,
     ComboboxProduction,
     EntityPreview,
@@ -134,7 +126,6 @@ export default {
 
   data() {
     return {
-      openedSidePanel: false,
       errors: {
         sharedAssets: false
       },
@@ -271,9 +262,8 @@ export default {
   display: flex;
   flex-direction: column;
   max-height: 100%;
-  padding: 4em 1em 1em 1em;
+  padding: 4em 2em 1em 2em;
   color: var(--text);
-  max-width: calc(1260px + 2em); // (300px * 4 + gap * 3) + padding * 2
   margin-left: auto;
   margin-right: auto;
 }

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -269,6 +269,14 @@
         <div class="flexrow mt1 mb1">
           <button-simple
             class="flexrow-item"
+            :title="$t('assets.new_asset')"
+            icon="plus"
+            @click="modals.isNewDisplayed = true"
+          />
+          <span class="filler"></span>
+
+          <button-simple
+            class="flexrow-item"
             :text="
               libraryDisplayed
                 ? $t('breakdown.hide_library')
@@ -277,13 +285,7 @@
             icon="assets"
             :is-on="libraryDisplayed"
             @click="libraryDisplayed = !libraryDisplayed"
-          />
-          <span class="filler"></span>
-          <button-simple
-            class="flexrow-item"
-            :title="$t('assets.new_asset')"
-            icon="plus"
-            @click="modals.isNewDisplayed = true"
+            v-if="!isOnlyCurrentEpisode"
           />
           <button-simple
             class="flexrow-item"

--- a/src/components/pages/breakdown/AssetBlock.vue
+++ b/src/components/pages/breakdown/AssetBlock.vue
@@ -165,7 +165,7 @@ export default {
   }
 
   &.shared {
-    box-shadow: 0 0 3px 2px var(--shared-color);
+    box-shadow: 0 0 0 2px var(--shared-color);
   }
 }
 
@@ -275,7 +275,7 @@ export default {
   margin-right: 0;
 
   &.shared {
-    box-shadow: 0 0 3px 2px var(--shared-color);
+    box-shadow: 0 0 0 2px var(--shared-color);
   }
 }
 

--- a/src/components/pages/breakdown/AvailableAssetBlock.vue
+++ b/src/components/pages/breakdown/AvailableAssetBlock.vue
@@ -162,7 +162,7 @@ export default {
   }
 
   &.shared {
-    box-shadow: 0 0 3px 2px var(--shared-color);
+    box-shadow: 0 0 0 2px var(--shared-color);
   }
 }
 
@@ -205,7 +205,7 @@ export default {
   margin-bottom: 0.5em;
 
   &.shared {
-    box-shadow: 0 0 3px 2px var(--shared-color);
+    box-shadow: 0 0 0 2px var(--shared-color);
   }
 }
 </style>

--- a/src/components/pages/playlists/RawVideoPlayer.vue
+++ b/src/components/pages/playlists/RawVideoPlayer.vue
@@ -467,14 +467,12 @@ export default {
     },
 
     runSetCurrentTime(currentTime) {
-      const isChromium = !!window.chrome
-      const change = isChromium ? 0 : 0
       if (
         this.currentPlayer &&
-        this.currentPlayer.currentTime !== currentTime + change
+        this.currentPlayer.currentTime !== currentTime
       ) {
         // tweaks needed because the html video player is messy with frames
-        this.currentPlayer.currentTime = currentTime + change + 0.001
+        this.currentPlayer.currentTime = currentTime + 0.001
         this.onTimeUpdate()
       }
     },

--- a/src/components/sides/ManageLibrary.vue
+++ b/src/components/sides/ManageLibrary.vue
@@ -7,7 +7,6 @@
       v-if="extendable"
     ></div>
     <div class="side manage-library">
-      <h2 class="mt0">{{ $t('library.manage') }}</h2>
       <div class="flexrowcolumn" v-if="selectedEntities.length">
         <delete-entities
           :error-text="$t('assets.multiple_delete_error')"
@@ -23,7 +22,7 @@
         <div class="has-text-centered pa1">
           <a @click="clearSelectedAssets()">{{ $t('main.clear_selection') }}</a>
         </div>
-        <h1 class="title mt05">{{ $tc('tasks.selected_entities') }}</h1>
+        <!--h1 class="title mt05">{{ $tc('tasks.selected_entities') }}</h1>
         <div class="pa2 mt1">
           <div
             class="entity-line"
@@ -32,9 +31,12 @@
           >
             {{ entity.full_name }}
           </div>
-        </div>
+        </div-->
       </div>
 
+      <hr v-if="selectedEntities.length" />
+
+      <h2 class="mt0">{{ $t('library.manage') }}</h2>
       <div class="has-text-centered mt2" v-if="!openProductions.length">
         {{ $t('library.no_open_productions') }}
       </div>
@@ -43,64 +45,50 @@
         <div class="flexcolumn mt2">
           <combobox-production
             class="flexrow-item"
-            :label="$t('library.import_from_production')"
+            :label="$t('library.select_production')"
             :production-list="openProductions"
             :with-margin="false"
             v-model="productionId"
           />
-          <button-simple
-            class="flexrow-item mt05"
-            :disabled="!productionId"
-            :is-loading="loading"
-            :text="$t('main.import')"
-            @click="importFromProduction(productionId)"
-          />
-        </div>
-        <div class="flexcolumn mt2">
           <combobox
-            class="flexrow-item"
+            class="flexrow-item mt2"
             :disabled="!productionId"
-            :label="$t('library.import_from_asset_type')"
+            :label="$t('library.select_asset_type')"
             :options="productionEntityTypes"
             :with-margin="false"
             v-model="entityTypeId"
           />
-          <button-simple
-            class="flexrow-item mt05"
-            :disabled="!productionId"
-            :is-loading="loading"
-            :text="$t('main.import')"
-            @click="importFromAssetType(productionId, entityTypeId)"
-          />
         </div>
         <div class="flexcolumn mt2">
-          <label class="label">
-            {{ $t('library.import_from_assets') }}
-          </label>
+          <button-simple
+            class="flexrow-item"
+            :disabled="!productionId"
+            :is-loading="loading"
+            :text="$t('library.import_from_asset_type')"
+            @click="importFromAssetType(productionId, entityTypeId)"
+          />
+          <hr class="mt1" />
+
+          <button-simple
+            class="flexrow-item"
+            :disabled="!entityIds.length"
+            :is-loading="loading"
+            text="$t('library.import_from_list')"
+            @click="importFromEntityIds(entityIds)"
+          />
+        </div>
+        <div class="flexcolumn">
           <div class="mt1" v-if="!productionUnsharedEntities.length">
             {{ $t('library.no_entities') }}
           </div>
-          <div class="unshared-entities" v-else>
-            <table
-              class="datatable multi-section"
-              v-for="(group, index) in productionUnsharedEntitiesByType"
-              :key="index"
+          <div class="unshared-entities mt1" v-else>
+           <table
+              class="datatable"
             >
-              <tr class="datatable-type-header">
-                <th>
-                  <span
-                    class="datatable-row-header pointer"
-                    @click="toggleEntities(group)"
-                  >
-                    {{ group[0]?.asset_type_name }}
-                  </span>
-                </th>
-              </tr>
-
               <tr
                 class="datatable-row"
                 :key="entity.id"
-                v-for="entity in group"
+                v-for="entity in productionUnsharedEntities"
               >
                 <td
                   class="datatable-row-header pointer"
@@ -120,7 +108,7 @@
                       :empty-width="50"
                       :empty-height="32"
                     />
-                    <span class="entity-name">
+                    <span class="entity-name ml05">
                       {{ entity.name }}
                     </span>
                   </div>
@@ -128,13 +116,6 @@
               </tr>
             </table>
           </div>
-          <button-simple
-            class="flexrow-item mt2"
-            :disabled="!entityIds.length"
-            :is-loading="loading"
-            :text="$t('main.import')"
-            @click="importFromEntityIds(entityIds)"
-          />
         </div>
       </template>
     </div>
@@ -144,20 +125,14 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 
-// import { domMixin } from '@/components/mixins/dom'
-
 import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import Combobox from '@/components/widgets/Combobox.vue'
 import ComboboxProduction from '@/components/widgets/ComboboxProduction.vue'
 import DeleteEntities from '@/components/tops/actions/DeleteEntities.vue'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
 
-// const DEFAULT_PANEL_WIDTH = 400
-
 export default {
   name: 'manage-library',
-
-  // mixins: [domMixin],
 
   components: {
     ButtonSimple,
@@ -181,31 +156,18 @@ export default {
       entityIds: [],
       loading: false,
       error: false
-      // domEvents: [
-      //   ['mousemove', this.onExtendMove],
-      //   ['touchmove', this.onExtendMove],
-      //   ['mouseup', this.onExtendUp],
-      //   ['mouseleave', this.onExtendUp],
-      //   ['touchend', this.onExtendUp],
-      //   ['touchcancel', this.onExtendUp]
-      // ],
     }
   },
 
   async mounted() {
-    // if (this.sideColumnParent) {
-    //   const panelWidth =
-    //     preferences.getIntPreference('task:panel-width') || DEFAULT_PANEL_WIDTH
-    //   this.setWidth(panelWidth)
-    // }
-
     this.productionId = this.openProductions[0]?.id
-
+    this.$nextTick(() => {
+      this.entityTypeId = this.productionEntityTypes[0]?.value
+    })
     await this.refresh()
   },
 
   beforeDestroy() {
-    // this.removeEvents(this.domEvents)
   },
 
   computed: {
@@ -234,9 +196,12 @@ export default {
 
     productionUnsharedEntities() {
       return this.unsharedAssets.filter(
-        entity => entity.project_id === this.productionId
+        entity =>
+          entity.project_id === this.productionId &&
+          entity.entity_type_id === this.entityTypeId
       )
     },
+
     productionUnsharedEntitiesByType() {
       return this.unsharedAssetsByType.map(type =>
         type.filter(entity => entity.project_id === this.productionId)
@@ -246,13 +211,6 @@ export default {
     selectedEntities() {
       return [...this.selectedAssets.values()]
     }
-
-    // sideColumnParent() {
-    //   if (this.$el.parentElement.classList.contains('side-column')) {
-    //     return this.$el.parentElement
-    //   }
-    //   return undefined
-    // },
   },
 
   methods: {
@@ -344,44 +302,6 @@ export default {
       this.loading = false
       await this.refresh()
     }
-
-    /*
-    onExtendDown(event) {
-      // if (!this.sideColumnParent) {
-      //   return
-      // }
-      this.lastWidthX = this.getClientX(event)
-      const panelWidth = this.sideColumnParent.offsetWidth
-      this.lastWidth = panelWidth
-      this.addEvents(this.domEvents)
-    },
-
-    onExtendMove(event) {
-      const diff = this.lastWidthX - this.getClientX(event)
-      let panelWidth = Math.max(this.lastWidth + diff, DEFAULT_PANEL_WIDTH)
-      if (panelWidth > 900) panelWidth = 900
-      this.setWidth(panelWidth)
-      this.refreshPreviewPlay()
-    },
-
-    onExtendUp() {
-      this.removeEvents(this.domEvents)
-      this.refreshPreviewPlay()
-      // if (this.sideColumnParent) {
-      const panelWidth = this.sideColumnParent.offsetWidth
-      preferences.setPreference('task:panel-width', panelWidth)
-      // }
-    },
-
-    setWidth(width) {
-      // if (!this.sideColumnParent) {
-      //   return
-      // }
-      this.sideColumnParent.style['min-width'] = `${width}px`
-      this.isWide = width > 699
-      this.isExtraWide = width >= 900
-    }
-    */
   }
 }
 </script>
@@ -402,7 +322,6 @@ export default {
   width: 3px;
   margin-left: 3px;
   background: #ccc;
-  // cursor: ew-resize;
 }
 
 .side-wrapper {

--- a/src/components/sides/ManageLibrary.vue
+++ b/src/components/sides/ManageLibrary.vue
@@ -82,9 +82,7 @@
             {{ $t('library.no_entities') }}
           </div>
           <div class="unshared-entities mt1" v-else>
-           <table
-              class="datatable"
-            >
+            <table class="datatable">
               <tr
                 class="datatable-row"
                 :key="entity.id"
@@ -165,9 +163,6 @@ export default {
       this.entityTypeId = this.productionEntityTypes[0]?.value
     })
     await this.refresh()
-  },
-
-  beforeDestroy() {
   },
 
   computed: {
@@ -301,6 +296,12 @@ export default {
       }
       this.loading = false
       await this.refresh()
+    }
+  },
+
+  watch: {
+    productionId() {
+      this.refresh()
     }
   }
 }

--- a/src/components/sides/Sidebar.vue
+++ b/src/components/sides/Sidebar.vue
@@ -48,12 +48,6 @@
                 {{ $t('productions.open_productions') }}
               </router-link>
             </p>
-            <p @click="toggleSidebar()">
-              <router-link :to="{ name: 'asset-library' }">
-                <kitsu-icon class="nav-icon" name="assets" />
-                {{ $t('library.asset_library') }}
-              </router-link>
-            </p>
           </div>
 
           <div v-if="!isCurrentUserClient && !isCurrentUserVendor">
@@ -121,6 +115,12 @@
               <router-link :to="{ name: 'entity-search' }">
                 <kitsu-icon class="nav-icon" name="search" />
                 {{ $t('search.title') }}
+              </router-link>
+            </p>
+            <p @click="toggleSidebar()">
+              <router-link :to="{ name: 'asset-library' }">
+                <kitsu-icon class="nav-icon" name="assets" />
+                {{ $t('library.asset_library') }}
               </router-link>
             </p>
           </div>

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -314,7 +314,7 @@
             :title="$t('menu.clear_selection')"
             @click="clearSelection"
           >
-            <x-icon :title="$t('menu.clear_selection')" size="16" />
+            <x-icon :title="$t('main.clear_selection')" :size="16" />
           </div>
         </div>
       </div>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -112,7 +112,7 @@ export default {
     label: 'Label',
     picture_mode: 'Switch to picture mode',
     save_error: 'Error while saving casting',
-    show_library: 'Show My Library',
+    show_library: 'Display Library',
     text_mode: 'Switch to text mode',
     title: 'Breakdown',
     options: {
@@ -1647,15 +1647,17 @@ export default {
 
   library: {
     asset_library: 'Asset Library',
-    manage: 'Manage your library',
+    manage: 'Add assets to your library',
     no_entities: 'No entities are available',
     no_open_productions: 'No open productions',
     no_shared_assets: 'No shared assets are available',
-    import_from_production: 'Import all assets from another production',
-    import_from_asset_type: 'Import an asset type from the selected production',
-    import_from_assets: 'Import unselected assets from the selected production',
+    import_from_production: 'Import all assets from the selected production',
+    import_from_asset_type: 'Import all assets from selected type and production',
+    import_from_assets: 'Import assets from the selected production and asset type',
+    select_asset_type: 'Select an asset type',
+    select_production: 'Select a production',
     selected_assets: 'Selected assets',
-    remove_selected_assets: 'Remove the selected asset | Remove the {nbSelectedAssets} selected assets',
+    remove_selected_assets: 'Remove the selected asset from the library | Remove {nbSelectedAssets} selected assets from the library',
     fields: {
       name: 'Name',
       production: 'Production',

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -962,7 +962,6 @@ const mutations = {
   },
 
   [LOAD_SHARED_ASSETS_END](state, { assets, productionMap, assetTypeMap }) {
-    // populate shared assets
     assets.forEach(asset => {
       asset.production = productionMap.get(asset.project_id)
       asset.assetType = assetTypeMap.get(asset.entity_type_id)
@@ -978,7 +977,6 @@ const mutations = {
   },
 
   [LOAD_UNSHARED_ASSETS_END](state, { assets, productionMap, assetTypeMap }) {
-    // populate unshared assets
     assets.forEach(asset => {
       asset.production = productionMap.get(asset.project_id)
       asset.assetType = assetTypeMap.get(asset.entity_type_id)

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -68,7 +68,7 @@ $yellow: #FFC107;
   --text-selected: #8F91EB;
   --poster-color: #000;
   --purple: #CFD1FF;
-  --shared-color: #F16919;
+  --shared-color: #F9E04B;
 }
 
 .dark {


### PR DESCRIPTION
**Problem**

The current asset library experience is sometimes confusing.

**Solution**

Simplify asset library import: 
* select context first production and asset type to filter the available asset list.
* Always show the import column
* Use better color (orange looks like a warning) to show asset library elements

