### PR TITLE
Fix setup of dark theme

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -107,7 +107,8 @@ export default {
       const darkTheme = localStorage.getItem('dark-theme')
       const isDarkTheme =
         darkTheme === 'true' ||
-        (darkTheme !== 'false' && this.mainConfig?.dark_theme_by_default)
+        (darkTheme !== 'false' &&
+          Boolean(this.mainConfig?.dark_theme_by_default))
       this.$store.commit('TOGGLE_DARK_THEME', isDarkTheme)
     },
 


### PR DESCRIPTION
**Problem**
- If no default theme is set, a wrong theme may be loaded.

**Solution**
- Fix the setup of a dark theme, due to a missing boolean condition.
