### PR TITLE
[logout] add a broadcastchannel between tabs to propagate logout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,6 +25,7 @@ import { mapGetters, mapActions } from 'vuex'
 import PreviewModal from '@/components/modals/PreviewModal.vue'
 import Spinner from '@/components/widgets/Spinner.vue'
 
+import auth from '@/lib/auth'
 import crisp from '@/lib/crisp'
 import localPreferences from '@/lib/preferences'
 import sentry from '@/lib/sentry'
@@ -71,12 +72,7 @@ export default {
     this.setupDarkTheme()
     this.setupCrisp(config)
     this.setupSentry(config)
-    const logoutChannel = new BroadcastChannel('logout')
-    logoutChannel.onmessage = event => {
-      if (event.data === 'logout') {
-        this.$router.push({ name: 'logout' })
-      }
-    }
+    this.setupAuthChannel()
   },
 
   methods: {
@@ -144,6 +140,19 @@ export default {
           dsn: config.sentry.dsn,
           sampleRate: config.sentry.sampleRate
         })
+      }
+    },
+
+    setupAuthChannel() {
+      if (auth.getBroadcastChannel()) {
+        auth.getBroadcastChannel().onmessage = event => {
+          if (this.$route.name !== 'login' && event.data === 'logout') {
+            this.$router.push({
+              name: 'login',
+              query: { redirect: this.$route.fullPath }
+            })
+          }
+        }
       }
     }
   },

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -8,6 +8,8 @@ import {
   USER_LOGIN_FAIL
 } from '@/store/mutation-types.js'
 
+let channel
+
 const auth = {
   logIn(payload, callback) {
     superagent
@@ -56,6 +58,7 @@ const auth = {
       await superagent.get('/api/auth/logout')
     } finally {
       store.commit(USER_LOGOUT)
+      this.postBroadcastMessage('logout')
     }
   },
 
@@ -137,6 +140,18 @@ const auth = {
 
   isPasswordValid(password, password2) {
     return password.length > 6 && password === password2
+  },
+
+  getBroadcastChannel() {
+    if (!channel && 'BroadcastChannel' in window) {
+      channel = new BroadcastChannel('auth')
+    }
+    return channel
+  },
+
+  postBroadcastMessage(message) {
+    const channel = this.getBroadcastChannel()
+    channel?.postMessage(message)
   }
 }
 export default auth

--- a/src/store/modules/login.js
+++ b/src/store/modules/login.js
@@ -62,8 +62,6 @@ const actions = {
     this.$socket.disconnect()
     await auth.logout()
     commit(RESET_ALL)
-    const logoutChannel = new BroadcastChannel('logout')
-    logoutChannel.postMessage('logout')
   },
 
   resetPassword({ commit }, email) {


### PR DESCRIPTION
**Problem**
- When you log out of a tab in your browser, other tabs aren't logged out. 

**Solution**
- Add a broadcast channel to propagate the logout between tabs. 
