### PR TITLE
Various fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "localStorage": "1.0.4",
         "prettier": "3.5.3",
         "sass": "1.87.0",
-        "vite": "6.3.3",
+        "vite": "6.3.4",
         "vitest": "3.1.2",
         "vitest-localstorage-mock": "0.1.2"
       },
@@ -8516,9 +8516,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.3.tgz",
-      "integrity": "sha512-5nXH+QsELbFKhsEfWLkHrvgRpTdGJzqOZ+utSdmPTvwHmvU6ITTm3xx+mRusihkcI8GeC7lCDyn3kDtiki9scw==",
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.4.tgz",
+      "integrity": "sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "localStorage": "1.0.4",
     "prettier": "3.5.3",
     "sass": "1.87.0",
-    "vite": "6.3.3",
+    "vite": "6.3.4",
     "vitest": "3.1.2",
     "vitest-localstorage-mock": "0.1.2"
   },

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1632,7 +1632,8 @@ export default {
 
     dayOffStyle(dayOff) {
       return {
-        left: `${this.getDayOffLeft(dayOff)}px`
+        left: `${this.getDayOffLeft(dayOff)}px`,
+        width: `${this.cellWidth - 1}px`
       }
     },
 
@@ -2798,8 +2799,9 @@ const setItemPositions = (items, unitOfTime = 'days') => {
 
   .day-off-icon {
     position: absolute;
-    left: 3px;
+    left: 0;
     top: 15px;
+    width: 100%;
     z-index: 100;
   }
 }

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -690,7 +690,7 @@ const actions = {
     })
   },
 
-  unassignSelectedTasks({ commit, state }, { taskIds }) {
+  unassignSelectedTasks({ commit, state }, { taskIds } = {}) {
     const selectedTaskIds = taskIds || Array.from(state.selectedTasks.keys())
     return tasksApi.unassignTasks(selectedTaskIds).then(() => {
       commit(UNASSIGN_TASKS, selectedTaskIds)


### PR DESCRIPTION
**Problem**
-  In the schedules, the style of days off does not adapt to the current zoom level.
-  In the side panel, the "unassign all" action is broken.
-  Some npm dependencies are outdated.

**Solution**
-  Fix the style of days off depending on the zoom level in schedules.
-  Fix "unassign all" action. Missing a default value for destructuring.
- Bump npm dependencies.
