### PR TITLE
[playlists] Reset pan zoom on reset canvas position

### DIFF
--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -1237,6 +1237,10 @@ export const playerMixin = {
 
     resetCanvasSize() {
       return this.$nextTick().then(() => {
+        if (!this.zoomEnabled) {
+          this.resetPanZoom()
+        }
+
         if (this.isCurrentPreviewMovie && this.isAnnotationCanvas()) {
           if (this.canvas) {
             // Video Ratio


### PR DESCRIPTION
**Problem**

The video player placement in the playlist is sometimes wrong, and annotations don't fit with it.

**Solution**

Reset the pan zoom when the annotation canvas is reset to ensure there is no wrong translation due to the pan / zoom feature.
