### PR TITLE
Various Improvements

### DIFF
--- a/src/components/pages/Asset.vue
+++ b/src/components/pages/Asset.vue
@@ -2,18 +2,6 @@
   <div class="columns fixed-page asset xyz-in" xyz="fade">
     <div class="page column main-column">
       <div class="page-header flexrow">
-        <!--router-link
-        class="flexrow-item has-text-centered back-link ml1"
-        :to="previousAssetPath"
-      >
-        <chevron-left-icon />
-      </router-link>
-      <router-link
-        class="flexrow-item has-text-centered back-link"
-        :to="nextAssetPath"
-      >
-        <chevron-right-icon />
-      </router-link-->
         <router-link
           class="flexrow-item has-text-centered back-link ml1"
           :to="assetsPath"
@@ -35,7 +23,7 @@
         </div>
         <div class="filler"></div>
         <div
-          class="ready-for flexrow block mr0"
+          class="ready-for flexrow block mr0 flexrow-item mt1 mb0"
           v-if="
             currentAsset &&
             currentAsset.ready_for &&
@@ -51,6 +39,20 @@
             :current-production-id="currentProduction.id"
           />
         </div>
+        <router-link
+          class="flexrow-item has-text-centered back-link ml1"
+          :to="previousEntityPath"
+          v-if="previousEntityPath && entityList.length > 1"
+        >
+          <chevron-left-icon />
+        </router-link>
+        <router-link
+          class="flexrow-item has-text-centered back-link"
+          :to="nextEntityPath"
+          v-if="nextEntityPath && entityList.length > 1"
+        >
+          <chevron-right-icon />
+        </router-link>
       </div>
 
       <div class="asset-data block">
@@ -365,7 +367,11 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import { CornerLeftUpIcon } from 'lucide-vue-next'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CornerLeftUpIcon
+} from 'lucide-vue-next'
 
 import assetStore from '@/store/modules/assets'
 
