### PR TITLE
[events] stop sending event preview-room:leave with temp as room_id

### DIFF
--- a/src/components/mixins/previewRoom.js
+++ b/src/components/mixins/previewRoom.js
@@ -14,15 +14,9 @@ export const previewRoomMixin = {
       })
     },
 
-    isValidRoomId(value) {
-      if (!value || value === 'temp') {
-        return false
-      }
-      return true
-    },
-
     joinRoom() {
-      if (!this.room.id) return
+      if (!this.room?.id) return
+
       if (this.isFullMode) this.isFullMode = false
 
       this.$socket.emit('preview-room:join', {
@@ -48,8 +42,8 @@ export const previewRoomMixin = {
     },
 
     leaveRoom() {
-      if (!this.room.id) return
-      if (!this.user) return
+      if (!this.room?.id || !this.user) return
+
       this.$socket.emit('preview-room:leave', {
         user_id: this.user.id,
         playlist_id: this.room.id
@@ -67,9 +61,7 @@ export const previewRoomMixin = {
     },
 
     updateRoomStatus() {
-      if (!this.room.id) return
-      if (!this.joinedRoom) return
-
+      if (!this.room?.id || !this.joinedRoom) return
       this.$socket.emit('preview-room:update-playing-status', {
         playlist_id: this.room.id,
         is_playing: this.isPlaying,
@@ -92,7 +84,7 @@ export const previewRoomMixin = {
     },
 
     postAnnotationAddition(time, serializedObj) {
-      if (!this.room.id) return
+      if (!this.room?.id) return
       this.$socket.emit('preview-room:add-annotation', {
         playlist_id: this.room.id,
         data: {
@@ -104,7 +96,7 @@ export const previewRoomMixin = {
     },
 
     postAnnotationDeletion(time, serializedObj) {
-      if (!this.room.id) return
+      if (!this.room?.id) return
       this.$socket.emit('preview-room:remove-annotation', {
         playlist_id: this.room.id,
         data: {
@@ -116,7 +108,7 @@ export const previewRoomMixin = {
     },
 
     postAnnotationUpdate(time, serializedObj) {
-      if (!this.room.id) return
+      if (!this.room?.id) return
       this.$socket.emit('preview-update-annotation', {
         playlist_id: this.room.id,
         data: {
@@ -255,8 +247,7 @@ export const previewRoomMixin = {
     events: {
       'preview-room:room-people-updated'(eventData) {
         // someone joined the room
-        if (!this.room.id) return
-
+        if (!this.room?.id) return
         this.room.people = eventData.people
         if (this.joinedRoom) {
           this.room.newComer = false

--- a/src/components/modals/ViewPlaylistModal.vue
+++ b/src/components/modals/ViewPlaylistModal.vue
@@ -82,7 +82,7 @@ export default {
       previewFileEntityMap: new Map(),
       currentEntities: {},
       currentPlaylist: {
-        id: 'temp',
+        id: '',
         name: 'Temporary playlist',
         shots: [],
         for_entity: 'shot'

--- a/src/components/pages/Edit.vue
+++ b/src/components/pages/Edit.vue
@@ -43,12 +43,7 @@
             @open-room="openRoom"
             @join-room="joinRoom"
             @leave-room="leaveRoom"
-            v-if="
-              currentEdit &&
-              isValidRoomId(currentEdit.id) &&
-              currentPreview &&
-              currentPreview.id
-            "
+            v-if="currentEdit?.id && currentPreview?.id"
           />
         </div>
       </div>

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -60,7 +60,7 @@
         @open-room="openRoom"
         @join-room="joinRoom"
         @leave-room="leaveRoom"
-        v-if="isValidRoomId(playlist.id) && !isFullMode"
+        v-if="playlist.id && !isFullMode"
       />
       <button-simple
         class="playlist-button topbar-button flexrow-item full-button"


### PR DESCRIPTION
**Problem**
- When entering the playlist page it sends an event "preview-room:leave" with "temp" as room_id, causing an error in zou-events.

**Solution**
- Stop sending that event when no playlist was previously selected. 
