### PR TITLE
Suggestion: enabling HMR for json changes in @/locales

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -10,4 +10,16 @@ const i18n = new createI18n({
   messages: locales
 })
 
+/*
+ * Enable HMR for locales
+ */
+if (import.meta.hot) {
+  import.meta.hot.accept('@/locales', mod => {
+    const updatedMessages = mod.default
+    for (const locale of Object.keys(updatedMessages)) {
+      i18n.global.setLocaleMessage(locale, updatedMessages[locale])
+    }
+  })
+}
+
 export default i18n


### PR DESCRIPTION
Hello.

**Problem**
I’m currently working on Japanese translations in the development environment, and I noticed that updating JSON files under @/locales always triggers a full page reload.

**Solution**
Add a minimal snippet to handle HMR updates.

**Reference**
- <https://kazupon.github.io/vue-i18n/guide/hot-reload.html#advanced-example>

Thanks in advance,