### PR TITLE
adjust Asset and Shot page task-list and info scrolling behaviour to …

### DIFF
--- a/src/components/pages/Asset.vue
+++ b/src/components/pages/Asset.vue
@@ -105,7 +105,7 @@
             </div>
           </div>
 
-          <div class="table-body metadata-infos">
+          <div class="table-body entity-infos">
             <table class="datatable no-header" v-if="currentAsset">
               <tbody class="table-body">
                 <tr class="datatable-row">
@@ -930,13 +930,6 @@ h2.subtitle {
   padding-top: 3px;
 }
 
-.task-list {
-  flex: 1;
-  margin-bottom: 3em;
-  min-width: 100%;
-  overflow: hidden;
-}
-
 .datatable-row {
   user-select: text;
 }
@@ -1011,15 +1004,24 @@ h2.subtitle {
 }
 
 .infos {
-  height: 100%;
+  flex: 1;
   margin-top: 1em;
-  margin-bottom: 1em;
-  max-height: 100%;
   overflow-y: auto;
 
-  .metadata-infos {
-    flex: unset;
-    overflow: auto;
+  .task-list {
+    width: 100%;
+    flex: none;
+    margin-bottom: 2em;
+
+    :deep(.task-list-body) {
+      overflow: unset;
+    }
+  }
+  .data-list {
+    width: 100%;
+  }
+  .entity-infos {
+    flex: none;
   }
 }
 

--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -82,7 +82,7 @@
               />
             </div>
           </div>
-          <div class="table-body">
+          <div class="table-body entity-infos">
             <table class="datatable no-header" v-if="currentShot">
               <tbody class="datatable-body">
                 <tr class="datatable-row">
@@ -714,18 +714,8 @@ h2.subtitle {
   align-items: center;
 }
 
-.data-list {
-  max-width: 100%;
-}
-
 .back-link {
   padding-top: 3px;
-}
-
-.task-list {
-  width: 100%;
-  flex: none;
-  margin-bottom: 2em;
 }
 
 .datatable-row {
@@ -806,9 +796,21 @@ h2.subtitle {
   margin-top: 1em;
   overflow-y: auto;
 
+  .task-list {
+    width: 100%;
+    flex: none;
+    margin-bottom: 2em;
+
+    :deep(.task-list-body) {
+      overflow: unset;
+    }
+  }
+
+  .data-list {
+    width: 100%;
+  }
   .entity-infos {
-    align-self: flex-start;
-    flex: 1;
+    flex: none;
   }
 }
 


### PR DESCRIPTION
**Problem**
The entity pages for Shot and Asset have the task-list and info as scroll areas. The are not consistent with each other and the scroll areas make readability difficult.

**Shot entity page**
problems in screenshot:
- 3 scrollbars
- table cut off when scrolling right
- information not appearing

![image](https://github.com/user-attachments/assets/b0d8d1cd-cfac-456d-b6c3-c56530eb826c)

**Asset entity page**
problems in screenshot:
- hard to see scrollbars
- hard to see there are more tasks
![image](https://github.com/user-attachments/assets/9c0ca9b1-cba9-4109-9b03-a71905ce5876)

**Solution**
Make one large scroll area for task-list and information consistent across both Asset and Shot entities.
![image](https://github.com/user-attachments/assets/f3077849-527b-4dca-948f-092692540cba)

