### PR TITLE
In dark theme fix the scrollbar colour over a block area

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2417,5 +2417,18 @@ th.validation-cell {
   ::-webkit-scrollbar-thumb:active {
     background-color: #5e6169;
   }
+  .block {
+    ::-webkit-scrollbar-thumb {
+      background-color: #53565e;
+    }
+
+    ::-webkit-scrollbar-thumb:hover {
+      background-color: #5e6169;
+    }
+
+    ::-webkit-scrollbar-thumb:active {
+      background-color: #5e6169;
+    }
+  }
 }
 </style>


### PR DESCRIPTION
**Problem**
Scrollbar was not visible when a scroll area was within a div with the "block" class as the scrollbar colour was the same colour as the block area.

**Solution**
css update

![image](https://github.com/user-attachments/assets/782b3b21-706b-4502-b2a7-dcc5b66c7b2f)

