### PR TITLE
Fix loading assets on edge case

### DIFF
--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -442,9 +442,13 @@ const actions = {
       })
       .then(assets => {
         assets.forEach(asset => {
-          if (!asset.asset_type_name) {
-            const assetType = assetTypeMap.get(asset.entity_type_id)
-            asset.asset_type_name = assetType?.name
+          if (
+            asset.asset_type_name === null ||
+            asset.asset_type_name === undefined
+          ) {
+            const typeId = asset.asset_type_id || asset.entity_type_id
+            const assetType = assetTypeMap.get(typeId)
+            asset.asset_type_name = assetType?.name || ''
           }
         })
         commit(LOAD_ASSETS_END, {


### PR DESCRIPTION
**Problem**
- Assets loading can crash if a task type has an empty name.

**Solution**
- Fix loading assets with an empty task type name.