### PR TITLE
Display embedded author for guests in comments and news

### DIFF
--- a/src/components/pages/entities/EntityNews.vue
+++ b/src/components/pages/entities/EntityNews.vue
@@ -24,9 +24,9 @@
           class="flexrow-item"
           :font-size="14"
           :is-link="false"
-          :person="personMap.get(news.author_id)"
+          :person="news.person"
           :size="30"
-          v-if="personMap.get(news.author_id)"
+          v-if="news.person"
         />
 
         <div class="flexrow-item task-type-wrapper ml1">
@@ -95,12 +95,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters([
-      'currentProduction',
-      'personMap',
-      'taskTypeMap',
-      'taskStatusMap'
-    ])
+    ...mapGetters(['currentProduction', 'taskTypeMap', 'taskStatusMap'])
   },
 
   methods: {
@@ -136,6 +131,7 @@ export default {
       this.isLoading = true
       this.getEntityNews(this.entity.id)
         .then(data => {
+          // The author is already resolved and enriched by the store action.
           this.newsList = data.data
         })
         .catch(err => {

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -26,12 +26,11 @@
             :is-link="!isCurrentUserClient"
             v-if="!isCurrentUserClient || isAuthorClient"
           />
-          <strong class="flexrow-item">
-            <people-name
-              :person="comment.person"
-              v-if="!isCurrentUserClient || isAuthorClient"
-            />
-          </strong>
+          <people-name
+            class="flexrow-item strong"
+            :person="comment.person"
+            v-if="!isCurrentUserClient || isAuthorClient"
+          />
           <div class="filler"></div>
           <span class="flexrow-item date" :title="fullDate">
             {{ shortDate }}
@@ -153,18 +152,23 @@
                 v-for="replyComment in comment.replies || []"
               >
                 <div class="flexrow">
-                  <people-avatar
-                    class="flexrow-item"
-                    :size="18"
-                    :font-size="10"
-                    :person="personMap.get(replyComment.person_id)"
-                    :is-link="!isCurrentUserClient"
-                  />
-                  <strong class="flexrow-item">
-                    <people-name
-                      :person="personMap.get(replyComment.person_id)"
+                  <template
+                    v-if="
+                      !isCurrentUserClient || isReplyAuthorClient(replyComment)
+                    "
+                  >
+                    <people-avatar
+                      class="flexrow-item"
+                      :size="18"
+                      :font-size="10"
+                      :person="replyComment.person"
+                      :is-link="!isCurrentUserClient"
                     />
-                  </strong>
+                    <people-name
+                      class="flexrow-item strong"
+                      :person="replyComment.person"
+                    />
+                  </template>
                   <span
                     class="flexrow-item reply-date"
                     :title="replyFullDate(replyComment.date)"
@@ -418,7 +422,7 @@
           :font-size="12"
           :is-link="!isCurrentUserClient"
         />
-        <people-name class="flexrow-item" :person="comment.person" />
+        <people-name class="flexrow-item strong" :person="comment.person" />
         <span class="filler"> </span>
         <span class="flexrow-item date" :title="fullDate">
           {{ shortDate }}
@@ -718,8 +722,15 @@ const boxShadowStyle = computed(() => {
 })
 
 const isAuthorClient = computed(() => {
-  return personMap.value.get(props.comment.person_id)?.role === 'client'
+  const author =
+    personMap.value.get(props.comment.person_id) || props.comment.person
+  return author?.role === 'client'
 })
+
+const isReplyAuthorClient = reply => {
+  const author = personMap.value.get(reply.person_id) || reply.person
+  return author?.role === 'client'
+}
 
 const shortenText = (text, length) => {
   return stringHelpers.shortenText(text, length)

--- a/src/components/widgets/PeopleName.vue
+++ b/src/components/widgets/PeopleName.vue
@@ -7,18 +7,20 @@
         person_id: person.id
       }
     }"
-    :title="person.full_name"
+    :title="displayName"
     v-if="person?.id && withLink"
   >
-    {{ person.full_name }}
+    {{ displayName }}
   </router-link>
   <span class="person-name" v-else-if="person">
-    {{ person.full_name }}
+    {{ displayName }}
   </span>
 </template>
 
 <script setup>
-defineProps({
+import { computed } from 'vue'
+
+const props = defineProps({
   person: {
     type: Object,
     required: true
@@ -28,6 +30,11 @@ defineProps({
     default: false
   }
 })
+
+// full_name is embedded by the API; name is the client-computed fallback.
+const displayName = computed(
+  () => props.person?.full_name || props.person?.name || undefined
+)
 </script>
 
 <style lang="scss" scoped>

--- a/src/store/modules/entities.js
+++ b/src/store/modules/entities.js
@@ -1,4 +1,5 @@
 import entitiesApi from '@/store/api/entities'
+import peopleStore from '@/store/modules/people'
 import { RESET_ALL } from '@/store/mutation-types'
 
 const initialState = {}
@@ -9,7 +10,15 @@ const getters = {}
 
 const actions = {
   async getEntityNews({ commit }, entityId) {
-    return entitiesApi.getEntityNews(entityId)
+    const news = await entitiesApi.getEntityNews(entityId)
+    // Resolve the author once: live personMap, API-embedded fallback for
+    // guests, then enrich it (initials, color, avatar) for the avatar.
+    news.data?.forEach(entry => {
+      entry.person =
+        peopleStore.cache.personMap.get(entry.author_id) || entry.person
+      peopleStore.helpers.addAdditionalInformation(entry.person)
+    })
+    return news
   },
 
   async getEntityPreviewFiles({ commit }, entityId) {

--- a/src/store/modules/people.js
+++ b/src/store/modules/people.js
@@ -78,7 +78,7 @@ const helpers = {
 
     if (person.has_avatar) {
       const lastUpdate = person.updated_at || person.created_at
-      const timestamp = Date.parse(lastUpdate)
+      const timestamp = Date.parse(lastUpdate) || ''
       person.avatarPath = `/api/pictures/thumbnails/persons/${person.id}.png?t=${timestamp}`
     }
 

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -119,6 +119,19 @@ const helpers = {
 
   getTaskStatus(taskStatusId) {
     return taskStatusStore.cache.taskStatusMap.get(taskStatusId)
+  },
+
+  // Fall back to the API-embedded author since guests aren't in personMap.
+  resolveAuthor(personId, embedded) {
+    const person = personStore.cache.personMap.get(personId) || embedded
+    return personStore.helpers.addAdditionalInformation(person)
+  },
+
+  enrichCommentAuthors(comment) {
+    comment.person = helpers.resolveAuthor(comment.person_id, comment.person)
+    comment.replies?.forEach(reply => {
+      reply.person = helpers.resolveAuthor(reply.person_id, reply.person)
+    })
   }
 }
 
@@ -878,9 +891,7 @@ const mutations = {
   },
 
   [LOAD_TASK_COMMENTS_END](state, { taskId, comments }) {
-    comments.forEach(comment => {
-      comment.person = personStore.cache.personMap.get(comment.person_id)
-    })
+    comments.forEach(comment => helpers.enrichCommentAuthors(comment))
     state.taskComments[taskId] = sortComments([...comments])
     state.taskPreviews[taskId] = comments.reduce((previews, comment) => {
       if (comment.previews && comment.previews.length > 0) {
@@ -926,14 +937,7 @@ const mutations = {
       comment.task_status = helpers.getTaskStatus(comment.task_status_id)
     }
 
-    if (comment.person === undefined) {
-      const getPerson = personStore.getters.getPerson(personStore.state)
-      comment.person = getPerson(comment.person_id)
-    }
-
-    comment.person = personStore.helpers.addAdditionalInformation(
-      comment.person
-    )
+    helpers.enrichCommentAuthors(comment)
 
     if (!taskId) {
       taskId = comment.object_id
@@ -1331,6 +1335,7 @@ const mutations = {
   [ADD_REPLY_TO_COMMENT](state, { comment, reply }) {
     if (!comment.replies) comment.replies = []
     if (!comment.replies.find(r => r.id === reply.id)) {
+      reply.person = helpers.resolveAuthor(reply.person_id, reply.person)
       comment.replies.push(reply)
       comment.attachment_files = [
         ...(comment.attachment_files || []),

--- a/tests/unit/components/widgets/PeopleName.spec.js
+++ b/tests/unit/components/widgets/PeopleName.spec.js
@@ -1,0 +1,23 @@
+import { mount } from '@vue/test-utils'
+
+import PeopleName from '@/components/widgets/PeopleName.vue'
+
+const mountName = person =>
+  mount(PeopleName, { props: { person, withLink: false } })
+
+describe('widgets/PeopleName', () => {
+  test('renders the embedded full_name', () => {
+    const wrapper = mountName({ id: 'person-guest', full_name: 'Guest Author' })
+    expect(wrapper.find('.person-name').text()).toEqual('Guest Author')
+  })
+
+  test('falls back to the client-computed name when full_name is missing', () => {
+    const wrapper = mountName({ id: 'person-guest', name: 'Guest Author' })
+    expect(wrapper.find('.person-name').text()).toEqual('Guest Author')
+  })
+
+  test('renders empty when neither full_name nor name is set', () => {
+    const wrapper = mountName({ id: 'person-guest' })
+    expect(wrapper.find('.person-name').text()).toEqual('')
+  })
+})

--- a/tests/unit/store/tasks.spec.js
+++ b/tests/unit/store/tasks.spec.js
@@ -1,0 +1,130 @@
+import { vi } from 'vitest'
+
+// Importing the tasks module transitively pulls in the root store
+// (lib/models → timezone → @/store); stub it so no Vuex store is built.
+vi.mock('@/store', () => ({ default: {} }))
+
+import tasksStore from '@/store/modules/tasks'
+import peopleStore from '@/store/modules/people'
+
+describe('Tasks store', () => {
+  describe('Comment author resolution', () => {
+    const studioPerson = {
+      id: 'person-studio',
+      first_name: 'Studio',
+      last_name: 'Member',
+      full_name: 'Studio Member (live)',
+      role: 'manager',
+      has_avatar: false
+    }
+
+    beforeEach(() => {
+      peopleStore.cache.personMap = new Map([['person-studio', studioPerson]])
+    })
+
+    afterEach(() => {
+      peopleStore.cache.personMap = new Map()
+    })
+
+    test('LOAD_TASK_COMMENTS_END prefers personMap over embedded author', () => {
+      const state = { taskComments: {}, taskPreviews: {} }
+      const comments = [
+        {
+          id: 'comment-studio',
+          person_id: 'person-studio',
+          created_at: '2026-05-20T10:00:00',
+          pinned: false,
+          // Embedded author is stale; the live personMap must win.
+          person: { id: 'person-studio', full_name: 'Studio Member (stale)' }
+        }
+      ]
+      tasksStore.mutations.LOAD_TASK_COMMENTS_END(state, {
+        taskId: 'task-1',
+        comments
+      })
+      const [comment] = state.taskComments['task-1']
+      expect(comment.person.full_name).toEqual('Studio Member (live)')
+    })
+
+    test('LOAD_TASK_COMMENTS_END falls back to the embedded guest author', () => {
+      const state = { taskComments: {}, taskPreviews: {} }
+      const comments = [
+        {
+          id: 'comment-guest',
+          person_id: 'person-guest',
+          created_at: '2026-05-20T11:00:00',
+          pinned: false,
+          // Guests are absent from personMap; the API embeds the author.
+          person: {
+            id: 'person-guest',
+            first_name: 'Guest',
+            last_name: 'Author',
+            full_name: 'Guest Author',
+            role: 'client',
+            has_avatar: false
+          }
+        }
+      ]
+      tasksStore.mutations.LOAD_TASK_COMMENTS_END(state, {
+        taskId: 'task-1',
+        comments
+      })
+      const [comment] = state.taskComments['task-1']
+      expect(comment.person.full_name).toEqual('Guest Author')
+      // addAdditionalInformation enriches the embedded author for the avatar.
+      expect(comment.person.initials).toEqual('GA')
+      expect(comment.person.name).toEqual('Guest Author')
+    })
+
+    test('LOAD_TASK_COMMENTS_END resolves embedded reply authors too', () => {
+      const state = { taskComments: {}, taskPreviews: {} }
+      const comments = [
+        {
+          id: 'comment-studio',
+          person_id: 'person-studio',
+          created_at: '2026-05-20T10:00:00',
+          pinned: false,
+          person: studioPerson,
+          replies: [
+            {
+              id: 'reply-guest',
+              person_id: 'person-guest',
+              person: {
+                id: 'person-guest',
+                first_name: 'Guest',
+                last_name: 'Author',
+                full_name: 'Guest Author',
+                role: 'client'
+              }
+            }
+          ]
+        }
+      ]
+      tasksStore.mutations.LOAD_TASK_COMMENTS_END(state, {
+        taskId: 'task-1',
+        comments
+      })
+      const [comment] = state.taskComments['task-1']
+      expect(comment.replies[0].person.full_name).toEqual('Guest Author')
+      expect(comment.replies[0].person.initials).toEqual('GA')
+    })
+
+    test('ADD_REPLY_TO_COMMENT resolves the embedded guest reply author', () => {
+      const comment = { id: 'comment-studio', replies: [] }
+      const reply = {
+        id: 'reply-guest',
+        person_id: 'person-guest',
+        person: {
+          id: 'person-guest',
+          first_name: 'Guest',
+          last_name: 'Author',
+          full_name: 'Guest Author',
+          role: 'client'
+        }
+      }
+      tasksStore.mutations.ADD_REPLY_TO_COMMENT({}, { comment, reply })
+      expect(comment.replies[0].person.full_name).toEqual('Guest Author')
+      expect(comment.replies[0].person.initials).toEqual('GA')
+    })
+  })
+})


### PR DESCRIPTION
**Problem**

Guests are excluded from the person store, so their comments, replies and news
showed as "Unknown" with no avatar.

**Solution**

- Resolve comments, replies, reply and news authors from the API-embedded person, with a
  `personMap` fallback, so guests render with a name and avatar.
- Avoid reintroducing a global guest load.
- Hide studio identities from clients on replies, matching the server.

---

Linked to the following Zou PR: https://github.com/cgwire/zou/pull/1082
