### PR TITLE
Various fixes

### DIFF
--- a/src/components/cells/DescriptionCell.vue
+++ b/src/components/cells/DescriptionCell.vue
@@ -53,8 +53,7 @@ export default {
   data() {
     return {
       isEditing: false,
-      isOpen: false,
-      timeout: null
+      isOpen: false
     }
   },
 
@@ -80,8 +79,8 @@ export default {
 
     onClick(event) {
       if (
-        event.target.className.substring(0, 11) === 'description' ||
-        event.target.parentNode.className.substring(0, 11) === 'description' ||
+        (event.currentTarget.classList.contains('description-cell') &&
+          !event.target.closest('.description-cell .tooltip')) ||
         event.keyCode === 27
       ) {
         this.isOpen = !this.isOpen

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -265,9 +265,13 @@
                   class="asset-link asset-name flexrow-item"
                   :to="assetPath(asset.id)"
                   :title="asset.full_name"
+                  v-if="!asset.shared"
                 >
                   {{ asset.name }}
                 </router-link>
+                <template v-else>
+                  {{ asset.name }}
+                </template>
               </div>
             </th>
 

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -1006,6 +1006,9 @@ td.ready-for {
       transparent
     ) !important;
   }
+  > td > :deep(*) {
+    display: none;
+  }
 }
 
 .datatable-row th.name {

--- a/src/components/pages/ProductionNewsFeed.vue
+++ b/src/components/pages/ProductionNewsFeed.vue
@@ -137,7 +137,7 @@
                       <task-type-name
                         class="task-type-name"
                         :task-type="buildTaskTypeFromNews(news)"
-                        :production-id="currentProduction.id"
+                        :production-id="news.project_id"
                         :is-static="true"
                       />
                     </div>
@@ -210,7 +210,7 @@
                       <task-type-name
                         class="task-type-name"
                         :task-type="buildTaskTypeFromNews(news)"
-                        :production-id="currentProduction.id"
+                        :production-id="news.project_id"
                       />
                     </div>
 


### PR DESCRIPTION
**Problem**
- A shared asset on the asset list should not be clickable (link on asset name) and should appear without additional information.
- A description cell on the asset list is not clickable if it contains Markdown.
- The task type links on the studio news feed always redirect to the first production.

**Solution**
- On asset list,
  - Disable the link on asset names if shared.
  - Hide additional information of asset if shared.
- Fix click on a description cell with markdown.
- Fix links to task type from the studio news feed: using the news production ID instead of the current production, which may be wrong on studio pages.