### PR TITLE
Fix annotation bugs in preview players

### DIFF
--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -1026,19 +1026,19 @@ export const annotationMixin = {
      */
     undoLastAction() {
       const action = this.doneActionStack.pop()
-      if (action && action.obj) {
-        if (action.type === 'add') {
-          this.deleteObject(action.obj)
-          this.addToDeletions(action.obj)
-          this.removeFromAdditions(action.obj)
-        } else if (action.type === 'remove') {
-          this.addObject(action.obj)
-          this.addToAdditions(action.obj)
-          this.removeFromDeletions(action.obj)
-        }
-        this.doneActionStack.pop()
-        this.undoneActionStack.push(action)
+      if (!action?.obj) return
+      // Snapshot length to drop side-effect pushes from deleteObject/addObject (incl. groups)
+      const stackLengthBefore = this.doneActionStack.length
+      if (action.type === 'add') {
+        this.deleteObject(action.obj)
+        this.removeFromAdditions(action.obj)
+      } else if (action.type === 'remove') {
+        this.addObject(action.obj)
+        this.addToAdditions(action.obj)
+        this.removeFromDeletions(action.obj)
       }
+      this.doneActionStack.length = stackLengthBefore
+      this.undoneActionStack.push(action)
     },
 
     /*
@@ -1046,13 +1046,16 @@ export const annotationMixin = {
      */
     redoLastAction() {
       const action = this.undoneActionStack.pop()
-      if (action) {
-        if (action.type === 'add') {
-          this.addObject(action.obj)
-        } else if (action.type === 'remove') {
-          this.deleteObject(action.obj)
-        }
+      if (!action?.obj) return
+      // Snapshot length to drop side-effect pushes from deleteObject/addObject (incl. groups)
+      const stackLengthBefore = this.doneActionStack.length
+      if (action.type === 'add') {
+        this.addObject(action.obj)
+      } else if (action.type === 'remove') {
+        this.deleteObject(action.obj)
       }
+      this.doneActionStack.length = stackLengthBefore
+      this.doneActionStack.push(action)
     },
 
     /*

--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -1464,7 +1464,7 @@ export const annotationMixin = {
      */
     startAnnotationSaving(preview, annotations) {
       this.notSaved = true
-      this.annotatedPreview = preview
+      this.annotatedPreview = markRaw(preview)
       this.annotationToSave = setTimeout(() => {
         this.endAnnotationSaving()
       }, 3000)
@@ -1477,12 +1477,12 @@ export const annotationMixin = {
     endAnnotationSaving() {
       if (this.notSaved) {
         const preview = this.annotatedPreview
-        this.changesToSave = {
+        this.changesToSave = markRaw({
           preview,
           additions: [...this.additions],
           updates: [...this.updates],
           deletions: [...this.deletions]
-        }
+        })
         this.clearModifications()
         clearTimeout(this.annotationToSave)
         this.notSaved = false

--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -88,7 +88,7 @@ export const annotationMixin = {
       updates: [],
       isShowingPalette: false,
       isShowingPencilPalette: false,
-      notSave: false,
+      notSaved: false,
       pencilColor: '#ff3860',
       pencilWidth: 'big',
       textColor: '#ff3860',
@@ -104,12 +104,17 @@ export const annotationMixin = {
       mouseDrawingMaxChangeRate: 0.03,
       mouseDrawingPrevPoint: null,
       mouseDrawingPrevPressure: null,
-      mouseDrawingDynamicDistanceMult: null
+      mouseDrawingDynamicDistanceMult: null,
+      // Per-instance to avoid mixing actions between sibling players
+      // (e.g. ProductionNewsFeed mounts many in a v-for). markRaw skips
+      // Vue's deep proxy on fabric.Object refs.
+      doneActionStack: markRaw([]),
+      undoneActionStack: markRaw([]),
+      silentAnnotation: false,
+      annotatedPreview: null,
+      annotationToSave: null,
+      changesToSave: null
     }
-  },
-
-  created() {
-    this.resetUndoStacks()
   },
 
   computed: {
@@ -179,13 +184,13 @@ export const annotationMixin = {
       if (activeObject._objects) {
         activeObject._objects.forEach(obj => {
           this.fabricCanvas.add(obj)
-          this.$options.doneActionStack.pop()
+          this.doneActionStack.pop()
         })
       } else {
         this.fabricCanvas.add(activeObject)
       }
       if (persist) {
-        this.$options.doneActionStack.push({ type: 'add', obj: activeObject })
+        this.doneActionStack.push({ type: 'add', obj: activeObject })
         this.saveAnnotations()
       }
     },
@@ -273,7 +278,7 @@ export const annotationMixin = {
         activeObject._objects.forEach(obj => {
           this.fabricCanvas.remove(obj)
           this.addToDeletions(obj)
-          this.$options.doneActionStack.push({
+          this.doneActionStack.push({
             type: 'remove',
             obj
           })
@@ -281,7 +286,7 @@ export const annotationMixin = {
       } else if (activeObject) {
         this.fabricCanvas.remove(activeObject)
         this.addToDeletions(activeObject)
-        this.$options.doneActionStack.push({
+        this.doneActionStack.push({
           type: 'remove',
           obj: activeObject
         })
@@ -646,9 +651,9 @@ export const annotationMixin = {
           tr: false,
           mtr: !this.isCurrentUserArtist
         })
-        this.$options.silentAnnnotation = true
+        this.silentAnnotation = true
         canvas.add(path)
-        this.$options.silentAnnnotation = false
+        this.silentAnnotation = false
       } else if (obj.type === 'i-text' || obj.type === 'text') {
         text = new fabric.IText(obj.text, {
           ...base,
@@ -675,9 +680,9 @@ export const annotationMixin = {
           tr: false,
           mtr: false
         })
-        this.$options.silentAnnnotation = true
+        this.silentAnnotation = true
         canvas.add(text)
-        this.$options.silentAnnnotation = false
+        this.silentAnnotation = false
       } else if (obj.type === 'PSStroke') {
         if (obj.canvasWidth) {
           let strokeMultiplier = canvasWidth / canvas.width
@@ -712,9 +717,9 @@ export const annotationMixin = {
             tr: false,
             mtr: !this.isCurrentUserArtist
           })
-          this.$options.silentAnnnotation = true
+          this.silentAnnotation = true
           canvas.add(psstroke)
-          this.$options.silentAnnnotation = false
+          this.silentAnnotation = false
         }
       } else if (
         obj.type === 'rect' ||
@@ -752,9 +757,9 @@ export const annotationMixin = {
           tr: false,
           mtr: !this.isCurrentUserArtist
         })
-        this.$options.silentAnnnotation = true
+        this.silentAnnotation = true
         canvas.add(shape)
-        this.$options.silentAnnnotation = false
+        this.silentAnnotation = false
         return shape
       }
       return path || text || psstroke
@@ -943,7 +948,7 @@ export const annotationMixin = {
      * stacks.
      */
     onObjectAdded(obj) {
-      if (this.$options.silentAnnnotation) return
+      if (this.silentAnnotation) return
       let o = obj.target ? obj.target : obj.targets[0]
       o = this.setObjectData(o)
       // if (this.fabricCanvas.width < 420) o.strokeWidth *= 2
@@ -1002,15 +1007,15 @@ export const annotationMixin = {
      * Clear all action stacks.
      */
     resetUndoStacks() {
-      this.$options.doneActionStack = []
-      this.$options.undoneActionStack = []
+      this.doneActionStack.length = 0
+      this.undoneActionStack.length = 0
     },
 
     /*
      * Add a add action to the stack.
      */
     stackAddAction({ target }) {
-      this.$options.doneActionStack.push({ type: 'add', obj: target })
+      this.doneActionStack.push({ type: 'add', obj: target })
       target.lockScalingX = true
       target.lockScalingY = true
       target.rotation = true
@@ -1020,7 +1025,7 @@ export const annotationMixin = {
      * Undo last action, update actions stack.
      */
     undoLastAction() {
-      const action = this.$options.doneActionStack.pop()
+      const action = this.doneActionStack.pop()
       if (action && action.obj) {
         if (action.type === 'add') {
           this.deleteObject(action.obj)
@@ -1031,8 +1036,8 @@ export const annotationMixin = {
           this.addToAdditions(action.obj)
           this.removeFromDeletions(action.obj)
         }
-        this.$options.doneActionStack.pop()
-        this.$options.undoneActionStack.push(action)
+        this.doneActionStack.pop()
+        this.undoneActionStack.push(action)
       }
     },
 
@@ -1040,7 +1045,7 @@ export const annotationMixin = {
      * Apply last undone action, update actions stack.
      */
     redoLastAction() {
-      const action = this.$options.undoneActionStack.pop()
+      const action = this.undoneActionStack.pop()
       if (action) {
         if (action.type === 'add') {
           this.addObject(action.obj)
@@ -1054,7 +1059,7 @@ export const annotationMixin = {
      * Clear all actions in the undone stack.
      */
     clearUndoneStack() {
-      this.$options.undoneActionStack = []
+      this.undoneActionStack.length = 0
     },
 
     // Canvas
@@ -1456,8 +1461,8 @@ export const annotationMixin = {
      */
     startAnnotationSaving(preview, annotations) {
       this.notSaved = true
-      this.$options.annotatedPreview = preview
-      this.$options.annotationToSave = setTimeout(() => {
+      this.annotatedPreview = preview
+      this.annotationToSave = setTimeout(() => {
         this.endAnnotationSaving()
       }, 3000)
     },
@@ -1468,19 +1473,19 @@ export const annotationMixin = {
      */
     endAnnotationSaving() {
       if (this.notSaved) {
-        const preview = this.$options.annotatedPreview
-        this.$options.changesToSave = {
+        const preview = this.annotatedPreview
+        this.changesToSave = {
           preview,
           additions: [...this.additions],
           updates: [...this.updates],
           deletions: [...this.deletions]
         }
         this.clearModifications()
-        clearTimeout(this.$options.annotationToSave)
+        clearTimeout(this.annotationToSave)
         this.notSaved = false
-        this.$emit('annotation-changed', this.$options.changesToSave)
+        this.$emit('annotation-changed', this.changesToSave)
         if (this.onAnnotationChanged) {
-          this.onAnnotationChanged(this.$options.changesToSave)
+          this.onAnnotationChanged(this.changesToSave)
         }
       }
     },

--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -1022,20 +1022,32 @@ export const annotationMixin = {
     },
 
     /*
+     * Resolve the fabric.Object an action targets. After a canvas reload
+     * (e.g. Esc-exit fullscreen) the entry holds a stale instance; look it
+     * up by id on the live canvas. Groups aren't in the canvas as a whole,
+     * fall back to the stored reference.
+     */
+    resolveActionObject(action) {
+      if (action.obj?._objects) return action.obj
+      return this.getObjectById(action.obj.id) ?? action.obj
+    },
+
+    /*
      * Undo last action, update actions stack.
      */
     undoLastAction() {
       const action = this.doneActionStack.pop()
       if (!action?.obj) return
+      const obj = this.resolveActionObject(action)
       // Snapshot length to drop side-effect pushes from deleteObject/addObject (incl. groups)
       const stackLengthBefore = this.doneActionStack.length
       if (action.type === 'add') {
-        this.deleteObject(action.obj)
-        this.removeFromAdditions(action.obj)
+        this.deleteObject(obj)
+        this.removeFromAdditions(obj)
       } else if (action.type === 'remove') {
-        this.addObject(action.obj)
-        this.addToAdditions(action.obj)
-        this.removeFromDeletions(action.obj)
+        this.addObject(obj)
+        this.addToAdditions(obj)
+        this.removeFromDeletions(obj)
       }
       this.doneActionStack.length = stackLengthBefore
       this.undoneActionStack.push(action)
@@ -1047,12 +1059,13 @@ export const annotationMixin = {
     redoLastAction() {
       const action = this.undoneActionStack.pop()
       if (!action?.obj) return
+      const obj = this.resolveActionObject(action)
       // Snapshot length to drop side-effect pushes from deleteObject/addObject (incl. groups)
       const stackLengthBefore = this.doneActionStack.length
       if (action.type === 'add') {
-        this.addObject(action.obj)
+        this.addObject(obj)
       } else if (action.type === 'remove') {
-        this.deleteObject(action.obj)
+        this.deleteObject(obj)
       }
       this.doneActionStack.length = stackLengthBefore
       this.doneActionStack.push(action)

--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -1174,11 +1174,10 @@ export const annotationMixin = {
     setupFabricCanvas() {
       if (!this.annotationCanvas) return
 
-      const canvasId = this.annotationCanvas.id
-
+      // Pass the DOM element via $refs to avoid id collisions across instances.
       // Use markRaw() to avoid reactivity on Fabric Canvas
       this.fabricCanvas = markRaw(
-        new fabric.Canvas(canvasId, {
+        new fabric.Canvas(this.annotationCanvas, {
           fireRightClick: true
         })
       )

--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -275,7 +275,12 @@ export const annotationMixin = {
      */
     deleteObject(activeObject) {
       if (activeObject && activeObject._objects) {
-        activeObject._objects.forEach(obj => {
+        // ActiveSelection children carry coords relative to the selection's
+        // center. discardActiveObject() restores them to absolute before we
+        // remove, so undo re-injects them at their original positions.
+        const children = [...activeObject._objects]
+        this.fabricCanvas.discardActiveObject()
+        children.forEach(obj => {
           this.fabricCanvas.remove(obj)
           this.addToDeletions(obj)
           this.doneActionStack.push({

--- a/src/components/mixins/annotation.js
+++ b/src/components/mixins/annotation.js
@@ -1050,8 +1050,8 @@ export const annotationMixin = {
         this.deleteObject(obj)
         this.removeFromAdditions(obj)
       } else if (action.type === 'remove') {
+        // addObject's 'object:added' fires onObjectAdded → addToAdditions.
         this.addObject(obj)
-        this.addToAdditions(obj)
         this.removeFromDeletions(obj)
       }
       this.doneActionStack.length = stackLengthBefore

--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -1360,7 +1360,7 @@ export const playerMixin = {
         if (!this.notSaved) {
           this.startAnnotationSaving(preview, annotations)
         } else {
-          this.$options.changesToSave = { preview, annotations }
+          this.changesToSave = { preview, annotations }
         }
 
         // Update information locally

--- a/src/components/mixins/player.js
+++ b/src/components/mixins/player.js
@@ -1,4 +1,6 @@
+import { markRaw } from 'vue'
 import { mapActions, mapGetters } from 'vuex'
+
 import {
   formatTime,
   formatFrame,
@@ -1360,7 +1362,7 @@ export const playerMixin = {
         if (!this.notSaved) {
           this.startAnnotationSaving(preview, annotations)
         } else {
-          this.changesToSave = { preview, annotations }
+          this.changesToSave = markRaw({ preview, annotations })
         }
 
         // Update information locally

--- a/src/components/previews/PreviewPlayer.vue
+++ b/src/components/previews/PreviewPlayer.vue
@@ -1362,9 +1362,11 @@ export default {
       const width = dimensions.width
       const height = dimensions.height
 
+      // Pass DOM elements via $refs to avoid id collisions across instances.
+
       // Use markRaw() to avoid reactivity on Fabric Canvas
       this.fabricCanvas = markRaw(
-        new fabric.Canvas(this.canvasId, {
+        new fabric.Canvas(this.$refs['annotation-canvas'], {
           fireRightClick: true,
           width,
           height,
@@ -1379,7 +1381,7 @@ export default {
       brush.pressureManager.fallback = 0.5 // Fallback value for mouse/touch
       this.fabricCanvas.freeDrawingBrush = brush
       this.fabricCanvasComparison = new fabric.StaticCanvas(
-        this.canvasId + '-comparison'
+        this.$refs['annotation-canvas-comparison']
       )
       this.configureCanvas()
     },

--- a/tests/unit/components/mixins/annotation.spec.js
+++ b/tests/unit/components/mixins/annotation.spec.js
@@ -1,0 +1,242 @@
+import { annotationMixin } from '@/components/mixins/annotation'
+
+const {
+  resolveActionObject,
+  undoLastAction,
+  redoLastAction,
+  deleteObject,
+  addObject,
+  getObjectById
+} = annotationMixin.methods
+
+// Build a fake fabric.Object identified by id. _objects marks it as a group.
+const makeObj = (id, extras = {}) => ({ id, ...extras })
+
+// Mocked instance with just enough surface for the stack logic to run.
+// We provide real implementations of methods under test, and stubs for
+// everything else they reach into.
+const makeInstance = ({ canvasObjects = [] } = {}) => {
+  const instance = {
+    doneActionStack: [],
+    undoneActionStack: [],
+    fabricCanvas: {
+      _objects: canvasObjects,
+      getObjects: () => canvasObjects,
+      add: vi.fn(obj => {
+        // Mirror real fabric: 'object:added' fires synchronously and our
+        // onObjectAdded calls addToAdditions then stackAddAction.
+        instance.addToAdditions(obj)
+        instance.doneActionStack.push({ type: 'add', obj })
+      }),
+      remove: vi.fn(obj => {
+        const idx = canvasObjects.indexOf(obj)
+        if (idx >= 0) canvasObjects.splice(idx, 1)
+      }),
+      discardActiveObject: vi.fn()
+    },
+    addToDeletions: vi.fn(),
+    addToAdditions: vi.fn(),
+    removeFromDeletions: vi.fn(),
+    removeFromAdditions: vi.fn(),
+    saveAnnotations: vi.fn(),
+    getObjectById,
+    resolveActionObject,
+    undoLastAction,
+    redoLastAction,
+    deleteObject,
+    addObject
+  }
+  return instance
+}
+
+describe('annotationMixin', () => {
+  describe('resolveActionObject', () => {
+    it('returns the live canvas instance when the id matches', () => {
+      const stored = makeObj('a')
+      const live = makeObj('a', { canvasOwned: true })
+      const instance = makeInstance({ canvasObjects: [live] })
+      const resolved = instance.resolveActionObject({ obj: stored })
+      expect(resolved).toBe(live)
+    })
+
+    it('falls back to action.obj when the id is absent from the canvas', () => {
+      const stored = makeObj('ghost')
+      const instance = makeInstance({ canvasObjects: [] })
+      const resolved = instance.resolveActionObject({ obj: stored })
+      expect(resolved).toBe(stored)
+    })
+
+    it('returns the stored object directly for groups (_objects)', () => {
+      const group = { _objects: [makeObj('a'), makeObj('b')] }
+      // Even with a same-id object on the canvas, groups skip the lookup.
+      const instance = makeInstance({ canvasObjects: [makeObj('a')] })
+      const resolved = instance.resolveActionObject({ obj: group })
+      expect(resolved).toBe(group)
+    })
+  })
+
+  describe('undoLastAction', () => {
+    it('returns early on an empty done stack', () => {
+      const instance = makeInstance()
+      instance.undoLastAction()
+      expect(instance.doneActionStack).toEqual([])
+      expect(instance.undoneActionStack).toEqual([])
+    })
+
+    it("undoes an 'add' by removing the live object and moving the action to undone", () => {
+      const live = makeObj('a')
+      const instance = makeInstance({ canvasObjects: [live] })
+      const action = { type: 'add', obj: live }
+      instance.doneActionStack.push(action)
+
+      instance.undoLastAction()
+
+      expect(instance.fabricCanvas.remove).toHaveBeenCalledWith(live)
+      expect(instance.removeFromAdditions).toHaveBeenCalledWith(live)
+      expect(instance.doneActionStack).toEqual([]) // side-effect pushes from deleteObject dropped by snapshot
+      expect(instance.undoneActionStack).toEqual([action])
+    })
+
+    it("undoes a 'remove' by re-adding the object, even when it's no longer on the canvas (stale obj)", () => {
+      const stale = makeObj('a')
+      const instance = makeInstance({ canvasObjects: [] })
+      const action = { type: 'remove', obj: stale }
+      instance.doneActionStack.push(action)
+
+      instance.undoLastAction()
+
+      expect(instance.fabricCanvas.add).toHaveBeenCalledWith(stale)
+      // addToAdditions must fire exactly once — via 'object:added' — not
+      // also via an explicit call (regression on the double-call bug).
+      expect(instance.addToAdditions).toHaveBeenCalledTimes(1)
+      expect(instance.addToAdditions).toHaveBeenCalledWith(stale)
+      expect(instance.removeFromDeletions).toHaveBeenCalledWith(stale)
+      // The 'object:added' side-effect push is dropped by the snapshot.
+      expect(instance.doneActionStack).toEqual([])
+      expect(instance.undoneActionStack).toEqual([action])
+    })
+
+    it('resolves the live canvas instance even when the stack holds a stale ref', () => {
+      const stale = makeObj('a')
+      const live = makeObj('a', { fresh: true })
+      const instance = makeInstance({ canvasObjects: [live] })
+      const action = { type: 'add', obj: stale }
+      instance.doneActionStack.push(action)
+
+      instance.undoLastAction()
+
+      // remove is called with the live instance, not the stale one.
+      expect(instance.fabricCanvas.remove).toHaveBeenCalledWith(live)
+    })
+
+    it("undoes an 'add' on a group, dropping the N 'remove' side-effect pushes", () => {
+      const child1 = makeObj('a')
+      const child2 = makeObj('b')
+      const group = { _objects: [child1, child2] }
+      const instance = makeInstance({ canvasObjects: [child1, child2] })
+      const action = { type: 'add', obj: group }
+      instance.doneActionStack.push(action)
+
+      instance.undoLastAction()
+
+      expect(instance.fabricCanvas.discardActiveObject).toHaveBeenCalled()
+      expect(instance.fabricCanvas.remove).toHaveBeenCalledTimes(2)
+      expect(instance.doneActionStack).toEqual([])
+      expect(instance.undoneActionStack).toEqual([action])
+    })
+  })
+
+  describe('redoLastAction', () => {
+    it('returns early on an empty undone stack', () => {
+      const instance = makeInstance()
+      instance.redoLastAction()
+      expect(instance.doneActionStack).toEqual([])
+      expect(instance.undoneActionStack).toEqual([])
+    })
+
+    it("redoes an 'add' by re-adding the object, leaving exactly one entry on done (drops the double-push)", () => {
+      // Regression: addObject for single object causes two pushes (the
+      // 'object:added' event + the persist branch). The snapshot pattern
+      // must drop both before pushing the action back onto done.
+      const obj = makeObj('a')
+      const instance = makeInstance({ canvasObjects: [] })
+      const action = { type: 'add', obj }
+      instance.undoneActionStack.push(action)
+
+      instance.redoLastAction()
+
+      expect(instance.fabricCanvas.add).toHaveBeenCalledWith(obj)
+      expect(instance.doneActionStack).toEqual([action]) // exactly one
+      expect(instance.undoneActionStack).toEqual([])
+    })
+
+    it("redoes a 'remove' by removing the object", () => {
+      const obj = makeObj('a')
+      const instance = makeInstance({ canvasObjects: [obj] })
+      const action = { type: 'remove', obj }
+      instance.undoneActionStack.push(action)
+
+      instance.redoLastAction()
+
+      expect(instance.fabricCanvas.remove).toHaveBeenCalledWith(obj)
+      expect(instance.doneActionStack).toEqual([action])
+    })
+
+    it("redoes a 'remove' on a group, dropping the N 'remove' side-effect pushes", () => {
+      const child1 = makeObj('a')
+      const child2 = makeObj('b')
+      const group = { _objects: [child1, child2] }
+      const instance = makeInstance({ canvasObjects: [child1, child2] })
+      const action = { type: 'remove', obj: group }
+      instance.undoneActionStack.push(action)
+
+      instance.redoLastAction()
+
+      expect(instance.fabricCanvas.discardActiveObject).toHaveBeenCalled()
+      expect(instance.fabricCanvas.remove).toHaveBeenCalledTimes(2)
+      expect(instance.doneActionStack).toEqual([action])
+      expect(instance.undoneActionStack).toEqual([])
+    })
+  })
+
+  describe('deleteObject', () => {
+    it('removes a single object and pushes a remove action', () => {
+      const obj = makeObj('a')
+      const instance = makeInstance({ canvasObjects: [obj] })
+
+      instance.deleteObject(obj)
+
+      expect(instance.fabricCanvas.remove).toHaveBeenCalledWith(obj)
+      expect(instance.addToDeletions).toHaveBeenCalledWith(obj)
+      expect(instance.doneActionStack).toEqual([{ type: 'remove', obj }])
+      expect(instance.saveAnnotations).toHaveBeenCalled()
+    })
+
+    it("discards the ActiveSelection before iterating, and clones _objects so it doesn't get emptied", () => {
+      // Regression: ActiveSelection children carry coords relative to the
+      // selection's center. discardActiveObject() restores them to absolute
+      // before we remove them.
+      const child1 = makeObj('a')
+      const child2 = makeObj('b')
+      const selection = { _objects: [child1, child2] }
+      const instance = makeInstance({ canvasObjects: [child1, child2] })
+
+      // Simulate fabric clearing the _objects on discardActiveObject(),
+      // proving the deleteObject implementation cloned the array up-front.
+      instance.fabricCanvas.discardActiveObject = vi.fn(() => {
+        selection._objects.length = 0
+      })
+
+      instance.deleteObject(selection)
+
+      expect(instance.fabricCanvas.discardActiveObject).toHaveBeenCalled()
+      expect(instance.fabricCanvas.remove).toHaveBeenCalledTimes(2)
+      expect(instance.fabricCanvas.remove).toHaveBeenNthCalledWith(1, child1)
+      expect(instance.fabricCanvas.remove).toHaveBeenNthCalledWith(2, child2)
+      expect(instance.doneActionStack).toEqual([
+        { type: 'remove', obj: child1 },
+        { type: 'remove', obj: child2 }
+      ])
+    })
+  })
+})


### PR DESCRIPTION
**Problem**

Multiple bugs in the preview annotation undo/redo mechanics: state shared across instances, side-effect pushes polluting the stack, stale `fabric.Object` refs after fullscreen exit, double additions payload, lost positions on `ActiveSelection` delete.

**Solution**
- per-instance undo stacks and silent-mode flag
- snapshot/restore around `addObject`/`deleteObject` in undo/redo
- `markRaw` on annotation save payloads
- resolve action targets by ID from the live canvas
- pass DOM elements to `fabric.Canvas` (avoid id collisions)
- drop redundant `addToAdditions` on 'remove' undo
- `discardActiveObject` before deleting an `ActiveSelection`
- add unit tests covering the undo/redo invariants
