### PR TITLE
Show the hard delete modal for tasks, assets, shots, edits, concepts to avoid accidental data loss.

### DIFF
--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -305,7 +305,9 @@
             :key="entity.id"
             v-for="entity in Array.from(selectedEntities.values())"
           >
-            <span :class="{ canceled: entity.canceled }">{{ entity.full_name }}</span>
+            <span :class="{ canceled: entity.canceled }">{{
+              entity.full_name
+            }}</span>
           </div>
         </div>
       </div>

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -305,9 +305,7 @@
             :key="entity.id"
             v-for="entity in Array.from(selectedEntities.values())"
           >
-            <span :class="entity.canceled ? 'canceled' : ''">{{
-              entity.full_name
-            }}</span>
+            <span :class="{ canceled: entity.canceled }">{{ entity.full_name }}</span>
           </div>
         </div>
       </div>

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -305,7 +305,9 @@
             :key="entity.id"
             v-for="entity in Array.from(selectedEntities.values())"
           >
-            {{ entity.full_name }}
+            <span :class="entity.canceled ? 'canceled' : ''">{{
+              entity.full_name
+            }}</span>
           </div>
         </div>
       </div>

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -575,7 +575,7 @@
             :error-text="$t('tasks.delete_for_selection_error')"
             :is-loading="loading.taskDeletion"
             :is-error="errors.taskDeletion"
-            :require-hard-delete-confirmation="allTasksCanceled"
+            :require-hard-delete-confirmation="true"
             :hard-delete-lock-text="
               $t('tasks.delete_for_selection_hard_lock_text')
             "

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -578,6 +578,9 @@
                 'is-loading': loading.taskDeletion
               }"
               @click="confirmTaskDeletion"
