### PR TITLE
Allow to see entity pages as contact sheets

### DIFF
--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -9,74 +9,69 @@
     :style="cellStyle"
     @click="onClick"
   >
-    <div
-      class="wrapper"
-      :style="wrapperStyle"
-      v-if="!minimized"
-    >
+    <div class="wrapper" :style="wrapperStyle" v-if="!minimized">
       <div
         class="wrapper status-wrapper"
         :style="statusWrapperStyle"
         v-if="!minimized"
       >
-
-      <template v-if="task">
-        <span
-          class="tag"
-          :title="taskStatus.name"
-          :style="tagStyle"
-          v-if="!contactSheet"
-        >
-          {{ taskStatus.short_name }}
+        <template v-if="task">
+          <span
+            class="tag"
+            :title="taskStatus.name"
+            :style="tagStyle"
+            v-if="!contactSheet"
+          >
+            {{ taskStatus.short_name }}
+          </span>
+          <span class="filler" v-if="contactSheet"> </span>
+          <span
+            :class="{
+              priority: true,
+              high: task.priority === 1,
+              veryhigh: task.priority === 2,
+              emergency: task.priority === 3
+            }"
+            :title="formatPriority(task.priority)"
+            v-if="!isCurrentUserClient && !disabled && task.priority > 0"
+          >
+            {{ priority }}
+          </span>
+          <span
+            class="casting-status"
+            :class="{ 'casting-status-not-ready': !isCastingReady }"
+            :title="castingTitle"
+            v-if="!isCurrentUserClient && castingTitle"
+          >
+            <img src="@/assets/icons/casting-ready.png" v-if="isCastingReady" />
+            <img src="@/assets/icons/casting-not-ready.png" v-else />
+          </span>
+        </template>
+        <template v-if="isAssignees && !isCurrentUserClient && !disabled">
+          <span
+            class="avatar has-text-centered"
+            :title="person.full_name"
+            :style="{
+              backgroundColor: person.color,
+              color: isDarkTheme ? '#333' : '#FFF',
+              'font-weight': isDarkTheme ? 'bold' : 'normal'
+            }"
+            :key="`avatar-${person.id}`"
+            v-for="person in assignees"
+          >
+            <img
+              loading="lazy"
+              alt=""
+              :src="person.avatarPath"
+              v-if="person.has_avatar"
+            />
+            <template v-else>{{ person.initials }}</template>
+          </span>
+        </template>
+        <span class="subscribed" v-if="task?.is_subscribed">
+          <eye-icon :size="12" />
         </span>
-        <span class="filler" v-if="contactSheet"> </span>
-        <span
-          :class="{
-            priority: true,
-            high: task.priority === 1,
-            veryhigh: task.priority === 2,
-            emergency: task.priority === 3
-          }"
-          :title="formatPriority(task.priority)"
-          v-if="!isCurrentUserClient && !disabled && task.priority > 0"
-        >
-          {{ priority }}
-        </span>
-        <span
-          class="casting-status"
-          :class="{ 'casting-status-not-ready': !isCastingReady }"
-          :title="castingTitle"
-          v-if="!isCurrentUserClient && castingTitle"
-        >
-          <img src="@/assets/icons/casting-ready.png" v-if="isCastingReady" />
-          <img src="@/assets/icons/casting-not-ready.png" v-else />
-        </span>
-      </template>
-      <template v-if="isAssignees && !isCurrentUserClient && !disabled">
-        <span
-          class="avatar has-text-centered"
-          :title="person.full_name"
-          :style="{
-            backgroundColor: person.color,
-            color: isDarkTheme ? '#333' : '#FFF',
-            'font-weight': isDarkTheme ? 'bold' : 'normal'
-          }"
-          :key="`avatar-${person.id}`"
-          v-for="person in assignees"
-        >
-          <img
-            loading="lazy"
-            alt=""
-            :src="person.avatarPath"
-            v-if="person.has_avatar"
-          />
-          <template v-else>{{ person.initials }}</template>
-        </span>
-      </template>
-      <span class="subscribed" v-if="task?.is_subscribed">
-        <eye-icon :size="12" />
-      </span>
-    </div>
+      </div>
     </div>
     <div class="wrapper" v-else>
       <span class="tag" :style="tagStyle"> &nbsp; </span>
@@ -92,8 +87,6 @@ import colors from '@/lib/colors'
 import { sortPeople } from '@/lib/sorting'
 import { formatListMixin } from '@/components/mixins/format'
 
