### PR TITLE
Various fixes

### DIFF
--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -436,7 +436,8 @@ export default {
         person =>
           !this.assignments.excludes.includes(person.id) &&
           person.role !== 'client' &&
-          (!person.departments.length ||
+          (['admin', 'manager'].includes(person.role) ||
+            !person.departments.length ||
             person.departments.includes(taskType?.department_id))
       )
     },

--- a/src/components/tops/TopbarSectionList.vue
+++ b/src/components/tops/TopbarSectionList.vue
@@ -23,6 +23,7 @@
           />
           {{ currentSection.label }}
         </div>
+        <chevron-down-icon class="down-icon flexrow-item" />
       </div>
       <div class="select-input" ref="select" v-if="showSectionList">
         <div
@@ -59,7 +60,7 @@
 </template>
 
 <script>
-import { HandCoinsIcon } from 'lucide-vue-next'
+import { ChevronDownIcon, HandCoinsIcon } from 'lucide-vue-next'
 import { mapActions, mapGetters } from 'vuex'
 
 import { getProductionPath } from '@/lib/path'
@@ -71,6 +72,7 @@ export default {
   name: 'topbar-section-list',
 
   components: {
+    ChevronDownIcon,
     ComboboxMask,
     KitsuIcon,
     HandCoinsIcon

--- a/tests/unit/lib/filtering.spec.js
+++ b/tests/unit/lib/filtering.spec.js
@@ -15,6 +15,13 @@ describe('lib/filtering', () => {
       expect(keyWords).toEqual(['chars', 'bunny'])
     })
 
+    it('hold space query', () => {
+      const keyWords = getKeyWords(
+        'chars "bunny fat" modeling=wip -bunnyfat [multiple]'
+      )
+      expect(keyWords).toEqual(['chars', 'bunny fat'])
+    })
+
     it('no keyword query', () => {
       const keyWords = getKeyWords('modeling=wip -bunnyfat')
       expect(keyWords).toEqual([])


### PR DESCRIPTION
**Problem**
- On the auto-assignment form of the production schedule, some people are missing from the available person list.
- Small UI regression on the section dropdown in the top bar.

**Solution**
- Fix the list of available persons in the production schedule. Avoid excluding admin or manager users linked to at least one department.
- Fix dropdown style.