### PR TITLE
[csv] when importing a task type csv add difficulty field

### DIFF
--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -517,7 +517,7 @@ export default {
       },
       parsedCSV: [],
       importCsvFormData: {},
-      optionalColumns: ['Estimation', 'Start date', 'Due date'],
+      optionalColumns: ['Estimation', 'Start date', 'Due date', 'Difficulty'],
       dataMatchers: ['Parent', 'Entity']
     }
   },


### PR DESCRIPTION
**Problem**
- When importing a task type CSV, importing "difficulty" field is impossible.
 
**Solution**
- Allow difficulty field.
