### PR TITLE
Various fixes

### DIFF
--- a/src/components/mixins/entities.js
+++ b/src/components/mixins/entities.js
@@ -271,12 +271,6 @@ export const entitiesMixin = {
       )
     },
 
-    confirmBuildFilter(query) {
-      this.modals.isBuildFilterDisplayed = false
-      this.searchField.setValue(query)
-      this.applySearch(query)
-    },
-
     onKeepTaskPanelOpenChanged(keepOpen) {
       this.keepTaskPanelOpen = keepOpen
     },

--- a/src/components/mixins/search.js
+++ b/src/components/mixins/search.js
@@ -15,6 +15,7 @@ export const searchMixin = {
     confirmBuildFilter(query) {
       this.modals.isBuildFilterDisplayed = false
       this.searchField.setValue(query)
+      this.setSearchInUrl(query)
       this.onSearchChange()
     },
 

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -957,7 +957,7 @@ export default {
     },
 
     onAssetTypeClicked(assetType) {
-      this.searchField.setValue(`${this.assetSearchText} type=${assetType}`)
+      this.searchField.setValue(`${this.assetSearchText} type=[${assetType}]`)
       this.onSearchChange()
     },
 

--- a/src/components/pages/Edits.vue
+++ b/src/components/pages/Edits.vue
@@ -915,12 +915,6 @@ export default {
       this.changeEditSort(sortInfo)
     },
 
-    confirmBuildFilter(query) {
-      this.modals.isBuildFilterDisplayed = false
-      this.$refs['edit-search-field'].setValue(query)
-      this.applySearch(query)
-    },
-
     async onFieldChanged({ entry, fieldName, value }) {
       const data = {
         id: entry.id,


### PR DESCRIPTION
**Problem**

* Filter builder doesn't apply to URLs 
* In the asset list, asset types are clickable shortcuts for filtering the view on asset types. It doesn't work when there are space in the asset type name.

**Solution**

* Fix the confirm filter function to set the current search in the URL and remove wrong overrides
* Use brackets when setting the filter from asset type names
