### PR TITLE
[Budget] Various fixes

### DIFF
--- a/src/components/modals/EditBudgetEntryModal.vue
+++ b/src/components/modals/EditBudgetEntryModal.vue
@@ -6,6 +6,7 @@
   >
     <form @submit.prevent>
       <combobox-department
+        ref="departmentField"
         :label="$t('budget.fields.department')"
         v-model="form.department_id"
         @enter="runConfirmation"
@@ -15,7 +16,7 @@
       <people-field
         class="mt2"
         :label="$t('budget.fields.person')"
-        :people="activePeople"
+        :people="departmentPeople"
         @select="onPersonChanged"
         @enter="runConfirmation"
         v-model="form.person"
@@ -232,6 +233,16 @@ export default {
       ).endOf('month')
       const maxDuration = projectEndDate.diff(startDate, 'months')
       return maxDuration > 0 ? maxDuration : 1
+    },
+
+    departmentPeople() {
+      if (this.form.department_id) {
+        return this.activePeople.filter(person =>
+          person.departments.includes(this.form.department_id)
+        )
+      } else {
+        return this.activePeople
+      }
     }
   },
 

--- a/src/components/modals/EditBudgetEntryModal.vue
+++ b/src/components/modals/EditBudgetEntryModal.vue
@@ -262,8 +262,8 @@ export default {
 
     onPersonChanged(person) {
       if (person) {
-        this.form.position = person.position
-        this.form.seniority = person.seniority
+        this.form.position = person.position || 'artist'
+        this.form.seniority = person.seniority || 'junior'
       } else {
         this.form.position = 'artist'
         this.form.seniority = 'junior'
@@ -281,8 +281,8 @@ export default {
           id: this.budgetEntryToEdit.id,
           department_id: this.budgetEntryToEdit.department_id,
           person,
-          position: this.budgetEntryToEdit.position,
-          seniority: this.budgetEntryToEdit.seniority,
+          position: this.budgetEntryToEdit.position || 'artist',
+          seniority: this.budgetEntryToEdit.seniority || 'junior',
           start_date: parseSimpleDate(
             this.budgetEntryToEdit.start_date
           ).toDate(),

--- a/src/components/modals/EditPersonModal.vue
+++ b/src/components/modals/EditPersonModal.vue
@@ -298,11 +298,13 @@ export default {
         { label: 'admin', value: 'admin' }
       ],
       positionOptions: [
+        { label: '', value: null },
         { label: 'artist', value: 'artist' },
         { label: 'supervisor', value: 'supervisor' },
         { label: 'lead', value: 'lead' }
       ],
       seniorityOptions: [
+        { label: '', value: null },
         { label: 'senior', value: 'senior' },
         { label: 'mid', value: 'mid' },
         { label: 'junior', value: 'junior' }

--- a/src/components/pages/budget/Budget.vue
+++ b/src/components/pages/budget/Budget.vue
@@ -292,7 +292,7 @@ export default {
       return this.monthsBetweenProductionDates.map(monthDate => {
         const monthKey = monthDate.format('YYYY-MM')
         const [year, month] = monthKey.split('-')
-        const label = month === '01' ? `${year.slice(2)}/${month}` : month
+        const label = `${month}/${year.slice(2)}`
         return [label, this.totalEntry.monthCosts[monthKey] || 0]
       })
     }

--- a/src/components/pages/budget/Budget.vue
+++ b/src/components/pages/budget/Budget.vue
@@ -210,7 +210,8 @@ export default {
           monthCosts: {},
           total: 0,
           duration: 0,
-          persons: []
+          persons: [],
+          start_date: null
         }
         departmentEntries.forEach(entry => {
           const monthlySalary = entry.daily_salary * 20
@@ -231,10 +232,27 @@ export default {
             months_duration: entry.months_duration,
             start_date: entry.start_date
           })
+          const startDate = moment(entry.start_date)
+          const departmentStartDate = moment(departmentData.start_date)
+          if (
+            !departmentData.start_date ||
+            startDate.isBefore(departmentStartDate)
+          ) {
+            departmentData.start_date = entry.start_date
+          }
           departmentData.persons.sort(this.sortDepartmentPersons)
         })
         helpers.resetDepartmentTotals(departmentData)
         budgetDepartments.push(departmentData)
+      })
+      budgetDepartments.sort((a, b) => {
+        if (a.start_date === b.start_date) {
+          const departmentA = this.departmentMap.get(a.id)
+          const departmentB = this.departmentMap.get(b.id)
+          return departmentA.name.localeCompare(departmentB.name)
+        } else {
+          return moment(a.start_date).isBefore(b.start_date) ? -1 : 1
+        }
       })
       return budgetDepartments
     },

--- a/src/components/pages/budget/Budget.vue
+++ b/src/components/pages/budget/Budget.vue
@@ -446,6 +446,7 @@ export default {
     },
 
     onAddBudgetEntry() {
+      this.budgetEntryToEdit = {}
       this.modals.createBudgetEntry = true
     },
 

--- a/src/components/pages/budget/BudgetList.vue
+++ b/src/components/pages/budget/BudgetList.vue
@@ -219,6 +219,8 @@ import { grabListMixin } from '@/components/mixins/grablist'
 
 import { ChevronDownIcon, ChevronRightIcon } from 'lucide-vue-next'
 
+import preferences from '@/lib/preferences'
+
 import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import PeopleName from '@/components/widgets/PeopleName.vue'
 import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
@@ -293,7 +295,9 @@ export default {
   },
 
   mounted() {
+    const key = `budget:collapsed-departments-${this.currentProduction.id}`
     this.addEvents(this.domEvents)
+    this.collapsedDepartments = preferences.getObjectPreference(key) || {}
   },
 
   beforeUnmount() {
@@ -302,7 +306,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['departmentMap', 'personMap'])
+    ...mapGetters(['currentProduction', 'departmentMap', 'personMap'])
   },
 
   methods: {
@@ -311,6 +315,9 @@ export default {
     toggleDepartment(departmentId) {
       this.collapsedDepartments[departmentId] =
         !this.collapsedDepartments[departmentId]
+
+      const key = `budget:collapsed-departments-${this.currentProduction.id}`
+      preferences.setObjectPreference(key, this.collapsedDepartments)
     },
 
     getDepartmentStyle(departmentId, opacity) {

--- a/src/components/tops/TopbarSectionList.vue
+++ b/src/components/tops/TopbarSectionList.vue
@@ -15,6 +15,7 @@
           />
           <hand-coins-icon
             class="section-icon"
+            :stroke-width="1.5"
             v-if="currentSectionValue === 'budget'"
           />
           {{ currentSectionLabel }}
@@ -39,6 +40,7 @@
             />
             <hand-coins-icon
               class="section-icon"
+              :stroke-width="1.5"
               v-if="section.value === 'budget'"
             />
             <span class="flexrow-item">


### PR DESCRIPTION
**Problem**

* The icon style is wrong
* Null value is not properly handled in the edit person modal
* People are not filtered by department in the edit budget entry modal
* When someone has no seniority or position, budget entry addition is not properly handled
* Department collapsing is not saved
* Monthly chart displays only values over 12 months
* Adding an entry after an edition doesn't reset the modal

**Solution**

* Make the outline width cohesive
* Add a null choice to the related combo box
* Filter the  people list on department change
* Use default values when seniority or position is missing
* Save the  department collapsing state in the local storage
* Set labels properly to avoid using the same one for different months
* Reset the entry to edit before opening the add modal
