### PR TITLE
Fix missing translations & metadata UI glitches

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1861,6 +1861,10 @@ tbody:last-child .empty-line:last-child {
     padding: 0;
     position: relative;
     vertical-align: top;
+
+    &.datatable-row-header {
+      position: sticky;
+    }
   }
 }
 

--- a/src/components/cells/MetadataInput.vue
+++ b/src/components/cells/MetadataInput.vue
@@ -280,7 +280,7 @@ const onNumberFieldKeyDown = event => {
   padding: 0.35rem 0.5rem;
   text-overflow: ellipsis;
   width: 100%;
-  z-index: 100;
+  z-index: auto;
 
   &[type='checkbox'] {
     display: block;

--- a/src/components/cells/MetadataInput.vue
+++ b/src/components/cells/MetadataInput.vue
@@ -226,6 +226,10 @@ const onNumberFieldKeyDown = event => {
   justify-content: center;
 }
 
+.metadata-input.is-checklist {
+  position: static;
+}
+
 .metadata-input.is-checklist .metadata-value,
 .metadata-input:not(.is-boolean) .input-editor:not([type='checkbox']) {
   flex: 1 1 auto;

--- a/src/components/cells/MetadataInput.vue
+++ b/src/components/cells/MetadataInput.vue
@@ -240,9 +240,9 @@ const onNumberFieldKeyDown = event => {
 }
 
 .metadata-input.is-taglist :deep(> div) {
+  align-items: center;
   display: flex;
   flex: 1 1 auto;
-  flex-direction: column;
   min-height: 0;
   width: 100%;
 }

--- a/src/components/modals/AddMetadataModal.vue
+++ b/src/components/modals/AddMetadataModal.vue
@@ -199,16 +199,16 @@ const valueToAdd = ref('')
 const checklist = ref([])
 const selectedDepartment = ref(null)
 
-const typeOptions = [
+// Computed
+
+const typeOptions = computed(() => [
   { label: t('productions.metadata.string'), value: 'string' },
   { label: t('productions.metadata.number'), value: 'number' },
   { label: t('productions.metadata.boolean'), value: 'boolean' },
   { label: t('productions.metadata.choices'), value: 'list' },
   { label: t('productions.metadata.tags'), value: 'taglist' },
   { label: t('productions.metadata.checklist'), value: 'checklist' }
-]
-
-// Computed
+])
 
 const currentProduction = computed(() => store.getters.currentProduction)
 const departmentMap = computed(() => store.getters.departmentMap)

--- a/src/components/modals/HardDeleteModal.vue
+++ b/src/components/modals/HardDeleteModal.vue
@@ -78,12 +78,12 @@ const confirmationName = ref(null)
 const selectionOnly = ref('true')
 const userLockText = ref('')
 
-const selectionOptions = [
+// Computed
+
+const selectionOptions = computed(() => [
   { label: t('tasks.for_selection'), value: 'true' },
   { label: t('tasks.for_project'), value: 'false' }
-]
-
-// Computed
+])
 
 const isLocked = computed(
   () => props.lockText === 'locked' || props.lockText !== userLockText.value

--- a/src/components/pages/Asset.vue
+++ b/src/components/pages/Asset.vue
@@ -583,6 +583,7 @@ export default {
           if (assetId) {
             return this.loadAsset(assetId).then(() => {
               asset = assetStore.cache.assetMap.get(assetId)
+              if (!asset) return resolve(null)
               this.localTasks = asset.tasks
                 .map(taskId => this.taskMap.get(taskId))
                 .filter(Boolean)

--- a/src/components/widgets/TableMetadataSelectorMenu.vue
+++ b/src/components/widgets/TableMetadataSelectorMenu.vue
@@ -108,9 +108,15 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue', 'update:isOpen'])
 
-// Constants (require t())
+// State
 
-const FIELD_TO_NAME = {
+const hostRef = ref(null)
+const menuStyle = ref({})
+const sortedMetadataDescriptors = ref([])
+
+// Computed
+
+const FIELD_TO_NAME = computed(() => ({
   estimation: t('main.estimation'),
   fps: t('main.fps'),
   frameIn: t('main.frame_in'),
@@ -121,22 +127,14 @@ const FIELD_TO_NAME = {
   resolution: t('shots.fields.resolution'),
   stdby: t('breakdown.fields.standby'),
   timeSpent: t('main.timeSpent')
-}
-
-// State
-
-const hostRef = ref(null)
-const menuStyle = ref({})
-const sortedMetadataDescriptors = ref([])
-
-// Computed
+}))
 
 const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
 
 const filteredFixedColumns = computed(() =>
   Object.keys(props.modelValue)
-    .filter(name => FIELD_TO_NAME[name] && !props.exclude[name])
-    .map(name => ({ field_name: name, name: FIELD_TO_NAME[name] }))
+    .filter(name => FIELD_TO_NAME.value[name] && !props.exclude[name])
+    .map(name => ({ field_name: name, name: FIELD_TO_NAME.value[name] }))
 )
 
 const filteredMetadataDescriptors = computed(() =>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1910,7 +1910,7 @@ export default {
     feedback: 'feedback',
     full_screen: 'Display in full screen',
     for_selection: 'For current list and filters',
-    for_production: 'For production',
+    for_project: 'For production',
     hide_assignations: 'Hide assignments',
     hide_infos: 'Hide additional information',
     hookup_playlist: 'Generate a hook-up playlist',


### PR DESCRIPTION
**Problem**
- `HardDeleteModal` and `createTasksModal`displayed a raw locale key instead of "For production".
- Static label maps with `t()` rendered as raw keys at init, before i18n was ready.
- Opening a missing asset crashed on `asset.tasks`.
- Sticky metadata cells' position is wrong.
- Metadata input content hides neighboring cells.
- Taglist metadata input is vertically misaligned.
- Checklist metadata input has an unwanted scroll bar.

**Solution**
- Rename English key `tasks.for_production` to `tasks.for_project`.
- Wrap label maps in `computed` so `t()` is called at render time.
- Return `null` early when the asset is not found in cache.
- Restore `position: sticky` on sticky body cells.
- Remove the `z-index` that made the input overlap neighboring cells.
- Fix the taglist vertical alignment.
- Fix the checklist wrapper.