### PR TITLE
Various fixes and template improvements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1705,7 +1705,8 @@ tbody:last-child .empty-line:last-child {
 
 // width: 0 + flex: 1 forces the link to size from flex space (not content), so the column can be resized smaller than the longest name.
 // :not(.thumbnail-wrapper) excludes the EntityThumbnail anchor which is also a direct child of .flexrow.
-.datatable th.name .flexrow > a:not(.thumbnail-wrapper) {
+.datatable th.name .flexrow > a:not(.thumbnail-wrapper),
+.datatable td.name .flexrow > a:not(.thumbnail-wrapper) {
   flex: 1;
   width: 0;
   min-width: 0;

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -1154,7 +1154,7 @@ export default {
 
 thead .name {
   min-width: 200px;
-  width: 200px;
+  width: 300px;
 }
 
 th.time-spent,

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -1266,7 +1266,7 @@ th.actions {
 
 thead .name.shot-name {
   min-width: 110px;
-  width: 110px;
+  width: 300px;
 }
 
 .episode {

--- a/src/components/mixins/entity_list.js
+++ b/src/components/mixins/entity_list.js
@@ -346,15 +346,17 @@ export const entityListMixin = {
           throw new Error(`Invalid entity type: ${type}`)
       }
 
-      entities.forEach((entity, i) => {
-        selection.push({
-          entity,
-          column: this.taskTypeMap.get(taskTypeId),
-          task: this.taskMap.get(entity.validations.get(taskTypeId)),
-          x: i,
-          y: this.lastHeaderMenuDisplayedIndexInGrid
+      entities
+        .filter(entity => !entity.canceled)
+        .forEach((entity, i) => {
+          selection.push({
+            entity,
+            column: this.taskTypeMap.get(taskTypeId),
+            task: this.taskMap.get(entity.validations.get(taskTypeId)),
+            x: i,
+            y: this.lastHeaderMenuDisplayedIndexInGrid
+          })
         })
-      })
 
       this.$store.commit('CLEAR_SELECTED_TASKS')
       this.$nextTick(() => {

--- a/src/components/pages/ProjectTemplateSettings.vue
+++ b/src/components/pages/ProjectTemplateSettings.vue
@@ -61,7 +61,7 @@
       <div class="tab" v-show="isActiveTab('parameters')">
         <div class="columns">
           <div class="column is-one-third box">
-            <form class="form" @submit.prevent="saveParameters">
+            <div class="form">
               <combobox-styled
                 class="mb2"
                 locale-key-prefix="productions.type."
@@ -133,16 +133,7 @@
               <p v-if="errors.parameters" class="error mt1">
                 {{ $t('productions.edit_error') }}
               </p>
-              <div class="has-text-right mt2">
-                <button-simple
-                  :is-primary="true"
-                  :class="{ 'is-loading': loading.parameters }"
-                  :disabled="loading.parameters"
-                  :text="$t('main.save')"
-                  type="submit"
-                />
-              </div>
-            </form>
+            </div>
           </div>
         </div>
       </div>
@@ -324,7 +315,6 @@ import BackgroundSettings from '@/components/pages/production/BackgroundSettings
 import RowActionsCell from '@/components/cells/RowActionsCell.vue'
 import BoardSettings from '@/components/pages/production/BoardSettings.vue'
 import StatusAutomationSettings from '@/components/pages/production/StatusAutomationSettings.vue'
-import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import ComboboxBoolean from '@/components/widgets/ComboboxBoolean.vue'
 import ComboboxStyled from '@/components/widgets/ComboboxStyled.vue'
 import Spinner from '@/components/widgets/Spinner.vue'
@@ -530,6 +520,17 @@ const saveParameters = async () => {
   }
   loading.parameters = false
 }
+
+let saveTimeout = null
+watch(
+  () => ({ ...params.value }),
+  () => {
+    if (!template.value?.id) return
+    clearTimeout(saveTimeout)
+    saveTimeout = setTimeout(saveParameters, 800)
+  },
+  { deep: true }
+)
 
 const onUpdateBoardRoles = async ({ taskStatusId, roles }) => {
   boardRoles.value = { ...boardRoles.value, [taskStatusId]: roles }

--- a/src/components/pages/ProjectTemplateSettings.vue
+++ b/src/components/pages/ProjectTemplateSettings.vue
@@ -417,7 +417,11 @@ const params = ref({
   max_retakes: 0
 })
 
-const allTaskTypes = computed(() => store.getters.taskTypes || [])
+const allTaskTypes = computed(() => {
+  const taskTypes = store.getters.taskTypes || []
+  if (params.value.production_type === 'tvshow') return taskTypes
+  return taskTypes.filter(tt => tt.for_entity !== 'Episode')
+})
 const allTaskStatuses = computed(() => store.getters.taskStatus || [])
 const allAssetTypes = computed(() => store.getters.assetTypes || [])
 const allAutomations = computed(() => store.getters.statusAutomations || [])
@@ -510,6 +514,8 @@ const saveParameters = async () => {
   try {
     await projectTemplatesApi.editProjectTemplate({
       id: templateId.value,
+      name: template.value.name,
+      description: template.value.description,
       ...params.value,
       is_clients_isolated: params.value.is_clients_isolated === 'true',
       is_preview_download_allowed:

--- a/src/components/pages/ProjectTemplates.vue
+++ b/src/components/pages/ProjectTemplates.vue
@@ -8,7 +8,7 @@
       @new-clicked="onNewClicked"
     />
 
-    <p class="info">
+    <p class="info" v-if="projectTemplates.length > 0">
       <info-icon class="info-icon" />
       {{ $t('project_templates.click_name_to_edit') }}
     </p>
@@ -20,7 +20,21 @@
       :is-error="errors.list"
       @edit-clicked="onEditClicked"
       @delete-clicked="onDeleteClicked"
+      v-if="loading.list || projectTemplates.length > 0"
     />
+
+    <div
+      class="empty-state has-text-centered"
+      v-else-if="!loading.list && projectTemplates.length === 0"
+    >
+      <p class="empty-text">{{ $t('project_templates.empty') }}</p>
+      <button-simple
+        class="mt1"
+        :text="$t('project_templates.new_project_template')"
+        icon="plus"
+        @click="onNewClicked"
+      />
+    </div>
 
     <edit-project-template-modal
       :active="modals.edit"
@@ -55,6 +69,7 @@ import { InfoIcon } from 'lucide-vue-next'
 import csv from '@/lib/csv'
 import stringHelpers from '@/lib/string'
 
+import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import DeleteModal from '@/components/modals/DeleteModal.vue'
 import EditProjectTemplateModal from '@/components/modals/EditProjectTemplateModal.vue'
 import ListPageHeader from '@/components/widgets/ListPageHeader.vue'
@@ -193,6 +208,15 @@ onMounted(async () => {
 .info-icon {
   width: 16px;
   height: 16px;
+}
+
+.empty-state {
+  margin-top: 3em;
+}
+
+.empty-text {
+  color: var(--text-alt);
+  font-size: 1.1em;
 }
 
 @media screen and (max-width: 768px) {

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1787,16 +1787,10 @@ export default {
       })
     },
 
-    extractVideoFrame(canvas, frame) {
-      return new Promise(resolve => {
-        this.setCurrentFrame(frame)
-        this.$nextTick(() => {
-          setTimeout(() => {
-            this.previewViewer.extractFrame(canvas, frame)
-            resolve()
-          }, 500)
-        })
-      })
+    async extractVideoFrame(canvas, frame) {
+      this.setCurrentFrame(frame)
+      await setTimeout(() => {}, 100)
+      await this.previewViewer.extractFrame(canvas, frame)
     },
 
     copyAnnotationCanvas(canvas, annotation) {

--- a/src/components/previews/PreviewViewer.vue
+++ b/src/components/previews/PreviewViewer.vue
@@ -492,14 +492,25 @@ export default {
     },
 
     extractFrame(canvas, frame) {
-      this.videoViewer.setCurrentFrame(frame)
-      const video = this.videoViewer.video
-      const context = canvas.getContext('2d')
-      const dimensions = this.videoViewer.getNaturalDimensions()
-      canvas.width = dimensions.width
-      canvas.height = dimensions.height
-      context.clearRect(0, 0, canvas.width, canvas.height)
-      context.drawImage(video, 0, 0, canvas.width, canvas.height)
+      return new Promise(resolve => {
+        const video = this.videoViewer.video
+        const draw = () => {
+          const context = canvas.getContext('2d')
+          const dimensions = this.videoViewer.getNaturalDimensions()
+          canvas.width = dimensions.width
+          canvas.height = dimensions.height
+          context.clearRect(0, 0, canvas.width, canvas.height)
+          context.drawImage(video, 0, 0, canvas.width, canvas.height)
+          resolve()
+        }
+        const targetTime = frame * this.videoViewer.frameDuration
+        if (Math.abs(video.currentTime - targetTime) < 0.01) {
+          draw()
+        } else {
+          video.addEventListener('seeked', draw, { once: true })
+          this.videoViewer.setCurrentFrame(frame)
+        }
+      })
     },
 
     resetZoom() {

--- a/src/components/widgets/FileUpload.vue
+++ b/src/components/widgets/FileUpload.vue
@@ -135,7 +135,7 @@ onMounted(() => {
   })
 })
 
-defineExpose({ reset })
+defineExpose({ filesChange, onDrop, reset })
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/widgets/PeopleField.vue
+++ b/src/components/widgets/PeopleField.vue
@@ -144,7 +144,7 @@ watch(
   }
 )
 
-defineExpose({ focus })
+defineExpose({ clear, focus })
 </script>
 
 <style lang="scss" scoped>
@@ -230,6 +230,7 @@ defineExpose({ focus })
     background: var(--background-selectable);
     color: inherit;
   }
+
   .multiselect__option--selected {
     background: var(--background-selected);
     color: inherit;

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -414,6 +414,7 @@ export default {
     apply_to_description: "Add a template's configuration to this production. Existing settings are preserved.",
     apply_confirm: "This will add the template's task types, statuses, asset types, automations, and metadata descriptors to this production. Existing settings are preserved. Continue?",
     from_production: 'Create from production',
+    empty: 'No production template yet. Create one to quickly configure new productions.',
     click_name_to_edit: 'Click on a template name to edit its configuration.',
     name_required: 'A name is required.',
     duplicate_name: 'A production template with this name already exists.',


### PR DESCRIPTION
## Problems

- FileUpload and PeopleField methods not exposed after composition API migration
- Annotation snapshot extraction captures blank frames from video
- Column selection includes canceled entities in playlists and bulk actions
- Template settings page shows episode task types for non-tvshow templates
- Template settings require manual save button click
- Template list page has no empty state
- Name column default width too narrow for shots and assets
- Resizable name column broken after selector change

## Solutions

- Expose filesChange/onDrop on FileUpload and clear on PeopleField via defineExpose
- Wait for video seeked event before drawing frame to canvas in extractFrame
- Filter canceled entities in onSelectColumn
- Filter task types with for_entity=Episode when template type is not tvshow
- Auto-save template parameters with 800ms debounce, remove save button
- Add empty state with message and create button on templates page
- Set default name column width to 300px for shots and assets
- Restore th.name selector for column resize support