### PR TITLE
Allows filtering of duplicate names in search on Assets page

### DIFF
--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -4,7 +4,6 @@ import {
   buildNameIndex,
   indexSearch
 } from '@/lib/indexing'
-import string from '@/lib/string'
 
 const UNION_REGEX = /\+\(.*\)/
 const EQUAL_REGEX =
@@ -41,6 +40,15 @@ export const applyFilters = (entries, filters, taskMap) => {
   } else {
     return entries
   }
+}
+
+/*
+ * Private function for filtering on names
+ * Simple hash to compare user name
+ * It removes spaces and lowercases the name
+ */
+const hashName = name => {
+  return name.toLowerCase().replace(/ /g, '')
 }
 
 const applyFiltersFunctions = {
@@ -550,7 +558,7 @@ export const getAssignedToFilters = (persons, taskTypes, queryText) => {
   // create a deep copy of persons with slugified names to avoid reference issues
   const shallowPersons = persons.map(person => ({
     ...JSON.parse(JSON.stringify(person)),
-    name: string.slugify(person.name.toLowerCase())
+    name: hashName(person.name)
   }))
 
   const results = []
@@ -573,7 +581,8 @@ export const getAssignedToFilters = (persons, taskTypes, queryText) => {
       value = cleanParenthesis(value)
       const excluding = value.startsWith('-')
       if (excluding) value = value.substring(1)
-      const simplifiedValue = string.slugify(value.toLowerCase())
+      const simplifiedValue = hashName(value)
+
       personIndex.forEach(person => {
         if (person.name === simplifiedValue) {
           results.push({


### PR DESCRIPTION
**Problem**
Related to issue: https://github.com/cgwire/kitsu/issues/712
First issue was solved.
Second issue is about "multiple users have the same name" and was not solved.

If several persons have the same name (first and last name), only one person is considered by filtering.

**Solution**
There were two issues with the filter handling for the person assigned to the task:
- a bug: in a forEach statement, "return true / return false" was coded to exit the loop, which is incorrect because the loop continues to move on to the next item. The function has been replaced with a simple for loop allowing the loop to be exited with a simple break. 

- the suggestion to use the person's ID was correct and already present in the code, transparent to the user. However, there was a flaw in the code because a map was used on the "Name" criterion, which automatically removed elements with the same key. The map is replaced with a simple array of objects, which allows the addition of people with the same name. Searching the array then finds all occurrences of people equal to the name specified in the filter.

In the screenshot below, I demonstrate the use of a complex filter, allowing to find the tasks associated with a username corresponding to 2 different people, as well as the tasks associated with another username

![image](https://github.com/user-attachments/assets/0accab09-2ab9-44ad-bd0c-a898c010b7bd)

