### PR TITLE
Various fixes

### DIFF
--- a/src/components/pages/EpisodeStats.vue
+++ b/src/components/pages/EpisodeStats.vue
@@ -254,6 +254,7 @@ export default {
     reset() {
       this.isLoading = true
       this.isLoadingError = false
+      this.setCountOptions()
       this.loadEpisodeStats(this.currentProduction.id)
         .then(() => {
           return this.loadEpisodeRetakeStats(this.currentProduction.id)

--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1604,6 +1604,7 @@ export default {
 
     onPreviewChanged(entity, previewFile) {
       if (!previewFile) return
+      this.currentPreviewIndex = 0
       this.changePreviewFile(entity, previewFile)
       this.updateRoomStatus()
     },


### PR DESCRIPTION
**Problem**

* Count options are wrong when switching from a 2D paper production to a frame production
* In playlists, switching from a subpreview to another task type, leads to an empty preview


**Solution**

* Reset count options on production change
* Reset subpreview index on preview change
