### PR TITLE
Bugfix for #1595 / Annotation Data is inconsistent between Preview Player and Playlist Player

### DIFF
--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -259,7 +259,7 @@ export const annotationMixin = {
     addToAdditions(obj) {
       this.markLastAnnotationTime()
       const currentTime = this.getCurrentTime()
-      const currentFrame = this.getCurrentFrame()
+      const currentFrame = this.getCurrentFrame() // this is different, depending if it is called in PreviewPlayer or player.js
       const additions = this.findAnnotation(this.additions, currentTime)
       if (additions) {
         additions.drawing.objects.push(obj.serialize())

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1126,10 +1126,10 @@ export default {
 
     getCurrentFrame() {
       if (this.currentFrame) {
-        return this.currentFrame
+        return this.currentFrame + 1 //match offset in player.js
       } else {
         const time = roundToFrame(this.currentTimeRaw, this.fps) || 0
-        return Math.round(time / this.frameDuration)
+        return Math.round(time / this.frameDuration) + 1 //match offset in player.js
       }
     },
 
@@ -1531,7 +1531,7 @@ export default {
       const annotation = this.getAnnotation(currentTime)
       const annotations = this.getNewAnnotations(
         currentTime,
-        this.currentFrame+1, // match player.js frame
+        this.currentFrame,
         annotation
       )
 

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1531,7 +1531,7 @@ export default {
       const annotation = this.getAnnotation(currentTime)
       const annotations = this.getNewAnnotations(
         currentTime,
-        this.currentFrame,
+        this.currentFrame+1, // match player.js frame
         annotation
       )
 


### PR DESCRIPTION
Problem
Annotation frame number was off by one frame when saving from PreviewPlayer.vue compared to player.js

This is due to the annotation.js mixins calling it's parents getCurrentFrame() function. This is implemented differently in player.js and PreviewPlayer.vue and thus returning different numbers.

Solution
Adapt `getCurrentFrame()` function in PreviewPlayer.vue to return the same number as the one in player.js

Limitation
player.js still returns a padded string as the framenumber whereas this patch returns an int.

Overall this might be a simplified patch - it would probably be better to align the two functions but I am not sure what else that might break.