### PR TITLE
[playlists] Fix temp playlist

### DIFF
--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -1731,7 +1731,7 @@ export default {
       }
     },
 
-    selectedTasks() {
+    'selectedTasks.size'() {
       this.selectedTaskIds = Array.from(this.selectedTasks.keys())
     },
 


### PR DESCRIPTION
**Problem**

Playlists from a selection made with the ctrl button showed only one element.

**Solution**

It was due to the fact the selection list was not properly reset when
the store selection changed. Listen to the map size instead of the map directly.
