### PR TITLE
Fix the filters with exact names

### DIFF
--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -1,7 +1,7 @@
 import {
-  buildTaskTypeIndex,
+  buildExactNameIndex,
   buildTaskStatusIndex,
-  buildNameIndex,
+  buildTaskTypeIndex,
   indexSearch
 } from '@/lib/indexing'
 
@@ -507,7 +507,7 @@ export const getDescFilters = (descriptors, taskTypes, queryText) => {
   const rgxMatches = queryText.match(EQUAL_REGEX)
 
   if (rgxMatches) {
-    const descriptorNameIndex = buildNameIndex(descriptors, false)
+    const descriptorNameIndex = buildExactNameIndex(descriptors)
     rgxMatches.forEach(rgxMatch => {
       const pattern = rgxMatch.split('=')
       const descriptorName = cleanParenthesis(pattern[0])
@@ -551,7 +551,7 @@ export const getDepartmentFilters = (departments, queryText) => {
   const rgxMatches = queryText.match(EQUAL_PEOPLE_DEPARTMENT_REGEX)
 
   if (rgxMatches) {
-    const departmentNameIndex = buildNameIndex(departments, false)
+    const departmentNameIndex = buildExactNameIndex(departments)
 
     rgxMatches.forEach(rgxMatch => {
       const pattern = rgxMatch.split('=')

--- a/src/lib/indexing.js
+++ b/src/lib/indexing.js
@@ -39,27 +39,41 @@ export const buildPeopleIndex = (entries, split = true) => {
 }
 
 /*
+ * Build an exact-name index. Used by filter parsers like `fx=DONE` or
+ * `department=fx`, which must match the full name and not a substring —
+ * otherwise filtering by "fx" would also pick up "cfx", "vfx", etc.
+ */
+export const buildExactNameIndex = entries => {
+  const index = Object.create(null)
+  entries.forEach(entry => {
+    if (entry?.name) {
+      const name = entry.name.toLowerCase()
+      if (!index[name]) index[name] = []
+      index[name].push(entry)
+    }
+  })
+  return index
+}
+
+/*
  * Generate an index to find task type easily.
  */
 export const buildTaskTypeIndex = taskTypes => {
-  const sortedTaskTypes = [...taskTypes].sort((a, b) =>
-    a.name.localeCompare(b.name, undefined, {
-      numeric: true
-    })
-  )
-  return buildNameIndex(sortedTaskTypes, false)
+  return buildExactNameIndex(taskTypes)
 }
 
 /*
  * Generate an index to find task status easily.
  */
 export const buildTaskStatusIndex = taskStatuses => {
-  const taskStatusShortNameIndex = {}
+  const index = Object.create(null)
   taskStatuses.forEach(taskStatus => {
-    const shortName = taskStatus.short_name.toLowerCase()
-    taskStatusShortNameIndex[shortName] = taskStatus
+    if (taskStatus?.short_name) {
+      const shortName = taskStatus.short_name.toLowerCase()
+      index[shortName] = taskStatus
+    }
   })
-  return taskStatusShortNameIndex
+  return index
 }
 
 /*

--- a/tests/unit/lib/filtering.spec.js
+++ b/tests/unit/lib/filtering.spec.js
@@ -182,7 +182,7 @@ describe('lib/filtering', () => {
       expect(filters[0].taskStatuses).toEqual(['task-status-1', 'task-status-3'])
     })
 
-    it('shortcut case', () => {
+    it('partial task type name does not match (exact match only)', () => {
       const filters = getFilters({
         entryIndex,
         assetTypes,
@@ -192,10 +192,25 @@ describe('lib/filtering', () => {
         persons,
         query: 'mode=wip'
       })
-      expect(filters).toHaveLength(2) // the descriptor is included too
-      const filter = filters[0]
-      expect(filter.taskType).toEqual(taskTypes[1])
-      expect(filter.taskStatuses[0]).toEqual('task-status-1')
+      expect(filters.some(f => f.type === 'status')).toBe(false)
+    })
+
+    it('task types sharing a substring are not confused (cfx vs fx)', () => {
+      const filters = getFilters({
+        entryIndex,
+        assetTypes,
+        taskTypes: [
+          { name: 'cfx', id: 'task-type-cfx' },
+          { name: 'fx', id: 'task-type-fx' }
+        ],
+        taskStatuses,
+        descriptors,
+        persons,
+        query: 'fx=wip'
+      })
+      const taskTypeFilters = filters.filter(f => f.type === 'status')
+      expect(taskTypeFilters).toHaveLength(1)
+      expect(taskTypeFilters[0].taskType.id).toEqual('task-type-fx')
     })
 
     it('several task types', () => {

--- a/tests/unit/lib/indexing.spec.js
+++ b/tests/unit/lib/indexing.spec.js
@@ -1,6 +1,7 @@
 import {
-  buildNameIndex,
   buildAssetIndex,
+  buildExactNameIndex,
+  buildNameIndex,
   buildShotIndex,
   buildTaskIndex,
   indexSearch
@@ -23,6 +24,53 @@ describe('lib/indexing', () => {
     expect(index.bunny[0].id).toEqual(3)
     expect(index.nny).toHaveLength(1)
     expect(index.nny[0].id).toEqual(3)
+  })
+
+  describe('buildExactNameIndex', () => {
+    it('matches by full name only, not substring', () => {
+      const entries = [
+        { name: 'fx', id: 1 },
+        { name: 'cfx', id: 2 },
+        { name: 'vfx', id: 3 }
+      ]
+      const index = buildExactNameIndex(entries)
+      expect(index.fx).toHaveLength(1)
+      expect(index.fx[0].id).toEqual(1)
+      expect(index.cfx).toHaveLength(1)
+      expect(index.cfx[0].id).toEqual(2)
+      expect(index.f).toBeUndefined()
+      expect(index.x).toBeUndefined()
+    })
+
+    it('is case-insensitive', () => {
+      const index = buildExactNameIndex([{ name: 'Modeling', id: 1 }])
+      expect(index.modeling).toHaveLength(1)
+      expect(index.MODELING).toBeUndefined()
+    })
+
+    it('groups entries that share the same name', () => {
+      const index = buildExactNameIndex([
+        { name: 'Animation', id: 1 },
+        { name: 'Animation', id: 2 }
+      ])
+      expect(index.animation).toHaveLength(2)
+    })
+
+    it('skips entries without a name', () => {
+      const index = buildExactNameIndex([
+        null,
+        undefined,
+        {},
+        { name: 'fx', id: 1 }
+      ])
+      expect(index.fx).toHaveLength(1)
+    })
+
+    it('is safe against prototype keys', () => {
+      const index = buildExactNameIndex([{ name: 'constructor', id: 1 }])
+      expect(index.constructor).toHaveLength(1)
+      expect(index.toString).toBeUndefined()
+    })
   })
 
   it('buildAssetIndex', () => {


### PR DESCRIPTION
**Problem**
- issue #1997

**Solution**
- Filter parsers now match names exactly, so a filter like `fx=DONE` no longer matches `cfx` (or any other name sharing the substring).
