### PR TITLE
Add setting to use hours instead of days for durations and estimations

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -474,9 +474,17 @@
         v-show="displayedAssetsTimeSpent > 0 || displayedAssetsEstimation > 0"
       >
         ({{ formatDuration(displayedAssetsTimeSpent) }}
-        {{ $tc('main.days_spent', displayedAssetsTimeSpent) }},
+        {{
+          isDurationInHours()
+            ? $tc('main.hours_spent', displayedAssetsTimeSpent)
+            : $tc('main.days_spent', displayedAssetsTimeSpent)
+        }},
         {{ formatDuration(displayedAssetsEstimation) }}
-        {{ $tc('main.man_days', displayedAssetsEstimation) }})
+        {{
+          isDurationInHours()
+            ? $tc('main.hours_estimated', displayedAssetsEstimation)
+            : $tc('main.man_days', displayedAssetsEstimation)
+        }})
       </span>
     </p>
   </div>
@@ -592,6 +600,7 @@ export default {
       'displayedAssetsTimeSpent',
       'displayedAssetsEstimation',
       'nbSelectedTasks',
+      'organisation',
       'isAssetDescription',
       'isBigThumbnails',
       'isCurrentUserClient',
@@ -693,6 +702,10 @@ export default {
 
     isAssetsOnly() {
       return this.currentProduction.production_type === 'assets'
+    },
+
+    formatDurationInHours() {
+      return this.organisation.format_duration_in_hours
     }
   },
 

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -532,8 +532,11 @@ export default {
       return date ? moment(date, 'YYYY-MM-DD').toDate() : null
     },
 
-    updateEstimation(days) {
-      const estimation = daysToMinutes(this.organisation, days)
+    updateEstimation(duration) {
+      const estimation = this.organisation.format_duration_in_hours
+        ? duration * 60
+        : daysToMinutes(this.organisation, duration)
+
       this.updateTasksEstimation({ estimation })
     },
 

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -284,9 +284,16 @@
       {{ tasks.length }} {{ $tc('tasks.number', tasks.length) }} ({{
         formatDuration(timeEstimated)
       }}
-      {{ $tc('main.days_estimated', isTimeEstimatedPlural) }},
+      {{
+        isDurationInHours()
+          ? $tc('main.hours_estimated', isTimeEstimatedPlural)
+          : $tc('main.days_estimated', isTimeEstimatedPlural)
+      }},
       {{ formatDuration(timeSpent) }}
-      {{ $tc('main.days_spent', isTimeSpentPlural)
+      {{
+        isDurationInHours()
+          ? $tc('main.hours_spent', isTimeSpentPlural)
+          : $tc('main.days_spent', isTimeSpentPlural)
       }}<span v-if="!isAssets"
         >, {{ nbFrames }} {{ $tc('main.nb_frames', nbFrames) }}</span
       >)
@@ -565,6 +572,7 @@ export default {
           )
             return
           data = getDatesFromStartDate(
+            this.organisation,
             startDate,
             dueDate,
             minutesToDays(this.organisation, task.estimation)
@@ -599,6 +607,7 @@ export default {
           )
             return
           data = getDatesFromEndDate(
+            this.organisation,
             startDate,
             dueDate,
             minutesToDays(this.organisation, task.estimation)

--- a/src/components/mixins/format.js
+++ b/src/components/mixins/format.js
@@ -28,13 +28,17 @@ export const formatListMixin = {
       if (!minutes) {
         return 0
       }
-      const days = minutesToDays(this.organisation, minutes)
+
+      const duration = this.organisation.format_duration_in_hours
+        ? minutes / 60
+        : minutesToDays(this.organisation, minutes)
+
       if (toLocale) {
-        return days.toLocaleString('fullwide', {
+        return duration.toLocaleString('fullwide', {
           maximumFractionDigits: 2
         })
       }
-      return days
+      return duration
     },
 
     formatPriority(priority) {

--- a/src/components/mixins/format.js
+++ b/src/components/mixins/format.js
@@ -41,6 +41,10 @@ export const formatListMixin = {
       return duration
     },
 
+    isDurationInHours() {
+      return this.organisation.format_duration_in_hours
+    },
+
     formatPriority(priority) {
       let label = priority + ''
       if (priority === 0) {

--- a/src/components/pages/Settings.vue
+++ b/src/components/pages/Settings.vue
@@ -65,6 +65,10 @@
           :label="$t('settings.fields.timesheets_locked')"
           v-model="form.timesheets_locked"
         />
+        <combobox-boolean
+          :label="$t('settings.fields.format_duration_in_hours')"
+          v-model="form.format_duration_in_hours"
+        />
         <h2>
           {{ $t('settings.integrations') }}
         </h2>
@@ -142,7 +146,8 @@ export default {
         hours_by_day: 0,
         name: '',
         timesheets_locked: 'false',
-        use_original_file_name: 'false'
+        use_original_file_name: 'false',
+        format_duration_in_hours: 'false'
       },
       errors: {
         save: false,
@@ -204,7 +209,9 @@ export default {
           ...this.form,
           hd_by_default: this.form.hd_by_default === 'true',
           timesheets_locked: this.form.timesheets_locked === 'true',
-          use_original_file_name: this.form.use_original_file_name === 'true'
+          use_original_file_name: this.form.use_original_file_name === 'true',
+          format_duration_in_hours:
+            this.form.format_duration_in_hours === 'true'
         }
         this.saveOrganisation(organisation)
           .catch(err => {
@@ -267,6 +274,9 @@ export default {
             ? 'true'
             : 'false',
           use_original_file_name: this.organisation.use_original_file_name
+            ? 'true'
+            : 'false',
+          format_duration_in_hours: this.organisation.format_duration_in_hours
             ? 'true'
             : 'false'
         }

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -144,7 +144,7 @@
                     <td class="field-label">
                       {{ $t('tasks.fields.estimation') }}
                     </td>
-                    <td>{{ task.estimation }}</td>
+                    <td>{{ formatDuration(task.estimation) }}</td>
                   </tr>
                   <tr class="datatable-row">
                     <td class="field-label">

--- a/src/components/pages/production/ProductionStats.vue
+++ b/src/components/pages/production/ProductionStats.vue
@@ -8,10 +8,21 @@
       </span>
       <span class="tag">
         {{ formatDuration(stats.total_duration) }}
-        {{ $tc('main.days_spent', formatDuration(stats.total_duration)) }}
+        {{
+          isDurationInHours()
+            ? $tc('main.hours_spent', formatDuration(stats.total_duration))
+            : $tc('main.days_spent', formatDuration(stats.total_duration))
+        }}
         /
         {{ formatDuration(stats.total_estimation) }}
-        {{ $tc('main.days_estimated', formatDuration(stats.total_estimation)) }}
+        {{
+          isDurationInHours()
+            ? $tc(
+                'main.hours_estimated',
+                formatDuration(stats.total_estimation)
+              )
+            : $tc('main.days_estimated', formatDuration(stats.total_estimation))
+        }}
       </span>
     </div>
     <div class="color-wrapper">

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -136,12 +136,13 @@ export const getEndDateFromString = (startDate, endDateString) => {
 }
 
 export const getDatesFromStartDate = (
+  organisation,
   startDate,
   dueDate,
   estimation,
   daysOff = []
 ) => {
-  if (estimation > 0) {
+  if (estimation > 0 && !organisation.format_duration_in_hours) {
     dueDate = addBusinessDays(startDate, Math.ceil(estimation) - 1, daysOff)
   }
 
@@ -166,12 +167,13 @@ export const getDatesFromStartDate = (
 }
 
 export const getDatesFromEndDate = (
+  organisation,
   startDate,
   dueDate,
   estimation,
   daysOff = []
 ) => {
-  if (estimation > 0) {
+  if (estimation > 0 && !organisation.format_duration_in_hours) {
     startDate = removeBusinessDays(dueDate, Math.ceil(estimation) - 1, daysOff)
   }
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -551,6 +551,8 @@ export default {
     days: 'days',
     days_spent: 'day spent | days spent',
     days_estimated: 'day estimated | days estimated',
+    hours_spent: 'hour spent | hours spent',
+    hours_estimated: 'hour estimated | hours estimated',
     delete: 'Delete',
     delete_all: 'Delete all',
     delete_text: 'Are you sure you want to remove {name} from your database?',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1195,7 +1195,8 @@ export default {
       discord_token: 'Discord Token (Optional)',
       timesheets_locked: 'Lock artist timesheets older than 1 week',
       use_original_name: 'Use original file name for downloads',
-      show_hd_default: 'Show movies with HD quality by default (slower)'
+      show_hd_default: 'Show movies with HD quality by default (slower)',
+      format_duration_in_hours: 'Display durations and estimations in hours'
     },
     production: {
       empty_list: 'The list is currently empty. It means that all data from the main settings are available to users. Add some entries to limit choices for this production.',

--- a/src/store/api/people.js
+++ b/src/store/api/people.js
@@ -16,7 +16,8 @@ export default {
       chat_token_slack: organisation.chat_token_slack,
       chat_webhook_mattermost: organisation.chat_webhook_mattermost,
       chat_token_discord: organisation.chat_token_discord,
-      has_avatar: organisation.has_avatar
+      has_avatar: organisation.has_avatar,
+      format_duration_in_hours: organisation.format_duration_in_hours
     }
     return client.pput(`/api/data/organisations/${organisation.id}`, data)
   },

--- a/src/store/modules/people.js
+++ b/src/store/modules/people.js
@@ -118,7 +118,8 @@ const initialState = {
     has_avatar: false,
     hd_by_default: false,
     timesheets_locked: false,
-    use_original_file_name: false
+    use_original_file_name: false,
+    format_duration_in_hours: false
   },
 
   people: [],


### PR DESCRIPTION
**Problem**
We have a mix of artist that can work more or less daily on a project so it's important for us to be able to estimate in hours.

**Solution**
I've added an organization-wide setting to toggle duration and estimates in hours. 
This will require a zou commit as well to persist the setting.



I'm more of a TD than a proper dev so this PR might be a bit of a mess but I hope this is helpful in at least getting the ball rolling for that feature.