### PR TITLE
Various fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fullcalendar/multimonth": "6.1.17",
         "@fullcalendar/vue3": "6.1.17",
         "@google/model-viewer": "4.1.0",
-        "@sentry/vue": "9.24.0",
+        "@sentry/vue": "9.27.0",
         "@unhead/vue": "2.0.10",
         "@vuepic/vue-datepicker": "11.0.2",
         "async": "3.2.6",
@@ -27,7 +27,7 @@
         "color-string": "1.9.1",
         "core-js": "3.42.0",
         "fabric": "cgwire/fabric.js",
-        "lucide-vue-next": "0.511.0",
+        "lucide-vue-next": "0.513.0",
         "marked": "15.0.12",
         "marked-emoji": "2.0.0",
         "moment": "2.30.1",
@@ -74,7 +74,7 @@
         "prettier": "3.5.3",
         "sass": "1.89.1",
         "vite": "6.3.5",
-        "vitest": "3.1.4",
+        "vitest": "3.2.2",
         "vitest-localstorage-mock": "0.1.2"
       },
       "engines": {
@@ -2056,88 +2056,88 @@
       ]
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.24.0.tgz",
-      "integrity": "sha512-fWIrHyui8KKufnbqhGyDvvr+u9wiOEEzxXEjs/CKp+6fa+jej6Mk8K+su1f/mz7R3HVzhxvht/gZ+y193uK4qw==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.27.0.tgz",
+      "integrity": "sha512-SJa7f6Ct1BzP8rWEomnshSGN1CmT+axNKvT+StrbFPD6AyHnYfFLJpKgc2iToIJHB/pmeuOI9dUwqtzVx+5nSw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.24.0"
+        "@sentry/core": "9.27.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.24.0.tgz",
-      "integrity": "sha512-Z9jQqKzRppwAEqiytLWNV8JOo52vlxcSGz52FjKx3KXG75PXwk0M3sBXh762WoGLisUIRLTp8LOk6304L/O8dg==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.27.0.tgz",
+      "integrity": "sha512-e7L8eG0y63RulN352lmafoCCfQGg4jLVT8YLx6096eWu/YKLkgmVpgi8livsT5WREnH+HB+iFSrejOwK7cRkhw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.24.0"
+        "@sentry/core": "9.27.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.24.0.tgz",
-      "integrity": "sha512-312wMPeQI8K2vO/lA/CF6Uv5UReoZC7RarsNUJEoOKa9Bq1BXWUq929oTHzu/2NDv194H2u3eqSGsSp6xiuKTw==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.27.0.tgz",
+      "integrity": "sha512-n2kO1wOfCG7GxkMAqbYYkpgTqJM5tuVLdp0JuNCqTOLTXWvw6svWGaYKlYpKUgsK9X/GDzJYSXZmfe+Dbg+FJQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "9.24.0",
-        "@sentry/core": "9.24.0"
+        "@sentry-internal/browser-utils": "9.27.0",
+        "@sentry/core": "9.27.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.24.0.tgz",
-      "integrity": "sha512-506RdDF6iE8hMyzpzp9Vc0GM7kELxxs7UCoi/6KpvXFftcydWI3S2bru8dEZsxVoKh2hdle6SpbNgl+iPI0DSQ==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.27.0.tgz",
+      "integrity": "sha512-44rVSt3LCH6qePYRQrl4WUBwnkOk9dzinmnKmuwRksEdDOkVq5KBRhi/IDr7omwSpX8C+KrX5alfKhOx1cP0gQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "9.24.0",
-        "@sentry/core": "9.24.0"
+        "@sentry-internal/replay": "9.27.0",
+        "@sentry/core": "9.27.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.24.0.tgz",
-      "integrity": "sha512-RP+27/owvIqD4J0TibIHK1UcA7iObxLOXBEilDKjaJOZMLhv3JkpU8A+UI9pFzEYqeIGVDDaBzYgbCHrLWcoCA==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.27.0.tgz",
+      "integrity": "sha512-geR3lhRJOmUQqi1WgovLSYcD/f66zYnctdnDEa7j1BW2XIB1nlTJn0mpYyAHghXKkUN/pBpp1Z+Jk0XlVwFYVg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "9.24.0",
-        "@sentry-internal/feedback": "9.24.0",
-        "@sentry-internal/replay": "9.24.0",
-        "@sentry-internal/replay-canvas": "9.24.0",
-        "@sentry/core": "9.24.0"
+        "@sentry-internal/browser-utils": "9.27.0",
+        "@sentry-internal/feedback": "9.27.0",
+        "@sentry-internal/replay": "9.27.0",
+        "@sentry-internal/replay-canvas": "9.27.0",
+        "@sentry/core": "9.27.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.24.0.tgz",
-      "integrity": "sha512-uRWrB4Y49ZOWcDLCXqdjd2Fs6Onill0GQI+JgXMw7wa+i03+QRiQvUAUyde8O62jR4dvP3GDo9PDWnDNhi3z5A==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.27.0.tgz",
+      "integrity": "sha512-Zb2SSAdWXQjTem+sVWrrAq9L6YYfxyoTwtapaE6C6qZBR5C8Uak0wcYww8StaCFH7dDA/PSW+VxOwjNXocrQHQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/vue": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-9.24.0.tgz",
-      "integrity": "sha512-FreIN5w9257U41imU8f2j+ix67s8MmZld9xhbA4nqCZDuW6m/fQtha+IdUNpcNYm6z+JsstGnPKdcPBJtDvTiA==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-9.27.0.tgz",
+      "integrity": "sha512-LeoxSCDtynAA89tcUD3r1JblCwFjzByID9O0y1JkMU1UlVL08vbV9fNSfEhJ66WdvBo5KPTRn5ScHLUOoae/WA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "9.24.0",
-        "@sentry/core": "9.24.0"
+        "@sentry/browser": "9.27.0",
+        "@sentry/core": "9.27.0"
       },
       "engines": {
         "node": ">=18"
@@ -2167,6 +2167,23 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.7",
@@ -2219,14 +2236,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.1.4.tgz",
-      "integrity": "sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.2.tgz",
+      "integrity": "sha512-ipHw0z669vEMjzz3xQE8nJX1s0rQIb7oEl4jjl35qWTwm/KIHERIg/p/zORrjAaZKXfsv7IybcNGHwhOOAPMwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.4",
-        "@vitest/utils": "3.1.4",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.2",
+        "@vitest/utils": "3.2.2",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -2235,13 +2253,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.1.4.tgz",
-      "integrity": "sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.2.tgz",
+      "integrity": "sha512-jKojcaRyIYpDEf+s7/dD3LJt53c0dPfp5zCPXz9H/kcGrSlovU/t1yEaNzM9oFME3dcd4ULwRI/x0Po1Zf+LTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.1.4",
+        "@vitest/spy": "3.2.2",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -2250,7 +2268,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -2272,9 +2290,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.4.tgz",
-      "integrity": "sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.2.tgz",
+      "integrity": "sha512-FY4o4U1UDhO9KMd2Wee5vumwcaHw7Vg4V7yR4Oq6uK34nhEJOmdRYrk3ClburPRUA09lXD/oXWZ8y/Sdma0aUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2285,13 +2303,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.1.4.tgz",
-      "integrity": "sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.2.tgz",
+      "integrity": "sha512-GYcHcaS3ejGRZYed2GAkvsjBeXIEerDKdX3orQrBJqLRiea4NSS9qvn9Nxmuy1IwIB+EjFOaxXnX79l8HFaBwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.1.4",
+        "@vitest/utils": "3.2.2",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2299,13 +2317,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.1.4.tgz",
-      "integrity": "sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.2.tgz",
+      "integrity": "sha512-aMEI2XFlR1aNECbBs5C5IZopfi5Lb8QJZGGpzS8ZUHML5La5wCbrbhLOVSME68qwpT05ROEEOAZPRXFpxZV2wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.4",
+        "@vitest/pretty-format": "3.2.2",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -2314,26 +2332,26 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.4.tgz",
-      "integrity": "sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.2.tgz",
+      "integrity": "sha512-6Utxlx3o7pcTxvp0u8kUiXtRFScMrUg28KjB3R2hon7w4YqOFAEA9QwzPVVS1QNL3smo4xRNOpNZClRVfpMcYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyspy": "^3.0.2"
+        "tinyspy": "^4.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.1.4.tgz",
-      "integrity": "sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.2.tgz",
+      "integrity": "sha512-qJYMllrWpF/OYfWHP32T31QCaLa3BAzT/n/8mNGhPdVcjY+JYazQFO1nsJvXU12Kp1xMpNY4AGuljPTNjQve6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.1.4",
+        "@vitest/pretty-format": "3.2.2",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -6113,9 +6131,9 @@
       "license": "ISC"
     },
     "node_modules/lucide-vue-next": {
-      "version": "0.511.0",
-      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-0.511.0.tgz",
-      "integrity": "sha512-VSv0F3pHniGN7JMMzDcLFNMQbl8381+shNnHwV8hi+El7xl2ZL8qdNuzPoiBViKk8mTKK5K3ZDfmE/wEcTZVIQ==",
+      "version": "0.513.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-0.513.0.tgz",
+      "integrity": "sha512-/J7DB2WBC+UPcRswOfJFXSWt8r5HTMVu0PRkR6e0+Ozx6kLJZv4m71vbT1DS9RCjj0pfuLskWIslSBeeXmg7BA==",
       "license": "ISC",
       "peerDependencies": {
         "vue": ">=3.0.1"
@@ -8115,9 +8133,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8145,9 +8163,9 @@
       }
     },
     "node_modules/tinypool": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
