### PR TITLE
Update comment rights

### DIFF
--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -237,7 +237,7 @@
                       isCurrentUserManager
                     "
                     :is-editable="
-                      user.id === comment.person?.id || isCurrentUserAdmin
+                      user.id === comment.person?.id || isCurrentUserManager
                     "
                     :is-pinnable="
                       isDepartmentSupervisor || isCurrentUserManager
@@ -474,7 +474,6 @@ export default {
       'getTaskComments',
       'getTaskPreviews',
       'getTaskComment',
-      'isCurrentUserAdmin',
       'isCurrentUserArtist',
       'isCurrentUserClient',
       'isCurrentUserManager',

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -204,7 +204,7 @@
                         isCurrentUserManager
                       "
                       :is-editable="
-                        user.id === comment.person?.id || isCurrentUserAdmin
+                        user.id === comment.person?.id || isCurrentUserManager
                       "
                       :is-pinnable="
                         isDepartmentSupervisor || isCurrentUserManager
@@ -522,7 +522,6 @@ export default {
       'getTaskComments',
       'getTaskPreviews',
       'getTaskStatusForCurrentUser',
-      'isCurrentUserAdmin',
       'isCurrentUserArtist',
       'isCurrentUserClient',
       'isCurrentUserManager',


### PR DESCRIPTION
**Problem**
- A production manager cannot edit comments on Kitsu, but is allowed on Zou.

**Solution**
- Allow production managers to edit comments.
