### PR TITLE
[ux] UX tweak for asset AssetLibrary

### DIFF
--- a/src/components/pages/AssetLibrary.vue
+++ b/src/components/pages/AssetLibrary.vue
@@ -61,24 +61,24 @@
                   v-for="entity in group"
                   @click="toggleEntity(entity)"
                 >
-                  <div class="card">
+                  <div class="card" :title="entity.full_name">
                     <entity-preview
-                      :empty-height="200"
-                      :empty-width="300"
-                      :height="200"
-                      :width="300"
+                      :empty-height="100"
+                      :empty-width="150"
+                      :height="100"
+                      :width="150"
                       :entity="entity"
                       is-rounded-top-border
                     />
                     <div class="item-description flexrow">
                       <production-name
-                        class="flexrow-item"
+                        class="flexrow-item mr0"
                         :production="entity.production"
-                        :size="30"
+                        :size="20"
                         only-avatar
                       />
                       <div class="entity-name ml1 flexrow-item">
-                        {{ entity.full_name }}
+                        {{ entity.name }}
                       </div>
                     </div>
                   </div>
@@ -300,10 +300,16 @@ export default {
     }
 
     .item-description {
-      max-width: 300px;
       color: var(--text-strong);
+      font-size: 0.9em;
       font-weight: bold;
-      padding: 0.3em 1em;
+      max-width: 150px;
+      min-width: 150px;
+      padding: 0.5em;
+
+      .entity-name {
+        margin-left: 0.5em;
+      }
     }
   }
 }

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -272,16 +272,13 @@
             :title="$t('assets.new_asset')"
             icon="plus"
             @click="modals.isNewDisplayed = true"
+            v-if="!isOnlyCurrentEpisode"
           />
           <span class="filler"></span>
 
           <button-simple
             class="flexrow-item"
-            :text="
-              libraryDisplayed
-                ? $t('breakdown.hide_library')
-                : $t('breakdown.show_library')
-            "
+            :text="$t('breakdown.show_library')"
             icon="assets"
             :is-on="libraryDisplayed"
             @click="libraryDisplayed = !libraryDisplayed"

--- a/src/components/sides/ManageLibrary.vue
+++ b/src/components/sides/ManageLibrary.vue
@@ -61,6 +61,14 @@
         </div>
         <div class="flexcolumn mt2">
           <button-simple
+            class="flexrow-item mb05"
+            :disabled="!productionId"
+            :is-loading="loading"
+            :text="$t('library.import_from_production')"
+            @click="importFromProduction(productionId)"
+          />
+
+          <button-simple
             class="flexrow-item"
             :disabled="!productionId"
             :is-loading="loading"

--- a/src/components/widgets/ProductionName.vue
+++ b/src/components/widgets/ProductionName.vue
@@ -76,7 +76,11 @@ export default {
 }
 
 .avatar-name {
-  color: var(--text);
+  color: $black;
   margin-left: 0.8em;
+
+  .dark & {
+    color: $white;
+  }
 }
 </style>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1649,6 +1649,7 @@ export default {
     asset_library: 'Asset Library',
     from_library: 'From the asset library',
     import_from_asset_type: 'Import all assets from selected type and production',
+    import_from_production: 'Import all assets from selected production',
     import_from_assets: 'Import assets from the selected production and asset type',
     import_from_list: 'Import selected assets from the list',
     manage: 'Add assets to your library',


### PR DESCRIPTION
**Problem**

A few things could be improved in the asset library.

**Solution**

* Allow to import all assets
* Use smaller thumbnails
* Keep display library tag
* Cleaner color for production name widget