### PR TITLE
bugfix for daily quotas giving the incorrect date range for days.

### DIFF
--- a/src/lib/csv.js
+++ b/src/lib/csv.js
@@ -18,20 +18,20 @@ const csv = {
     unit,
     organisation,
     detailLevel,
+    todayYear,
+    todayMonth,
     year,
     month,
-    currentYear,
-    currentMonth,
-    currentWeek
+    week
   ) {
     const headers = csv.getTimesheetHeaders(
       timesheet,
       detailLevel,
+      todayYear,
+      todayMonth,
       year,
       month,
-      currentYear,
-      currentMonth,
-      currentWeek
+      week
     )
     const entries = csv.getTimesheetEntries(
       organisation,
@@ -47,11 +47,11 @@ const csv = {
   getTimesheetHeaders(
     timesheet,
     detailLevel,
+    todayYear,
+    todayMonth,
     year,
     month,
-    currentYear,
-    currentMonth,
-    currentWeek
+    week
   ) {
     const headers = ['Person']
     let range = []
@@ -60,11 +60,11 @@ const csv = {
         headers.push(yearLabel)
       })
     } else if (detailLevel === 'month') {
-      range = getMonthRange(year, currentYear, currentMonth)
+      range = getMonthRange(year, todayYear, todayMonth)
     } else if (detailLevel === 'week') {
-      range = getWeekRange(year, currentYear, currentWeek)
+      range = getWeekRange(year, todayYear)
     } else if (detailLevel === 'day') {
-      range = getDayRange(year, month, currentYear, currentMonth)
+      range = getDayRange(year, month, todayYear, todayMonth)
     }
     for (const unit in range) {
       let value = parseInt(unit) + 1
@@ -403,7 +403,10 @@ const csv = {
             quotas[person.id] &&
             quotas[person.id][detailLevel][countMode][key]
           ) {
-            line.push(quotas[person.id][detailLevel][countMode][key])
+            let value = quotas[person.id][detailLevel][countMode][key]
+            if (typeof value === 'number')
+              value = Math.round((value + Number.EPSILON) * 100) / 100
+            line.push(value)
           } else {
             line.push('-')
           }


### PR DESCRIPTION
**Problem**
download the daily quotas for month January 2025 and the headers are for the current month, February.

**Solution**
There was a mix up between month and currentMonth, and todayMonth.  Changed to todayMonth to make it consistent accross the csv.js file.
