### PR TITLE
Improve Stats pages

### DIFF
--- a/src/components/cells/ValidationHeader.vue
+++ b/src/components/cells/ValidationHeader.vue
@@ -18,6 +18,9 @@
       />
       <router-link
         class="flexrow-item datatable-dropdown ellipsis task-type-name"
+        :title="
+          !hiddenColumns[columnId] ? taskTypeMap.get(columnId).name : null
+        "
         :to="taskTypePath(columnId)"
         v-if="!isCurrentUserClient"
       >
@@ -25,6 +28,9 @@
       </router-link>
       <span
         class="flexrow-item datatable-dropdown ellipsis task-type-name"
+        :title="
+          !hiddenColumns[columnId] ? taskTypeMap.get(columnId).name : null
+        "
         v-else
       >
         {{ !hiddenColumns[columnId] ? taskTypeMap.get(columnId).name : '' }}

--- a/src/components/lists/EpisodeStatsList.vue
+++ b/src/components/lists/EpisodeStatsList.vue
@@ -20,13 +20,18 @@
                 :style="getValidationStyle(columnId)"
               >
                 <router-link
-                  class="flexrow-item"
+                  class="flexrow-item ellipsis"
+                  :title="taskTypeMap.get(columnId).name"
                   :to="taskTypePath(columnId)"
                   v-if="!isCurrentUserClient"
                 >
                   {{ taskTypeMap.get(columnId).name }}
                 </router-link>
-                <span class="flexrow-item" v-else>
+                <span
+                  class="flexrow-item ellipsis"
+                  :title="taskTypeMap.get(columnId).name"
+                  v-else
+                >
                   {{ taskTypeMap.get(columnId).name }}
                 </span>
               </div>

--- a/src/components/lists/ProductionAssetTypeList.vue
+++ b/src/components/lists/ProductionAssetTypeList.vue
@@ -20,13 +20,18 @@
                 :style="getValidationStyle(columnId)"
               >
                 <router-link
-                  class="flexrow-item"
+                  class="flexrow-item ellipsis"
+                  :title="taskTypeMap.get(columnId).name"
                   :to="taskTypePath(columnId)"
                   v-if="!isCurrentUserClient"
                 >
                   {{ taskTypeMap.get(columnId).name }}
                 </router-link>
-                <span class="flexrow-item" v-else>
+                <span
+                  class="flexrow-item ellipsis"
+                  :title="taskTypeMap.get(columnId).name"
+                  v-else
+                >
                   {{ taskTypeMap.get(columnId).name }}
                 </span>
               </div>

--- a/src/components/lists/SequenceStatsList.vue
+++ b/src/components/lists/SequenceStatsList.vue
@@ -20,13 +20,18 @@
                 :style="getValidationStyle(columnId)"
               >
                 <router-link
-                  class="flexrow-item"
+                  class="flexrow-item ellipsis"
+                  :title="taskTypeMap.get(columnId).name"
                   :to="taskTypePath(columnId)"
                   v-if="!isCurrentUserClient"
                 >
                   {{ taskTypeMap.get(columnId).name }}
                 </router-link>
-                <span class="flexrow-item" v-else>
+                <span
+                  class="flexrow-item ellipsis"
+                  :title="taskTypeMap.get(columnId).name"
+                  v-else
+                >
                   {{ taskTypeMap.get(columnId).name }}
                 </span>
               </div>

--- a/src/components/pages/EpisodeStats.vue
+++ b/src/components/pages/EpisodeStats.vue
@@ -45,6 +45,7 @@
       />
       <button-simple
         class="flexrow-item"
+        :disabled="isLoading"
         icon="download"
         @click="exportStatisticsToCsv"
       />

--- a/src/components/pages/EpisodeStats.vue
+++ b/src/components/pages/EpisodeStats.vue
@@ -235,7 +235,8 @@ export default {
           this.taskTypeMap,
           this.taskStatusMap,
           this.episodeMap,
-          this.countMode
+          this.countMode,
+          this.currentProduction
         )
       } else {
         csv.generateStatReports(
@@ -244,7 +245,8 @@ export default {
           this.taskTypeMap,
           this.taskStatusMap,
           this.episodeMap,
-          this.countMode
+          this.countMode,
+          this.currentProduction
         )
       }
     },

--- a/src/components/pages/ProductionAssetTypes.vue
+++ b/src/components/pages/ProductionAssetTypes.vue
@@ -153,7 +153,8 @@ export default {
         this.taskTypeMap,
         this.taskStatusMap,
         this.assetTypeMap,
-        this.countMode
+        this.countMode,
+        this.currentProduction
       )
     },
 

--- a/src/components/pages/SequenceStats.vue
+++ b/src/components/pages/SequenceStats.vue
@@ -231,7 +231,8 @@ export default {
         this.taskTypeMap,
         this.taskStatusMap,
         this.sequenceMap,
-        this.countMode
+        this.countMode,
+        this.currentProduction
       )
     },
 

