### PR TITLE
[csv] fix csv exports with boolean values (force boolean values)

### DIFF
--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -726,11 +726,17 @@ const actions = {
         asset.description,
         asset.ready_for !== 'None' ? taskTypeMap.get(asset.ready_for).name : ''
       ])
+      asset.data = asset.data || {}
       sortByName([...production.descriptors])
         .filter(d => d.entity_type === 'Asset')
         .forEach(descriptor => {
-          asset.data = asset.data || {}
-          assetLine.push(asset.data[descriptor.field_name])
+          if (descriptor.data_type === 'boolean') {
+            assetLine.push(
+              asset.data[descriptor.field_name]?.toLowerCase() === 'true'
+            )
+          } else {
+            assetLine.push(asset.data[descriptor.field_name])
+          }
         })
       if (state.isAssetTime) {
         assetLine.push(minutesToDays(organisation, asset.timeSpent).toFixed(2))

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -539,7 +539,13 @@ const actions = {
       sortByName([...production.descriptors])
         .filter(d => d.entity_type === 'Edit')
         .forEach(descriptor => {
-          editLine.push(edit.data[descriptor.field_name])
+          if (descriptor.data_type === 'boolean') {
+            editLine.push(
+              edit.data[descriptor.field_name]?.toLowerCase() === 'true'
+            )
+          } else {
+            editLine.push(edit.data[descriptor.field_name])
+          }
         })
       if (state.isEditTime) {
         editLine.push(minutesToDays(organisation, edit.timeSpent).toFixed(2))

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -654,7 +654,13 @@ const actions = {
       sortByName([...production.descriptors])
         .filter(d => d.entity_type === 'Shot')
         .forEach(descriptor => {
-          shotLine.push(shot.data[descriptor.field_name])
+          if (descriptor.data_type === 'boolean') {
+            shotLine.push(
+              shot.data[descriptor.field_name]?.toLowerCase() === 'true'
+            )
+          } else {
+            shotLine.push(shot.data[descriptor.field_name])
+          }
         })
       if (state.isShotTime) {
         shotLine.push(minutesToDays(organisation, shot.timeSpent).toFixed(2))


### PR DESCRIPTION
**Problem**
- When exporting CSV (for assets, shots, and edits) meta descriptors values with checkboxes aren't always true or false.

**Solution**
- Cast those values.