### PR TITLE
Various fixes

### DIFF
--- a/src/components/pages/playlists/PlaylistPlayer.vue
+++ b/src/components/pages/playlists/PlaylistPlayer.vue
@@ -1594,11 +1594,11 @@ export default {
       }
 
       // we've seen all the frames the picture should be visible
-      this.framesSeenOfPicture = 1
       const previews = this.currentEntity.preview_file_previews
       if (previews.length === this.currentPreviewIndex) {
         this.$nextTick(() => {
           this.onPlayNextEntity(true)
+          this.framesSeenOfPicture = 1
         })
       } else {
         this.currentPreviewIndex++

--- a/src/components/previews/PictureViewer.vue
+++ b/src/components/previews/PictureViewer.vue
@@ -372,7 +372,6 @@ export default {
         this.emitPanZoom(this.panzoomBig)
       })
       this.panzoomBig.on('panend', () => {
-        console.log(this.isBig)
         if (!this.big) return
         this.emitPanZoom(this.panzoomBig)
       })

--- a/src/components/previews/VideoProgress.vue
+++ b/src/components/previews/VideoProgress.vue
@@ -45,40 +45,38 @@
         @touchstart="startProgressDrag"
       ></progress>
 
-      <template v-if="!empty">
-        <span
-          :key="`annotation-${index}`"
-          class="annotation-mark"
-          :style="{
-            left: getAnnotationPosition(annotation) + 'px',
-            width: Math.max(frameSize - 1, 5) + 'px'
-          }"
-          @mouseenter="isFrameNumberVisible = true"
-          @mouseleave="isFrameNumberVisible = true"
-          @touchstart="isFrameNumberVisible = true"
-          @touchend="isFrameNumberVisible = false"
-          @touchcancel="isFrameNumberVisible = false"
-          @click="_emitProgressEvent($event, annotation)"
-          v-for="(annotation, index) in annotations"
-        >
-        </span>
-        <span
-          :key="`annotation-comparison-${index}`"
-          class="annotation-mark comparison-mark"
-          :style="{
-            left: getAnnotationPosition(annotation) + 'px',
-            width: Math.max(frameSize - 1, 5) + 'px'
-          }"
-          @mouseenter="isFrameNumberVisible = true"
-          @mouseleave="isFrameNumberVisible = true"
-          @touchstart="isFrameNumberVisible = true"
-          @touchend="isFrameNumberVisible = false"
-          @touchcancel="isFrameNumberVisible = false"
-          @click="_emitProgressEvent($event, annotation)"
-          v-for="(annotation, index) in comparisonAnnotations"
-        >
-        </span>
-      </template>
+      <span
+        :key="`annotation-${index}`"
+        class="annotation-mark"
+        :style="{
+          left: getAnnotationPosition(annotation) + 'px',
+          width: Math.max(frameSize - 1, 5) + 'px'
+        }"
+        @mouseenter="isFrameNumberVisible = true"
+        @mouseleave="isFrameNumberVisible = true"
+        @touchstart="isFrameNumberVisible = true"
+        @touchend="isFrameNumberVisible = false"
+        @touchcancel="isFrameNumberVisible = false"
+        @click="_emitProgressEvent($event, annotation)"
+        v-for="(annotation, index) in annotations"
+      >
+      </span>
+      <span
+        :key="`annotation-comparison-${index}`"
+        class="annotation-mark comparison-mark"
+        :style="{
+          left: getAnnotationPosition(annotation) + 'px',
+          width: Math.max(frameSize - 1, 5) + 'px'
+        }"
+        @mouseenter="isFrameNumberVisible = true"
+        @mouseleave="isFrameNumberVisible = true"
+        @touchstart="isFrameNumberVisible = true"
+        @touchend="isFrameNumberVisible = false"
+        @touchcancel="isFrameNumberVisible = false"
+        @click="_emitProgressEvent($event, annotation)"
+        v-for="(annotation, index) in comparisonAnnotations"
+      >
+      </span>
     </div>
 
     <div class="frame-number-rail">


### PR DESCRIPTION
**Problem**

* The playlist progress jumps to the start before switching to the next entity when playing pictures.
* There is no red mark when there is an annotation on a picture


**Solution**

* Put the frame back to 1 after switching to the next entity
* Show a red mark when there is an annotation