### PR TITLE
Feat: frontend support for all entities on production schedule page #1921

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -701,6 +701,7 @@ export default {
     empty_comment: 'Empty comment',
     empty_schedule: 'There are no tasks or they don\'t have start dates.',
     end_date: 'End date',
+    entities: 'Entities',
     estimation: 'Estimation',
     estimation_short: 'Est.',
     expand_all: 'Expand all',
@@ -1584,10 +1585,7 @@ export default {
       new: 'new schedule',
       name: 'version name',
       locked: 'locked version'
-    },
-    entities: 'Entities',
-    all_entities: 'All',
-    selected: 'selected'
+    }
   },
 
   team_schedule: {


### PR DESCRIPTION
**Changed head branch from previous PR.**

Problem
Before now, only assets and shots rendered on the production schedule page. This PR, in tandem with a PR on the backend Zou repo, fixes that. Asset, shot, sequence, episode, and edit task types now display on the production schedule (if configured for that production and at least one task exists for a given entity). It also includes a dropdown to filter by specific entities. Closes https://github.com/cgwire/kitsu/issues/1920

Solution
Production managers can now see ALL entity types on the production schedule page, as I've also seen requested by several community members in my search. The frontend implementation matches existing styling.

I should emphasize: BOTH THIS PR AND THE PR ON THE BACKEND ZOU REPO (https://github.com/cgwire/zou/pull/1005) MUST BE APPROVED FOR THIS FUNCTIONALITY TO WORK PROPERLY. Without the backend changes, the necessary data is never sent to the frontend at all.