### PR TITLE
Fix subsequent annotations not saving from side panel

### DIFF
--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1079,17 +1079,22 @@ export default {
       this.currentPreviewDlPath = this.getOriginalDlPath()
     },
 
-    onAnnotationChanged({ preview, additions, deletions, updates }) {
+    async onAnnotationChanged({ preview, additions, deletions, updates }) {
       let taskId = this.task ? this.task.id : this.previousTaskId
       taskId = taskId || preview.task_id
-      if (taskId) {
-        this.updatePreviewAnnotation({
+      if (!taskId) return
+      const previewPlayer = this.$refs['preview-player']
+      try {
+        await this.updatePreviewAnnotation({
           taskId,
           preview,
           additions,
           deletions,
           updates
         })
+        previewPlayer?.confirmAnnotationsSaved()
+      } catch {
+        previewPlayer?.restoreFailedAnnotations()
       }
     },
 


### PR DESCRIPTION
**Problem**
- When drawing annotations from the side panel preview (Shots, Concepts, Todos, AllTasks, TaskType…), only the first annotation is saved; subsequent ones are silently dropped.

**Solution**
- Fix subsequent annotations not saving from side panel

`TaskInfo`'s annotation handler was missed in ab8c3ae and never confirmed the save back to the player, leaving it stuck. Align it with the other consumers (`Task`, `Edit`, `Playlist`, `ViewPlaylistModal`).
