### PR TITLE
Fix retake stats CSV export

### DIFF
--- a/src/lib/csv.js
+++ b/src/lib/csv.js
@@ -326,13 +326,13 @@ const csv = {
               total,
               lineMap
             )
+          } else {
+            Object.keys(mainStats[entryId].all).forEach(taskStatusId => {
+              if (!['max_retake_count', 'evolution'].includes(taskStatusId)) {
+                lineMap[taskStatusId] = lineMap[taskStatusId].concat(['', ''])
+              }
+            })
           }
-        } else {
-          Object.keys(mainStats[entryId].all).forEach(taskStatusId => {
-            if (!['max_retake_count', 'evolution'].includes(taskStatusId)) {
-              lineMap[taskStatusId] = lineMap[taskStatusId].concat(['', ''])
-            }
-          })
         }
       })
 


### PR DESCRIPTION
**Problem**
- In the Stats pages, the export of Retake stats may be wrong with empty cells.

**Solution**
- Fix the Retake stats export with data on matching columns in the CSV file.