+              :disabled="
+                deleteConfirmationText.trim().toLowerCase() !== 'delete'
+              "
             >
               {{
                 $tc('tasks.delete_for_selection', nbSelectedTasks, {
@@ -586,6 +589,18 @@
               }}
             </button>
           </div>
+          <div class="flexrow-item">
+            <label class="label is-warning">
+              To permanently delete the selected tasks type 'delete':
+            </label>
+            <input
+              class="input"
+              type="text"
+              v-model="deleteConfirmationText"
+              @keyup.enter="confirmTaskDeletion"
+            />
+          </div>
+
           <div class="flexrow-item error" v-if="errors.taskDeletion">
             {{ $t('tasks.delete_error') }}
           </div>
@@ -882,6 +897,7 @@ export default {
       availableTaskStatuses: [],
       customAction: {},
       customActions: [],
+      deleteConfirmationText: '',
       isUseCurrentFrame: false,
       person: null,
       priority: '0',
@@ -1364,11 +1380,15 @@ export default {
     },
 
     confirmTaskDeletion() {
+      if (this.deleteConfirmationText.trim().toLowerCase() !== 'delete') {
+        return
+      }
       this.loading.taskDeletion = true
       this.errors.taskDeletion = false
       this.deleteSelectedTasks()
         .then(() => {
           this.loading.taskDeletion = false
+          this.deleteConfirmationText = ''
         })
         .catch(err => {
           console.error(err)
@@ -1874,6 +1894,11 @@ export default {
   font-size: 0.8em;
   font-style: italic;
   text-align: center;
+}
+
+.is-warning {
+  margin-top: 0.5em;
+  color: $red;
 }
 
 .tags {

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -1094,7 +1094,6 @@ export default {
       const allShotsCanceled = Array.from(this.selectedShots.values()).every(
         shot => shot.canceled
       )
-      console.log('allShotsCanceled', this.selectedShots)
       return allShotsCanceled
     },
 

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -571,39 +571,22 @@
         </div>
 
         <div class="flexrow-item is-wide" v-if="selectedBar === 'delete-tasks'">
-          <div class="flexrow is-wide">
-            <button
-              class="button is-danger confirm-button is-wide"
-              :class="{
-                'is-loading': loading.taskDeletion
-              }"
-              @click="confirmTaskDeletion"
-              :disabled="
-                deleteConfirmationText.trim().toLowerCase() !== 'delete'
-              "
-            >
-              {{
-                $tc('tasks.delete_for_selection', nbSelectedTasks, {
-                  nbSelectedTasks
-                })
-              }}
-            </button>
-          </div>
-          <div class="flexrow-item">
-            <label class="label is-warning">
-              To permanently delete the selected tasks type 'delete':
-            </label>
-            <input
-              class="input"
-              type="text"
-              v-model="deleteConfirmationText"
-              @keyup.enter="confirmTaskDeletion"
-            />
-          </div>
-
-          <div class="flexrow-item error" v-if="errors.taskDeletion">
-            {{ $t('tasks.delete_error') }}
-          </div>
+          <delete-entities
+            :error-text="$t('tasks.delete_for_selection_error')"
+            :is-loading="loading.taskDeletion"
+            :is-error="errors.taskDeletion"
+            :require-hard-delete-confirmation="allTasksCanceled"
+            :hard-delete-lock-text="
+              $t('tasks.delete_for_selection_hard_lock_text')
+            "
+            :hard-delete-text="$t('tasks.delete_for_selection_hard_text')"
+            :text="
+              $tc('tasks.delete_for_selection', nbSelectedTasks, {
+                nbSelectedTasks
+              })
+            "
+            @confirm="confirmTaskDeletion"
+          />
         </div>
 
         <div class="flexcolumn filler" v-if="selectedBar === 'custom-actions'">
@@ -697,6 +680,11 @@
                 nbSelectedAssets
               })
             "
+            :require-hard-delete-confirmation="allAssetsCanceled"
+            :hard-delete-lock-text="
+              $tc('assets.delete_for_selection_hard_lock_text')
+            "
+            :hard-delete-text="$tc('assets.delete_for_selection_hard_text')"
             @confirm="confirmAssetDeletion"
           />
         </div>
@@ -711,6 +699,11 @@
                 nbSelectedShots
               })
             "
+            :require-hard-delete-confirmation="allShotsCanceled"
+            :hard-delete-lock-text="
+              $t('shots.delete_for_selection_hard_lock_text')
+            "
+            :hard-delete-text="$t('shots.delete_for_selection_hard_text')"
             @confirm="confirmShotDeletion"
           />
         </div>
@@ -725,6 +718,11 @@
                 nbSelectedEdits
               })
             "
+            :require-hard-delete-confirmation="allEditsCanceled"
+            :hard-delete-lock-text="
+              $t('edits.delete_for_selection_hard_lock_text')
+            "
+            :hard-delete-text="$t('edits.delete_for_selection_hard_text')"
             @confirm="confirmEditDeletion"
           />
         </div>
@@ -742,6 +740,7 @@
                 nbSelectedEpisodes
               })
             "
+            :require-hard-delete-confirmation="true"
             @confirm="confirmEpisodeDeletion"
           />
         </div>
@@ -759,6 +758,11 @@
                 nbSelectedConcepts
               })
             "
+            :require-hard-delete-confirmation="true"
+            :hard-delete-lock-text="
+              $t('concepts.delete_for_selection_hard_lock_text')
+            "
+            :hard-delete-text="$t('concepts.delete_for_selection_hard_text')"
             @confirm="confirmConceptDeletion"
           />
         </div>
