### PR TITLE
fix for line thickness on At-vue task type in comments

### DIFF
--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -1085,6 +1085,11 @@ article.add-comment {
   }
 }
 
+// tag for vue-at
+.tag.thin {
+  line-height: 1.2em;
+}
+
 .attachment-title {
   margin-left: 3px;
   margin-top: 6px;


### PR DESCRIPTION
In a comment text area enter a hash key to tag a Task Type. #TASK

**Problem**
Before:
<img width="161" height="86" alt="before" src="https://github.com/user-attachments/assets/f16b4b40-7442-4420-8911-aba8e707362c" />

**Solution**
After:
<img width="178" height="107" alt="after" src="https://github.com/user-attachments/assets/316cebef-a587-4ec5-8ef8-2d34284c51db" />
