### PR TITLE
Various optimizations

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -46,6 +46,7 @@ export default {
       'departmentMap',
       'editMap',
       'episodeMap',
+      'todoMap',
       'isCurrentUserAdmin',
       'isDataLoading',
       'isDarkTheme',
@@ -57,6 +58,7 @@ export default {
       'productionMap',
       'sequenceMap',
       'shotMap',
+      'taskComments',
       'taskMap',
       'taskStatusMap',
       'taskTypeMap',
@@ -415,11 +417,19 @@ export default {
 
       'comment:new'(eventData) {
         const commentId = eventData.comment_id
-        if (
-          !this.isSavingCommentPreview &&
-          this.taskMap.get(eventData.task_id)
-        ) {
-          this.loadComment({ commentId }).catch(console.error)
+        const task = this.taskMap.get(eventData.task_id)
+        if (!this.isSavingCommentPreview && task) {
+          if (
+            this.taskComments[eventData.task_id] ||
+            this.todoMap.get(eventData.task_id)
+          ) {
+            this.loadComment({ commentId }).catch(console.error)
+          } else {
+            this.$store.commit('UPDATE_TASK', {
+              task,
+              taskStatusId: eventData.task_status_id
+            })
+          }
         }
       },
 

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -615,9 +615,11 @@ export default {
 
     reloadEpisodeShotsIfNeeded() {
       if (
-        (this.isTVShow && this.displayedSequences.length === 0) ||
-        this.displayedSequences[0]?.episode_id !== this.currentEpisode?.id ||
-        this.displayedShots[0]?.episode_id !== this.currentEpisode?.id
+        ((this.isTVShow && this.displayedSequences.length === 0) ||
+          this.displayedSequences[0]?.episode_id !== this.currentEpisode?.id ||
+          this.displayedShots[0]?.episode_id !== this.currentEpisode?.id) &&
+        !this.isShotsLoading &&
+        !this.initialLoading
       ) {
         this.$refs['shot-search-field']?.setValue('')
         this.$store.commit('SET_SHOT_LIST_SCROLL_POSITION', 0)
@@ -1159,23 +1161,19 @@ export default {
     },
 
     currentProduction() {
-      this.$refs['shot-search-field']?.setValue('')
-      this.$store.commit('SET_SHOT_LIST_SCROLL_POSITION', 0)
+      if (!this.initialLoading) {
+        this.$refs['shot-search-field']?.setValue('')
+        this.$store.commit('SET_SHOT_LIST_SCROLL_POSITION', 0)
 
-      this.initialLoading = true
-      if (!this.isTVShow) {
-        this.loadShots(() => {
-          this.initialLoading = false
-        })
+        if (!this.isTVShow) {
+          this.loadShots()
+        }
       }
     },
 
     currentEpisode() {
       const finalize = () => {
-        this.initialLoading = true
-        this.loadShots(() => {
-          this.initialLoading = false
-        })
+        this.loadShots()
       }
       if (this.isTVShow && this.currentEpisode) {
         if (

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -197,7 +197,7 @@ const actions = {
 
   loadComment({ commit }, { commentId }) {
     return tasksApi.getTaskComment({ id: commentId }).then(comment => {
-      // FIXME: currently the API returns a list of comment IDs
+      // The API returns a list of preview IDs instead of objects.
       comment.previews = comment.previews.map(id => ({ id }))
       commit(NEW_TASK_COMMENT_END, { comment })
       return comment
@@ -1211,9 +1211,10 @@ const mutations = {
     }
   },
 
-  [UPDATE_TASK](state, { task, nbAssetsReady, updatedAt }) {
+  [UPDATE_TASK](state, { task, nbAssetsReady, updatedAt, taskStatusId }) {
     if (nbAssetsReady) task.nb_assets_ready = nbAssetsReady
     if (updatedAt) task.updated_at = updatedAt
+    if (taskStatusId) task.task_status_id = taskStatusId
   },
 
   [EDIT_TASK_DATES](state, { taskId, data }) {

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -108,6 +108,7 @@ const initialState = {
   isTodosLoading: false,
   isTodosLoadingError: false,
   todos: [],
+  todoMap: new Map(),
   displayedTodos: [],
   displayedDoneTasks: [],
   todosSearchText: '',
@@ -144,6 +145,7 @@ const getters = {
   isSaveProfileLoadingError: state => state.isSaveProfileLoadingError,
   changePassword: state => state.changePassword,
 
+  todoMap: state => state.todoMap,
   displayedTodos: state => state.displayedTodos,
   displayedDoneTasks: state => state.displayedDoneTasks,
   doneSelectionGrid: state => state.doneSelectionGrid,
@@ -561,6 +563,7 @@ const mutations = {
     })
     state.todoSelectionGrid = buildSelectionGrid(tasks.length, 1)
     state.todos = sortTasks(tasks, taskTypeMap)
+    state.todoMap = new Map(tasks.map(task => [task.id, task]))
     cache.todosIndex = buildTaskIndex(tasks)
     const keywords = getKeyWords(state.todosSearchText)
     const searchResult = indexSearch(cache.todosIndex, keywords)


### PR DESCRIPTION
**Problem**

* The shot page loads data twice while it's a big request
* Posting a new comment generates many requests related to real time, which can flood the server

**Solution**

* Do not load data when production or episode is changed if data are already loading
* Reload comment only if the task is listed in the todo list or if the task panel is open