### PR TITLE
[player] Change resize sensitivity

### DIFF
--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -995,7 +995,7 @@ export const playerMixin = {
     onWindowResize() {
       const now = new Date().getTime()
       this.lastCall = this.lastCall || 0
-      if (now - this.lastCall > 600) {
+      if (now - this.lastCall > 100) {
         this.lastCall = now
         setTimeout(() => {
           this.resetHeight()


### PR DESCRIPTION
**Problem**

Sometimes the annotations are not well located.

**Solution**

It seems it is related to resizing event that is not triggered after too many resizes occurring fast (when dragging the window width).
