### PR TITLE
Improve UI for shared assets

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -367,7 +367,7 @@
             <description-cell
               class="description"
               @description-changed="value => onDescriptionChanged(asset, value)"
-              :editable="isCurrentUserManager"
+              :editable="isCurrentUserManager && !asset.shared"
               v-if="!isCurrentUserClient && isShowInfos && isAssetDescription"
               :entry="asset"
             />
@@ -1076,9 +1076,17 @@ td.ready-for {
       var(--shared-color) 20%,
       transparent
     ) !important;
+
+    &:hover {
+      opacity: 1;
+    }
   }
-  > td > :deep(*) {
-    display: none;
+  > td:not(.description-cell) {
+    font-size: 0;
+
+    > :deep(*) {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
**Problem**
- The asset list does not display the description of a shared asset, but it does show the unwanted time and estimate cells.

**Solution**
- Display only the description cell for shared assets.
