### PR TITLE
width style fix for breakdown columns alignment

### DIFF
--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -109,9 +109,7 @@
           <div
             class="entity-header"
             ref="name-header"
-            :style="{
-              'min-width': columnWidth.name ? columnWidth.name + 'px' : '250px'
-            }"
+            :style="{ 'min-width': nameHeaderMinWidth }"
           >
             <div>
               {{ $t('shots.fields.name') }}
@@ -750,6 +748,12 @@ export default {
       } else {
         return this.assetMetadataDescriptors
       }
+    },
+
+    nameHeaderMinWidth() {
+      return this.columnWidth.name
+        ? parseInt(this.columnWidth.name, 10) + 1 + 'px'
+        : '251px'
     }
   },
 
@@ -1829,8 +1833,8 @@ export default {
 }
 
 .descriptor-header {
-  min-width: 119px;
-  max-width: 119px;
+  min-width: 110px;
+  max-width: 110px;
 }
 
 .frames-header {

--- a/src/components/pages/breakdown/ShotLine.vue
+++ b/src/components/pages/breakdown/ShotLine.vue
@@ -12,7 +12,8 @@
     <div
       class="flexrow-item sticky"
       :style="{
-        'max-width': columnWidth.name ? columnWidth.name + 'px' : '250px'
+        'max-width': columnWidth.name ? columnWidth.name + 'px' : '250px',
+        'min-width': columnWidth.name ? columnWidth.name + 'px' : '250px'
       }"
     >
       <p class="error has-text-left info-message" v-if="isSaveError">


### PR DESCRIPTION
**Problem**
Related to : https://github.com/cgwire/kitsu/issues/1531

Some columns have width issues between header and lines

**Solution**
2 issues
Metadata columns
![image](https://github.com/user-attachments/assets/75f678f2-0910-4d0e-8ae5-744c1cffb9f1)
Solution => change from 119px to 110px for metadata header width

Name column
When the page is displayed in a smaller window
![image](https://github.com/user-attachments/assets/d48dfb9d-88c9-4190-87d3-332b8151a6c2)
Solution => add min-witdh on name line cell 

