### PR TITLE
Preserve fields on partial edits of productions and people

### DIFF
--- a/src/components/modals/EditPersonModal.vue
+++ b/src/components/modals/EditPersonModal.vue
@@ -439,7 +439,22 @@ export default {
           departments: [...(this.personToEdit.departments || [])],
           studio_id: this.personToEdit.studio_id,
           expiration_date: this.personToEdit.expiration_date,
-          is_bot: this.personToEdit.is_bot
+          is_bot: this.personToEdit.is_bot,
+          notifications_enabled: this.personToEdit.notifications_enabled
+            ? 'true'
+            : 'false',
+          notifications_slack_enabled: this.personToEdit
+            .notifications_slack_enabled
+            ? 'true'
+            : 'false',
+          notifications_mattermost_enabled: this.personToEdit
+            .notifications_mattermost_enabled
+            ? 'true'
+            : 'false',
+          notifications_discord_enabled: this.personToEdit
+            .notifications_discord_enabled
+            ? 'true'
+            : 'false'
         }
       } else {
         this.form = {

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -2244,7 +2244,7 @@ export default {
         this.currentProduction.start_date !== start_date
       ) {
         this.editProduction({
-          ...this.currentProduction,
+          id: this.currentProduction.id,
           start_date
         })
       }
@@ -2258,7 +2258,7 @@ export default {
         this.currentProduction.end_date !== end_date
       ) {
         this.editProduction({
-          ...this.currentProduction,
+          id: this.currentProduction.id,
           end_date
         })
       }

--- a/src/store/api/productions.js
+++ b/src/store/api/productions.js
@@ -1,5 +1,7 @@
 import client from '@/store/api/client'
 
+const toBoolean = value => value === true || value === 'true'
+
 export default {
   getProductions() {
     return client.pget('/api/data/projects/all')
@@ -25,35 +27,23 @@ export default {
     return client.ppost('/api/data/projects/', production)
   },
 
+  // HTTP PUT, but Zou preserves any field absent from the payload — so
+  // callers can send a full or partial payload and only the fields they
+  // explicitly provide are forwarded.
   updateProduction(production) {
-    const data = {
-      name: production.name,
-      code: production.code,
-      description: production.description,
-      project_status_id: production.project_status_id,
-      production_type: production.production_type,
-      production_style: production.production_style,
-      fps: production.fps,
-      ratio: production.ratio,
-      resolution: production.resolution,
-      start_date: production.start_date,
-      end_date: production.end_date,
-      man_days: production.man_days,
-      max_retakes: production.max_retakes,
-      nb_episodes: production.nb_episodes,
-      episode_span: production.episode_span,
-      is_clients_isolated: production.is_clients_isolated === 'true',
-      is_preview_download_allowed:
-        production.is_preview_download_allowed === 'true',
-      is_set_preview_automated: production.is_set_preview_automated === 'true',
-      is_publish_default_for_artists:
-        production.is_publish_default_for_artists === 'true',
-      homepage: production.homepage
-    }
-    if (production.data !== undefined) {
-      data.data = production.data
-    }
-    return client.pput(`/api/data/projects/${production.id}`, data)
+    const BOOLEAN_FIELDS = [
+      'is_clients_isolated',
+      'is_preview_download_allowed',
+      'is_set_preview_automated',
+      'is_publish_default_for_artists'
+    ]
+    const { id, ...data } = production
+    BOOLEAN_FIELDS.forEach(field => {
+      if (data[field] !== undefined) {
+        data[field] = toBoolean(data[field])
+      }
+    })
+    return client.pput(`/api/data/projects/${id}`, data)
   },
 
   postAvatar(productionId, formData) {
@@ -145,7 +135,7 @@ export default {
       name: descriptor.name,
       data_type: descriptor.data_type,
       choices: descriptor.values,
-      for_client: descriptor.for_client === 'true',
+      for_client: toBoolean(descriptor.for_client),
       entity_type: descriptor.entity_type,
       departments: descriptor.departments
     }
@@ -167,7 +157,7 @@ export default {
       name: descriptor.name,
       data_type: descriptor.data_type,
       choices: descriptor.values,
-      for_client: descriptor.for_client === 'true',
+      for_client: toBoolean(descriptor.for_client),
       entity_type: descriptor.entity_type,
       departments: descriptor.departments
     }

--- a/src/store/modules/productions.js
+++ b/src/store/modules/productions.js
@@ -460,9 +460,9 @@ const actions = {
   },
 
   editProduction({ commit, state }, data) {
-    // The metadata bag (`data.data`) is replaced wholesale by the API, so when
-    // editing a single field we have to merge with the locally cached values
-    // first to avoid losing the others. Other top-level fields are sent as-is.
+    // The metadata bag (`data.data`) is a JSONB column replaced wholesale by
+    // the API, so we merge it with the locally cached values to avoid losing
+    // the other fields.
     const payload = { ...data }
     if (data.data) {
       const previous = findProductionInState(state, data.id)

--- a/tests/unit/store/productions.spec.js
+++ b/tests/unit/store/productions.spec.js
@@ -3,7 +3,9 @@ import assetTypeStore from '@/store/modules/assettypes'
 import taskStatusStore from '@/store/modules/taskstatus'
 import taskTypeStore from '@/store/modules/tasktypes'
 
+import client from '@/store/api/client'
 import productionApi from '@/store/api/productions.js'
+
 import {
   ADD_METADATA_DESCRIPTOR_END,
   ADD_PRODUCTION,
@@ -350,22 +352,90 @@ describe('Productions store', () => {
       }
     })
 
-    test('editProduction', async () => {
-      let mockCommit = vi.fn()
-      productionApi.updateProduction = vi.fn(() => Promise.resolve({ id: '1' }))
-      await store.actions.editProduction({ commit: mockCommit, state: null }, 'production-id')
-      expect(productionApi.updateProduction).toBeCalledTimes(1)
-      expect(mockCommit).toBeCalledTimes(1)
-      expect(mockCommit).toHaveBeenNthCalledWith(1, UPDATE_PRODUCTION, { id: '1' })
+    describe('editProduction', () => {
+      let updateProduction
 
-      mockCommit = vi.fn()
-      productionApi.updateProduction = vi.fn(() => Promise.reject(new Error('error')))
-      try {
-        await store.actions.editProduction({ commit: mockCommit, state: null }, 'production-id')
-      } catch {
-        expect(productionApi.updateProduction).toBeCalledTimes(1)
+      beforeEach(() => {
+        updateProduction = vi
+          .spyOn(productionApi, 'updateProduction')
+          .mockResolvedValue({ id: '1' })
+      })
+
+      afterEach(() => {
+        updateProduction.mockRestore()
+      })
+
+      test('dispatches API call and commits UPDATE_PRODUCTION', async () => {
+        const state = {
+          productionMap: new Map(),
+          productions: [],
+          openProductions: []
+        }
+        const mockCommit = vi.fn()
+        await store.actions.editProduction(
+          { commit: mockCommit, state },
+          { id: '1', start_date: '2026-01-01' }
+        )
+        expect(updateProduction).toBeCalledTimes(1)
+        expect(mockCommit).toBeCalledTimes(1)
+        expect(mockCommit).toHaveBeenNthCalledWith(1, UPDATE_PRODUCTION, {
+          id: '1'
+        })
+      })
+
+      test('does not commit when API rejects', async () => {
+        const state = {
+          productionMap: new Map(),
+          productions: [],
+          openProductions: []
+        }
+        const mockCommit = vi.fn()
+        updateProduction.mockRejectedValue(new Error('error'))
+        await expect(
+          store.actions.editProduction(
+            { commit: mockCommit, state },
+            { id: '1', start_date: '2026-01-01' }
+          )
+        ).rejects.toThrow('error')
+        expect(updateProduction).toBeCalledTimes(1)
         expect(mockCommit).toBeCalledTimes(0)
-      }
+      })
+
+      test('merges data.data with cached metadata', async () => {
+        const state = {
+          productionMap: new Map([
+            ['1', { id: '1', data: { existing: 'kept', other: 'kept' } }]
+          ]),
+          productions: [],
+          openProductions: []
+        }
+        await store.actions.editProduction(
+          { commit: vi.fn(), state },
+          { id: '1', data: { existing: 'updated' } }
+        )
+        expect(updateProduction).toHaveBeenCalledWith({
+          id: '1',
+          data: { existing: 'updated', other: 'kept' }
+        })
+      })
+
+      test('omits data when caller did not provide it', async () => {
+        const state = {
+          productionMap: new Map([
+            ['1', { id: '1', data: { should: 'not_be_sent' } }]
+          ]),
+          productions: [],
+          openProductions: []
+        }
+        await store.actions.editProduction(
+          { commit: vi.fn(), state },
+          { id: '1', start_date: '2026-01-01' }
+        )
+        expect(updateProduction).toHaveBeenCalledWith({
+          id: '1',
+          start_date: '2026-01-01'
+        })
+      })
     })
 
     test('deleteProduction', async () => {
@@ -937,6 +1007,64 @@ describe('Productions store', () => {
       expect(store.helpers.isEmptyArray({ arrayName: null }, 'arrayName')).toBeTruthy()
       expect(store.helpers.isEmptyArray({ arrayName: [] }, 'arrayName')).toBeTruthy()
       expect(store.helpers.isEmptyArray({ arrayName: [1] }, 'arrayName')).toBeFalsy()
+    })
+  })
+
+  describe('API', () => {
+    describe('updateProduction', () => {
+      let pput
+
+      beforeEach(() => {
+        pput = vi.spyOn(client, 'pput').mockResolvedValue({ id: '1' })
+      })
+
+      afterEach(() => {
+        pput.mockRestore()
+      })
+
+      test('coerces string boolean fields to real booleans', () => {
+        productionApi.updateProduction({
+          id: '1',
+          is_clients_isolated: 'true',
+          is_preview_download_allowed: 'false',
+          is_set_preview_automated: true,
+          is_publish_default_for_artists: false
+        })
+        expect(pput).toHaveBeenCalledWith('/api/data/projects/1', {
+          is_clients_isolated: true,
+          is_preview_download_allowed: false,
+          is_set_preview_automated: true,
+          is_publish_default_for_artists: false
+        })
+      })
+
+      test('omits boolean fields the caller did not provide', () => {
+        productionApi.updateProduction({
+          id: '1',
+          start_date: '2026-01-01'
+        })
+        expect(pput).toHaveBeenCalledWith('/api/data/projects/1', {
+          start_date: '2026-01-01'
+        })
+      })
+
+      // Guards the original bug: an explicitly `undefined` boolean must not be
+      // coerced to `false`, otherwise a partial spread with missing flags
+      // would silently reset them server-side.
+      test('does not coerce explicitly undefined booleans', () => {
+        productionApi.updateProduction({
+          id: '1',
+          is_clients_isolated: true,
+          is_preview_download_allowed: undefined,
+          is_set_preview_automated: undefined,
+          is_publish_default_for_artists: undefined
+        })
+        const [, payload] = pput.mock.calls[0]
+        expect(payload.is_clients_isolated).toBe(true)
+        expect(payload.is_preview_download_allowed).toBeUndefined()
+        expect(payload.is_set_preview_automated).toBeUndefined()
+        expect(payload.is_publish_default_for_artists).toBeUndefined()
+      })
     })
   })
 })


### PR DESCRIPTION
**Problem**
- Editing a single date on a production resets every `is_*` flag to `false` and drops any field outside a hard-coded whitelist.
- Editing a person resets their Slack, Mattermost, Discord, and global notification preferences.

**Solution**
- Forward only the fields the caller provides when updating a production, so absent fields are preserved server-side.
- Initialize the four `notifications_*_enabled` form fields from the edited person.