### PR TITLE
Setup Node.js in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+          cache: npm
       - name: Build release
         run: |
           echo "Node.js $(node -v)"


### PR DESCRIPTION
**Problem**

GitHub Actions runners don't honor the `engines.node` field from `package.json`. Since the bump to `>=22.22.1`, the release workflow keeps running with the runner's default Node, which no longer satisfies the constraint — `npm ci` and `npm run build` fail, and no artifact is produced.

**Solution**

Add an explicit `actions/setup-node@v6` step that reads the version from `package.json`, so the release runtime stays aligned with `engines`.