-import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
-
 export default {
   name: 'validation-cell',
 
@@ -106,8 +99,7 @@ export default {
   },
 
   components: {
-    EyeIcon,
-    EntityThumbnail
+    EyeIcon
   },
 
   props: {
@@ -252,28 +244,30 @@ export default {
 
     wrapperStyle() {
       if (!this.task || !this.contactSheet) return {}
-      const path = '/api/pictures/thumbnails/preview-files/' +
-        this.task.last_preview_file_id + '.png'
+      const path =
+        '/api/pictures/thumbnails/preview-files/' +
+        this.task.last_preview_file_id +
+        '.png'
       return {
         'background-image': 'url(' + path + ')',
-        'height': '100px',
-        'width': '150px',
+        height: '100px',
+        width: '150px'
       }
     },
 
     statusWrapperStyle() {
-      if (!this.task || !this.contactSheet) return {
-        'padding': '6px'
-      }
+      if (!this.task || !this.contactSheet)
+        return {
+          padding: '6px'
+        }
       return {
         'background-color': this.taskStatus.color + '44',
-        'height': '100px',
-        'width': '150px',
-        'padding': '6px',
+        height: '100px',
+        width: '150px',
+        padding: '6px',
         'text-align:': 'right'
       }
     },
-
 
     taskStatus() {
       const taskStatusId = this.task?.task_status_id

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -9,11 +9,27 @@
     :style="cellStyle"
     @click="onClick"
   >
-    <div class="wrapper" v-if="!minimized">
+    <div
+      class="wrapper"
+      :style="wrapperStyle"
+      v-if="!minimized"
+    >
+      <div
+        class="wrapper status-wrapper"
+        :style="statusWrapperStyle"
+        v-if="!minimized"
+      >
+
       <template v-if="task">
-        <span class="tag" :title="taskStatus.name" :style="tagStyle">
+        <span
+          class="tag"
+          :title="taskStatus.name"
+          :style="tagStyle"
+          v-if="!contactSheet"
+        >
           {{ taskStatus.short_name }}
         </span>
+        <span class="filler" v-if="contactSheet"> </span>
         <span
           :class="{
             priority: true,
@@ -61,6 +77,7 @@
         <eye-icon :size="12" />
       </span>
     </div>
+    </div>
     <div class="wrapper" v-else>
       <span class="tag" :style="tagStyle"> &nbsp; </span>
     </div>
@@ -75,6 +92,8 @@ import colors from '@/lib/colors'
 import { sortPeople } from '@/lib/sorting'
 import { formatListMixin } from '@/components/mixins/format'
 
+import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
+
 export default {
   name: 'validation-cell',
 
@@ -87,7 +106,8 @@ export default {
   },
 
   components: {
-    EyeIcon
+    EyeIcon,
+    EntityThumbnail
   },
 
   props: {
@@ -163,6 +183,10 @@ export default {
     canceled: {
       default: false,
       type: Boolean
+    },
+    contactSheet: {
+      default: false,
+      type: Boolean
     }
   },
 
@@ -226,6 +250,31 @@ export default {
       }
     },
 
+    wrapperStyle() {
+      if (!this.task || !this.contactSheet) return {}
+      const path = '/api/pictures/thumbnails/preview-files/' +
+        this.task.last_preview_file_id + '.png'
+      return {
+        'background-image': 'url(' + path + ')',
+        'height': '100px',
+        'width': '150px',
+      }
+    },
+
+    statusWrapperStyle() {
+      if (!this.task || !this.contactSheet) return {
+        'padding': '6px'
+      }
+      return {
+        'background-color': this.taskStatus.color + '44',
+        'height': '100px',
+        'width': '150px',
+        'padding': '6px',
+        'text-align:': 'right'
+      }
+    },
+
+
     taskStatus() {
       const taskStatusId = this.task?.task_status_id
       return this.taskStatusMap?.get(taskStatusId) || {}
@@ -274,6 +323,7 @@ export default {
 .validation {
   cursor: pointer;
   margin-bottom: 3px;
+  padding: 0;
 
   &.selected {
     background-color: #bfc1ff !important;
@@ -293,9 +343,10 @@ export default {
 }
 
 .wrapper {
-  position: relative;
   display: flex;
+  flex: 1;
   flex-wrap: wrap;
+  position: relative;
 }
 
 .avatar {
@@ -345,8 +396,8 @@ export default {
 
 .subscribed {
   position: absolute;
-  bottom: -10px;
-  right: -5px;
+  bottom: -4px;
+  right: 4px;
   color: $grey;
 }
 

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -330,6 +330,7 @@
                     'hidden-validation-cell': hiddenColumns[columnId],
                     'datatable-row-header': true
                   }"
+                  :contact-sheet="contactSheetMode"
                   :key="'sticky-validation-' + columnId + '-' + asset.id"
                   :canceled="asset.canceled"
                   :column="taskTypeMap.get(columnId)"
@@ -476,6 +477,7 @@
                   :key="'validation' + columnId + '-' + asset.id"
                   :canceled="asset.canceled"
                   :column="taskTypeMap.get(columnId)"
+                  :contact-sheet="contactSheetMode"
                   :entity="asset"
                   :task-test="taskMap.get(asset.validations.get(columnId))"
                   :selected="
@@ -619,6 +621,10 @@ export default {
   },
 
   props: {
+    contactSheetMode: {
+      type: Boolean,
+      default: false
+    },
     displayedAssets: {
       type: Array,
       default: () => []

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -317,6 +317,7 @@
                     'hidden-validation-cell': hiddenColumns[columnId],
                     'datatable-row-header': true
                   }"
+                  :contact-sheet="contactSheetMode"
                   :column="taskTypeMap.get(columnId)"
                   :column-y="j"
                   :entity="edit"
@@ -400,6 +401,7 @@
                     'validation-cell': !hiddenColumns[columnId],
                     'hidden-validation-cell': hiddenColumns[columnId]
                   }"
+                  :contact-sheet="contactSheetMode"
                   :key="`${columnId}-${edit.id}`"
                   :column="taskTypeMap.get(columnId)"
                   :entity="edit"
@@ -511,6 +513,10 @@ export default {
   ],
 
   props: {
+    contactSheetMode: {
+      type: Boolean,
+      default: false
+    },
     displayedEdits: {
       type: Array,
       default: () => []

--- a/src/components/lists/EpisodeList.vue
+++ b/src/components/lists/EpisodeList.vue
@@ -283,6 +283,7 @@
                   }"
                   :column="taskTypeMap.get(columnId)"
                   :column-y="j"
+                  :contact-sheet="contactSheetMode"
                   :entity="episode"
                   :is-assignees="isShowAssignations"
                   :is-static="true"
@@ -421,11 +422,12 @@
                   :ref="`validation-${i}-${
                     j + stickedDisplayedValidationColumns.length
                   }`"
+                  :key="`${columnId}-${episode.id}`"
                   :class="{
                     'validation-cell': !hiddenColumns[columnId],
                     'hidden-validation-cell': hiddenColumns[columnId]
                   }"
-                  :key="`${columnId}-${episode.id}`"
+                  :contact-sheet="contactSheetMode"
                   :column="taskTypeMap.get(columnId)"
                   :entity="episode"
                   :task-test="
@@ -521,6 +523,10 @@ export default {
   ],
 
   props: {
+    contactSheetMode: {
+      type: Boolean,
+      default: false
+    },
     displayedEpisodes: {
       type: Array,
       default: () => []

--- a/src/components/lists/SequenceList.vue
+++ b/src/components/lists/SequenceList.vue
@@ -270,6 +270,7 @@
                     'hidden-validation-cell': hiddenColumns[columnId],
                     'datatable-row-header': true
                   }"
+                  :contact-sheet="contactSheetMode"
                   :column="taskTypeMap.get(columnId)"
                   :column-y="j"
                   :entity="sequence"
@@ -394,6 +395,7 @@
                     'validation-cell': !hiddenColumns[columnId],
                     'hidden-validation-cell': hiddenColumns[columnId]
                   }"
+                  :contact-sheet="contactSheetMode"
                   :key="`${columnId}-${sequence.id}`"
                   :column="taskTypeMap.get(columnId)"
                   :entity="sequence"
@@ -493,6 +495,10 @@ export default {
   ],
 
   props: {
+    contactSheetMode: {
+      type: Boolean,
+      default: false
+    },
     displayedSequences: {
       type: Array,
       default: () => []

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -341,6 +341,7 @@
                   :canceled="shot.canceled"
                   :column="taskTypeMap.get(columnId)"
                   :column-y="j"
+                  :contact-sheet="contactSheetMode"
                   :entity="shot"
                   :is-assignees="isShowAssignations"
                   :is-casting-ready="isCastingReady(shot, columnId)"
@@ -621,6 +622,7 @@
                   :canceled="shot.canceled"
                   :key="`${columnId}-${shot.id}`"
                   :column="taskTypeMap.get(columnId)"
+                  :contact-sheet="contactSheetMode"
                   :entity="shot"
                   :task-test="
                     taskMap.get(
@@ -757,6 +759,10 @@ export default {
   },
 
   props: {
+    contactSheetMode: {
+      type: Boolean,
+      default: false
+    },
     displayedShots: {
       type: Array,
       default: () => []

--- a/src/components/lists/TaskStatusList.vue
+++ b/src/components/lists/TaskStatusList.vue
@@ -151,6 +151,12 @@ export default {
       )
       this.$emit('update-priorities', taskStatusPriorities)
     }
+  },
+
+  watch: {
+    entries() {
+      this.taskStatuses = this.entries
+    }
   }
 }
 </script>

--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -1456,11 +1456,11 @@ export const annotationMixin = {
             if (obj._objects) {
               obj._objects.forEach(obj => {
                 tmpCanvas.add(obj)
-                obj.strokeWidth = 8 / scaleRatio
+                obj.strokeWidth = obj.strokeWidth / scaleRatio
               })
             } else {
               tmpCanvas.add(obj)
-              obj.strokeWidth = 8 / scaleRatio
+              obj.strokeWidth = obj.strokeWidth / scaleRatio
             }
           })
           tmpCanvas.setZoom(scaleRatio)

--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -525,16 +525,24 @@ export const annotationMixin = {
             }
           }
         })
-        const preview = this.$options.annotatedPreview
+      }
+      this.updateAnnotationsInStore()
+      const annotations = []
+      this.annotations.forEach(a => annotations.push({ ...a }))
+      return annotations
+    },
+
+    updateAnnotationsInStore(preview) {
+      if (!preview) {
+        preview = this.$options.annotatedPreview
+      }
+      if (preview) {
         this.$store.commit('UPDATE_PREVIEW_ANNOTATION', {
           taskId: preview.task_id,
           preview: preview,
           annotations: this.annotations
         })
       }
-      const annotations = []
-      this.annotations.forEach(a => annotations.push({ ...a }))
-      return annotations
     },
 
     /*

--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -1503,7 +1503,10 @@ export const playerMixin = {
         this.rawPlayer.setCurrentFrame(frame)
         this.onFrameUpdate(frame)
         this.syncComparisonPlayer()
-      }, 20)
+        this.$nextTick(() => {
+          this.reloadCurrentAnnotation()
+        })
+      }, 100)
     },
 
     // Annotation extraction
@@ -1541,6 +1544,7 @@ export const playerMixin = {
         const filename = `annotation ${index}.png`
         const frameNumber =
           roundToFrame(annotation.time, this.fps) / this.frameDuration
+        console.log('exctaing frame', frameNumber)
         await this.extractVideoFrame(canvas, frameNumber)
         await this.copyAnnotationCanvas(canvas, annotation)
         const file = await this.getFileFromCanvas(canvas, filename)

--- a/src/components/mixins/search.js
+++ b/src/components/mixins/search.js
@@ -66,20 +66,32 @@ export const searchMixin = {
 
   watch: {
     $route(newRoute, previousRoute) {
-      if (
-        !this.$route.query ||
-        !this.type ||
-        previousRoute.query.task_id !== newRoute.query.task_id
-      ) {
-        return
-      }
+      if (newRoute.query.episode_id !== previousRoute.query.episode_id) {
+        this.clearSelection()
+      } else {
+        if (
+          !this.$route.query ||
+          !this.type ||
+          previousRoute.query.task_id !== newRoute.query.task_id
+        ) {
+          if (
+            newRoute.query.task_id &&
+            previousRoute.query.task_id !== newRoute.query.task_id
+          ) {
+            const listName = `${this.type}-list`
+            this.clearSelection()
+            this.$refs[listName]?.selectTaskFromQuery()
+          }
+          return
+        }
 
-      const search = this.$route.query.search
-      const searchTextVariable = `${this.type}SearchText`
-      if (search !== this[searchTextVariable]) {
-        this.applySearchFromUrl()
-        if (this.clearSelection) {
-          this.clearSelection()
+        const search = this.$route.query.search
+        const searchTextVariable = `${this.type}SearchText`
+        if (search !== this[searchTextVariable]) {
+          this.applySearchFromUrl()
+          if (this.clearSelection) {
+            this.clearSelection()
+          }
         }
       }
     }

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -35,6 +35,13 @@
                 v-model="selectedDepartment"
                 v-if="departments.length > 0"
               />
+              <button-simple
+                class="flexrow-item"
+                icon="grid"
+                :is-on="contactSheetMode"
+                :title="$t('tasks.show_contact_sheet')"
+                @click="contactSheetMode = !contactSheetMode"
+              />
               <show-assignations-button class="flexrow-item" />
               <show-infos-button class="flexrow-item" />
               <big-thumbnails-button class="flexrow-item" />
@@ -85,6 +92,7 @@
         />
         <asset-list
           ref="asset-list"
+          :contact-sheet-mode="contactSheetMode"
           :displayed-assets="
             showSharedAssets
               ? displayedAssetsByType
@@ -92,8 +100,8 @@
           "
           :is-loading="isAssetsLoading || initialLoading"
           :is-error="isAssetsLoadingError"
-          :validation-columns="assetValidationColumns"
           :department-filter="departmentFilter"
+          :validation-columns="assetValidationColumns"
           @change-sort="onChangeSortClicked"
           @create-tasks="showCreateTasksModal"
           @delete-all-tasks="onDeleteAllTasksClicked"
@@ -330,6 +338,7 @@ export default {
         }
       ],
       assetFilterTypes: ['Type'],
+      contactSheetMode: false,
       deleteAllTasksLockText: null,
       descriptorToEdit: {},
       departmentFilter: [],
@@ -451,6 +460,7 @@ export default {
       'assetSorting',
       'assetTypes',
       'assetValidationColumns',
+      'contactSheetMode',
       'currentEpisode',
       'currentProduction',
       'currentSection',

--- a/src/components/pages/Edits.vue
+++ b/src/components/pages/Edits.vue
@@ -29,6 +29,13 @@
               v-if="departments.length > 0"
             />
             <div class="flexrow flexrow-item" v-if="!isCurrentUserClient">
+              <button-simple
+                class="flexrow-item"
+                icon="grid"
+                :is-on="contactSheetMode"
+                :title="$t('tasks.show_contact_sheet')"
+                @click="contactSheetMode = !contactSheetMode"
+              />
               <show-assignations-button class="flexrow-item" />
               <show-infos-button class="flexrow-item" />
               <big-thumbnails-button class="flexrow-item" />
@@ -78,6 +85,7 @@
         />
         <edit-list
           ref="edit-list"
+          :contact-sheet-mode="contactSheetMode"
           :displayed-edits="displayedEdits"
           :is-loading="isEditsLoading || initialLoading"
           :is-error="isEditsLoadingError"
@@ -310,6 +318,7 @@ export default {
   data() {
     return {
       type: 'edit',
+      contactSheetMode: false,
       deleteAllTasksLockText: null,
       descriptorToEdit: {},
       departmentFilter: [],

--- a/src/components/pages/Episodes.vue
+++ b/src/components/pages/Episodes.vue
@@ -27,6 +27,13 @@
                 v-model="selectedDepartment"
                 v-if="departments.length > 0"
               />
+              <button-simple
+                class="flexrow-item"
+                icon="grid"
+                :is-on="contactSheetMode"
+                :title="$t('tasks.show_contact_sheet')"
+                @click="contactSheetMode = !contactSheetMode"
+              />
               <show-assignations-button class="flexrow-item" />
               <show-infos-button class="flexrow-item" />
               <big-thumbnails-button class="flexrow-item" />
@@ -58,6 +65,7 @@
         />
         <episode-list
           ref="episode-list"
+          :contact-sheet-mode="contactSheetMode"
           :displayed-episodes="displayedEpisodes"
           :is-loading="isEpisodesLoading || initialLoading"
           :is-error="isEpisodesLoadingError"
@@ -248,6 +256,7 @@ export default {
   data() {
     return {
       type: 'episode',
+      contactSheetMode: false,
       deleteAllTasksLockText: null,
       descriptorToEdit: {},
       departmentFilter: [],

--- a/src/components/pages/Sequences.vue
+++ b/src/components/pages/Sequences.vue
@@ -27,6 +27,13 @@
                 v-model="selectedDepartment"
                 v-if="departments.length > 0"
               />
+              <button-simple
+                class="flexrow-item"
+                icon="grid"
+                :is-on="contactSheetMode"
+                :title="$t('tasks.show_contact_sheet')"
+                @click="contactSheetMode = !contactSheetMode"
+              />
               <show-assignations-button class="flexrow-item" />
               <show-infos-button class="flexrow-item" />
               <big-thumbnails-button class="flexrow-item" />
@@ -58,6 +65,7 @@
         />
         <sequence-list
           ref="sequence-list"
+          :contact-sheet-mode="contactSheetMode"
           :displayed-sequences="displayedSequences"
           :is-loading="isSequencesLoading || initialLoading"
           :is-error="isSequencesLoadingError"
@@ -247,6 +255,7 @@ export default {
   data() {
     return {
       type: 'sequence',
+      contactSheetMode: false,
       deleteAllTasksLockText: null,
       descriptorToEdit: {},
       departmentFilter: [],

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -82,7 +82,6 @@
                 icon="plus"
                 @click="showManageShots"
               />
-
             </div>
           </div>
 

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -33,6 +33,13 @@
                 v-model="selectedDepartment"
                 v-if="departments.length > 0"
               />
+              <button-simple
+                class="flexrow-item"
+                icon="grid"
+                :is-on="contactSheetMode"
+                :title="$t('tasks.show_contact_sheet')"
+                @click="contactSheetMode = !contactSheetMode"
+              />
               <show-assignations-button class="flexrow-item" />
               <show-infos-button class="flexrow-item" />
               <big-thumbnails-button class="flexrow-item" />
@@ -75,6 +82,7 @@
                 icon="plus"
                 @click="showManageShots"
               />
+
             </div>
           </div>
 
@@ -97,11 +105,12 @@
         />
         <shot-list
           ref="shot-list"
+          :contact-sheet-mode="contactSheetMode"
+          :department-filter="departmentFilter"
           :displayed-shots="displayedShotsBySequence"
           :is-loading="isShotsLoading || initialLoading"
           :is-error="isShotsLoadingError"
           :validation-columns="shotValidationColumns"
-          :department-filter="departmentFilter"
           @add-metadata="onAddMetadataClicked"
           @add-shots="showManageShots"
           @change-sort="onChangeSortClicked"
@@ -368,11 +377,12 @@ export default {
   data() {
     return {
       type: 'shot',
-      initialLoading: true,
+      contactSheetMode: false,
       deleteAllTasksLockText: null,
       descriptorToEdit: {},
       formData: null,
       historyShot: {},
+      initialLoading: true,
       optionalColumns: [
         'Description',
         'Nb Frames',

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -100,6 +100,7 @@
           :entity-type="entityType"
           :extendable="false"
           :is-preview="false"
+          :player="this"
           :root="false"
           :silent="isCommentsHidden"
           :task="task"

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1747,11 +1747,11 @@ export default {
             if (obj._objects) {
               obj._objects.forEach(obj => {
                 tmpCanvas.add(obj)
-                obj.strokeWidth = 8 / scaleRatio
+                obj.strokeWidth = obj.strokeWidth / scaleRatio
               })
             } else {
               tmpCanvas.add(obj)
-              obj.strokeWidth = 8 / scaleRatio
+              obj.strokeWidth = obj.strokeWidth / scaleRatio
             }
           })
           tmpCanvas.setZoom(scaleRatio)

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1392,6 +1392,7 @@ export default {
         this.clearFocus()
         this.previewViewer.resize()
         this.comparisonViewer.resize()
+        this.triggerResize()
       })
     },
 
@@ -1519,6 +1520,10 @@ export default {
     },
 
     // Annotations
+
+    triggerResize() {
+      window.dispatchEvent(new Event('resize'))
+    },
 
     onDeleteClicked() {
       this.clearFocus()

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -888,7 +888,7 @@ export default {
         this.currentPreviewDlPath = this.getOriginalDlPath()
         this.resetDraft()
         this.$nextTick(() => {
-          this.$refs['preview-player'].focus()
+          this.$refs['preview-player']?.focus()
         })
       }
     },

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -888,7 +888,7 @@ export default {
         this.currentPreviewDlPath = this.getOriginalDlPath()
         this.resetDraft()
         this.$nextTick(() => {
-          this.focusCommentTextarea()
+          this.$refs['preview-player'].focus()
         })
       }
     },


### PR DESCRIPTION
**Problem**

Sometimes, on entity pages, it's easier to see tasks as visuals, like in a contact sheet. 

**Solution**

Use `last_preview_file_id` to display pictures instead of status names in the entities pages.
