### PR TITLE
Various fixes

### DIFF
--- a/src/components/modals/BuildFilterModal.vue
+++ b/src/components/modals/BuildFilterModal.vue
@@ -888,7 +888,9 @@ export default {
 
     setFiltersFromAssignedToQuery(filter) {
       this.assignation.value = filter.excluding ? '-assignedto' : 'assignedto'
-      this.assignation.person = this.people.find(p => p.id === filter.personId)
+      this.assignation.person = this.people.find(
+        p => p.id === filter.personIds[0]
+      )
       this.assignation.taskTypeId = filter.taskType?.id
     },
 

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -70,7 +70,6 @@ const applyFiltersFunctions = {
 
   assignedto(entry, filter, taskMap) {
     let isOk = false
-    console.log('filter', filter)
     if (filter.taskType) {
       const taskId = entry.validations.get(filter.taskType.id)
       const task = taskMap.get(taskId)

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -76,7 +76,6 @@ const applyFiltersFunctions = {
       filter.personIds.forEach(personId => {
         isOk = task?.assignees.includes(personId) || isOk
       })
-      console.log('task', isOk, task.assignees, filter.pesonIds)
     } else {
       isOk =
         entry.tasks?.some(taskId => {

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -70,10 +70,14 @@ const applyFiltersFunctions = {
 
   assignedto(entry, filter, taskMap) {
     let isOk = false
+    console.log('filter', filter)
     if (filter.taskType) {
       const taskId = entry.validations.get(filter.taskType.id)
       const task = taskMap.get(taskId)
-      isOk = task?.assignees.includes(filter.personId)
+      filter.personIds.forEach(personId => {
+        isOk = task?.assignees.includes(personId) || isOk
+      })
+      console.log('task', isOk, task.assignees, filter.pesonIds)
     } else {
       isOk =
         entry.tasks?.some(taskId => {
@@ -565,9 +569,12 @@ export const getAssignedToFilters = (persons, taskTypes, queryText) => {
   const rgxMatches = queryText.match(EQUAL_ASSIGNATION_REGEX)
   if (rgxMatches) {
     const taskTypeNameIndex = buildTaskTypeIndex(taskTypes)
-    const personIndex = []
+    const personIndex = {}
     shallowPersons.forEach(person => {
-      personIndex.push(person)
+      if (!personIndex[person.name]) {
+        personIndex[person.name] = []
+      }
+      personIndex[person.name].push(person.id)
     })
 
     rgxMatches.forEach(rgxMatch => {
@@ -583,17 +590,15 @@ export const getAssignedToFilters = (persons, taskTypes, queryText) => {
       if (excluding) value = value.substring(1)
       const simplifiedValue = hashName(value)
 
-      personIndex.forEach(person => {
-        if (person.name === simplifiedValue) {
-          results.push({
-            personId: person.id,
-            taskType,
-            value,
-            type: 'assignedto',
-            excluding
-          })
-        }
-      })
+      if (personIndex[simplifiedValue]) {
+        results.push({
+          personIds: personIndex[simplifiedValue],
+          taskType,
+          value,
+          type: 'assignedto',
+          excluding
+        })
+      }
     })
   }
   return results

--- a/tests/unit/lib/filtering.spec.js
+++ b/tests/unit/lib/filtering.spec.js
@@ -418,7 +418,7 @@ describe('lib/filtering', () => {
       })
       expect(filters).toHaveLength(1)
       expect(filters[0].type).toEqual('assignedto')
-      expect(filters[0].personId).toEqual('person-1')
+      expect(filters[0].personIds[0]).toEqual('person-1')
       expect(filters[0].taskType.id).toEqual('task-type-2')
       expect(filters[0].excluding).toEqual(false)
     })


### PR DESCRIPTION
**Problem**

* There is no quick filter for statuses in the task type page while it's common to filter on this. Typing the status works but it's not intuitive
* The previous commits about people with similar names filtering don't look to work

**Solution**

* Add a status combobox to the task type page and filter results on value change
* Set an array of user ids when the filter representation  is built
