### PR TITLE
Show entity preview files as a contact sheet

### DIFF
--- a/src/components/pages/entities/EntityPreviewFileCard.vue
+++ b/src/components/pages/entities/EntityPreviewFileCard.vue
@@ -1,0 +1,200 @@
+<template>
+  <div class="preview-card flexcolumn" :key="previewFile.id">
+    <entity-preview
+      :entity="{
+        preview_file_id: previewFile.id,
+        preview_file_extension: previewFile.extension
+      }"
+      :empty-height="200"
+      :empty-width="300"
+      :height="200"
+      :width="300"
+      is-rounded-top-border
+      show-movie
+    />
+    <div class="preview-card-data">
+      <div class="flexrow">
+        <span class="card-revision tag strong flexrow-item">
+          v{{ previewFile.revision }}
+        </span>
+        <span
+          class="card-file-name flexrow-item"
+          :title="previewFile.original_name"
+        >
+          {{ `${previewFile.original_name}` }}
+        </span>
+        <span class="filler"></span>
+        <span class="card-extension flexrow-item mr0">
+          {{ previewFile.extension }}
+        </span>
+      </div>
+      <div class="flexrow mt1">
+        <span
+          class="preview-status mr05"
+          :title="previewFile.validation_status"
+          :style="getPreviewValidationStyle(previewFile)"
+        >
+          &nbsp;
+        </span>
+        <people-avatar
+          class="person"
+          :person="personMap.get(previewFile.person_id)"
+          :font-size="10"
+          :size="20"
+        />
+        <span class="filler"></span>
+        <span
+          class="card-file-size flexrow-item mr05"
+          v-if="previewFile.file_size"
+        >
+          {{ renderFileSize(previewFile.file_size) }}B
+        </span>
+        <a
+          class="download-button"
+          :href="getDownloadPath(previewFile.id)"
+          :title="$t('playlists.actions.download_file')"
+          v-if="!isCurrentUserArtist"
+        >
+          <download-icon class="icon is-small" />
+        </a>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+import { DownloadIcon } from 'lucide-vue-next'
+
+import { renderFileSize } from '@/lib/render'
+
+import EntityPreview from '@/components/widgets/EntityPreview.vue'
+import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
+
+export default {
+  name: 'entity-preview-files',
+
+  components: {
+    DownloadIcon,
+    EntityPreview,
+    PeopleAvatar
+  },
+
+  data() {
+    return {
+      contactSheetMode: false,
+      isLoading: false,
+      previewFiles: []
+    }
+  },
+
+  props: {
+    previewFile: {
+      type: Object,
+      required: true,
+      default: () => {}
+    }
+  },
+
+  mounted() {},
+
+  computed: {
+    ...mapGetters([
+      'currentProduction',
+      'isCurrentUserArtist',
+      'personMap',
+      'taskMap',
+      'taskTypeMap'
+    ])
+  },
+
+  methods: {
+    getPreviewValidationStyle(previewFile) {
+      let color = '#AAA'
+      if (previewFile.validation_status === 'validated') {
+        color = '#67BE48' // green
+      } else if (previewFile.validation_status === 'rejected') {
+        color = '#FF3860' // red
+      }
+      return { background: color }
+    },
+
+    getTaskType(previewFile) {
+      const task = this.taskMap.get(previewFile.task_id)
+      return this.taskTypeMap.get(task.task_type_id)
+    },
+
+    getDownloadPath(previewFileId) {
+      const type = this.previewFile.extension === 'mp4' ? 'movies' : 'pictures'
+      return (
+        `/api/${type}/originals/preview-files/` + `${previewFileId}/download`
+      )
+    },
+
+    renderFileSize
+  },
+
+  watch: {}
+}
+</script>
+
+<style lang="scss" scoped>
+.preview-card {
+  background: var(--background);
+  border-radius: 10px;
+  box-shadow: 4px 4px 5px 0 rgba(0, 0, 0, 0.1);
+  margin-right: 1rem;
+  margin-bottom: 1rem;
+  max-width: 300px;
+  overflow: hidden;
+
+  .card-revision {
+    margin-right: 0.5rem;
+  }
+
+  .preview-card-data {
+    padding: 0.5rem;
+  }
+
+  .card-file-name {
+    display: inline-block;
+    font-size: 0.9rem;
+    overflow: hidden;
+    max-width: 240px;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+    word-break: none;
+  }
+
+  .card-extension {
+    background: var(--background-alt);
+    border-radius: 4px;
+    font-size: 0.8rem;
+    padding: 0.2rem 0.5rem;
+    margin-right: 0rem;
+    text-transform: uppercase;
+  }
+
+  .preview-status {
+    border-radius: 50%;
+    border: 2px solid $grey;
+    cursor: pointer;
+    height: 20px;
+    min-width: 20px;
+    transition: background 0.3s ease;
+    width: 20px;
+  }
+
+  .card-file-size {
+    color: var(--text-light);
+    font-weight: 600;
+    font-size: 0.9rem;
+  }
+
+  .download-button {
+    padding-top: 0.5rem;
+    padding-right: 0.1rem;
+  }
+}
+</style>

--- a/src/components/pages/entities/EntityPreviewFileCard.vue
+++ b/src/components/pages/entities/EntityPreviewFileCard.vue
@@ -72,7 +72,7 @@ import EntityPreview from '@/components/widgets/EntityPreview.vue'
 import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
 
 export default {
-  name: 'entity-preview-files',
+  name: 'entity-preview-file-card',
 
   components: {
     DownloadIcon,

--- a/src/components/pages/entities/EntityPreviewFiles.vue
+++ b/src/components/pages/entities/EntityPreviewFiles.vue
@@ -57,6 +57,9 @@
             <th class="person">
               {{ $t('entities.preview_files.uploader') }}
             </th>
+            <th class="date">
+              {{ $t('entities.preview_files.uploaded_at') }}
+            </th>
             <th class="end-cell"></th>
           </tr>
         </thead>
@@ -99,6 +102,9 @@
               class="person"
               :person="personMap.get(previewFile.person_id)"
             />
+            <td class="date">
+              {{ previewFile.date }}
+            </td>
 
             <td class="download">
               <a
@@ -293,6 +299,9 @@ td.type {
 }
 .download {
   width: 40px;
+}
+.date {
+  width: 80px;
 }
 
 .original-name {

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -685,7 +685,7 @@ export default {
       isLoading: false,
       isMuted: false,
       isPlaying: false,
-      isOrdering: false,
+      isOrdering: true,
       isRepeating: false,
       isTyping: false,
       isWireframe: false,
@@ -755,6 +755,7 @@ export default {
       this.onObjectBackgroundSelected()
     }
     this.resetPencilConfiguration()
+    this.isOrdering = this.previews.length > 1
   },
 
   beforeUnmount() {
@@ -2122,6 +2123,7 @@ export default {
         }
       })
       this.setDefaultComparisonTaskType()
+      this.isOrdering = this.previews.length > 1
     },
 
     'currentPreview.revision'() {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -353,6 +353,7 @@ export default {
       size: 'Size',
       status: 'Status',
       task_type: 'Task type',
+      uploaded_at: 'Uploaded at',
       uploader: 'Uploaded by'
     },
 


### PR DESCRIPTION
**Problem**

In the entity page, the preview files tab is not visual enough to be efficiently browsed.

**Solution**

Allow previews to be displayed as a contact sheet to give a better overview of what was uploaded.
