### PR TITLE
Fix Staging workflow

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -11,10 +11,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: current
       - name: Update Kitsu on staging server
         uses: appleboy/ssh-action@v1
         env:


### PR DESCRIPTION
**Problem**
- Useless config of Node.js version

**Solution**
- Node.js is set up on the remote machine. The staging is now bumped to Node 22 LTS.
