### PR TITLE
various improvements

### DIFF
--- a/src/components/modals/AddPreviewModal.vue
+++ b/src/components/modals/AddPreviewModal.vue
@@ -289,17 +289,19 @@ export default {
       handler() {
         this.$nextTick(() => {
           this.isWrongDuration = false
-          Object.keys(this.$refs).forEach(key => {
-            const ref = this.$refs[key]
-            if (key.startsWith('video-') && ref[0]) {
-              ref[0].onloadedmetadata = () => {
-                const frames = Math.round(ref[0].duration * this.fps) - 1
-                if (frames !== this.expectedFrames) {
-                  this.isWrongDuration = true
+          if (this.expectedFrames !== 0) {
+            Object.keys(this.$refs).forEach(key => {
+              const ref = this.$refs[key]
+              if (key.startsWith('video-') && ref[0]) {
+                ref[0].onloadedmetadata = () => {
+                  const frames = Math.round(ref[0].duration * this.fps)
+                  if (frames !== this.expectedFrames) {
+                    this.isWrongDuration = true
+                  }
                 }
               }
-            }
-          })
+            })
+          }
         })
       }
     }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1419,7 +1419,7 @@ export default {
     sequences: 'Sequences',
     tasks: 'Shot Tasks',
     title: 'Shots',
-    wrong_file_duration: 'One of the upldoaded video file duration doesn\'t match the expected duration of the current shot.',
+    wrong_file_duration: 'One of the uploaded video file duration doesn\'t match the expected duration of the current shot.',
     fields: {
       description: 'Description',
       nb_frames: 'Frames',

--- a/src/locales/en_nft.js
+++ b/src/locales/en_nft.js
@@ -103,7 +103,7 @@ export default {
     restore_error: 'An error occurred while restoring this NFT.',
     tasks: 'NFT Tasks',
     title: 'NFT Collection',
-    wrong_file_duration: 'One of the upldoaded video file duration doesn\'t match the expected duration of the current NFT.',
+    wrong_file_duration: 'One of the uploaded video file duration doesn\'t match the expected duration of the current NFT.',
     fields: {
       placeholder: "NFT01"
     }

--- a/src/locales/en_video-game.js
+++ b/src/locales/en_video-game.js
@@ -166,7 +166,7 @@ export default {
     sequences: 'Levels',
     tasks: 'Map Tasks',
     title: 'Maps',
-    wrong_file_duration: 'One of the upldoaded video file duration doesn\'t match the expected duration of the current map.',
+    wrong_file_duration: 'One of the uploaded video file duration doesn\'t match the expected duration of the current map.',
     fields: {
       episode: 'Chapter',
       placeholder: 'MP01',

--- a/src/store/api/client.js
+++ b/src/store/api/client.js
@@ -130,7 +130,7 @@ const client = {
   },
 
   getEvents(after, before) {
-    const path = `/api/data/events/last?after=${after}&before=${before}&page_size=100000`
+    const path = `/api/data/events/last?after=${after}&before=${before}&limit=100000`
     return client.pget(path)
   },
 


### PR DESCRIPTION
**Problem**
- Due to this PR (https://github.com/cgwire/zou/pull/895), page_size is changed with limit.
- When uploading a movie preview a warning message always tells that there's a wrong number of frames in that movie preview. 

**Solution**
- The page_size query parameter for getEvents has been changed with a limit.
- Fix frame calculation from the original movie (no need to add one frame in the calculation) + don't show this warning if there's no information about frame duration in that entity + fix locales
