### PR TITLE
Various fixes

### DIFF
--- a/src/components/mixins/entity_list.js
+++ b/src/components/mixins/entity_list.js
@@ -557,6 +557,8 @@ export const entityListMixin = {
     },
 
     startBrowsing(event) {
+      if (event.target.tagName === 'INPUT') return
+
       document.body.style.cursor = 'grabbing'
       this.isBrowsingX = true
       this.isBrowsingY = true

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -1262,7 +1262,10 @@ const mutations = {
   },
 
   [CLEAR_SELECTED_TASKS](state, validationInfo) {
-    if (tasksStore.state.nbSelectedTasks > 0) {
+    if (
+      tasksStore.state.nbSelectedValidations > 0 ||
+      tasksStore.state.nbSelectedTasks > 0
+    ) {
       const tmpGrid = JSON.parse(JSON.stringify(state.assetSelectionGrid))
       state.assetSelectionGrid = clearSelectionGrid(tmpGrid)
     }

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -991,7 +991,10 @@ const mutations = {
   },
 
   [CLEAR_SELECTED_TASKS](state, validationInfo) {
-    if (tasksStore.state.nbSelectedTasks > 0) {
+    if (
+      tasksStore.state.nbSelectedValidations > 0 ||
+      tasksStore.state.nbSelectedTasks > 0
+    ) {
       const tmpGrid = JSON.parse(JSON.stringify(state.editSelectionGrid))
       state.editSelectionGrid = clearSelectionGrid(tmpGrid)
     }

--- a/src/store/modules/episodes.js
+++ b/src/store/modules/episodes.js
@@ -918,7 +918,10 @@ const mutations = {
   },
 
   [CLEAR_SELECTED_TASKS](state, validationInfo) {
-    if (taskStore.state.nbSelectedTasks > 0) {
+    if (
+      taskStore.state.nbSelectedValidations > 0 ||
+      taskStore.state.nbSelectedTasks > 0
+    ) {
       const tmpGrid = JSON.parse(JSON.stringify(state.episodeSelectionGrid))
       state.episodeSelectionGrid = clearSelectionGrid(tmpGrid)
     }

--- a/src/store/modules/people.js
+++ b/src/store/modules/people.js
@@ -771,7 +771,10 @@ const mutations = {
   },
 
   [CLEAR_SELECTED_TASKS](state, validationInfo) {
-    if (taskStore.state.nbSelectedTasks > 0) {
+    if (
+      taskStore.state.nbSelectedValidations > 0 ||
+      taskStore.state.nbSelectedTasks > 0
+    ) {
       state.personTaskSelectionGrid = clearSelectionGrid(
         state.personTaskSelectionGrid
       )

--- a/src/store/modules/sequences.js
+++ b/src/store/modules/sequences.js
@@ -984,7 +984,10 @@ const mutations = {
   },
 
   [CLEAR_SELECTED_TASKS](state, validationInfo) {
-    if (taskStore.state.nbSelectedTasks > 0) {
+    if (
+      taskStore.state.nbSelectedValidations > 0 ||
+      taskStore.state.nbSelectedTasks > 0
+    ) {
       const tmpGrid = JSON.parse(JSON.stringify(state.sequenceSelectionGrid))
       state.sequenceSelectionGrid = clearSelectionGrid(tmpGrid)
     }

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -1186,7 +1186,10 @@ const mutations = {
   },
 
   [CLEAR_SELECTED_TASKS](state, validationInfo) {
-    if (tasksStore.state.nbSelectedTasks > 0) {
+    if (
+      tasksStore.state.nbSelectedValidations > 0 ||
+      tasksStore.state.nbSelectedTasks > 0
+    ) {
       const tmpGrid = JSON.parse(JSON.stringify(state.shotSelectionGrid))
       state.shotSelectionGrid = clearSelectionGrid(tmpGrid)
     }

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -1168,6 +1168,8 @@ const mutations = {
     if (state.nbSelectedTasks > 0) {
       state.selectedTasks = new Map()
       state.nbSelectedTasks = 0
+    }
+    if (state.nbSelectedValidations > 0) {
       state.selectedValidations = new Map()
       state.nbSelectedValidations = 0
     }

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -710,8 +710,11 @@ const mutations = {
         )
         if (filterGroup) {
           Object.assign(filterGroup, userFilterGroup)
+          // update the shared status of filters in group
           state.userFilters?.[typeName]?.[projectId].forEach(filter => {
-            filter.is_shared = userFilterGroup.is_shared
+            if (filter.search_filter_group_id === userFilterGroup.id) {
+              filter.is_shared = userFilterGroup.is_shared
+            }
           })
         }
       })


### PR DESCRIPTION
**Problem**
- On an entity list, select an empty cell, and then another cell performs an unwanted multiple selection.
- On the Shots page, drag scrolling prevents text from being selected in an input field.
- Update a shared filter will mark all filters as shared.

**Solution**
- Fix selection when selecting an empty task. Missing condition on clear selection.
- Fix the scroll by dragging. Disable it if the event starts on an input field.
- Fix update of shared status for filters in a group. Add a missing condition to filter items.