### PR TITLE
Fix for #1595  / Annotation Data is inconsistent between Preview Player and Playlist Player

### DIFF
--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1531,7 +1531,7 @@ export default {
       const annotation = this.getAnnotation(currentTime)
       const annotations = this.getNewAnnotations(
         currentTime,
-        this.currentFrame,
+        this.currentFrame+1, // match player.js frame
         annotation
       )
 


### PR DESCRIPTION
**Problem**
Annotation frame number was off by one frame when saving from PreviewPlayer.vue compared to player.js

**Solution**
Add 1 to frame number when saving from PreviewPlayer.vue after checking and confirming that both ways save the same 'raw' time.
