### PR TITLE
Fix breakdown

### DIFF
--- a/src/store/modules/breakdown.js
+++ b/src/store/modules/breakdown.js
@@ -478,8 +478,8 @@ const mutations = {
         'asset_type_name'
       )
     })
-    state.casting = { ...state.casting }
-    state.castingByType = { ...state.castingByType }
+    state.casting = casting
+    state.castingByType = entityCastingByType
   },
 
   [CASTING_ADD_TO_CASTING](state, { entityId, asset, nbOccurences, label }) {


### PR DESCRIPTION
**Problem**
- On the Breakdown page, Character casting assignments disappear after navigation/reload (#1606)

**Solution**
- Fix an invalid store initialization on casting loading.
