### PR TITLE
Fix init of schedule on task type

### DIFF
--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1654,7 +1654,7 @@ export default {
           children: [],
           editable: false,
           daysOff: this.daysOffByPerson[person.id],
-          timesheet: this.timesheetByPerson[person.id],
+          timesheet: this.timesheetByPerson[person.id] ?? [],
           route: getPersonPath(person.id, 'schedule')
         }
       }


### PR DESCRIPTION
**Problem**
- The schedule fails to load correctly on the task type page

**Solution**
- Fix undefined value when timesheet display is disabled.
