### PR TITLE
Various fixes

### DIFF
--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -669,6 +669,7 @@ export default {
           const startDate = moment(task.start_date)
           const dueDate = task.due_date ? moment(task.due_date) : null
           data = getDatesFromStartDate(
+            this.organisation,
             startDate,
             dueDate,
             minutesToDays(this.organisation, estimation)

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -989,12 +989,13 @@ export default {
       const entityIds = Object.keys(this.selection).filter(
         key => this.selection[key]
       )
-
       for (const entityId of entityIds) {
-        const nbOccurences = this.casting[entityId].find(
+        const asset = this.casting[entityId].find(
           asset => asset.asset_id === assetId
-        ).nb_occurences
-        await this.removeOneAsset(assetId, entityId, nbOccurences)
+        )
+        if (asset) {
+          await this.removeOneAsset(assetId, entityId, asset.nb_occurences)
+        }
       }
     },
 

--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -239,11 +239,14 @@
                     />
                     <div class="break-word">
                       {{ asset.asset_name }}
-                      <span v-if="asset.nb_occurences > 1">
+                      <template v-if="asset.nb_occurences > 1">
                         ({{ asset.nb_occurences }})
-                      </span>
+                      </template>
                     </div>
-                    <div class="ready-for flexrow">
+                    <div
+                      class="ready-for flexrow"
+                      v-if="!asset.shared && asset.ready_for"
+                    >
                       <task-type-name
                         class="flexrow-item"
                         :task-type="taskTypeMap.get(asset.ready_for)"
@@ -251,7 +254,6 @@
                         :title="
                           'Ready for: ' + taskTypeMap.get(asset.ready_for).name
                         "
-                        v-if="asset.ready_for"
                       />
                     </div>
                   </router-link>

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1119,6 +1119,7 @@ export default {
       const startDate = parseDate(task.start_date)
       const dueDate = task.due_date ? parseDate(task.due_date) : null
       data = getDatesFromStartDate(
+        this.organisation,
         startDate,
         dueDate,
         minutesToDays(this.organisation, estimation),

--- a/src/components/pages/breakdown/AssetBlock.vue
+++ b/src/components/pages/breakdown/AssetBlock.vue
@@ -10,8 +10,10 @@
     v-if="!textMode"
   >
     <div class="asset-wrapper">
-      <div class="asset-add-1" @click="addOneAsset" v-if="!readOnly">+ 1</div>
-      <div class="asset-add" @click="removeOneAsset" v-if="!readOnly">- 1</div>
+      <template v-if="!readOnly && active">
+        <div class="asset-add-1" @click.stop="addOneAsset">+ 1</div>
+        <div class="asset-add" @click.stop="removeOneAsset">- 1</div>
+      </template>
       <div class="asset-picture" v-if="asset.preview_file_id">
         <img
           loading="lazy"
@@ -39,14 +41,13 @@
     }"
     v-else
   >
-    <span class="asset-text-name flexrow-item">
+    <span class="asset-text-name flexrow-item filler">
       {{ asset.name }} ({{ nbOccurences }})
     </span>
-    <span class="filler"></span>
     <span
       class="modify-asset flexrow-item"
-      @click="removeOneAsset"
-      v-if="!readOnly"
+      @click.stop="removeOneAsset"
+      v-if="!readOnly && active"
     >
       - 1
     </span>
@@ -94,13 +95,11 @@ export default {
 
   methods: {
     removeOneAsset(event) {
-      this.pauseEvent(event)
-      this.$emit('remove-one', this.asset.asset_id, this.nbOccurences)
+      this.$emit('remove-one', this.asset.asset_id)
     },
 
     addOneAsset(event) {
-      this.pauseEvent(event)
-      this.$emit('add-one', this.asset.asset_id, this.nbOccurences)
+      this.$emit('add-one', this.asset.asset_id)
     },
 
     shortenName(name) {
@@ -200,7 +199,7 @@ export default {
   font-weight: bold;
   font-size: 0.9em;
   opacity: 0;
-  z-index: 2;
+  z-index: 3;
 }
 
 .asset-add-1 {

--- a/src/components/pages/breakdown/ShotLine.vue
+++ b/src/components/pages/breakdown/ShotLine.vue
@@ -1,10 +1,9 @@
 <template>
   <div
     :id="entity.id"
+    class="shot unselectable"
     :class="{
-      shot: true,
-      selected: selected,
-      unselectable: true,
+      selected,
       stdby: entity ? entity.is_casting_standby : false,
       'text-mode': textMode
     }"
@@ -391,12 +390,12 @@ export default {
       this.$emit('edit-label', asset, label, this.entity.id)
     },
 
-    removeOneAsset(assetId, nbOccurences) {
-      this.$emit('remove-one', assetId, this.entity.id, nbOccurences)
+    removeOneAsset(assetId) {
+      this.$emit('remove-one', assetId)
     },
 
-    addOneAsset(assetId, nbOccurences) {
-      this.$emit('add-one', assetId, this.entity.id, nbOccurences)
+    addOneAsset(assetId) {
+      this.$emit('add-one', assetId)
     },
 
     onDescriptionChanged(entity, event) {

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -1,11 +1,5 @@
 <template>
   <div class="topbar">
-    <div
-      class="c-mask-user-menu"
-      @click="toggleUserMenu()"
-      v-if="!isUserMenuHidden"
-    ></div>
-
     <nav class="nav">
       <div class="nav-left">
         <a
@@ -137,12 +131,13 @@
       </div>
     </nav>
 
-    <nav
-      class="user-menu"
-      :style="{
-        top: isUserMenuHidden ? '-500px' : '60px'
-      }"
-    >
+    <div
+      class="c-mask-user-menu"
+      @click="toggleUserMenu()"
+      v-if="!isUserMenuHidden"
+    ></div>
+
+    <nav class="user-menu" v-if="!isUserMenuHidden">
       <ul>
         <li>
           <router-link
@@ -907,6 +902,7 @@ export default {
 }
 
 .user-menu {
+  animation: slide-down 0.5s ease;
   background-color: $white;
   box-shadow: 2px 3px 3px rgba(0, 0, 0, 0.2);
   border-left: 1px solid $white-grey;
@@ -915,10 +911,19 @@ export default {
   min-width: 220px;
   padding: 10px;
   position: fixed;
-  transition: top 0.5s ease;
   right: 0;
+  top: 60px;
   width: 220px;
   z-index: 203;
+}
+
+@keyframes slide-down {
+  from {
+    transform: translateY(-100%);
+  }
+  to {
+    transform: translateY(0);
+  }
 }
 
 .user-menu ul {


### PR DESCRIPTION
**Problem**
- On the Breakdown page, toggle the casting on Picture mode, select a line with an asset, and click on the "+1" button. The action will fail, and a UUID value will be displayed.
- On the Breakdown page, select two lines in the casting: a line with an item and a line without items, then click on the "-1" button. A silent error will be raised in the developer console.
- On the Task Type page, updating an estimate file will incorrectly update the start/end dates.
- An UX glitch on the user menu in the Japanese language (see #1571).
- On the Shot page, In the Casting section, display the Ready For status of a shared asset is not wanted.

**Solution**
- On the Breakdown page, fix the add/remove one asset action. A wrong parameter could be passed to the method
- On the Breakdown page, fix the remove one asset action with a multiple line selection. Check empty values before run actions.
- On the Task Type page, fix the update of task estimation. Add a missing parameter.
- Fix an overflow glitch when the user menu is closed. Remove the component if closed and use keyframes for the opening animation.
- On the Shot page, hide the Ready For status for shared assets in the Casting section.