### PR TITLE
Allow searching for shots by name with name including space

### DIFF
--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -966,6 +966,9 @@ export default {
     },
 
     onSequenceClicked(sequenceName) {
+      if (sequenceName.includes(' ')) {
+        sequenceName = `"${sequenceName}"`
+      }
       this.searchField.setValue(`${this.shotSearchText} ${sequenceName}`)
       this.onSearchChange()
     },

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -191,9 +191,9 @@ const applyFiltersFunctions = {
 /**
  * Extract keywords from a given text. Remove equality and exclusion
  * expressions.
- * Replace spaces inside quotes with '@' to allow searching for names containing spaces
+ * Replace spaces inside quotes with '\u00A0' to allow searching for names containing spaces
  *    (e.g., "my sequence" becomes "my@sequence")
- * The '@' will be removed after splitting on spaces
+ * The '\u00A0' will be removed after splitting on spaces
  */
 export const getKeyWords = queryText => {
   if (!queryText) {

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -191,11 +191,19 @@ const applyFiltersFunctions = {
 /**
  * Extract keywords from a given text. Remove equality and exclusion
  * expressions.
+ * Replace spaces inside quotes with '@' to allow searching for names containing spaces
+ *    (e.g., "my sequence" becomes "my@sequence")
+ * The '@' will be removed after splitting on spaces
  */
 export const getKeyWords = queryText => {
   if (!queryText) {
     return []
   } else {
+    queryText = queryText.trim()
+    queryText = queryText.replace(/"([^"]*)"/g, (match, p1) => {
+      return '"' + p1.replace(/ /g, '@') + '"'
+    })
+
     return queryText
       .replace(UNION_REGEX, '')
       .replace(EQUAL_PRIORITY_REGEX, '')
@@ -203,6 +211,16 @@ export const getKeyWords = queryText => {
       .replace(EQUAL_REGEX, '')
       .replace(MULTIPLE_REGEX, '')
       .split(' ')
+      .map(query => query.replace(/@/g, ' '))
+      .map(query => {
+        if (query[0] === '"') {
+          query = query.substring(1)
+        }
+        if (query[query.length - 1] === '"') {
+          query = query.substring(0, query.length - 1)
+        }
+        return query.trim()
+      })
       .filter(query => {
         return query.length > 0 && query[0] !== '-' && query !== 'withthumbnail'
       })

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -201,7 +201,7 @@ export const getKeyWords = queryText => {
   } else {
     queryText = queryText.trim()
     queryText = queryText.replace(/"([^"]*)"/g, (match, p1) => {
-      return '"' + p1.replace(/ /g, '@') + '"'
+      return '"' + p1.replace(/ /g, '\u00A0') + '"'
     })
 
     return queryText
@@ -211,7 +211,7 @@ export const getKeyWords = queryText => {
       .replace(EQUAL_REGEX, '')
       .replace(MULTIPLE_REGEX, '')
       .split(' ')
-      .map(query => query.replace(/@/g, ' '))
+      .map(query => query.replace(/\u00A0/g, ' '))
       .map(query => {
         if (query[0] === '"') {
           query = query.substring(1)

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -192,7 +192,7 @@ const applyFiltersFunctions = {
  * Extract keywords from a given text. Remove equality and exclusion
  * expressions.
  * Replace spaces inside quotes with '\u00A0' to allow searching for names containing spaces
- *    (e.g., "my sequence" becomes "my@sequence")
+ *    (e.g., "my sequence" becomes "my\u00A0sequence")
  * The '\u00A0' will be removed after splitting on spaces
  */
 export const getKeyWords = queryText => {


### PR DESCRIPTION
**Problem**
https://github.com/cgwire/kitsu/issues/1576
if a sequence is called “blue rabbit”, clicking on the name of the sequence won't return any results, and neither will typing rabbit nor blue in the filter bar.

**Solution**
Main constraint: spaces are used as a separator to manage different filter criteria.

To avoid changing this feature and allow names containing spaces, we can add " around the names to protect the space contained in the name.
The characters " are added automatically when you click on the sequence name. You can also add them manually in the search field.

Examples available after this modification:
    "lapin bleu" [Storyboard]=[todo] assignedto[Storyboard]=[john Doe]
    "nom plusieurs mots"
    [Storyboard]=[todo] aa"aa