-      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
+      "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8165,9 +8183,9 @@
       }
     },
     "node_modules/tinyspy": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8479,17 +8497,17 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.1.4.tgz",
-      "integrity": "sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.2.tgz",
+      "integrity": "sha512-Xj/jovjZvDXOq2FgLXu8NsY4uHUMWtzVmMC2LkCu9HWdr9Qu1Is5sanX3Z4jOFKdohfaWDnEJWp9pRP0vVpAcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "es-module-lexer": "^1.7.0",
         "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
       },
       "bin": {
         "vite-node": "vite-node.mjs"
@@ -8515,32 +8533,34 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.1.4.tgz",
-      "integrity": "sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.2.tgz",
+      "integrity": "sha512-fyNn/Rp016Bt5qvY0OQvIUCwW2vnaEBLxP42PmKbNIoasSYjML+8xyeADOPvBe+Xfl/ubIw4og7Lt9jflRsCNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "3.1.4",
-        "@vitest/mocker": "3.1.4",
-        "@vitest/pretty-format": "^3.1.4",
-        "@vitest/runner": "3.1.4",
-        "@vitest/snapshot": "3.1.4",
-        "@vitest/spy": "3.1.4",
-        "@vitest/utils": "3.1.4",
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.2",
+        "@vitest/mocker": "3.2.2",
+        "@vitest/pretty-format": "^3.2.2",
+        "@vitest/runner": "3.2.2",
+        "@vitest/snapshot": "3.2.2",
+        "@vitest/spy": "3.2.2",
+        "@vitest/utils": "3.2.2",
         "chai": "^5.2.0",
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "expect-type": "^1.2.1",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
         "std-env": "^3.9.0",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.13",
-        "tinypool": "^1.0.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.0",
         "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0",
-        "vite-node": "3.1.4",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.2",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -8556,8 +8576,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.1.4",
-        "@vitest/ui": "3.1.4",
+        "@vitest/browser": "3.2.2",
+        "@vitest/ui": "3.2.2",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -8593,6 +8613,19 @@
       "license": "MIT",
       "peerDependencies": {
         "vitest": "*"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vue": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@fullcalendar/multimonth": "6.1.17",
     "@fullcalendar/vue3": "6.1.17",
     "@google/model-viewer": "4.1.0",
-    "@sentry/vue": "9.24.0",
+    "@sentry/vue": "9.27.0",
     "@unhead/vue": "2.0.10",
     "@vuepic/vue-datepicker": "11.0.2",
     "async": "3.2.6",
@@ -37,7 +37,7 @@
     "color-string": "1.9.1",
     "core-js": "3.42.0",
     "fabric": "cgwire/fabric.js",
-    "lucide-vue-next": "0.511.0",
+    "lucide-vue-next": "0.513.0",
     "marked": "15.0.12",
     "marked-emoji": "2.0.0",
     "moment": "2.30.1",
@@ -84,7 +84,7 @@
     "prettier": "3.5.3",
     "sass": "1.89.1",
     "vite": "6.3.5",
-    "vitest": "3.1.4",
+    "vitest": "3.2.2",
     "vitest-localstorage-mock": "0.1.2"
   },
   "engines": {

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1098,10 +1098,19 @@ export default {
     getTasks(entities) {
       const tasks = []
       entities.forEach(entity => {
-        const entityTasks = entity.tasks || []
-        entityTasks.forEach(taskId => {
+        if (
+          entity.canceled ||
+          !entity.tasks?.length ||
+          (this.isTVShow &&
+            !['all', entity.episode_id || 'main'].includes(
+              this.currentEpisode?.id
+            ))
+        ) {
+          return
+        }
+        entity.tasks.forEach(taskId => {
           const task = this.taskMap.get(taskId.id || taskId)
-          if (task && !entity.canceled) {
+          if (task) {
             // Hack to allow filtering on linked entity metadata.
             this.$store.commit('SET_TASK_EXTRA_DATA', {
               task,

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1462,7 +1462,8 @@ export default {
     show_assigned: 'Show assigned entities',
     force_unassign: 'Override previous assignments',
     forced_daily_quotas: 'Forced daily quotas:',
-    estimated_daily_quotas: 'Auto estimated daily quotas:'
+    estimated_daily_quotas: 'Auto estimated daily quotas:',
+    edit_task: 'Edit task'
   },
 
   team_schedule: {


### PR DESCRIPTION
**Problem**
- Unwanted tasks are displayed in the Task Type page with an episode selected. Tasks linked by breakdown should not be in the list.
- A title is missing in the edit estimation form of the production schedule.
- Some npm dependencies are outdated.

**Solution**
-  Display tasks only if their entity is linked to the current episode.
- Add missing i18 key.
- Bump npm dependencies.
