### PR TITLE
Fixed "Failed to resolve entry for package" error introduced by #1927

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -22,9 +22,9 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, 'src/'),
       vue: 'vue/dist/vue.esm-bundler.js',
-      '@arch-inc/fabricjs-psbrush': path.resolve(
+      'fabricjs-psbrush': path.resolve(
         __dirname,
-        'node_modules/@arch-inc/fabricjs-psbrush/dist/index.js'
+        'node_modules/fabricjs-psbrush/dist/index.mjs'
       )
     }
   },


### PR DESCRIPTION
It was impossible to run npm run build because the package fabricjs-psbrush was incorrectly setup after the change from @arch-inc/fabricjs-psbrush to just fabricjs-psbrush