### PR TITLE
Various fixes

### DIFF
--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -130,7 +130,7 @@
                 :value="task.difficulty"
                 @input="updateDifficulty($event)"
                 v-if="isInDepartment(task) && selectionGrid[task.id]"
-                v-models="task.difficulty"
+                v-model="task.difficulty"
               />
               <span
                 class="difficulty number-cell"

--- a/src/components/modals/EditBackgroundModal.vue
+++ b/src/components/modals/EditBackgroundModal.vue
@@ -36,7 +36,7 @@
             v-model.trim="form.name"
           />
           <boolean-field
-            class="mb2"
+            is-field
             :label="$t('backgrounds.fields.is_default')"
             @enter="confirmClicked"
             v-model="form.is_default"

--- a/src/components/modals/EditTaskTypeModal.vue
+++ b/src/components/modals/EditTaskTypeModal.vue
@@ -31,6 +31,7 @@
             @enter="confirmClicked"
           />
           <boolean-field
+            is-field
             :label="$t('task_types.fields.allow_timelog')"
             @enter="confirmClicked"
             v-model="form.allow_timelog"

--- a/src/components/pages/Notifications.vue
+++ b/src/components/pages/Notifications.vue
@@ -136,7 +136,6 @@
                 <boolean-field
                   class="selector"
                   :label="$t('notifications.read')"
-                  :is-field="false"
                   is-small
                   @input="value => toggleNotificationRead(notification, value)"
                   :value="notification.read ? 'true' : 'false'"

--- a/src/components/pages/Notifications.vue
+++ b/src/components/pages/Notifications.vue
@@ -476,7 +476,7 @@ export default {
       }
     },
 
-    loadFollowingNotifications() {
+    async loadFollowingNotifications() {
       if (!this.loading.more && !this.loading.notifications) {
         this.loading.more = true
         const params = {
@@ -490,9 +490,8 @@ export default {
         if (this.parameters.watchingMode) {
           params.watching = this.parameters.watchingMode === 'watching'
         }
-        this.loadMoreNotifications().then(() => {
-          this.loading.more = false
-        })
+        await this.loadMoreNotifications(params)
+        this.loading.more = false
       }
     },
 

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -481,12 +481,14 @@ export default {
     },
 
     previewOptions() {
-      return this.taskPreviews.map(preview => {
-        return {
-          label: `v${preview.revision}`,
-          value: preview.id
-        }
-      })
+      return [...this.taskPreviews]
+        .sort((a, b) => b.revision - a.revision)
+        .map(preview => {
+          return {
+            label: `v${preview.revision}`,
+            value: preview.id
+          }
+        })
     },
 
     isPreviewButtonVisible() {

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -914,12 +914,12 @@ export default {
 
     lastPreviewFileOptions() {
       if (!this.lastPreviewFiles) return []
-      return this.lastPreviewFiles.map(previewFile => {
-        return {
-          label: `v${previewFile.revision}`,
-          value: previewFile.id
-        }
-      })
+      return [...this.lastPreviewFiles]
+        .sort((a, b) => b.revision - a.revision)
+        .map(preview => ({
+          value: preview.id,
+          label: `v${preview.revision}`
+        }))
     },
 
     previewFileOptions() {

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -715,10 +715,12 @@ export default {
 
     previewOptions() {
       if (!this.taskPreviews) return []
-      return this.taskPreviews.map(preview => ({
-        value: preview.id,
-        label: `v${preview.revision}`
-      }))
+      return [...this.taskPreviews]
+        .sort((a, b) => b.revision - a.revision)
+        .map(preview => ({
+          value: preview.id,
+          label: `v${preview.revision}`
+        }))
     },
 
     selectedTasksToDisplay() {

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -17,6 +17,8 @@
         "
         :is-movie-preview="isMoviePreview"
         :is-set-frame-thumbnail-loading="loading.setFrameThumbnail"
+        :production-id="currentProductionId"
+        :team="currentTeam"
         @export-task="onExportClick"
         @set-frame-thumbnail="onSetCurrentFrameAsThumbnail"
       />
@@ -466,6 +468,7 @@ export default {
     ...mapGetters([
       'isSavingCommentPreview',
       'currentEpisode',
+      'currentProduction',
       'getTaskComment',
       'getTaskComments',
       'getTaskPreviews',
@@ -507,6 +510,10 @@ export default {
 
     selectedEntities() {
       return this[`selected${this.entityType}s`]
+    },
+
+    currentProductionId() {
+      return this.task?.project_id || this.currentProduction?.id
     },
 
     currentTeam() {

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -967,6 +967,7 @@ export default {
     currentEntityType() {
       if (this.isCurrentViewAsset) return 'asset'
       if (this.isCurrentViewShot) return 'shot'
+      if (this.isCurrentViewSequence) return 'sequence'
       if (this.isCurrentViewEdit) return 'edit'
       return 'episode'
     },

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -355,28 +355,26 @@
           class="flexcolumn flexrow-item is-wide"
           v-if="selectedBar === 'assignation'"
         >
-          <div class="assignation flexrow-item">
-            <span v-show="isCurrentUserArtist">
-              {{ $tc('tasks.to_myself') }}
-            </span>
+          <div class="mb05" v-if="isCurrentUserArtist">
+            {{ $tc('tasks.to_myself') }}
           </div>
-          <div class="flexrow mb05">
+          <div
+            class="mb05"
+            v-else-if="isCurrentUserManager || isCurrentUserSupervisor"
+          >
             <people-field
-              class="flexrow-item is-wide assignation-field"
+              class="is-wide assignation-field"
               ref="assignation-field"
               :people="currentTeam"
               :placeholder="$t('tasks.assign_explaination')"
               big
               wide
               v-model="person"
-              v-show="isCurrentUserManager || isCurrentUserSupervisor"
             />
           </div>
-          <div v-if="loading.assignation">
-            <div class="flexrow-item">
-              <spinner :size="20" class="spinner" />
-            </div>
-            <div class="flexrow-item">&nbsp;</div>
+
+          <div class="flexrow-item mt1 mb1" v-if="loading.assignation">
+            <spinner :size="20" class="spinner" />
           </div>
           <div class="flexrow-item is-wide" v-if="!loading.assignation">
             <button
@@ -387,7 +385,7 @@
             </button>
           </div>
           <div
-            class="flexrow-item is-wide has-text-centered flexrow"
+            class="flexrow-item is-wide flexrow"
             v-if="
               !loading.assignation &&
               (isCurrentUserManager || isSupervisorInDepartment)
@@ -400,9 +398,7 @@
               >
                 {{ $t('tasks.clear_assignations') }}
               </button>
-              <span>
-                {{ $t('main.or') }}
-              </span>
+              {{ $t('main.or') }}
               <button
                 class="button is-link clear-assignation-button"
                 @click="clearAllAssignations"


### PR DESCRIPTION
**Problem**
- Preview is not the last if older preview is pinned (see #1587).
- In the task panel, the assignable list may suggest the wrong people as available.
- On the Task Type page, the difficulty field is not saved after updating.

**Solution**
- Fix preview order based on revision number. Avoid store mutations on sorting
- Fix the list of assignable persons in the task panel:
  - Always load the current team from the production linked to the task.
  - Allow to select people without department if supervisor.
 - Fix code typo on the difficulty field (invalid v-model).

In addition, fix some UX improvements.