### PR TITLE
Add a tooltip to the preview thumbnail to show the original name. 

### DIFF
--- a/src/components/previews/RevisionPreview.vue
+++ b/src/components/previews/RevisionPreview.vue
@@ -11,6 +11,7 @@
         width="150px"
         height="103px"
         :preview-file-id="previewFile.id"
+        :title="originalName"
         v-if="hasThumbnail"
       />
       <span :title="originalName" v-else> .{{ previewFile.extension }} </span>


### PR DESCRIPTION
Useful if you have several similar looking previews.

**Problem**
We have several previews for different lighting passes and the team wanted to be able to identify the name of the pass.

**Solution**
Add a tooltip to the thumbnail showing the original preview file name.
