### PR TITLE
Fix shots loading

### DIFF
--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -427,7 +427,7 @@ const actions = {
         return shotsApi.getShots(production, episode)
       })
       .then(shots => {
-        const sequenceMap = rootGetters.sequenceMap
+        const sequenceMap = sequenceStore.cache.sequenceMap
         const taskMap = rootGetters.taskMap
         commit(LOAD_SHOTS_END, {
           production,


### PR DESCRIPTION
**Problem**
- #1619

**Solution**
- Fix sequences loading when switching episodes. Reactivity issue due to cache.
