### PR TITLE
Various fixes

### DIFF
--- a/src/components/mixins/entities.js
+++ b/src/components/mixins/entities.js
@@ -265,12 +265,14 @@ export const entitiesMixin = {
       this.$store.commit('SET_EDIT_LIST_SCROLL_POSITION', scrollPosition)
     },
 
-    onSearchChange() {
+    onSearchChange(clearSelection = true) {
       if (!this.searchField) return
       this.isSearchActive = false
       const searchQuery = this.searchField.getValue() || ''
       this.applySearch(searchQuery)
-      this.clearSelection()
+      if (clearSelection) {
+        this.clearSelection()
+      }
     },
 
     onChangeSortClicked(sortInfo) {

--- a/src/components/modals/EditPlaylistModal.vue
+++ b/src/components/modals/EditPlaylistModal.vue
@@ -220,7 +220,7 @@ export default {
         this.forClient = this.playlistToEdit.for_client ? 'true' : 'false'
         this.resetForm()
         setTimeout(() => {
-          this.$refs.nameField.focus()
+          this.$refs.nameField?.focus()
         }, 100)
       }
     }

--- a/src/components/pages/AssetLibrary.vue
+++ b/src/components/pages/AssetLibrary.vue
@@ -1,5 +1,5 @@
 <template>
-  <page-layout>
+  <page-layout :side="isCurrentUserManager">
     <template #main>
       <div class="asset-library">
         <header class="flexrow">
@@ -55,11 +55,12 @@
                 <li
                   class="item flexcolumn"
                   :class="{
+                    'selectable-item': isCurrentUserManager,
                     'selected-item': isSelected(entity)
                   }"
                   :key="entity.id"
                   v-for="entity in group"
-                  @click="toggleEntity(entity)"
+                  @click="isCurrentUserManager && toggleEntity(entity)"
                 >
                   <div class="card" :title="entity.full_name">
                     <entity-preview
@@ -156,6 +157,7 @@ export default {
     ...mapGetters([
       'displayedSharedAssets',
       'displayedSharedAssetsByType',
+      'isCurrentUserManager',
       'openProductions',
       'productionMap',
       'selectedAssets'
@@ -188,10 +190,6 @@ export default {
         }
         return type.sort(firstBy(nameFilter).thenBy(productionFilter))
       })
-    },
-
-    hasSelectedAssets() {
-      return this.selectedAssets.size > 0
     }
   },
 
