### PR TITLE
Rollback @unhead/vue npm dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@fullcalendar/vue3": "6.1.19",
         "@google/model-viewer": "4.1.0",
         "@sentry/vue": "10.18.0",
-        "@unhead/vue": "2.0.18",
+        "@unhead/vue": "2.0.17",
         "@vuepic/vue-datepicker": "11.0.2",
         "async": "3.2.6",
         "bowser": "2.12.1",
@@ -2319,13 +2319,13 @@
       "license": "ISC"
     },
     "node_modules/@unhead/vue": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.0.18.tgz",
-      "integrity": "sha512-2i3AWz+0G5eS11iJPDKXc8u+rciI63oT3uh/bYzehLiC688IQ2cCnthu0rvIv2sLB+8LKIj1jv8JIHZZTMnJOg==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.0.17.tgz",
+      "integrity": "sha512-jzmGZYeMAhETV6qfetmLbZzUjjx1TjdNvFSobeFZb73D7dwD9wl/nOAx36qq+TvjZsLJdF5PQWToz2oDGAUqCg==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^5.5.3",
-        "unhead": "2.0.18"
+        "unhead": "2.0.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
@@ -8442,9 +8442,9 @@
       }
     },
     "node_modules/unhead": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.0.18.tgz",
-      "integrity": "sha512-WisN0JGW+ydCpWnarD70mc9VP2m6zWX8ebW2ZpHm/gpishkdyBQskZvd8cesfF8JSL/P8rIhEm9d256njnyPgA==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.0.17.tgz",
+      "integrity": "sha512-xX3PCtxaE80khRZobyWCVxeFF88/Tg9eJDcJWY9us727nsTC7C449B8BUfVBmiF2+3LjPcmqeoB2iuMs0U4oJQ==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^5.5.3"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@fullcalendar/vue3": "6.1.19",
     "@google/model-viewer": "4.1.0",
     "@sentry/vue": "10.18.0",
-    "@unhead/vue": "2.0.18",
+    "@unhead/vue": "2.0.17",
     "@vuepic/vue-datepicker": "11.0.2",
     "async": "3.2.6",
     "bowser": "2.12.1",


### PR DESCRIPTION
**Problem**
- @unhead/vue in version 2.0.18 does not update title dynamically

**Solution**
- Rollback @unhead/vue to v2.0.17
