### PR TITLE
Feature: Add a task hook-ups button for shots to see a playlist of 

### DIFF
--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -94,8 +94,21 @@
 
               <div
                 class="set-main-preview flexrow-item flexrow pull-right"
-                v-if="isCurrentUserManager && $refs['preview-player']"
+                v-if="$refs['preview-player']"
               >
+                <button
+                  :class="{
+                    button: true,
+                    'flexrow-item': true
+                  }"
+                  v-if="isHookupButtonVisible"
+                  @click="showHookupPlaylistModal"
+                >
+                  <kitsu-icon
+                    name="playlists"
+                    :title="$t('tasks.hookup_playlist')"
+                  />
+                </button>
                 <button
                   :class="{
                     button: true,
@@ -103,6 +116,7 @@
                     'is-loading': loading.setPreview
                   }"
                   @click="setPreview"
+                  v-if="isCurrentUserManager"
                 >
                   <image-icon class="icon" />
                   <span class="text">
@@ -113,6 +127,12 @@
                   {{ $t('tasks.set_preview_error') }}
                 </span>
               </div>
+              <view-playlist-modal
+                :active="modals.hookupPlaylist"
+                :task-ids="hookupPlaylistTaskIds"
+                sort
+                @cancel="hideHookupPlaylistModal"
+              />
             </div>
 
             <div class="preview-area mt1">
@@ -363,6 +383,7 @@ import ComboboxStyled from '@/components/widgets/ComboboxStyled.vue'
 import DeleteModal from '@/components/modals/DeleteModal.vue'
 import EditCommentModal from '@/components/modals/EditCommentModal.vue'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
+import KitsuIcon from '@/components/widgets/KitsuIcon.vue'
 import PageSubtitle from '@/components/widgets/PageSubtitle.vue'
 import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
 import Spinner from '@/components/widgets/Spinner.vue'
@@ -370,6 +391,7 @@ import SubscribeButton from '@/components/widgets/SubscribeButton.vue'
 import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
 import ValidationTag from '@/components/widgets/ValidationTag.vue'
 import PreviewPlayer from '@/components/previews/PreviewPlayer.vue'
