### PR TITLE
Various fixes

### DIFF
--- a/src/components/cells/MetadataInput.vue
+++ b/src/components/cells/MetadataInput.vue
@@ -2,6 +2,7 @@
   <!-- text input -->
   <input
     class="input-editor"
+    :readonly="!isEditable"
     @input="event => onMetadataFieldChanged(entity, descriptor, event)"
     @keyup.ctrl="
       event =>
@@ -12,13 +13,12 @@
         )
     "
     :value="getMetadataFieldValue(descriptor, entity)"
-    v-if="
-      (!descriptor.data_type || descriptor.data_type === 'string') && isEditable
-    "
+    v-if="!descriptor.data_type || descriptor.data_type === 'string'"
   />
   <!-- number input -->
   <input
     class="input-editor"
+    :readonly="!isEditable"
     type="number"
     step="any"
     @keydown="onNumberFieldKeyDown"
@@ -32,11 +32,12 @@
         )
     "
     :value="getMetadataFieldValue(descriptor, entity)"
-    v-else-if="descriptor.data_type === 'number' && isEditable"
+    v-else-if="descriptor.data_type === 'number'"
   />
   <!-- boolean input -->
   <input
     class="input-editor"
+    :disabled="!isEditable"
     @input="event => onMetadataFieldChanged(entity, descriptor, event)"
     @keyup.ctrl="
       event =>
@@ -48,7 +49,7 @@
     "
     type="checkbox"
     :checked="getMetadataFieldValue(descriptor, entity) === 'true'"
-    v-else-if="descriptor.data_type === 'boolean' && isEditable"
+    v-else-if="descriptor.data_type === 'boolean'"
   />
   <!-- checklist input -->
   <div
@@ -76,16 +77,14 @@
       <label
         :for="`${entity.id}-${descriptor.id}-${i}-${option.text}-input`"
         :style="[isEditable ? { cursor: 'pointer' } : { cursor: 'auto' }]"
+        class="ml05"
       >
         {{ option.text }}
       </label>
     </p>
   </div>
   <!-- list input -->
-  <span
-    class="select"
-    v-else-if="descriptor.data_type === 'list' && isEditable"
-  >
+  <span class="select" v-else-if="descriptor.data_type === 'list'">
     <select
       class="select-input"
       @keyup.ctrl="
@@ -99,6 +98,7 @@
       @change="event => onMetadataFieldChanged(entity, descriptor, event)"
     >
       <option
+        :disabled="!isEditable"
         :key="`desc-value-${entity.id}-${descriptor.id}-${i}-${option.label}-${option.value}`"
         :value="option.value"
         :selected="getMetadataFieldValue(descriptor, entity) === option.value"
@@ -110,6 +110,7 @@
   </span>
   <!-- tag list input -->
   <combobox-tag
+    :disabled="!isEditable"
     :options="getDescriptorChoicesOptions(descriptor, false)"
     :shy="true"
     :model-value="getMetadataFieldValue(descriptor, entity)"
@@ -117,7 +118,7 @@
     @update:model-value="
       value => onMetadataFieldChanged(entity, descriptor, value)
     "
-    v-else-if="descriptor.data_type === 'taglist' && isEditable"
+    v-else-if="descriptor.data_type === 'taglist'"
   />
   <!-- default -->
   <span class="metadata-value selectable" v-else>
@@ -270,6 +271,10 @@ export default {
 }
 
 .metadata-value {
+  display: inline-block;
+  max-width: 100%;
   padding: 0.8rem;
+  overflow: auto;
+  white-space: nowrap;
 }
 </style>

--- a/src/components/pages/Notifications.vue
+++ b/src/components/pages/Notifications.vue
@@ -711,6 +711,7 @@ a {
   margin-bottom: 0.5em;
   padding: 1rem;
   transition: all 0.2s ease-in-out;
+  overflow-x: auto;
 
   &.unread {
     border: 4px solid #f0c5d1;

--- a/src/components/pages/Notifications.vue
+++ b/src/components/pages/Notifications.vue
@@ -138,7 +138,7 @@
                   :label="$t('notifications.read')"
                   is-small
                   @click="value => toggleNotificationRead(notification, value)"
-                  :value="notification.read ? 'true' : 'false'"
+                  :model-value="notification.read ? 'true' : 'false'"
                 />
               </div>
             </div>

--- a/src/components/widgets/ComboboxTag.vue
+++ b/src/components/widgets/ComboboxTag.vue
@@ -23,10 +23,15 @@
         <div
           :key="option.id"
           class="option-line flexrow"
-          @click="selectOption(option)"
+          @click="!disabled && selectOption(option)"
           v-for="option in optionList"
         >
-          <input type="checkbox" class="mr05" :checked="isChecked(option)" />
+          <input
+            type="checkbox"
+            class="mr05"
+            :checked="isChecked(option)"
+            :disabled="disabled"
+          />
           {{ getOptionLabel(option) }}
         </div>
       </div>
@@ -62,6 +67,10 @@ export default {
   },
 
   props: {
+    disabled: {
+      default: false,
+      type: Boolean
+    },
     label: {
       default: '',
       type: String

--- a/src/components/widgets/DateField.vue
+++ b/src/components/widgets/DateField.vue
@@ -15,6 +15,7 @@
       :min-date="minDate"
       :max-date="maxDate"
       :placeholder="placeholder"
+      :teleport="true"
       :utc="utc ? 'preserve' : false"
       v-model="localValue"
     >


### PR DESCRIPTION
**Problem**
- https://github.com/cgwire/kitsu/issues/1629
- https://github.com/cgwire/kitsu/issues/1643
- https://github.com/cgwire/kitsu/issues/1626

**Solution**
- Fix a wrong state on the "read" notification button (issue due to vue3 migration).
- Improve the display of metadata in read-only mode, in order to avoid UX overflow.
- Fix the visibility of the date picker if hidden overflow. Thanks to the "teleport" option from the date picker lib.