### PR TITLE
Fix Kitsu build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -20,7 +20,11 @@ export default defineConfig({
     extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],
     alias: {
       '@': path.resolve(__dirname, 'src/'),
-      vue: 'vue/dist/vue.esm-bundler.js'
+      vue: 'vue/dist/vue.esm-bundler.js',
+      '@arch-inc/fabricjs-psbrush': path.resolve(
+        __dirname,
+        'node_modules/@arch-inc/fabricjs-psbrush/dist/index.js'
+      )
     }
   },
   css: {


### PR DESCRIPTION
**Problem**
- The Kitsu production build is broken due to an npm dependency.

**Solution**
- Fix vite config for production build.
