### PR TITLE
Fix 2FA workflows

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1372,8 +1372,7 @@ export default {
         registered_devices_title: 'Registered FIDO devices:',
         button_register: 'Register new FIDO device',
         error_register: 'An error occurred while registering FIDO device.',
-        error_unregister: 'An error occurred while unregistering FIDO device.',
-        button_unregister: 'Validate and unregister FIDO device'
+        error_unregister: 'An error occurred while unregistering FIDO device.'
       },
       recovery_codes: {
         title: 'Recovery codes',

--- a/src/store/api/people.js
+++ b/src/store/api/people.js
@@ -194,8 +194,8 @@ export default {
     return client.pget(`/api/auth/fido?email=${email}`)
   },
 
-  unregisterFIDO(twoFactorPayload, deviceName) {
-    const data = { ...twoFactorPayload, device_name: deviceName }
+  unregisterFIDO(deviceName) {
+    const data = { device_name: deviceName }
     return client.pdel('/api/auth/fido', data)
   },
 

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -265,12 +265,9 @@ const actions = {
       .then(body => coercePublicKeyFromJSON(body))
   },
 
-  unregisterFIDO({ commit, state }, { twoFactorPayload, deviceName }) {
-    return peopleApi
-      .unregisterFIDO(coerceTwoFactorPayload(twoFactorPayload), deviceName)
-      .then(() => {
-        commit(USER_UNREGISTER_FIDO_SUCCESS, deviceName)
-      })
+  async unregisterFIDO({ commit }, { deviceName }) {
+    await peopleApi.unregisterFIDO(deviceName)
+    commit(USER_UNREGISTER_FIDO_SUCCESS, deviceName)
   },
 
   newRecoveryCodes({ commit, state }, twoFactorPayload) {


### PR DESCRIPTION
PR linked to https://github.com/cgwire/zou/pull/1014

**Problem**
Some 2FA processes, such as deleting a FIDO key or disabling OTP, no longer work.
Additionally, you cannot delete a FIDO key if it has been lost.

**Solution**
- Make unregistering a FIDO key easier. Requesting a valid challenge is unnecessary for this workflow.
- Improve the 2FA form style