--- a/src/lib/csv.js
+++ b/src/lib/csv.js
@@ -430,13 +430,17 @@ const getStatsTaskTypeIds = (mainStats, taskTypeMap) => {
 }
 
 const getStatsEntryIds = (mainStats, entryMap) => {
-  return Object.keys(mainStats).sort((a, b) => {
-    if (a === 'all') return -1
-    if (b === 'all') return 1
-    return entryMap.get(a).name.localeCompare(entryMap.get(b).name, undefined, {
-      numeric: true
+  return Object.keys(mainStats)
+    .filter(entryId => entryId === 'all' || entryMap.get(entryId))
+    .sort((a, b) => {
+      if (a === 'all') return -1
+      if (b === 'all') return 1
+      return entryMap
+        .get(a)
+        .name.localeCompare(entryMap.get(b).name, undefined, {
+          numeric: true
+        })
     })
-  })
 }
 
 const getStatsTotalCount = (mainStats, taskStatusIds, countMode, entryId) => {

--- a/src/lib/csv.js
+++ b/src/lib/csv.js
@@ -292,13 +292,7 @@ const csv = {
       )
 
       taskTypeIds.forEach(taskTypeId => {
-        if (taskTypeId === 'all') {
-          Object.keys(mainStats[entryId].all).forEach(taskStatusId => {
-            if (!['max_retake_count', 'evolution'].includes(taskStatusId)) {
-              lineMap[taskStatusId] = lineMap[taskStatusId].concat(['', ''])
-            }
-          })
-        } else {
+        if (taskTypeId !== 'all') {
           const taskTypeStats = mainStats[entryId][taskTypeId]
           if (taskTypeStats) {
             const total = getStatsTotalEntryCount(
@@ -318,6 +312,12 @@ const csv = {
               lineMap
             )
           }
+        } else {
+          Object.keys(mainStats[entryId].all).forEach(taskStatusId => {
+            if (!['max_retake_count', 'evolution'].includes(taskStatusId)) {
+              lineMap[taskStatusId] = lineMap[taskStatusId].concat(['', ''])
+            }
+          })
         }
       })
 

--- a/src/lib/csv.js
+++ b/src/lib/csv.js
@@ -128,8 +128,7 @@ const csv = {
 
   buildCsvFile(name, entries) {
     const csvContent = csv.turnEntriesToCsvString(entries)
-    const result =
-      'data:text/csv;charset=utf-8,' + encodeURIComponent(csvContent)
+    const result = `data:text/csv;charset=utf-8,${encodeURIComponent(csvContent)}`
     const link = document.createElement('a')
     link.setAttribute('href', result)
     link.setAttribute('download', `${name}.csv`)
@@ -419,7 +418,14 @@ const getStatsTaskTypeIds = (mainStats, taskTypeMap) => {
     .sort((a, b) => {
       if (a === 'all') return 1
       if (b === 'all') return -1
-      return taskTypeMap.get(a).priority - taskTypeMap.get(b).priority
+      const taskTypeA = taskTypeMap.get(a)
+      const taskTypeB = taskTypeMap.get(b)
+      if (taskTypeA.priority === taskTypeB.priority) {
+        return taskTypeA.name.localeCompare(taskTypeB.name, undefined, {
+          numeric: true
+        })
+      }
+      return taskTypeA.priority - taskTypeB.priority
     })
 }
 
@@ -485,7 +491,7 @@ const buildTotalLines = (
       name,
       taskStatusName,
       count || '0',
-      percentage + '%'
+      `${percentage}%`
     ]
   })
   return lineMap
@@ -507,7 +513,7 @@ const addEntryStatusStats = (
     const percentage = getPercentage(count, total)
     lineMap[taskStatusId] = lineMap[taskStatusId].concat([
       count || '0',
-      percentage + '%'
+      `${percentage}%`
     ])
   })
 }

--- a/src/lib/csv.js
+++ b/src/lib/csv.js
@@ -1,5 +1,6 @@
 import Papa from 'papaparse'
 
+import { getTaskTypePriorityOfProd } from '@/lib/productions'
 import { getPercentage } from '@/lib/stats'
 import stringHelpers from '@/lib/string'
 import {
@@ -143,22 +144,28 @@ const csv = {
     taskTypeMap,
     taskStatusMap,
     entryMap,
-    countMode
+    countMode,
+    production
   ) {
-    const headers = csv.getStatReportsHeaders(mainStats, taskTypeMap)
+    const headers = csv.getStatReportsHeaders(
+      mainStats,
+      taskTypeMap,
+      production
+    )
     const entries = csv.getStatReportsEntries(
       mainStats,
       taskTypeMap,
       taskStatusMap,
       entryMap,
-      countMode
+      countMode,
+      production
     )
     const lines = [headers, ...entries]
     return csv.buildCsvFile(name, lines)
   },
 
-  getStatReportsHeaders(mainStats, taskTypeMap) {
-    const taskTypeIds = getStatsTaskTypeIds(mainStats, taskTypeMap)
+  getStatReportsHeaders(mainStats, taskTypeMap, production) {
+    const taskTypeIds = getStatsTaskTypeIds(mainStats, taskTypeMap, production)
     const initialHeaders = ['Name', '', 'All', '']
     return taskTypeIds.reduce((acc, taskTypeId) => {
       if (taskTypeId !== 'all') {
@@ -175,10 +182,11 @@ const csv = {
     taskTypeMap,
     taskStatusMap,
     entryMap,
-    countMode = 'count'
+    countMode = 'count',
+    production
   ) {
     let entries = []
-    const taskTypeIds = getStatsTaskTypeIds(mainStats, taskTypeMap)
+    const taskTypeIds = getStatsTaskTypeIds(mainStats, taskTypeMap, production)
     const entryIds = getStatsEntryIds(mainStats, entryMap)
 
     entryIds.forEach(entryId => {
@@ -245,15 +253,21 @@ const csv = {
     taskTypeMap,
     taskStatusMap,
     entryMap,
-    countMode
+    countMode,
+    production
   ) {
-    const headers = csv.getStatReportsHeaders(mainStats, taskTypeMap)
+    const headers = csv.getStatReportsHeaders(
+      mainStats,
+      taskTypeMap,
+      production
+    )
     const entries = csv.getRetakeStatReportsEntries(
       mainStats,
       taskTypeMap,
       taskStatusMap,
       entryMap,
-      countMode
+      countMode,
+      production
     )
     const lines = [headers, ...entries]
     return csv.buildCsvFile(name, lines)
@@ -264,10 +278,11 @@ const csv = {
     taskTypeMap,
     taskStatusMap,
     entryMap,
-    countMode = 'count'
+    countMode = 'count',
+    production
   ) {
     let entries = []
-    const taskTypeIds = getStatsTaskTypeIds(mainStats, taskTypeMap)
+    const taskTypeIds = getStatsTaskTypeIds(mainStats, taskTypeMap, production)
     const entryIds = getStatsEntryIds(mainStats, entryMap)
 
     entryIds.forEach(entryId => {
@@ -412,7 +427,7 @@ const csv = {
   }
 }
 
-const getStatsTaskTypeIds = (mainStats, taskTypeMap) => {
+const getStatsTaskTypeIds = (mainStats, taskTypeMap, production) => {
   return Object.keys(mainStats.all)
     .filter(taskTypeId => taskTypeId !== 'evolution')
     .sort((a, b) => {
@@ -420,12 +435,14 @@ const getStatsTaskTypeIds = (mainStats, taskTypeMap) => {
       if (b === 'all') return -1
       const taskTypeA = taskTypeMap.get(a)
       const taskTypeB = taskTypeMap.get(b)
-      if (taskTypeA.priority === taskTypeB.priority) {
+      const taskTypeAPriority = getTaskTypePriorityOfProd(taskTypeA, production)
+      const taskTypeBPriority = getTaskTypePriorityOfProd(taskTypeB, production)
+      if (taskTypeAPriority === taskTypeBPriority) {
         return taskTypeA.name.localeCompare(taskTypeB.name, undefined, {
           numeric: true
         })
       }
-      return taskTypeA.priority - taskTypeB.priority
+      return taskTypeAPriority - taskTypeBPriority
     })
 }
 

--- a/src/store/modules/episodes.js
+++ b/src/store/modules/episodes.js
@@ -455,11 +455,12 @@ const actions = {
 
   loadEpisodeStats({ commit, rootGetters }, productionId) {
     const taskTypeMap = rootGetters.taskTypeMap
-    commit(SET_EPISODE_STATS, { episodeStats: {}, taskTypeMap })
+    const production = rootGetters.currentProduction
+    commit(SET_EPISODE_STATS, { episodeStats: {}, taskTypeMap, production })
     return shotsApi
       .getEpisodeStats(productionId)
       .then(episodeStats => {
-        commit(SET_EPISODE_STATS, { episodeStats, taskTypeMap })
+        commit(SET_EPISODE_STATS, { episodeStats, taskTypeMap, production })
         return Promise.resolve(episodeStats)
       })
       .catch(console.error)
@@ -842,7 +843,8 @@ const mutations = {
   ) {
     state.episodeValidationColumns = helpers.sortStatColumns(
       episodeRetakeStats,
-      taskTypeMap
+      taskTypeMap,
+      production
     )
     state.episodeRetakeStats = episodeRetakeStats
   },


### PR DESCRIPTION
**Problem**
In the Stats pages,
- The column order may be wrong on Kitsu or CSV export file.
- Export button will fail while loading data.
- The export of Retake stats may be wrong with empty cells.
- A long header name may overflow the column.

**Solution**
- Fix the column order in stats pages, based on production or studio settings.
- Disable the export button during stats loading.
- Fix the Retake stats export with data on matching columns in the CSV file.
- Improve style of table headers with long text (ellipsis + title).