### PR TITLE
Display remaining seats

### DIFF
--- a/src/components/lists/PeopleList.vue
+++ b/src/components/lists/PeopleList.vue
@@ -158,6 +158,10 @@ export default {
     isLoading: {
       type: Boolean,
       default: false
+    },
+    seatsRemaining: {
+      type: Number,
+      default: null
     }
   },
 
@@ -211,6 +215,14 @@ export default {
         this.isBots ? 'bots.bots' : 'people.persons',
         nbUsers
       )
+      if (!this.isBots && this.seatsRemaining !== null) {
+        const labelRemaining = this.$tc(
+          'people.seats_remaining',
+          this.seatsRemaining,
+          { count: this.seatsRemaining }
+        )
+        return `${nbUsers} ${labelUsers} (${labelRemaining})`
+      }
       return `${nbUsers} ${labelUsers}`
     }
   },

--- a/src/components/pages/People.vue
+++ b/src/components/pages/People.vue
@@ -72,6 +72,7 @@
       :entries="activeTab === 'active' ? activePeople : unactivePeople"
       :is-loading="isPeopleLoading"
       :is-error="isPeopleLoadingError"
+      :seats-remaining="activeTab === 'active' ? seatsRemaining : null"
       @avatar-clicked="onAvatarClicked"
       @delete-clicked="onDeleteClicked"
       @edit-clicked="onEditClicked"
@@ -279,16 +280,24 @@ export default {
 
   computed: {
     ...mapGetters([
+      'activePeopleWithoutBot',
       'displayedPeople',
       'isCurrentUserAdmin',
-      'isPeopleLoading',
-      'isPeopleLoadingError',
       'isImportPeopleLoading',
       'isImportPeopleLoadingError',
+      'isPeopleLoading',
+      'isPeopleLoadingError',
+      'mainConfig',
       'peopleSearchQueries',
       'personCsvFormData',
-      'studioMap'
+      'studioMap',
+      'userLimit'
     ]),
+
+    seatsRemaining() {
+      if (this.mainConfig.is_self_hosted) return null
+      return Math.max(0, this.userLimit - this.activePeopleWithoutBot.length)
+    },
 
     tabs() {
       return [

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -966,6 +966,7 @@ export default {
     new_person: 'Add a new user',
     no_task_assigned: 'There are no running tasks assigned to you',
     persons: 'user | users',
+    seats_remaining: 'no seats remaining | {count} seat remaining | {count} seats remaining',
     running_tasks: 'Running tasks',
     select_person: 'Select a user...',
     team: 'Team',

--- a/src/store/modules/people.js
+++ b/src/store/modules/people.js
@@ -37,6 +37,7 @@ import {
   PERSON_LOAD_TIME_SPENTS_END,
   SET_ORGANISATION,
   SET_PERSON_TASKS_SCROLL_POSITION,
+  SET_USER_LIMIT,
   PEOPLE_SET_DAY_OFFS,
   PEOPLE_SET_DAYS_OFF,
   PEOPLE_SEARCH_CHANGE,
@@ -165,7 +166,9 @@ const initialState = {
   personTimeSpentTotal: 0,
   personDayOff: {},
   daysOff: [],
-  dayOffMap: {}
+  dayOffMap: {},
+
+  userLimit: 0
 }
 
 const state = {
@@ -214,7 +217,9 @@ const getters = {
   personTimeSpentMap: state => state.personTimeSpentMap,
   personTimeSpentTotal: state => state.personTimeSpentTotal,
   dayOffMap: state => state.dayOffMap,
-  daysOff: state => state.daysOff
+  daysOff: state => state.daysOff,
+
+  userLimit: state => state.userLimit
 }
 
 const actions = {
@@ -881,6 +886,10 @@ const mutations = {
 
   [SET_ORGANISATION](state, organisation) {
     state.organisation = { ...state.organisation, ...organisation }
+  },
+
+  [SET_USER_LIMIT](state, userLimit) {
+    state.userLimit = userLimit
   },
 
   [RESET_ALL](state) {

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -73,6 +73,7 @@ import {
   LOAD_ASSET_TYPES_END,
   LOAD_PLUGINS_END,
   SET_NOTIFICATION_COUNT,
+  SET_USER_LIMIT,
   LOAD_OPEN_PRODUCTIONS_END,
   RESET_ALL,
   SET_CURRENT_PRODUCTION
@@ -387,6 +388,7 @@ const actions = {
       commit(LOAD_STATUS_AUTOMATIONS_END, context.status_automations)
       commit(LOAD_ASSET_TYPES_END, context.asset_types)
       commit(SET_NOTIFICATION_COUNT, context.notification_count)
+      commit(SET_USER_LIMIT, context.user_limit)
       commit(LOAD_OPEN_PRODUCTIONS_END, context.projects)
       if (rootGetters.currentProduction) {
         commit(SET_CURRENT_PRODUCTION, rootGetters.currentProduction.id)

--- a/src/store/mutation-types.js
+++ b/src/store/mutation-types.js
@@ -555,6 +555,8 @@ export const REMOVE_BUILD_JOB = 'REMOVE_BUILD_JOB'
 
 export const ADD_PLAYLISTS = 'ADD_PLAYLISTS'
 
+export const SET_USER_LIMIT = 'SET_USER_LIMIT'
+
 // Notifications
 
 export const CLEAR_NOTIFICATIONS = 'CLEAR_NOTIFICATIONS'


### PR DESCRIPTION
**Problem**
- The administrators do not explicitly know the number of seats remaining.

**Solution**
- Display the remaining seat count on the People page according to the user limit.
