### PR TITLE
[github-actions][releases] adapt our github-actions+scripts with the …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,7 @@
 ---
 name: 'Kitsu CI'
 
-on:
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   ci:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: 'Kitsu release'
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - '*'
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,7 +3,7 @@ name: Deploy Kitsu to staging environment
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Update Kitsu on staging server
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1.1.0
         env:
           HUSKY: 0
           NODE_OPTIONS: '--max_old_space_size=8192'

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For further information about features and installation, please refer to the
 ## Contributing
 
 There are many ways to contribute to Kitsu, from simple tasks to most complex ones. We created a
-[contributing guide](https://github.com/cgwire/kitsu/blob/master/CONTRIBUTING.md) explaining everything.
+[contributing guide](https://github.com/cgwire/kitsu/blob/main/CONTRIBUTING.md) explaining everything.
 You will find all the information you are looking for!
 
 ## Sponsors

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,17 +3,17 @@
 We release Kitsu versions through GitHub.
 Every time a new version is ready, we follow this process:
 
-1. Rebase sources on the `master` branch.
+1. Rebase sources on the `main` branch.
 2. Up the version number through the `npm` CLI.
 3. Tag the commit with the Kitsu version.
-4. Push changes to the `master` branch.
+4. Push changes to the `main` branch.
 
 You can run the following script to perform these commands at once:
 
 ```bash
-git pull --rebase origin master
+git pull --rebase origin main
 npm version patch
-git push origin master --tag
+git push origin main --tag
 ```
 
 # Deployment

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
 set -e
-git pull --rebase origin master
+git pull --rebase origin main
 npm version patch
-git push origin master --tag
+git push origin main --tag


### PR DESCRIPTION
…fact that main branch will replace master branch

**Problem**
- We want to use the main branch instead of master branch. 

**Solution**
- Rename all the reference to the master branch in github actions and release script.
- We also need to set protections rules for the main branch (as master branch) + change default branch for PR