@@ -897,7 +901,6 @@ export default {
       availableTaskStatuses: [],
       customAction: {},
       customActions: [],
-      deleteConfirmationText: '',
       isUseCurrentFrame: false,
       person: null,
       priority: '0',
@@ -1081,6 +1084,37 @@ export default {
       return this.selectedConcepts.size
     },
 
+    allAssetsCanceled() {
+      return Array.from(this.selectedAssets.values()).every(
+        asset => asset.canceled
+      )
+    },
+
+    allShotsCanceled() {
+      const allShotsCanceled = Array.from(this.selectedShots.values()).every(
+        shot => shot.canceled
+      )
+      console.log('allShotsCanceled', this.selectedShots)
+      return allShotsCanceled
+    },
+
+    allEditsCanceled() {
+      return Array.from(this.selectedEdits.values()).every(
+        edit => edit.canceled
+      )
+    },
+
+    allConceptsCanceled() {
+      return Array.from(this.selectedConcepts.values()).every(
+        concept => concept.canceled
+      )
+    },
+
+    allSequencesCanceled() {
+      return Array.from(this.selectedSequences.values()).every(
+        sequence => sequence.canceled
+      )
+    },
     isHidden() {
       return (
         (this.nbSelectedTasks === 0 &&
@@ -1380,15 +1414,12 @@ export default {
     },
 
     confirmTaskDeletion() {
-      if (this.deleteConfirmationText.trim().toLowerCase() !== 'delete') {
-        return
-      }
       this.loading.taskDeletion = true
       this.errors.taskDeletion = false
       this.deleteSelectedTasks()
         .then(() => {
           this.loading.taskDeletion = false
-          this.deleteConfirmationText = ''
+          this.clearSelectedTasks()
         })
         .catch(err => {
           console.error(err)
@@ -1894,11 +1925,6 @@ export default {
   font-size: 0.8em;
   font-style: italic;
   text-align: center;
-}
-
-.is-warning {
-  margin-top: 0.5em;
-  color: $red;
 }
 
 .tags {

--- a/src/components/tops/actions/DeleteEntities.vue
+++ b/src/components/tops/actions/DeleteEntities.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flexrow">
     <div class="flexrow-item is-wide" v-if="!isLoading">
-      <button class="button is-danger is-wide" @click="$emit('confirm')">
+      <button class="button is-danger is-wide" @click="confirmDeletion">
         {{ text }}
       </button>
     </div>
@@ -12,16 +12,29 @@
       {{ errorText }}
     </div>
   </div>
+  <hard-delete-modal
+    :active="modals.deleteConfirmation"
+    :error-text="errorText"
+    :is-loading="isLoading"
+    :is-error="isError"
+    :text="hardDeleteTextComputed"
+    :lock-text="hardDeleteLockTextComputed"
+    @cancel="modals.deleteConfirmation = false"
+    @confirm="confirm"
+    vif="modals.deleteConfirmation"
+  />
 </template>
 
 <script>
 import Spinner from '@/components/widgets/Spinner.vue'
+import HardDeleteModal from '@/components/modals/HardDeleteModal.vue'
 
 export default {
   name: 'delete-entities',
 
   components: {
-    Spinner
+    Spinner,
+    HardDeleteModal
   },
 
   props: {
@@ -40,10 +53,59 @@ export default {
     text: {
       default: '',
       type: String
+    },
+    // HARD DELETE MODAL
+    requireHardDeleteConfirmation: {
+      default: false,
+      type: Boolean
+    },
+    hardDeleteText: {
+      default: '',
+      type: String
+    },
+    hardDeleteLockText: {
+      default: '',
+      type: String
     }
   },
 
-  emits: ['confirm']
+  emits: ['confirm'],
+
+  data() {
+    return {
+      modals: {
+        deleteConfirmation: false
+      }
+    }
+  },
+
+  computed: {
+    hardDeleteTextComputed() {
+      return (
+        this.hardDeleteText ||
+        this.$t('hard_delete.delete_for_selection_hard_text')
+      )
+    },
+    hardDeleteLockTextComputed() {
+      return (
+        this.hardDeleteLockText ||
+        this.$t('hard_delete.delete_for_selection_hard_lock_text')
+      )
+    }
+  },
+
+  methods: {
+    confirmDeletion() {
+      if (this.requireHardDeleteConfirmation) {
+        this.modals.deleteConfirmation = true
+      } else {
+        this.confirm()
+      }
+    },
+    confirm() {
+      this.$emit('confirm')
+    }
+  }
 }
 </script>
 

--- a/src/components/tops/actions/DeleteEntities.vue
+++ b/src/components/tops/actions/DeleteEntities.vue
@@ -13,7 +13,7 @@
     </div>
   </div>
   <hard-delete-modal
-    :active="modals.deleteConfirmation"
+    active
     :error-text="errorText"
     :is-loading="isLoading"
     :is-error="isError"
@@ -21,7 +21,7 @@
     :lock-text="hardDeleteLockTextComputed"
     @cancel="modals.deleteConfirmation = false"
     @confirm="confirm"
-    vif="modals.deleteConfirmation"
+    v-if="modals.deleteConfirmation"
   />
 </template>
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -5,6 +5,8 @@ export default {
     cancel_text: 'Are you sure you want to archive {name}?',
     delete_error: 'An error occurred while deleting this asset. There may be existing data currently linked to it. Are you sure this asset type has no task linked to it?',
     delete_for_selection: 'Delete the selected asset | Delete the {nbSelectedAssets} selected assets',
+    delete_for_selection_hard_text: 'Are you sure you want to permanently remove the selected assets? All related tasks, comments and previews will also be deleted. Please confirm by typing \'DELETE\' below.',
+    delete_for_selection_hard_lock_text: 'DELETE',
     delete_text: 'Are you sure you want to remove {name} from your database?',
     edit_fail: 'Saving failed. An asset with a similar name may already exist.',
     edit_success: 'Asset {name} successfully edited.',
@@ -263,6 +265,8 @@ export default {
     add_concept: 'Add files for new concepts',
     add_concept_error: 'An error occurred while adding concepts.',
     delete_for_selection: 'Delete the selected concept | Delete the {nbSelectedConcepts} selected concepts',
+    delete_for_selection_hard_text: 'Are you sure you want to permanently remove the selected concepts? All related tasks, comments and previews will also be deleted. Please confirm by typing \'DELETE\' below.',
+    delete_for_selection_hard_lock_text: 'DELETE',
     empty: 'There are no concepts for this production',
     multiple_delete_error: 'An error occurred while deleting a concept. There may be existing data currently linked to it. Are you sure there is no task linked to a selected concept?',
     no_concept_selected: 'No concept selected',
@@ -490,6 +494,11 @@ export default {
       'standby': 'Stand By',
       'running': 'Running'
     }
+  },
+
+  hard_delete: {
+    delete_for_selection_hard_text: 'Are you sure you want to permanently remove the selected items? Please confirm by typing \'DELETE\' below.',
+    delete_for_selection_hard_lock_text: 'DELETE',
   },
 
   hardware_items: {
@@ -1467,6 +1476,9 @@ export default {
     delete_text: 'Are you sure you want to remove {name} from your database?',
     delete_error: 'An error occurred while deleting this edit. There may be existing data currently linked to it.',
     delete_for_selection: 'Delete the selected edit | Delete the {nbSelectedEdits} selected edits',
+    delete_for_selection_error: 'An error occurred while deleting the selected edits.',
+    delete_for_selection_hard_text: 'Are you sure you want to permanently remove the selected edits? All related tasks, comments and previews will also be deleted. Please confirm by typing \'DELETE\' below.',
+    delete_for_selection_hard_lock_text: 'DELETE',
     edit_error: 'An error occurred while saving this edit. Are you sure there is no edit with a similar name?',
     edit_success: 'Modifications were saved successfully.',
     edit_title: 'Change edit',
@@ -1475,6 +1487,7 @@ export default {
     new_edit: 'New edit',
     history: 'Edit values history',
     number: 'edit | edits',
+    multiple_delete_error: 'An error occurred while deleting an edit. There may be existing data currently linked to it. Are you sure there are no tasks linked to a selected edit?',
     restore_text: 'Are you sure you want to restore {name} from your archive?',
     restore_error: 'An error occurred while restoring this edit.',
     tasks: 'Tasks',
@@ -1591,6 +1604,8 @@ export default {
     delete_text: 'Are you sure you want to remove {name} from your database?',
     delete_error: 'An error occurred while deleting this shot. There may be existing data currently linked to it. Are you sure this shot has no task linked to it?',
     edit_success: 'Shot {name} successfully edited.',
+    delete_for_selection_hard_text: 'Are you sure you want to permanently remove the selected shots? All related tasks, comments and previews will also be deleted. Please confirm by typing \'DELETE\' below.',
+    delete_for_selection_hard_lock_text: 'DELETE',
     edit_fail: 'Creation or edit failed, an error occurred. Make sure that you are not renaming the shot with a name already listed for a given sequence.',
     edit_title: 'Edit shot',
     empty_list: 'There are no shots in the production. How about creating some?',
@@ -1710,6 +1725,9 @@ export default {
     delete_comment: 'Are you sure you want to delete comments?',
     delete_comment_error: 'An error occurred while deleting comments.',
     delete_for_selection: 'Delete the selected task | Delete the {nbSelectedTasks} selected tasks',
+    delete_for_selection_error: 'An error occurred while deleting the selected tasks.',
+    delete_for_selection_hard_text: 'Are you sure you want to permanently remove the selected tasks? All related comments and previews will also be deleted. Please confirm by typing \'DELETE\' below.',
+    delete_for_selection_hard_lock_text: 'DELETE',
     delete_preview: 'Are you sure you want to delete this preview?',
     delete_preview_error: 'An error occurred while deleting preview.',
     done: 'Done',


### PR DESCRIPTION
**Problem**
We had a user with correct permissions accidentally delete a number of tasks when trying to create a playlist.

There is a hard delete prompt message when deleting episodes, sequences and budgets to let the user know that the delete button will permanently lose the data. 
When you delete tasks they hard delete with no warning losing all comments, previews etc. 
When you delete entities such as shots and assets they soft delete first (canceled = True) then the second time they hard delete with no warning. 
Concepts delete first time, with no soft delete option. 

**Solution**
This PR adds a hard delete modal for these extra cases where data will be lost on pressing the delete button and differentiates between the soft delete. This makes for a consistent experience for users and helps avoid accidental deletion.

### TASKS
Select tasks and delete should always show a hard delete modal as tasks does not have a soft delete option. 

<img width="483" height="221" alt="image" src="https://github.com/user-attachments/assets/4616cd48-3815-4c2f-a729-ce3ee0c982b8" />

Type DELETE to approve the permanent deletion. 

<img width="660" height="239" alt="image" src="https://github.com/user-attachments/assets/d7907f6d-fed9-4962-b32a-ee071690ab72" />

### ASSETS, EDITS, SHOTS - soft delete
Cancelled entities now show as strike-through in the list to differentiate 

<img width="191" height="149" alt="image" src="https://github.com/user-attachments/assets/2974f3f0-facf-4523-9279-127d27903ef4" />

Assets, edits and shots are soft deleted if any selected item is not already cancelled. The list above will be soft deleted and no hard delete modal will appear on clicking delete button.

### ASSETS, EDITS, SHOTS - hard delete

We check if all items are cancelled already and if so the process will be a hard deleted.

<img width="486" height="215" alt="image" src="https://github.com/user-attachments/assets/0f17d6a5-7094-4d87-894e-a8c1458ec357" />

For this list all items are already cancelled so the hard delete modal will show.

<img width="660" height="252" alt="image" src="https://github.com/user-attachments/assets/1253c390-0451-469c-854b-2c5565982d7e" />

### Concepts
Although concepts have a soft delete, UI currently hard deletes first time. Always on hard delete modal added. 

