### PR TITLE
Fix CI staging workflow

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ Start developing for Kitsu using Docker on Windows, Linux and macOS.
 
 **Prerequisites**
 
-- [Node.js >= 20.18](https://nodejs.org)
+- [Node.js >= 20.19](https://nodejs.org)
 - [Docker >= 1.13](https://store.docker.com/search?type=edition&offering=community)
 
 **Setup**

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
         "vitest-localstorage-mock": "0.1.2"
       },
       "engines": {
-        "node": ">=20.18"
+        "node": ">=20.19"
       }
     },
     "node_modules/@animxyz/core": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "vitest-localstorage-mock": "0.1.2"
   },
   "engines": {
-    "node": ">=20.18"
+    "node": ">=20.19"
   },
   "lint-staged": {
     "*.{js,vue}": "eslint --cache"


### PR DESCRIPTION
**Problem**
- The CI staging workflow can fail due to an invalid Node.js version. `@vitejs/plugin-vue` v6 requires Node >= 20.19

**Solution**
- Fix minimum Node.js version (from 20.18 to 20.19)