@@ -280,10 +278,13 @@ export default {
     border: 5px solid transparent;
     border-radius: 1em;
     transition: border-color 0.2s ease-in-out;
-    cursor: pointer;
 
-    &:hover {
-      border-color: var(--background-selectable);
+    &.selectable-item {
+      cursor: pointer;
+
+      &:hover {
+        border-color: var(--background-selectable);
+      }
     }
 
     &.selected-item {

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -411,7 +411,7 @@ export default {
         this.onSearchChange()
         this.$refs['asset-list'].setScrollPosition(this.assetListScrollPosition)
         this.$nextTick(() => {
-          this.$refs['asset-list'].selectTaskFromQuery()
+          this.$refs['asset-list']?.selectTaskFromQuery()
         })
       }
     }

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -629,7 +629,7 @@ export default {
         .then(form => {
           this.loading.edit = false
           this.modals.isNewDisplayed = false
-          this.onSearchChange()
+          this.onSearchChange(false)
         })
         .catch(err => {
           console.error(err)
@@ -837,7 +837,7 @@ export default {
       this.showImportModal()
     },
 
-    onSearchChange() {
+    onSearchChange(clearSelection = true) {
       const searchQuery = this.searchField.getValue() || ''
       if (
         searchQuery.length !== 1 &&
@@ -847,7 +847,9 @@ export default {
         this.setAssetSearch(searchQuery)
         this.setSearchInUrl()
       }
-      this.clearSelection()
+      if (clearSelection) {
+        this.clearSelection()
+      }
     },
 
     saveSearchQuery(searchQuery) {
@@ -988,26 +990,28 @@ export default {
     },
 
     async onFieldChanged({ entry, fieldName, value }) {
-      const data = { id: entry.id }
-      data[fieldName] = value
+      const data = {
+        id: entry.id,
+        [fieldName]: value
+      }
       await this.editAsset(data)
-      this.onSearchChange()
+      this.onSearchChange(false)
     },
 
     async onMetadataChanged({ entry, descriptor, value }) {
-      const metadata = {}
-      metadata[descriptor.field_name] = value
       const data = {
         id: entry.id,
-        data: metadata
+        data: {
+          [descriptor.field_name]: value
+        }
       }
       await this.editAsset(data)
-      this.onSearchChange()
+      this.onSearchChange(false)
     },
 
     async onAssetChanged(asset) {
       await this.editAsset(asset)
-      this.onSearchChange()
+      this.onSearchChange(false)
     },
 
     reset() {

--- a/src/components/pages/Edits.vue
+++ b/src/components/pages/Edits.vue
@@ -607,7 +607,7 @@ export default {
         .then(form => {
           this.loading.edit = false
           this.modals.isNewDisplayed = false
-          this.onSearchChange()
+          this.onSearchChange(false)
         })
         .catch(err => {
           console.error(err)
@@ -828,7 +828,7 @@ export default {
       this.modals.isDeleteAllTasksDisplayed = true
     },
 
-    onSearchChange() {
+    onSearchChange(clearSelection = true) {
       if (!this.searchField) return
       this.isSearchActive = false
       const searchQuery = this.searchField.getValue() || ''
@@ -838,7 +838,9 @@ export default {
       if (searchQuery.length === 0 && this.isLongEditList) {
         this.applySearch('')
       }
-      this.clearSelection()
+      if (clearSelection) {
+        this.clearSelection()
+      }
     },
 
     saveScrollPosition(scrollPosition) {
@@ -941,22 +943,22 @@ export default {
     async onFieldChanged({ entry, fieldName, value }) {
       const data = {
         id: entry.id,
-        description: entry.description
+        description: entry.description,
+        [fieldName]: value
       }
-      data[fieldName] = value
       await this.editEdit(data)
-      this.onSearchChange()
+      this.onSearchChange(false)
     },
 
     async onMetadataChanged({ entry, descriptor, value }) {
-      const metadata = {}
-      metadata[descriptor.field_name] = value
       const data = {
         id: entry.id,
-        data: metadata
+        data: {
+          [descriptor.field_name]: value
+        }
       }
       await this.editEdit(data)
-      this.onSearchChange()
+      this.onSearchChange(false)
     }
   },
 

--- a/src/components/pages/Episodes.vue
+++ b/src/components/pages/Episodes.vue
@@ -334,7 +334,7 @@ export default {
           this.episodeListScrollPosition
         )
         this.$nextTick(() => {
-          this.$refs['episode-list'].selectTaskFromQuery()
+          this.$refs['episode-list']?.selectTaskFromQuery()
         })
       }
     }

--- a/src/components/pages/Episodes.vue
+++ b/src/components/pages/Episodes.vue
@@ -559,22 +559,22 @@ export default {
     async onFieldChanged({ entry, fieldName, value }) {
       const data = {
         id: entry.id,
-        description: entry.description
+        description: entry.description,
+        [fieldName]: value
       }
-      data[fieldName] = value
       await this.editEpisode(data)
-      this.onSearchChange()
+      this.onSearchChange(false)
     },
 
     async onMetadataChanged({ entry, descriptor, value }) {
-      const metadata = {}
-      metadata[descriptor.field_name] = value
       const data = {
         id: entry.id,
-        data: metadata
+        data: {
+          [descriptor.field_name]: value
+        }
       }
       await this.editEpisode(data)
-      this.onSearchChange()
+      this.onSearchChange(false)
     },
 
     onEditClicked(episode) {
@@ -596,7 +596,7 @@ export default {
           .then(() => {
             this.loading.edit = false
             this.modals.isNewDisplayed = false
-            this.onSearchChange()
+            this.onSearchChange(false)
           })
           .catch(err => {
             console.error(err)

--- a/src/components/pages/MyChecks.vue
+++ b/src/components/pages/MyChecks.vue
@@ -277,7 +277,7 @@ export default {
       const isName = this.currentSort === 'entity_name'
       const isPriority = this.currentSort === 'priority'
       const isDueDate = this.currentSort === 'due_date'
-      const tasks = this.filteredTasks
+      const tasks = [...this.filteredTasks]
       if (isName) {
         return tasks.sort(
           firstBy('project_name')

--- a/src/components/pages/Sequences.vue
+++ b/src/components/pages/Sequences.vue
@@ -559,22 +559,22 @@ export default {
     async onFieldChanged({ entry, fieldName, value }) {
       const data = {
         id: entry.id,
-        description: entry.description
+        description: entry.description,
+        [fieldName]: value
       }
-      data[fieldName] = value
       await this.editSequence(data)
-      this.onSearchChange()
+      this.onSearchChange(false)
     },
 
     async onMetadataChanged({ entry, descriptor, value }) {
-      const metadata = {}
-      metadata[descriptor.field_name] = value
       const data = {
         id: entry.id,
-        data: metadata
+        data: {
+          [descriptor.field_name]: value
+        }
       }
       await this.editSequence(data)
-      this.onSearchChange()
+      this.onSearchChange(false)
     },
 
     onEditClicked(sequence) {
@@ -595,7 +595,7 @@ export default {
           .then(() => {
             this.loading.edit = false
             this.modals.isNewDisplayed = false
-            this.onSearchChange()
+            this.onSearchChange(false)
           })
           .catch(err => {
             console.error(err)

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -705,7 +705,7 @@ export default {
         .then(() => {
           this.loading.edit = false
           this.modals.isNewDisplayed = false
-          this.onSearchChange()
+          this.onSearchChange(false)
         })
         .catch(err => {
           console.error(err)
@@ -935,7 +935,7 @@ export default {
       this.onSearchChange()
     },
 
-    onSearchChange() {
+    onSearchChange(clearSelection = true) {
       if (!this.searchField) return
       this.isSearchActive = false
       const searchQuery = this.searchField.getValue() || ''
@@ -945,7 +945,9 @@ export default {
       if (searchQuery.length === 0 && this.isLongShotList) {
         this.applySearch('')
       }
-      this.clearSelection()
+      if (clearSelection) {
+        this.clearSelection()
+      }
     },
 
     saveScrollPosition(scrollPosition) {
@@ -1080,15 +1082,15 @@ export default {
       }
       data[fieldName] = value
       await this.editShot(data)
-      this.onSearchChange()
+      this.onSearchChange(false)
     },
 
     async onMetadataChanged({ entry, descriptor, value }) {
-      const metadata = {}
-      metadata[descriptor.field_name] = value
       const data = {
         id: entry.id,
-        data: metadata
+        data: {
+          [descriptor.field_name]: value
+        }
       }
       const shot = this.shotMap.get(entry.id)
       if (
@@ -1106,7 +1108,7 @@ export default {
         data.nb_frames = parseInt(value) - parseInt(shot.data.frame_in) + 1
       }
       await this.editShot(data)
-      this.onSearchChange()
+      this.onSearchChange(false)
     },
 
     showEDLImportModal() {

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -458,7 +458,7 @@ export default {
             // Needed to be sure the shots are loaded
             this.onSearchChange()
             this.$nextTick(() => {
-              this.$refs['shot-list'].selectTaskFromQuery()
+              this.$refs['shot-list']?.selectTaskFromQuery()
             })
           })
         })
@@ -487,7 +487,7 @@ export default {
       this.onSearchChange()
       this.$refs['shot-list'].setScrollPosition(this.shotListScrollPosition)
       this.$nextTick(() => {
-        this.$refs['shot-list'].selectTaskFromQuery()
+        this.$refs['shot-list']?.selectTaskFromQuery()
       })
     }
   },

--- a/src/components/tops/GlobalSearchField.vue
+++ b/src/components/tops/GlobalSearchField.vue
@@ -20,21 +20,15 @@
     <div
       class="search-results"
       :style="{
-        'min-height': nbResults * 60 + 'px'
+        'min-height': `${(nbResults || 1) * 60}px`
       }"
       v-if="isSearchActive"
     >
       <div class="result-line" v-if="searchQuery.length < 3">
         {{ $t('main.search.type') }}
       </div>
-      <div
-        class="search-loader"
-        :style="{
-          'min-height': nbResults * 60 + 'px'
-        }"
-        v-else-if="isLoading"
-      >
-        <div><spinner /></div>
+      <div class="search-loader" v-else-if="isLoading">
+        <spinner />
       </div>
       <div v-else-if="nbResults > 0">
         <div
@@ -47,7 +41,7 @@
           v-for="(asset, index) in assets"
         >
           <router-link
-            :id="'result-link-' + index"
+            :id="`result-link-${index}`"
             :to="entityPath(asset, 'asset')"
           >
             <div class="flexrow" @mouseover="selectedIndex = index">
@@ -83,7 +77,7 @@
           v-for="(shot, index) in shots"
         >
           <router-link
-            :id="'result-link-' + (index + assets.length)"
+            :id="`result-link-${index + assets.length}`"
             :to="entityPath(shot, 'shot')"
           >
             <div
@@ -126,7 +120,7 @@
           v-for="(person, index) in persons"
         >
           <router-link
-            :id="'result-link-' + (index + assets.length + shots.length)"
+            :id="`result-link-${index + assets.length + shots.length}`"
             :to="personPath(person)"
           >
             <div
@@ -143,7 +137,6 @@
           </router-link>
         </div>
       </div>
-
       <div class="result-line" v-else>
         {{ $t('main.search.no_result') }}
       </div>
@@ -368,12 +361,7 @@ export default {
 }
 
 .search-loader {
-  background: var(--background);
-  left: 0;
   opacity: 0.5;
   padding-top: 0.8em;
-  position: absolute;
-  top: 0;
-  width: 350px;
 }
 </style>

--- a/src/components/widgets/EntityPreview.vue
+++ b/src/components/widgets/EntityPreview.vue
@@ -19,10 +19,9 @@
       @click="onVideoClicked()"
     />
   </div>
-  <a
+  <div
     class="preview-wrapper preview-picture"
     :class="{ cover }"
-    target="_blank"
     :style="{
       width: emptyWidth ? `${emptyWidth}px` : undefined,
       'min-width': emptyWidth ? `${emptyWidth}px` : undefined,
@@ -46,11 +45,11 @@
         :width="width || ''"
         alt=""
       />
-      <span class="view-icon" @click.stop="onPictureClicked()">
+      <a class="view-icon" @click.stop="onPictureClicked()">
         <eye-icon :size="18" />
-      </span>
+      </a>
     </template>
-  </a>
+  </div>
 </template>
 
 <script>
@@ -120,7 +119,7 @@ export default {
 
     thumbnailPath() {
       const previewFileId = this.previewFileId || this.entity.preview_file_id
-      return '/api/pictures/previews/preview-files/' + previewFileId + '.png'
+      return `/api/pictures/previews/preview-files/${previewFileId}.png`
     },
 
     thumbnailKey() {
@@ -172,52 +171,41 @@ export default {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
 }
 
-a {
+.preview-picture {
+  position: relative;
   background: $black;
   display: flex;
   align-items: center;
   justify-content: center;
   overflow: auto;
-}
 
-img {
-  display: block;
-  border: 0;
-  border-radius: 0;
-}
-
-span.thumbnail-empty {
-  background: $white-grey;
-  display: block;
-  margin: 0;
-}
-
-span.view-icon {
-  background: rgba(0, 0, 0, 0.5);
-  border-radius: 5px;
-  color: $light-grey-light;
-  display: none;
-  padding: 0.4rem;
-  height: 30px;
-  position: absolute;
-  right: 10px;
-  top: 10px;
-  width: 30px;
-  transition: all 0.2s ease-in-out;
-
-  &:hover {
-    background: rgba(0, 0, 0, 0.75);
-    color: $white;
+  .thumbnail-picture {
+    display: block;
+    border: 0;
+    border-radius: 0;
   }
-}
 
-.preview-wrapper {
-  position: relative;
+  .view-icon {
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: 5px;
+    color: $light-grey-light;
+    display: none;
+    padding: 0.4rem;
+    height: 30px;
+    position: absolute;
+    right: 10px;
+    top: 10px;
+    width: 30px;
+    transition: all 0.2s ease-in-out;
 
-  &:hover {
-    span.view-icon {
-      display: block;
+    &:hover {
+      background: rgba(0, 0, 0, 0.75);
+      color: $white;
     }
+  }
+
+  &:hover .view-icon {
+    display: block;
   }
 }
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -634,7 +634,7 @@ export default {
     unstick: 'Unstick',
     user: 'User',
     week: 'Week',
-    white_theme: 'White Theme',
+    white_theme: 'Light Theme',
     workspace: 'Workspace',
     yes: 'Yes',
     search: {

--- a/src/store/modules/breakdown.js
+++ b/src/store/modules/breakdown.js
@@ -386,7 +386,7 @@ const mutations = {
       return {
         label: 'All',
         value: production.id,
-        route: route
+        route
       }
     })
   },
@@ -408,7 +408,7 @@ const mutations = {
       return {
         label: sequence.name,
         value: sequence.id,
-        route: route
+        route
       }
     })
     if (state.castingEpisodeSequences.length > 0) {
@@ -442,7 +442,7 @@ const mutations = {
       return {
         label: assetType.name,
         value: assetType.id,
-        route: route
+        route
       }
     })
   },
@@ -493,7 +493,8 @@ const mutations = {
         asset_type_name: asset.asset_type_name,
         nb_occurences: nbOccurences,
         preview_file_id: asset.preview_file_id,
-        label
+        label,
+        shared: asset.shared
       }
       state.casting[entityId].push(newAsset)
     }


### PR DESCRIPTION
**Problem**
- On the entity lists, editing an entity will close the selected task on the side panel.
- On the My Checks page, the 'sorted by' option has no immediate effect on the list (see #1540).
- User and Supervisor.
- Shared assets added to the Breakdown are not marked as shared without reloading the page

**Solution**
- Keep the task panel open on entity update.
- On the My Checks page, fix sorting reactivity
- Allow only admin and manager users to manage the asset library.
- Fix the style of shared assets when adding them to the breakdown.