### PR TITLE
Add tooltip to entity information footer icon

### DIFF
--- a/src/components/pages/Asset.vue
+++ b/src/components/pages/Asset.vue
@@ -98,6 +98,7 @@
             <div class="flexrow-item has-text-right">
               <button-simple
                 icon="edit"
+                :title="$t('assets.edit_title')"
                 @click="modals.edit = true"
                 v-if="isCurrentUserManager"
               />

--- a/src/components/pages/Edit.vue
+++ b/src/components/pages/Edit.vue
@@ -482,6 +482,7 @@
                   <div class="flexrow-item has-text-right">
                     <button-simple
                       icon="edit"
+                      :title="$t('edits.edit_title')"
                       @click="modals.edit = true"
                       v-if="isCurrentUserManager"
                     />

--- a/src/components/pages/Episode.vue
+++ b/src/components/pages/Episode.vue
@@ -47,6 +47,7 @@
               <div class="flexrow-item has-text-right">
                 <button-simple
                   icon="edit"
+                  :title="$t('episodes.edit_title')"
                   @click="modals.edit = true"
                   v-if="isCurrentUserManager"
                 />

--- a/src/components/pages/Sequence.vue
+++ b/src/components/pages/Sequence.vue
@@ -47,6 +47,7 @@
               <div class="flexrow-item has-text-right">
                 <button-simple
                   icon="edit"
+                  :title="$t('sequences.edit_title')"
                   @click="modals.edit = true"
                   v-if="isCurrentUserManager"
                 />

--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -76,6 +76,7 @@
             <div class="flexrow-item has-text-right">
               <button-simple
                 icon="edit"
+                :title="$t('shots.edit_title')"
                 @click="modals.edit = true"
                 v-if="isCurrentUserManager"
               />


### PR DESCRIPTION
**Problem**
In the management screens of each entity (Asset, Shot, Sequence, ...), in the footer there is an INFORMATION section and an icon on the right to access the popup for modifying the entity description. 
The tooltip on the icon is missing

**Solution**
Add the tooltip title for each entity
