### PR TITLE
Various fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "5.2.4",
-        "@vue/compiler-sfc": "3.5.14",
+        "@vue/compiler-sfc": "3.5.13",
         "@vue/test-utils": "2.4.6",
         "autoprefixer": "10.4.21",
         "eslint": "8.57.1",
@@ -72,7 +72,7 @@
         "lint-staged": "16.1.0",
         "localStorage": "1.0.4",
         "prettier": "3.5.3",
-        "sass": "1.89.0",
+        "sass": "1.89.1",
         "vite": "6.3.5",
         "vitest": "3.1.4",
         "vitest-localstorage-mock": "0.1.2"
@@ -2342,57 +2342,53 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.14.tgz",
-      "integrity": "sha512-k7qMHMbKvoCXIxPhquKQVw3Twid3Kg4s7+oYURxLGRd56LiuHJVrvFKI4fm2AM3c8apqODPfVJGoh8nePbXMRA==",
-      "dev": true,
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.2",
-        "@vue/shared": "3.5.14",
+        "@babel/parser": "^7.25.3",
+        "@vue/shared": "3.5.13",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.14.tgz",
-      "integrity": "sha512-1aOCSqxGOea5I80U2hQJvXYpPm/aXo95xL/m/mMhgyPUsKe9jhjwWpziNAw7tYRnbz1I61rd9Mld4W9KmmRoug==",
-      "dev": true,
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
+      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.14",
-        "@vue/shared": "3.5.14"
+        "@vue/compiler-core": "3.5.13",
+        "@vue/shared": "3.5.13"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.14.tgz",
-      "integrity": "sha512-9T6m/9mMr81Lj58JpzsiSIjBgv2LiVoWjIVa7kuXHICUi8LiDSIotMpPRXYJsXKqyARrzjT24NAwttrMnMaCXA==",
-      "dev": true,
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
+      "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.27.2",
-        "@vue/compiler-core": "3.5.14",
-        "@vue/compiler-dom": "3.5.14",
-        "@vue/compiler-ssr": "3.5.14",
-        "@vue/shared": "3.5.14",
+        "@babel/parser": "^7.25.3",
+        "@vue/compiler-core": "3.5.13",
+        "@vue/compiler-dom": "3.5.13",
+        "@vue/compiler-ssr": "3.5.13",
+        "@vue/shared": "3.5.13",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.3",
-        "source-map-js": "^1.2.1"
+        "magic-string": "^0.30.11",
+        "postcss": "^8.4.48",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.14.tgz",
-      "integrity": "sha512-Y0G7PcBxr1yllnHuS/NxNCSPWnRGH4Ogrp0tsLA5QemDZuJLs99YjAKQ7KqkHE0vCg4QTKlQzXLKCMF7WPSl7Q==",
-      "dev": true,
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
+      "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.14",
-        "@vue/shared": "3.5.14"
+        "@vue/compiler-dom": "3.5.13",
+        "@vue/shared": "3.5.13"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -2410,12 +2406,6 @@
         "@vue/shared": "3.5.13"
       }
     },
-    "node_modules/@vue/reactivity/node_modules/@vue/shared": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
-      "license": "MIT"
-    },
     "node_modules/@vue/runtime-core": {
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
@@ -2425,12 +2415,6 @@
         "@vue/reactivity": "3.5.13",
         "@vue/shared": "3.5.13"
       }
-    },
-    "node_modules/@vue/runtime-core/node_modules/@vue/shared": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
-      "license": "MIT"
     },
     "node_modules/@vue/runtime-dom": {
       "version": "3.5.13",
@@ -2443,12 +2427,6 @@
         "@vue/shared": "3.5.13",
         "csstype": "^3.1.3"
       }
-    },
-    "node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
-      "license": "MIT"
     },
     "node_modules/@vue/server-renderer": {
       "version": "3.5.13",
@@ -2463,50 +2441,10 @@
         "vue": "3.5.13"
       }
     },