@@ -400,10 +406,12 @@ export default {
 
   components: {
     ButtonSimple,
+    ChevronLeftIcon,
+    ChevronRightIcon,
     ConceptCard,
     ComboboxNumber,
-    CornerLeftUpIcon,
     ComboboxStatus,
+    CornerLeftUpIcon,
     DescriptionCell,
     EditAssetModal,
     EntityChat,
@@ -499,58 +507,6 @@ export default {
       return castIn.reduce((acc, shots) => {
         return acc + shots.length
       }, 0)
-    },
-
-    previousAssetPath() {
-      const assets = Array.from(this.assetMap.values())
-      if (assets.length === 0) return { name: 'open-productions' }
-      const currentIndex = assets.findIndex(asset => {
-        return asset && this.currentAsset && asset.id === this.currentAsset.id
-      })
-      const index = currentIndex !== 0 ? currentIndex - 1 : assets.length - 1
-      const asset = assets[index]
-      if (!asset) return { name: 'open-productions' }
-      const route = {
-        name: 'asset',
-        params: {
-          production_id: this.currentProduction.id,
-          asset_id: asset.id
-        },
-        query: {
-          search: ''
-        }
-      }
-      if (this.currentEpisode) {
-        route.name = 'episode-asset'
-        route.params.episode_id = this.currentEpisode.id
-      }
-      return route
-    },
-
-    nextAssetPath() {
-      const assets = Array.from(this.assetMap.values())
-      if (assets.length === 0) return { name: 'open-productions' }
-      const currentIndex = assets.findIndex(asset => {
-        return asset && this.currentAsset && asset.id === this.currentAsset.id
-      })
-      const index = currentIndex === assets.length - 1 ? 0 : currentIndex + 1
-      const asset = assets[index]
-      if (!asset) return { name: 'open-productions' }
-      const route = {
-        name: 'asset',
-        params: {
-          production_id: this.currentProduction.id,
-          asset_id: asset.id
-        },
-        query: {
-          search: ''
-        }
-      }
-      if (this.currentEpisode) {
-        route.name = 'episode-asset'
-        route.params.episode_id = this.currentEpisode.id
-      }
-      return route
     },
 
     assetsPath() {
@@ -817,6 +773,11 @@ export default {
   .wrapper {
     background: $dark-grey-2;
   }
+}
+
+.ready-for {
+  margin-top: 0em;
+  margin-bottom: 0em;
 }
 
 .main-column {

--- a/src/components/pages/Edit.vue
+++ b/src/components/pages/Edit.vue
@@ -46,6 +46,20 @@
             v-if="isValidRoomId(currentEdit) && currentPreview?.id"
           />
         </div>
+        <router-link
+          class="flexrow-item has-text-centered back-link ml1"
+          :to="previousEntityPath"
+          v-if="previousEntityPath && entityList.length > 1"
+        >
+          <chevron-left-icon />
+        </router-link>
+        <router-link
+          class="flexrow-item has-text-centered back-link"
+          :to="nextEntityPath"
+          v-if="nextEntityPath && entityList.length > 1"
+        >
+          <chevron-right-icon />
+        </router-link>
       </div>
 
       <div ref="container" class="edit player block">
@@ -578,6 +592,8 @@
 import { mapGetters, mapActions } from 'vuex'
 import {
   ArrowUpRightIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
   CornerLeftUpIcon,
   DownloadIcon
 } from 'lucide-vue-next'
@@ -631,6 +647,8 @@ export default {
   components: {
     ArrowUpRightIcon,
     ButtonSimple,
+    ChevronLeftIcon,
+    ChevronRightIcon,
     CornerLeftUpIcon,
     ColorPicker,
     ComboboxStyled,
@@ -689,22 +707,7 @@ export default {
   },
 
   mounted() {
-    this.resetData()
-    this.$options.scrubbing = false
-    this.isHd = Boolean(this.organisation.hd_by_default)
-    if (this.picturePlayer) {
-      this.picturePlayer.addEventListener('load', async () => {
-        const wasPlaying = this.isPlaying
-        await this.resetPictureCanvas()
-        this.isPlaying = wasPlaying
-      })
-    }
-    this.$nextTick(() => {
-      this.configureEvents()
-      this.setupFabricCanvas()
-      this.setPlayerSpeed(1)
-      this.onFrameUpdate(1)
-    })
+    this.init()
   },
 
   computed: {
@@ -750,6 +753,25 @@ export default {
       'loadTaskEntityPreviewFiles',
       'updatePreviewAnnotation'
     ]),
+
+    init() {
+      this.resetData()
+      this.$options.scrubbing = false
+      this.isHd = Boolean(this.organisation.hd_by_default)
+      if (this.picturePlayer) {
+        this.picturePlayer.addEventListener('load', async () => {
+          const wasPlaying = this.isPlaying
+          await this.resetPictureCanvas()
+          this.isPlaying = wasPlaying
+        })
+      }
+      this.$nextTick(() => {
+        this.configureEvents()
+        this.setupFabricCanvas()
+        this.setPlayerSpeed(1)
+        this.onFrameUpdate(1)
+      })
+    },
 
     resetPreviewFileMap() {
       this.previewFileMap.clear()

--- a/src/components/pages/Episode.vue
+++ b/src/components/pages/Episode.vue
@@ -21,6 +21,21 @@
         <div class="flexrow-item">
           <page-title :text="title" class="entity-title" />
         </div>
+        <div class="filler"></div>
+        <router-link
+          class="flexrow-item has-text-centered back-link ml1"
+          :to="previousEntityPath"
+          v-if="previousEntityPath && entityList.length > 1"
+        >
+          <chevron-left-icon />
+        </router-link>
+        <router-link
+          class="flexrow-item has-text-centered back-link"
+          :to="nextEntityPath"
+          v-if="nextEntityPath && entityList.length > 1"
+        >
+          <chevron-right-icon />
+        </router-link>
       </div>
 
       <div class="episode-data block">
@@ -258,7 +273,11 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import { CornerLeftUpIcon } from 'lucide-vue-next'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CornerLeftUpIcon
+} from 'lucide-vue-next'
 
 import episodeStore from '@/store/modules/episodes'
 
@@ -291,6 +310,8 @@ export default {
 
   components: {
     ButtonSimple,
+    ChevronLeftIcon,
+    ChevronRightIcon,
     ComboboxNumber,
     CornerLeftUpIcon,
     DescriptionCell,

--- a/src/components/pages/Notifications.vue
+++ b/src/components/pages/Notifications.vue
@@ -47,6 +47,13 @@
             :is-loading="loading.markAll"
             :text="$t('notifications.mark_all_as_read')"
             @click="markAllNotificationsRead"
+            v-if="
+              parameters.taskTypeId === '' &&
+              parameters.taskStatusId === '' &&
+              parameters.typeMode === '' &&
+              [null, 'unread'].includes(parameters.statusMode) &&
+              parameters.watchingMode === null
+            "
           />
         </div>
         <div

--- a/src/components/pages/Profile.vue
+++ b/src/components/pages/Profile.vue
@@ -75,7 +75,7 @@
               @change="localeChanged"
             >
               <option value="zh_Hans_CN">Chinese</option>
-              <option value="zh_Hant_TW">Chinese (TW)</option>
+              <option value="zh_Hant_TW">Chinese (TC)</option>
               <option value="da_DA">Dannish</option>
               <option value="nl_NL">Dutch</option>
               <option value="en_US">English</option>

--- a/src/components/pages/Sequence.vue
+++ b/src/components/pages/Sequence.vue
@@ -21,6 +21,21 @@
         <div class="flexrow-item">
           <page-title :text="title" class="entity-title" />
         </div>
+        <div class="filler"></div>
+        <router-link
+          class="flexrow-item has-text-centered back-link ml1"
+          :to="previousEntityPath"
+          v-if="previousEntityPath && entityList.length > 1"
+        >
+          <chevron-left-icon />
+        </router-link>
+        <router-link
+          class="flexrow-item has-text-centered back-link"
+          :to="nextEntityPath"
+          v-if="nextEntityPath && entityList.length > 1"
+        >
+          <chevron-right-icon />
+        </router-link>
       </div>
 
       <div class="sequence-data block">
@@ -252,7 +267,11 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import { CornerLeftUpIcon } from 'lucide-vue-next'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CornerLeftUpIcon
+} from 'lucide-vue-next'
 
 import sequenceStore from '@/store/modules/sequences'
 
@@ -285,6 +304,8 @@ export default {
 
   components: {
     ButtonSimple,
+    ChevronLeftIcon,
+    ChevronRightIcon,
     ComboboxNumber,
     CornerLeftUpIcon,
     DescriptionCell,

--- a/src/components/pages/Shot.vue
+++ b/src/components/pages/Shot.vue
@@ -21,6 +21,21 @@
         <div class="entity-title flexrow-item">
           {{ title }}
         </div>
+        <div class="filler"></div>
+        <router-link
+          class="flexrow-item has-text-centered back-link ml1"
+          :to="previousEntityPath"
+          v-if="previousEntityPath && entityList.length > 1"
+        >
+          <chevron-left-icon />
+        </router-link>
+        <router-link
+          class="flexrow-item has-text-centered back-link"
+          :to="nextEntityPath"
+          v-if="nextEntityPath && entityList.length > 1"
+        >
+          <chevron-right-icon />
+        </router-link>
       </div>
 
       <div class="entity-data block">
@@ -326,7 +341,11 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
-import { CornerLeftUpIcon } from 'lucide-vue-next'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CornerLeftUpIcon
+} from 'lucide-vue-next'
 
 import shotStore from '@/store/modules/shots'
 
@@ -359,6 +378,8 @@ export default {
   components: {
     ButtonSimple,
     ComboboxNumber,
+    ChevronLeftIcon,
+    ChevronRightIcon,
     CornerLeftUpIcon,
     DescriptionCell,
     EditShotModal,

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -70,6 +70,22 @@
               @click="toggleSubscribe"
               v-if="!isAssigned"
             />
+
+            <router-link
+              class="flexrow-item"
+              :to="previousTaskPath"
+              v-if="previousTaskPath"
+            >
+              <chevron-left-icon />
+            </router-link>
+
+            <router-link
+              class="flexrow-item"
+              :to="nextTaskPath"
+              v-if="nextTaskPath"
+            >
+              <chevron-right-icon />
+            </router-link>
           </div>
         </div>
       </div>
@@ -362,7 +378,12 @@
 </template>
 
 <script>
-import { CornerLeftUpIcon, ImageIcon } from 'lucide-vue-next'
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CornerLeftUpIcon,
+  ImageIcon
+} from 'lucide-vue-next'
 import { mapGetters, mapActions } from 'vuex'
 
 import drafts from '@/lib/drafts'
@@ -389,6 +410,12 @@ import ValidationTag from '@/components/widgets/ValidationTag.vue'
 import PreviewPlayer from '@/components/previews/PreviewPlayer.vue'
 import ViewPlaylistModal from '@/components/modals/ViewPlaylistModal.vue'
 
+import assetsStore from '@/store/modules/assets'
+import editsStore from '@/store/modules/edits'
+import episodesStore from '@/store/modules/episodes'
+import sequencesStore from '@/store/modules/sequences'
+import shotsStore from '@/store/modules/shots'
+
 export default {
   name: 'task',
 
@@ -397,6 +424,8 @@ export default {
   components: {
     AddComment,
     AddPreviewModal,
+    ChevronLeftIcon,
+    ChevronRightIcon,
     ComboboxStyled,
     Comment,
     CornerLeftUpIcon,
@@ -511,8 +540,37 @@ export default {
       'user'
     ]),
 
+    assetList() {
+      return assetsStore.cache.assets
+    },
+
+    editList() {
+      return editsStore.cache.edits
+    },
+
+    episodeList() {
+      return episodesStore.cache.episodes
+    },
+
+    sequenceList() {
+      return sequencesStore.cache.sequences
+    },
+
+    shotList() {
+      return shotsStore.cache.shots
+    },
+
     currentEntity() {
       return this.task && this.task.entity
+    },
+
+    currentType() {
+      const genericNames = ['Shot', 'Episode', 'Sequence', 'Edit']
+      if (genericNames.includes(this.task.entity_type_name)) {
+        return this.task.entity_type_name
+      } else {
+        return 'Asset'
+      }
     },
 
     previewOptions() {
@@ -633,109 +691,47 @@ export default {
     },
 
     entityList() {
-      const hasEntity = this.displayedShots.some(
-        entity => entity.id === this.task.entity_id
-      )
-      return hasEntity ? this.displayedShots : this.displayedAssets
+      return this[`${this.currentType.toLowerCase()}List`]
     },
 
-    previousEntity() {
-      if (this.task) {
-        const taskTypeId = this.task.task_type_id
-        const entityIndex = this.entityList.findIndex(entity => {
-          return entity.id === this.task.entity_id
-        })
-        let firstTraversal = false
+    /*
+     * Get the path to the previous task. The previous task is the fist task
+     * found in the previous entities with the same task type.
+     */
+    previousTaskPath() {
+      if (!this.task) return null
 
-        let previousEntityIndex = entityIndex - 1
-        if (previousEntityIndex < 0) {
-          previousEntityIndex = this.entityList.length - 1
-        }
+      const entityIndex = this.getEntityIndex(this.task.entity_id)
+      if (entityIndex === -1) return null
 
-        let taskId = null
-        while (!taskId) {
-          if (this.entityList[previousEntityIndex]) {
-            const entity = this.entityList[previousEntityIndex]
-            taskId = entity.tasks.find(ctaskId => {
-              const task = this.taskMap.get(taskId)
-              if (task) {
-                return task.task_type_id === taskTypeId
-              } else {
-                return false
-              }
-            })
-          } else {
-            taskId = this.task.id
-          }
-
-          if (!taskId) {
-            previousEntityIndex--
-            if (previousEntityIndex < 0) {
-              previousEntityIndex = this.entityList.length
-              if (firstTraversal) {
-                return null
-              }
-              firstTraversal = true
-            }
-          }
-        }
-
-        return this.taskPath({ id: taskId })
-      } else {
-        return {
-          name: 'open-productions'
+      let previousEntityIndex = this.getPreviousEntityIndex(entityIndex)
+      let taskId = null
+      while (!taskId && previousEntityIndex !== entityIndex) {
+        taskId = this.getTaskIdFromEntity(previousEntityIndex)
+        if (!taskId) {
+          previousEntityIndex = this.getPreviousEntityIndex(previousEntityIndex)
         }
       }
+
+      return taskId ? this.taskPath({ id: taskId }) : null
     },
 
-    nextEntity() {
-      if (this.task) {
-        const taskTypeId = this.task.task_type_id
-        let firstTraversal = false
-        const entityIndex = this.entityList.findIndex(entity => {
-          return entity.id === this.task.entity_id
-        })
+    nextTaskPath() {
+      if (!this.task) return null
 
-        let nextEntityIndex = entityIndex + 1
-        if (nextEntityIndex >= this.entityList.length) {
-          nextEntityIndex = 0
-        }
+      const entityIndex = this.getEntityIndex(this.task.entity_id)
+      if (entityIndex === -1) return null
 
-        let taskId = null
-        while (!taskId) {
-          if (this.entityList[nextEntityIndex]) {
-            const entity = this.entityList[nextEntityIndex]
-            taskId = entity.tasks.find(ctaskId => {
-              const task = this.taskMap.get(taskId)
-              if (task) {
-                return task.task_type_id === taskTypeId
-              } else {
-                return false
-              }
-            })
-          } else {
-            taskId = this.task.id
-          }
-
-          if (!taskId) {
-            nextEntityIndex++
-            if (nextEntityIndex >= this.entityList.length) {
-              nextEntityIndex = 0
-
-              if (firstTraversal) {
-                return null
-              }
-              firstTraversal = true
-            }
-          }
-        }
-
-        return this.taskPath({ id: taskId })
-      } else {
-        return {
-          name: 'open-productions'
+      let nextEntityIndex = this.getNextEntityIndex(entityIndex)
+      let taskId = null
+      while (!taskId && nextEntityIndex !== entityIndex) {
+        taskId = this.getTaskIdFromEntity(nextEntityIndex)
+        if (!taskId) {
+          nextEntityIndex = this.getNextEntityIndex(nextEntityIndex)
         }
       }
+
+      return taskId ? this.taskPath({ id: taskId }) : null
     },
 
     title() {
@@ -807,7 +803,6 @@ export default {
     },
 
     isHookupButtonVisible() {
-      // only show the hookup button for shots
       return this.task?.entity_type_name === 'Shot'
     },
 
@@ -854,6 +849,30 @@ export default {
       'unsubscribeFromTask',
       'updatePreviewAnnotation'
     ]),
+
+    getPreviousEntityIndex(index) {
+      const result = index - 1
+      return result < 0 ? this.entityList.length - 1 : result
+    },
+
+    getNextEntityIndex(index) {
+      const result = index + 1
+      return result >= this.entityList.length ? 0 : result
+    },
+
+    getEntityIndex(entityId) {
+      return this.entityList.findIndex(entity => entity.id === entityId)
+    },
+
+    getTaskIdFromEntity(index) {
+      const taskTypeId = this.task.task_type_id
+      const entity = this.entityList[index]
+      if (!entity) return null
+      return entity.tasks.find(ctaskId => {
+        const task = this.taskMap.get(ctaskId)
+        return task && task.task_type_id === taskTypeId
+      })
+    },
 
     loadTaskData() {
       const task = this.getCurrentTask()
@@ -973,42 +992,43 @@ export default {
       this.modals.hookupPlaylist = false
     },
 
+    /*
+     * Create a playlist with the previous, current and next task within the
+     * same sequence
+     */
     showHookupPlaylistModal() {
-      // create a playlist with the previous, current and next task
-      const current_task_id = this.task.id
-
+      const currentTaskId = this.task.id
       const tasks = Array.from(this.taskMap.values())
-        // get all tasks for this entity
+        // get all tasks for this sequence
         .filter(
           task =>
             task.episode_id === this.task.episode_id &&
             task.sequence_name === this.task.sequence_name &&
             task.task_type_id === this.task.task_type_id
         )
-        // sort the tasks by entity_name
+        // sort the tasks by shot name
         .sort((a, b) =>
           a.entity_name.localeCompare(b.entity_name, undefined, {
             numeric: true
           })
         )
 
-      const current_task_index = tasks.findIndex(
-        task => task.id === current_task_id
+      const currentTaskIndex = tasks.findIndex(
+        task => task.id === currentTaskId
       )
 
-      const previous_task_id =
-        current_task_index > 0 ? tasks[current_task_index - 1].id : null
+      const previousTaskId =
+        currentTaskIndex > 0 ? tasks[currentTaskIndex - 1].id : null
 
-      const next_task_id =
-        current_task_index < tasks.length - 1
-          ? tasks[current_task_index + 1].id
+      const nextTaskId =
+        currentTaskIndex < tasks.length - 1
+          ? tasks[currentTaskIndex + 1].id
           : null
 
-      this.hookupPlaylistTaskIds = [current_task_id]
-      if (previous_task_id) this.hookupPlaylistTaskIds.unshift(previous_task_id)
-      if (next_task_id) this.hookupPlaylistTaskIds.push(next_task_id)
+      this.hookupPlaylistTaskIds = [currentTaskId]
+      if (previousTaskId) this.hookupPlaylistTaskIds.unshift(previousTaskId)
+      if (nextTaskId) this.hookupPlaylistTaskIds.push(nextTaskId)
 
-      // open the playlist
       this.modals.hookupPlaylist = true
     },
 
@@ -1216,6 +1236,7 @@ export default {
         route = {
           name: section,
           params: {
+            type: this.currentType.toLowerCase() + 's',
             production_id: task.project_id,
             task_id: task.id
           }
@@ -1408,7 +1429,7 @@ export default {
     },
 
     selectedPreviewId() {
-      if (this.task) {
+      if (this.task && this.selectedPreviewId) {
         this.$router.push(this.previewPath(this.selectedPreviewId))
       }
     }

--- a/src/lib/path.js
+++ b/src/lib/path.js
@@ -113,12 +113,12 @@ export const getEntityPath = (
     }
   }
 
-  if (episodeId) {
+  if (episodeId && section !== 'episode') {
     route.name = `episode-${section}`
     route.params.episode_id = episodeId
   }
 
-  if (['shot', 'asset', 'edit', 'sequence'].includes(section)) {
+  if (['shot', 'asset', 'edit', 'sequence', 'episode'].includes(section)) {
     route.params[`${section}_id`] = entityId
   }
 


### PR DESCRIPTION
**Problem**

* The traditional Chinese locale is not properly named
* In the notification page, the Mark all read button is confusing when using filters
* It's not possible to go to the previous/next entity in an entity page
* It's not possible to go to the previous/next task in a task page

**Solution**

* Change the label to Chinese (TC)
* Hide the mark all read button when a filter is active
* Add buttons to go to the previous/next entity in the list (note: when going directly to the page, the full list is not loaded, so they are not displayed in that case)
* Add buttons to go to the previous/next task in the list 
