### PR TITLE
Various fixes

### DIFF
--- a/src/components/mixins/entity_list.js
+++ b/src/components/mixins/entity_list.js
@@ -543,8 +543,9 @@ export const entityListMixin = {
             list = list.flat()
           }
           const x = list.findIndex(e => e.id === entity.id)
-          const y = this.validationColumns.indexOf(task.task_type_id)
-
+          const y = this.nonStickedDisplayedValidationColumns.indexOf(
+            task.task_type_id
+          )
           this.$store.commit('ADD_SELECTED_TASK', {
             task,
             entity,

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -31,7 +31,8 @@ export const applyFilters = (entries, filters, taskMap) => {
       filters.forEach(filter => {
         if (isOk === false && !filters.union) return false
         if (isOk === true && filters.union) return true
-        isOk = applyFiltersFunctions[filter.type](entry, filter, taskMap)
+        isOk =
+          applyFiltersFunctions[filter.type](entry, filter, taskMap) || false
       })
       return isOk
     })
@@ -138,6 +139,7 @@ const applyFiltersFunctions = {
     const task = taskMap.get(entry.validations.get(filter.taskType.id))
     let isOk = true
     isOk = task && filter.taskStatuses.includes(task.task_status_id)
+    isOk = isOk || false
     if (filter.excluding) isOk = !isOk
     return isOk
   },


### PR DESCRIPTION
**Problem**

* Empty tasks are added to search results in entity lists.
* Sometimes the selected task is not properly displayed (another task next to it is selected).


**Solution**

* Undefined in filter results is always considered as false
* Use the right array to get the index of currently selected task
