### PR TITLE
fix: Topbar.vue edge case when there's no episodes

### DIFF
--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -733,7 +733,8 @@ export default {
         !isAssetSection &&
         !isEditSection &&
         !isBreakdownSection &&
-        ['all', 'main'].includes(episodeId)
+        ['all', 'main'].includes(episodeId) &&
+        this.episodes.length > 0
       ) {
         episodeId = this.episodes[0].id
         this.currentEpisodeId = episodeId


### PR DESCRIPTION
**Problem**

Fixes #1944 

**Solution**

Explicitly check that `this.episodes` is not empty.
