### PR TITLE
Fix the selected version of previews

### DIFF
--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -444,6 +444,7 @@
               is-reversed
               is-preview
               thin
+              :value="currentPreview?.id"
               @input="changeCurrentPreviewFile"
             />
           </div>

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -91,6 +91,7 @@
                     :options="previewOptions"
                     is-preview
                     thin
+                    :value="previewOptions[currentPreviewIndex]?.value"
                     @input="onPreviewChanged"
                   />
                 </div>

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -882,7 +882,7 @@ const mutations = {
     comments.forEach(comment => {
       comment.person = personStore.state.personMap.get(comment.person_id)
     })
-    state.taskComments[taskId] = sortComments(comments)
+    state.taskComments[taskId] = sortComments([...comments])
     Vue.set(
       state.taskPreviews,
       taskId,


### PR DESCRIPTION
**Problem**
- The version dropdown does not update between fullscreen and non-fullscreen previews.  
Eg . select a version and then go to fullscreen. The correct video is at full screen, but the version dropdown shows the latest version.

**Solution**
- Synchronize the selected version in the task panel and the preview player in fullscreen mode.