+import ViewPlaylistModal from '@/components/modals/ViewPlaylistModal.vue'
 
 export default {
   name: 'task',
@@ -385,6 +407,7 @@ export default {
     DeleteModal,
     EditCommentModal,
     EntityThumbnail,
+    KitsuIcon,
     ImageIcon,
     PageSubtitle,
     PeopleAvatar,
@@ -392,7 +415,8 @@ export default {
     Spinner,
     SubscribeButton,
     TaskTypeName,
-    ValidationTag
+    ValidationTag,
+    ViewPlaylistModal
   },
 
   provide() {
@@ -407,6 +431,7 @@ export default {
       previewForms: [],
       currentFrame: 0,
       currentTask: null,
+      hookupPlaylistTaskIds: [],
       selectedTab: 'validation',
       taskLoading: {
         isLoading: true,
@@ -417,7 +442,8 @@ export default {
         addExtraPreview: false,
         deleteExtraPreview: false,
         deleteComment: false,
-        editComment: false
+        editComment: false,
+        hookupPlaylist: false
       },
       loading: {
         addComment: false,
@@ -784,6 +810,11 @@ export default {
       return this.user.departments.includes(this.taskType?.department_id)
     },
 
+    isHookupButtonVisible() {
+      // only show the hookup button for shots
+      return this.task?.entity_type_name === 'Shot'
+    },
+
     taskType() {
       return this.taskTypeMap.get(this.task?.task_type_id)
     },
@@ -940,6 +971,46 @@ export default {
           this.errors.addComment = !isRetakeError
           this.errors.addCommentMaxRetakes = isRetakeError
         })
+    },
+
+    hideHookupPlaylistModal() {
+      this.modals.hookupPlaylist = false
+    },
+    showHookupPlaylistModal() {
+      // use a method instead of computed property for hookupPlaylistTaskIds so that it is only calculated if the modal is opened
+
+      // create a playlist with the previous, current and next task
+      const current_task_id = this.task.id
+
+      const tasks = Array.from(this.taskMap.values())
+        // get all tasks for this entity
+        .filter(
+          task =>
+            task.episode_id === this.task.episode_id &&
+            task.sequence_name === this.task.sequence_name &&
+            task.task_type_id === this.task.task_type_id
+        )
+        // sort the tasks by entity_name
+        .sort((a, b) => a.entity_name.localeCompare(b.entity_name))
+
+      const current_task_index = tasks.findIndex(
+        task => task.id === current_task_id
+      )
+
+      const previous_task_id =
+        current_task_index > 0 ? tasks[current_task_index - 1].id : null
+
+      const next_task_id =
+        current_task_index < tasks.length - 1
+          ? tasks[current_task_index + 1].id
+          : null
+
+      this.hookupPlaylistTaskIds = [current_task_id]
+      if (previous_task_id) this.hookupPlaylistTaskIds.unshift(previous_task_id)
+      if (next_task_id) this.hookupPlaylistTaskIds.push(next_task_id)
+
+      // open the playlist
+      this.modals.hookupPlaylist = true
     },
 
     reset({ keepPreviewFiles = false } = {}) {

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -97,12 +97,9 @@
                 v-if="$refs['preview-player']"
               >
                 <button
-                  :class="{
-                    button: true,
-                    'flexrow-item': true
-                  }"
-                  v-if="isHookupButtonVisible"
+                  class="button flexrow-item"
                   @click="showHookupPlaylistModal"
+                  v-if="isHookupButtonVisible"
                 >
                   <kitsu-icon
                     name="playlists"
@@ -110,9 +107,8 @@
                   />
                 </button>
                 <button
+                  class="button flexrow-item"
                   :class="{
-                    button: true,
-                    'flexrow-item': true,
                     'is-loading': loading.setPreview
                   }"
                   @click="setPreview"
@@ -976,9 +972,8 @@ export default {
     hideHookupPlaylistModal() {
       this.modals.hookupPlaylist = false
     },
-    showHookupPlaylistModal() {
-      // use a method instead of computed property for hookupPlaylistTaskIds so that it is only calculated if the modal is opened
 
+    showHookupPlaylistModal() {
       // create a playlist with the previous, current and next task
       const current_task_id = this.task.id
 
@@ -991,7 +986,11 @@ export default {
             task.task_type_id === this.task.task_type_id
         )
         // sort the tasks by entity_name
-        .sort((a, b) => a.entity_name.localeCompare(b.entity_name))
+        .sort((a, b) =>
+          a.entity_name.localeCompare(b.entity_name, undefined, {
+            numeric: true
+          })
+        )
 
       const current_task_index = tasks.findIndex(
         task => task.id === current_task_id

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1666,6 +1666,7 @@ export default {
     for_project: 'For project',
     hide_assignations: 'Hide assignments',
     hide_infos: 'Hide additional information',
+    hookup_playlist: 'Generate a hook-up playlist',
     late: 'Late status',
     my_checks: 'My Checks',
     my_tasks: 'My Tasks',


### PR DESCRIPTION
Add a playlist button to the top of the preview window when viewed in the "Task" view.

![image](https://github.com/user-attachments/assets/716f0d68-7057-47d6-a5b7-db26277154e3)

This button will open a playlist modal to show the previous, current and next task.  This allows the artist to review the shot in context of the tasks before and after and ensure continuity or "hook-ups".

![image](https://github.com/user-attachments/assets/53762c18-4d02-489e-8f30-292988aab3c5)


 "hook-ups" refer to the process of ensuring that shots are connected seamlessly, meaning that the end of one shot matches the beginning of the next. This involves visual consistency, like matching camera angles, lighting, and character positions between shots. 
