### PR TITLE
Fix entity group filters UI issue

### DIFF
--- a/src/components/widgets/SearchQueryList.vue
+++ b/src/components/widgets/SearchQueryList.vue
@@ -570,10 +570,6 @@ export default {
   transform: scale(1.1);
 }
 
-.search-queries .group.tag.open .tag:hover {
-  transform: scale(1.03);
-}
-
 .search-queries .group.tag:hover, // avoid bug (overflow)
 .search-queries .tag.empty:hover {
   transform: none;


### PR DESCRIPTION
**Problem**
- Overflow issue when hovering the cursor over a grouped filter.

**Solution**
- Restore the previous CSS rule to disable the hover effect on groups. Apply the effect only when a link is hovered.
