### PR TITLE
[breakdown] Fix episode casting loading

### DIFF
--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -809,8 +809,10 @@ export default {
 
     async reloadEntities() {
       this.isLoading = true
-      await this.loadSequences()
-      await this.loadShots()
+      if (this.currentEpisode.id !== 'main') {
+        await this.loadSequences()
+        await this.loadShots()
+      }
       if (this.isTVShow) {
         if (this.currentEpisode) {
           this.episodeId = this.currentEpisode.id
@@ -826,7 +828,10 @@ export default {
         this.setCastingAssetTypes()
         if (this.assetTypeId) {
           this.setCastingAssetType(this.assetTypeId)
-        } else {
+        } else if (
+          this.episodeId &&
+          !['main', 'all'].includes(this.episodeId)
+        ) {
           this.setCastingSequence(this.sequenceId || 'all')
         }
         this.resetSequenceOption()
@@ -1591,7 +1596,7 @@ export default {
     episodeId() {
       if (this.episodeId && this.episodes && this.episodes.length > 0) {
         if (this.episodeId === 'all') {
-          this.setCastingForProductionEpisodes(this.episodeId)
+          this.setCastingForProductionEpisodes()
         }
         this.resetSelection()
       }

--- a/src/store/modules/breakdown.js
+++ b/src/store/modules/breakdown.js
@@ -78,7 +78,7 @@ const getters = {
 }
 
 const actions = {
-  setCastingForProductionEpisodes({ commit, rootState }, episodeId) {
+  setCastingForProductionEpisodes({ commit, rootState }) {
     const production = rootState.productions.currentProduction
     if (!production) return Promise.resolve()
 
@@ -87,7 +87,7 @@ const actions = {
     )
     commit(CASTING_SET_FOR_EPISODES, episodes)
     return breakdownApi
-      .getProductionEpisodesCasting(production.id, episodeId)
+      .getProductionEpisodesCasting(production.id)
       .then(casting => {
         commit(CASTING_SET_CASTING, { casting, production })
       })


### PR DESCRIPTION
**Problem**

* The episode casting is not always properly loaded.

**Solution**

The data were erased by an additional sequence casting loading that erased the actual casting data. This loading didn't make sense because the episodes section doesn't manage sequences.