### PR TITLE
Fix mode selector on production schedule

### DIFF
--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -478,10 +478,10 @@ export default {
         { label: '2', value: 2 },
         { label: '3', value: 3 }
       ],
-      detailLevel: 'prev',
-      detailOptions: [
-        { label: this.$t('schedule.detail_level_prev'), value: 'prev' },
-        { label: this.$t('schedule.detail_level_real'), value: 'real' }
+      mode: 'prev',
+      modeOptions: [
+        { label: this.$t('schedule.mode_prev'), value: 'prev' },
+        { label: this.$t('schedule.mode_real'), value: 'real' }
       ],
       loading: {
         schedule: false

--- a/src/components/widgets/ComboboxDisplayOptions.vue
+++ b/src/components/widgets/ComboboxDisplayOptions.vue
@@ -29,7 +29,7 @@
         >
           <toggle-button
             :label="option.label"
-            :modelValue="modelValue[option.value]"
+            :model-value="modelValue[option.value]"
           />
         </div>
       </div>


### PR DESCRIPTION
**Problem**
- We can no longer change modes in the production schedule

**Solution**
- Fix invalid data for the mode combobox after renaming.
