### PR TITLE
Various fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,6 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import { getCurrentInstance } from 'vue'
 
 import PreviewModal from '@/components/modals/PreviewModal.vue'
 import Spinner from '@/components/widgets/Spinner.vue'
@@ -68,7 +67,7 @@ export default {
     const config = await this.setMainConfig()
     this.setupDarkTheme()
     this.setupCrisp(config)
-    // this.setupSentry(config)
+    this.setupSentry(config)
   },
 
   methods: {
@@ -127,9 +126,7 @@ export default {
 
     setupSentry(config) {
       if (config.sentry?.dsn?.length) {
-        const instance = getCurrentInstance()
-        const app = instance.appContext.app
-
+        const app = this.$.appContext.app
         sentry.init(app, this.$router, {
           dsn: config.sentry.dsn,
           sampleRate: config.sentry.sampleRate

--- a/src/components/lists/TimesheetList.vue
+++ b/src/components/lists/TimesheetList.vue
@@ -3,6 +3,7 @@
     <div class="flexrow timesheet-header">
       <div class="flexrow-item current-date">
         <date-field
+          :can-delete="false"
           :min-date="disabledDates.from"
           :max-date="disabledDates.to"
           :with-margin="false"

--- a/src/components/lists/TimesheetList.vue
+++ b/src/components/lists/TimesheetList.vue
@@ -4,8 +4,8 @@
       <div class="flexrow-item current-date">
         <date-field
           :can-delete="false"
-          :min-date="disabledDates.from"
-          :max-date="disabledDates.to"
+          :min-date="disabledDates.to"
+          :max-date="disabledDates.from"
           :with-margin="false"
           v-model="selectedDate"
         />

--- a/src/components/pages/ProductionNewsFeed.vue
+++ b/src/components/pages/ProductionNewsFeed.vue
@@ -408,12 +408,7 @@ export default {
     this.$options.silent = false
     window.addEventListener('keydown', this.onKeyDown, false)
 
-    if (
-      (this.newsList.length === 0 ||
-        (this.currentProduction &&
-          this.newsList[0].project_id !== this.currentProduction.id)) &&
-      !this.loading.news
-    ) {
+    if (!this.loading.news) {
       this.init()
     }
   },
@@ -438,8 +433,6 @@ export default {
       'taskStatusMap',
       'taskTypeMap',
       'taskStatusMap',
-      'taskStatus',
-      'taskTypes',
       'user'
     ]),
 
@@ -454,12 +447,13 @@ export default {
     },
 
     isStudio() {
-      return this.$route.path.indexOf('productions') < 0
+      return !this.$route.path.includes('productions')
     },
 
     params() {
-      const params = {
-        productionId: this.currentProduction?.id,
+      return {
+        isStudio: this.isStudio || undefined,
+        productionId: !this.isStudio ? this.currentProduction?.id : undefined,
         only_preview: this.previewMode === 'previews',
         page_size: this.previewMode === 'previews' ? 6 : 50,
         task_type_id: this.taskTypeId !== '' ? this.taskTypeId : undefined,
@@ -467,12 +461,10 @@ export default {
           this.taskStatusId !== '' ? this.taskStatusId : undefined,
         person_id: this.person ? this.person.id : undefined,
         page: this.currentPage,
-        episode_id: this.episodeId,
+        episode_id: this.episodeId !== 'all' ? this.episodeId : undefined,
         before: formatFullDateWithRevertedTimezone(this.before, this.timezone),
         after: formatFullDateWithRevertedTimezone(this.after, this.timezone)
       }
-      if (this.episodeId === 'all') delete params['episode_id']
-      return params
     },
 
     taskStatusList() {
@@ -651,9 +643,6 @@ export default {
           task_type_id: this.params.task_type_id
         }
         if (this.$router) this.$router.push({ query })
-        if (this.$route.path.indexOf('productions') < 0) {
-          this.params.isStudio = true
-        }
         this.loadNews(this.params)
           .then(() => {
             this.loading.news = false

--- a/src/components/pages/tasktype/EstimationHelper.vue
+++ b/src/components/pages/tasktype/EstimationHelper.vue
@@ -230,6 +230,12 @@ import { CornerDownRightIcon } from 'lucide-vue-next'
 import { firstBy } from 'thenby'
 import { mapGetters, mapActions } from 'vuex'
 
+import assetsStore from '@/store/modules/assets.js'
+import editsStore from '@/store/modules/edits.js'
+import episodesStore from '@/store/modules/episodes.js'
+import sequencesStore from '@/store/modules/sequences.js'
+import shotsStore from '@/store/modules/shots.js'
+
 import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
 import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
 import PeopleName from '@/components/widgets/PeopleName.vue'
@@ -274,16 +280,11 @@ export default {
 
   computed: {
     ...mapGetters([
-      'assetMap',
       'currentProduction',
-      'editMap',
-      'episodeMap',
       'isCurrentUserManager',
       'isCurrentUserSupervisor',
       'organisation',
       'personMap',
-      'sequenceMap',
-      'shotMap',
       'taskStatusMap',
       'taskTypeMap',
       'user'
@@ -299,6 +300,26 @@ export default {
 
     tasksByPerson() {
       return [...this.tasks].sort(this.compareFirstAssignees)
+    },
+
+    assetMap() {
+      return assetsStore.cache.assetMap
+    },
+
+    editMap() {
+      return editsStore.cache.editMap
+    },
+
+    episodeMap() {
+      return episodesStore.cache.episodeMap
+    },
+
+    sequenceMap() {
+      return sequencesStore.cache.sequenceMap
+    },
+
+    shotMap() {
+      return shotsStore.cache.shotMap
     },
 
     entityMap() {

--- a/src/store/api/news.js
+++ b/src/store/api/news.js
@@ -3,8 +3,7 @@ import { buildQueryString } from '@/lib/query'
 
 export default {
   getLastNews(params) {
-    const isStudio = params.isStudio
-    const productionId = params.productionId
+    const { isStudio, productionId } = params
     if (isStudio) {
       delete params.isStudio
       const path = buildQueryString(`/api/data/projects/news`, params)

--- a/src/store/modules/news.js
+++ b/src/store/modules/news.js
@@ -59,29 +59,22 @@ const getters = {
 }
 
 const actions = {
-  loadNews({ commit, state }, params) {
+  async loadNews({ commit, state }, params) {
     commit(CLEAR_NEWS)
-    return newsApi.getLastNews(params).then(newsList => {
-      commit(ADD_PREVIOUS_NEWS, newsList.data)
-      commit(NEWS_SET_TOTAL, newsList.total)
-      commit(NEWS_SET_STATS, newsList.stats)
-      return Promise.resolve()
-    })
+    const newsList = await newsApi.getLastNews(params)
+    commit(ADD_PREVIOUS_NEWS, newsList.data)
+    commit(NEWS_SET_TOTAL, newsList.total)
+    commit(NEWS_SET_STATS, newsList.stats)
   },
 
-  loadMoreNews({ commit, state }, params) {
-    return newsApi
-      .getLastNews(params)
-      .then(newsList => commit(ADD_PREVIOUS_NEWS, newsList.data))
+  async loadMoreNews({ commit, state }, params) {
+    const newsList = await newsApi.getLastNews(params)
+    commit(ADD_PREVIOUS_NEWS, newsList.data)
   },
 
-  loadSingleNews({ commit, state }, { productionId, newsId }) {
-    return new Promise((resolve, reject) => {
-      newsApi
-        .getNews(productionId, newsId)
-        .then(news => commit(ADD_FIRST_NEWS, news))
-        .catch(reject)
-    })
+  async loadSingleNews({ commit, state }, { productionId, newsId }) {
+    const news = await newsApi.getNews(productionId, newsId)
+    return commit(ADD_FIRST_NEWS, news)
   }
 }
 
@@ -105,14 +98,11 @@ const mutations = {
   },
 
   [NEWS_ADD_PREVIEW](state, { commentId, previewId, extension }) {
-    if (commentId) {
-      const news = state.newsList.find(news => {
-        return news.comment_id === commentId
-      })
-      if (news) {
-        news.preview_file_id = previewId
-        news.preview_file_extension = extension
-      }
+    if (!commentId) return
+    const news = state.newsList.find(news => news.comment_id === commentId)
+    if (news) {
+      news.preview_file_id = previewId
+      news.preview_file_extension = extension
     }
   },
 


### PR DESCRIPTION
**Problem**
- On the timesheets tab, clearing the selected date raises an error on loading data.
- On the Task Type page, the Estimation tab fails to load.
- The newsfeed page may display news inconsistently (missing news or unwanted production news)
- #1622
- Sentry no longer runs on Kitsu 0.20

**Solution**
- Disable the clear date button to avoid sending an invalid date to the API.
- Fix estimation display (wrong caching of entity maps).
- Fix news loading (Improve init data and load more data).
- Fix available dates on timesheets (parameters reverted).
- Enable Sentry (fix the SDK configuration for Vue 3).