-    "node_modules/@vue/server-renderer/node_modules/@vue/compiler-core": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
-      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.25.3",
-        "@vue/shared": "3.5.13",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.0"
-      }
-    },
-    "node_modules/@vue/server-renderer/node_modules/@vue/compiler-dom": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
-      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.13",
-        "@vue/shared": "3.5.13"
-      }
-    },
-    "node_modules/@vue/server-renderer/node_modules/@vue/compiler-ssr": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
-      "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.13",
-        "@vue/shared": "3.5.13"
-      }
-    },
-    "node_modules/@vue/server-renderer/node_modules/@vue/shared": {
+    "node_modules/@vue/shared": {
       "version": "3.5.13",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
       "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
-      "license": "MIT"
-    },
-    "node_modules/@vue/shared": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.14.tgz",
-      "integrity": "sha512-oXTwNxVfc9EtP1zzXAlSlgARLXNC84frFYkS0HHz0h3E4WZSP9sywqjqzGCP9Y34M8ipNmd380pVgmMuwELDyQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vue/test-utils": {
@@ -7453,9 +7391,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.89.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.0.tgz",
-      "integrity": "sha512-ld+kQU8YTdGNjOLfRWBzewJpU5cwEv/h5yyqlSeJcj6Yh8U4TDA9UA5FPicqDz/xgRPWRSYIQNiFks21TbA9KQ==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.89.1.tgz",
+      "integrity": "sha512-eMLLkl+qz7tx/0cJ9wI+w09GQ2zodTkcE/aVfywwdlRcI3EO19xGnbmJwg/JMIm+5MxVJ6outddLZ4Von4E++Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9016,62 +8954,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/vue/node_modules/@vue/compiler-core": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
-      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.25.3",
-        "@vue/shared": "3.5.13",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.0"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/compiler-dom": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
-      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.13",
-        "@vue/shared": "3.5.13"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/compiler-sfc": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
-      "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.25.3",
-        "@vue/compiler-core": "3.5.13",
-        "@vue/compiler-dom": "3.5.13",
-        "@vue/compiler-ssr": "3.5.13",
-        "@vue/shared": "3.5.13",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.11",
-        "postcss": "^8.4.48",
-        "source-map-js": "^1.2.0"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/compiler-ssr": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
-      "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.13",
-        "@vue/shared": "3.5.13"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/shared": {
-      "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
-      "license": "MIT"
     },
     "node_modules/vuedraggable": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "5.2.4",
-    "@vue/compiler-sfc": "3.5.14",
+    "@vue/compiler-sfc": "3.5.13",
     "@vue/test-utils": "2.4.6",
     "autoprefixer": "10.4.21",
     "eslint": "8.57.1",
@@ -82,7 +82,7 @@
     "lint-staged": "16.1.0",
     "localStorage": "1.0.4",
     "prettier": "3.5.3",
-    "sass": "1.89.0",
+    "sass": "1.89.1",
     "vite": "6.3.5",
     "vitest": "3.1.4",
     "vitest-localstorage-mock": "0.1.2"

--- a/src/components/mixins/format.js
+++ b/src/components/mixins/format.js
@@ -42,7 +42,7 @@ export const formatListMixin = {
           maximumFractionDigits: 2
         })
       }
-      return duration
+      return Math.round(duration * 100) / 100 // Round to 2 decimal places
     },
 
     formatPriority(priority) {

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -177,8 +177,8 @@
             v-for="descriptor in visibleMetadataDescriptors"
             v-show="isShowInfosBreakdown"
           >
-            <div
-              class="mr1"
+            <span
+              class="descriptor-departments mr05"
               v-if="descriptorCurrentDepartments(descriptor).length"
             >
               <department-name
@@ -188,9 +188,9 @@
                 only-dot
                 v-for="department in descriptorCurrentDepartments(descriptor)"
               />
-            </div>
+            </span>
             <span
-              class="flexrow-item ellipsis descriptor-name filler"
+              class="ellipsis nowrap descriptor-name filler"
               :title="descriptor.name"
             >
               {{ descriptor.name }}
@@ -212,7 +212,9 @@
             class="asset-type-header"
             v-for="assetType in castingAssetTypes"
           >
-            {{ assetType }}
+            <span class="ellipsis nowrap" :title="assetType">
+              {{ assetType }}
+            </span>
           </div>
 
           <div class="actions filler"></div>
@@ -1835,6 +1837,11 @@ export default {
 .descriptor-header {
   min-width: 110px;
   max-width: 110px;
+}
+
+.descriptor-departments {
+  display: inline-flex;
+  gap: 2px;
 }
 
 .frames-header {

--- a/src/components/pages/breakdown/ShotLine.vue
+++ b/src/components/pages/breakdown/ShotLine.vue
@@ -198,6 +198,7 @@
               ]"
             />
             <label
+              class="ml05"
               :for="`${entity.id}-${descriptor.id}-${i}-${option.text}-input`"
               :style="[
                 isCurrentUserManager ||

--- a/src/components/pages/budget/SalaryScale.vue
+++ b/src/components/pages/budget/SalaryScale.vue
@@ -14,7 +14,7 @@
                   <th>{{ $t('budget.fields.department') }}</th>
                   <th>{{ $t('budget.fields.seniority') }}</th>
                   <th>{{ $t('budget.fields.position') }}</th>
-                  <th>{{ $t('budget.fields.salary') }}</th>
+                  <th>{{ $t('budget.fields.base_salary') }}</th>
                 </tr>
               </thead>
 

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1225,7 +1225,7 @@ export default {
           target &&
           target.dataset.personId &&
           target.dataset.entityTypeId &&
-          !this.currentElement.assignees.includes(target.dataset.personId)
+          !this.currentElement.assignees?.includes(target.dataset.personId)
         ) {
           // check rights
           if (


### PR DESCRIPTION
**Problem**
- On the Task Type page, A 0.33 value differed between display and edit.
- On the Breakdown, a header name that is too long may be truncated.
- On the Salary Scale page, the last header name is wrong.
- Some npm dependencies are outdated.

**Solution**
- Fix the estimation input field with the rounded value.
- Improve the column header style of the breakdown.
- Fix the wrong i18n key.
- Bump npm dependencies.
