### PR TITLE
Various fixes

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -797,6 +797,7 @@ export default {
     ...mapActions(['displayMoreAssets', 'editAsset', 'setAssetSelection']),
 
     assetEpisodes(asset, full) {
+      if (!this.episodeMap) return ''
       const mainEpisode = this.episodeMap.get(asset.episode_id)
       const mainEpisodeName = mainEpisode ? mainEpisode.name : 'MP'
       const episodeNames = (asset.casting_episode_ids || [])

--- a/src/components/mixins/entity_list.js
+++ b/src/components/mixins/entity_list.js
@@ -428,6 +428,7 @@ export const entityListMixin = {
     validationColumnsIsInDepartmentFilter(columnId) {
       return (
         this.departmentFilter.length === 0 ||
+        this.taskTypeMap.get(columnId).department_id === null ||
         this.departmentFilter.includes(
           this.taskTypeMap.get(columnId).department_id
         )

--- a/src/components/mixins/entity_list.js
+++ b/src/components/mixins/entity_list.js
@@ -428,7 +428,7 @@ export const entityListMixin = {
     validationColumnsIsInDepartmentFilter(columnId) {
       return (
         this.departmentFilter.length === 0 ||
-        this.taskTypeMap.get(columnId).department_id === null ||
+        this.taskTypeMap.get(columnId)?.department_id === null ||
         this.departmentFilter.includes(
           this.taskTypeMap.get(columnId).department_id
         )

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -489,6 +489,7 @@ export default {
       this.$nextTick(() => {
         this.$refs['shot-list']?.selectTaskFromQuery()
       })
+      this.reloadEpisodeShotsIfNeeded()
     }
   },
 
@@ -615,6 +616,23 @@ export default {
       'uploadShotFile',
       'uploadEdlFile'
     ]),
+
+    reloadEpisodeShotsIfNeeded() {
+      if (
+        (this.isTVShow && this.displayedSequences.length === 0) ||
+        this.displayedSequences[0]?.episode_id !== this.currentEpisode?.id ||
+        this.displayedShots[0]?.episode_id !== this.currentEpisode?.id
+      ) {
+        this.$refs['shot-search-field'].setValue('')
+        this.$store.commit('SET_SHOT_LIST_SCROLL_POSITION', 0)
+        this.initialLoading = true
+        this.loadShots(() => {
+          this.initialLoading = false
+          this.setSearchFromUrl()
+          this.onSearchChange()
+        })
+      }
+    },
 
     addEpisode(episode, callback) {
       this.newEpisode(episode).then(callback).catch(console.error)
@@ -1174,21 +1192,7 @@ export default {
     },
 
     currentSection() {
-      if (
-        (this.isTVShow && this.displayedSequences.length === 0) ||
-        this.displayedSequences[0]?.episode_id !== this.currentEpisode?.id ||
-        this.displayedShots[0]?.episode_id !== this.currentEpisode?.id
-      ) {
-        this.$refs['shot-search-field'].setValue('')
-        this.$store.commit('SET_SHOT_LIST_SCROLL_POSITION', 0)
-
-        this.initialLoading = true
-        this.loadShots(() => {
-          this.initialLoading = false
-          this.setSearchFromUrl()
-          this.onSearchChange()
-        })
-      }
+      this.reloadEpisodeShotsIfNeeded()
     },
 
     currentProduction() {

--- a/src/components/pages/production/ProductionStats.vue
+++ b/src/components/pages/production/ProductionStats.vue
@@ -67,7 +67,7 @@
             :style="{
               backgroundColor: taskStatusMap.get(statusStats.task_status_id)
                 .color,
-              width: `${(statsByStatus[statusStats.task_status_id] / taskTypeStatsMap[taskType.id].amount) * 100}%`
+              width: `${(statusStats.amount / taskTypeStatsMap[taskType.id].amount) * 100}%`
             }"
             :key="taskType.id + statusStats.task_status_id"
             :title="`${taskStatusMap.get(statusStats.task_status_id).name} - ${statusStats.amount} tasks`"

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1315,7 +1315,7 @@ export default {
         this.loading.setFrameThumbnail = true
         let frame = null
         if (isUseCurrentFrame) {
-          frame = this.currentFrameRaw
+          frame = this.currentFrameRaw + 1
         }
         return this.setCurrentPreviewAsEntityThumbnail(frame)
       }

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -278,7 +278,13 @@
           class="flexrow-item round-name revision"
           :to="previewRoute"
         >
-          {{ $t('comments.revision') }} {{ comment.previews[0].revision }}
+          <template v-if="comment.pinned">
+            {{ $t('comments.pinned_revision') }}
+            {{ comment.previews[0].revision }}
+          </template>
+          <template v-else>
+            {{ $t('comments.revision') }} {{ comment.previews[0].revision }}
+          </template>
         </router-link>
         <a
           class="preview-link button flexrow-item"

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -887,6 +887,7 @@ article.comment {
 }
 
 .pinned {
+  border: 2px solid var(--border-alt);
   transform: scale(1.02);
 }
 

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -278,13 +278,12 @@
           class="flexrow-item round-name revision"
           :to="previewRoute"
         >
-          <template v-if="comment.pinned">
-            {{ $t('comments.pinned_revision') }}
-            {{ comment.previews[0].revision }}
-          </template>
-          <template v-else>
-            {{ $t('comments.revision') }} {{ comment.previews[0].revision }}
-          </template>
+          {{
+            comment.pinned
+              ? $t('comments.pinned_revision')
+              : $t('comments.revision')
+          }}
+          {{ comment.previews[0].revision }}
         </router-link>
         <a
           class="preview-link button flexrow-item"

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -162,6 +162,7 @@ export default {
     no_file_attached: 'No preview attached',
     pin: 'Pin',
     pinned: 'Pinned',
+    pinned_revision: 'Pinned revision',
     post_status: 'Post comment',
     previews: 'Preview files to publish as a new revision',
     retake: 'Retake',


### PR DESCRIPTION
**Problem**

* Pinned revisions can be confused with being the last revision.
* Task columns with no department are hidden when a department filter is selected in entity pages.
* Shots loading doesn't occur when the episode is changed outside of the shot page.
* The set current frame as thumbnail option selects the previous frame instead of the current frame.
* Task type stats is not properly displayed in the production page.

**Solution**

* Change revision label to "Pinned Revision" for revisions in pinned comments
* Include task columns with no department in the selected column when a department is selected
* Check if the episode changed on Shots page mount.
* Add 1 frame to the selected frame to match ffmpeg way of counting frames
* Use the right number to compute the width of colored bars showing the amount of tasks for each status
