### PR TITLE
[players] Annotation snapshot polish and player bug fixes

### DIFF
--- a/src/components/modals/AddAttachmentModal.vue
+++ b/src/components/modals/AddAttachmentModal.vue
@@ -38,10 +38,10 @@
             @fileselected="onFileSelected"
             hide-file-names
           />
-          <p class="flexrow-item mt1" v-if="isMovie">
+          <p class="flexrow-item mt1" v-if="isMovie || isPicture">
             {{ $t('main.or') }}
           </p>
-          <p class="flexrow-item" v-if="isMovie">
+          <p class="flexrow-item" v-if="isMovie || isPicture">
             <button
               :class="{
                 button: true,
@@ -118,6 +118,7 @@ const props = defineProps({
   isError: { type: Boolean, default: false },
   isLoading: { type: Boolean, default: false },
   isMovie: { type: Boolean, default: false },
+  isPicture: { type: Boolean, default: false },
   title: { type: String, default: '' }
 })
 

--- a/src/components/modals/AddAttachmentModal.vue
+++ b/src/components/modals/AddAttachmentModal.vue
@@ -27,10 +27,9 @@
           {{ $t('tasks.comment_image') }}
         </h1>
 
-        <div class="flexrow buttons attachment-modal-buttons">
+        <div class="attachment-upload-zone">
           <file-upload
             ref="fileField"
-            class="flexrow-item"
             :label="$t('main.select_file')"
             :accept="extensions"
             :multiple="true"
@@ -38,20 +37,31 @@
             @fileselected="onFileSelected"
             hide-file-names
           />
-          <p class="flexrow-item mt1" v-if="isMovie || isPicture">
-            {{ $t('main.or') }}
-          </p>
-          <p class="flexrow-item" v-if="isMovie || isPicture">
-            <button
-              :class="{
-                button: true,
-                'is-loading': isAnnotationLoading
-              }"
-              @click="$emit('add-snapshots')"
-            >
-              {{ $t('main.attach_snapshots') }}
-            </button>
-          </p>
+        </div>
+
+        <div class="snapshot-actions" v-if="isMovie || isPicture">
+          <button
+            :class="{
+              button: true,
+              'snapshot-button': true,
+              'is-loading': snapshotLoading === 'standard'
+            }"
+            :disabled="snapshotLoading && snapshotLoading !== 'standard'"
+            @click="$emit('add-snapshots')"
+          >
+            {{ $t('main.attach_snapshots') }}
+          </button>
+          <button
+            :class="{
+              button: true,
+              'snapshot-button': true,
+              'is-loading': snapshotLoading === 'label'
+            }"
+            :disabled="snapshotLoading && snapshotLoading !== 'label'"
+            @click="$emit('add-snapshots-with-label')"
+          >
+            {{ $t('main.attach_snapshots_with_label') }}
+          </button>
         </div>
 
         <h3 class="subtitle has-text-centered" v-if="forms.length > 0">
@@ -122,13 +132,20 @@ const props = defineProps({
   title: { type: String, default: '' }
 })
 
-const emit = defineEmits(['add-snapshots', 'cancel', 'confirm'])
+const emit = defineEmits([
+  'add-snapshots',
+  'add-snapshots-with-label',
+  'cancel',
+  'confirm'
+])
 
 useModal(toRef(props, 'active'), emit)
 
 const fileField = ref(null)
 const forms = ref([])
-const isAnnotationLoading = ref(false)
+// Tracks which snapshot button is currently extracting:
+// 'standard', 'label', or null when idle.
+const snapshotLoading = ref(null)
 const isDraggingFile = ref(false)
 
 const onFileSelected = newForms => {
@@ -196,11 +213,11 @@ onBeforeUnmount(() => {
 
 defineExpose({
   addFiles,
-  showAnnotationLoading: () => {
-    isAnnotationLoading.value = true
+  showAnnotationLoading: (kind = 'standard') => {
+    snapshotLoading.value = kind
   },
   hideAnnotationLoading: () => {
-    isAnnotationLoading.value = false
+    snapshotLoading.value = null
   }
 })
 </script>
@@ -263,6 +280,57 @@ h3.subtitle {
 
 .buttons {
   flex-wrap: wrap;
+}
+
+.attachment-upload-zone {
+  border: 2px dashed var(--border);
+  border-radius: 10px;
+  margin: 1em 0;
+  padding: 1.5em;
+  text-align: center;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease;
+
+  &:hover {
+    background: var(--background-hover, rgba(255, 255, 255, 0.03));
+    border-color: var(--background-selectable, $purple-strong);
+  }
+
+  // Strip Bulma's button background off the file-upload label so the
+  // dropzone's outline is the single visual container — the text sits
+  // directly on the dashed area, no inner button chip.
+  :deep(.dropbox) {
+    background: transparent;
+    border: 0;
+    justify-content: center;
+    padding: 0;
+  }
+
+  :deep(.dropbox label.button) {
+    background: transparent;
+    border: 0;
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 500;
+
+    &:hover {
+      background: transparent;
+      color: var(--background-selectable, $purple-strong);
+    }
+  }
+}
+
+.snapshot-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  margin-bottom: 1em;
+}
+
+.snapshot-button {
+  width: 100%;
+  margin-left: 0;
 }
 
 .drop-mask {

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -270,6 +270,9 @@
                 @file-drop="selectFile"
                 @clear-files="clearPreviewFiles"
                 @annotation-snapshots-requested="extractAnnotationSnapshots"
+                @annotation-snapshots-with-label-requested="
+                  extractAnnotationSnapshots(true)
+                "
                 @remove-preview="onPreviewFormRemoved"
                 v-if="isCommentingAllowed"
               />
@@ -1548,10 +1551,13 @@ export default {
       this.taskPreviews = this.getCurrentTaskPreviews()
     },
 
-    async extractAnnotationSnapshots() {
-      this.$refs['add-comment'].showAnnotationLoading()
-      const files =
-        await this.$refs['preview-player'].extractAnnotationSnapshots()
+    async extractAnnotationSnapshots(withLabel = false) {
+      this.$refs['add-comment'].showAnnotationLoading(
+        withLabel ? 'label' : 'standard'
+      )
+      const files = await this.$refs[
+        'preview-player'
+      ].extractAnnotationSnapshots({ withLabel })
       this.$refs['add-comment'].setAnnotationSnapshots(files)
       this.$refs['add-comment'].hideAnnotationLoading()
       return files

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -257,6 +257,7 @@
                 :is-max-retakes-error="errors.addCommentMaxRetakes"
                 :is-loading="loading.addComment"
                 :is-movie="isMovie"
+                :is-picture="isPicture"
                 :team="currentTeam"
                 :task-types="currentTaskTypes"
                 :task="task"
@@ -628,6 +629,10 @@ export default {
 
     isMovie() {
       return this.extension === 'mp4'
+    },
+
+    isPicture() {
+      return ['png', 'gif'].includes(this.extension)
     },
 
     isPreviewPlayerReadOnly() {

--- a/src/components/players/annotations/AnnotationCanvas.vue
+++ b/src/components/players/annotations/AnnotationCanvas.vue
@@ -202,12 +202,11 @@ defineExpose({
 .annotation-clip {
   position: absolute;
   z-index: 500;
-  // Clip on all sides so a zoomed / panned overlay stays within the
-  // media bounds — otherwise strokes spill onto the header above and
-  // the playback / progress bars below.
-  clip-path: inset(0);
-  // The wrapper exists only to clip — never to capture events. The
-  // inner overlay decides for itself whether to be interactive.
+  // Clipping is delegated to the player's outer container
+  // (PreviewPlayer's .preview-container, PlaylistPlayer's
+  // .video-container — both with overflow: hidden) so the overlay
+  // can extend with the panzoom transform without being cropped to
+  // the media's un-zoomed bounds.
   pointer-events: none;
 }
 

--- a/src/components/players/annotations/AnnotationCanvas.vue
+++ b/src/components/players/annotations/AnnotationCanvas.vue
@@ -90,6 +90,11 @@ const updateBounds = () => {
     canvas.setDimensions({ width: mediaRect.width, height: mediaRect.height })
     emit('resized', { width: mediaRect.width, height: mediaRect.height })
   }
+  // Refresh fabric's cached canvas offset. setDimensions doesn't
+  // always trigger it on its own, and a stale offset shifts pointer
+  // coordinates (so freshly drawn strokes land at the wrong y) until
+  // any window resize forces a recalculation.
+  canvas?.calcOffset()
 }
 
 const observe = el => el && resizeObserver?.observe(el)

--- a/src/components/players/bars/PlayerPlaybackBar.vue
+++ b/src/components/players/bars/PlayerPlaybackBar.vue
@@ -30,7 +30,7 @@
 
   <div class="left flexrow" v-if="isMovie && !compact">
     <span
-      class="flexrow-item time-indicator"
+      class="flexrow-item time-indicator current-time"
       :title="$t('playlists.actions.current_time')"
     >
       {{ currentTime }}
@@ -194,7 +194,15 @@ const volume = defineModel('volume', { default: 50 })
 <style lang="scss" scoped>
 .time-indicator {
   color: $light-grey;
-  padding-left: 0.8em;
+  padding-left: 0.2em;
   margin-right: 0;
+}
+
+// Hide the timecode when PreviewPlayer is narrow — the frame counter
+// next to it carries enough position info on its own.
+@container preview-player (max-width: 600px) {
+  .current-time {
+    display: none;
+  }
 }
 </style>

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -378,6 +378,7 @@
         :current-parent-preview="currentPreview"
         :fps="fps"
         :extendable="false"
+        :in-playlist="true"
         :is-preview="false"
         :silent="isCommentsHidden"
         :task="task"

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -4297,6 +4297,7 @@ const playerProxy = {
 }
 
 .video-container {
+  overflow: hidden;
   position: relative;
 }
 

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -889,6 +889,8 @@ import { usePreviewRoom } from '@/composables/previewRoom'
 import preferences from '@/lib/preferences'
 import {
   buildAnnotationSnapshotFilename,
+  buildAnnotationSnapshotTitle,
+  drawSnapshotTitle,
   isModelPreview,
   isMoviePreview,
   isPdfPreview,
@@ -2816,24 +2818,31 @@ const extractPicture = canvas => {
   context.drawImage(image, 0, 0, canvas.width, canvas.height)
 }
 
-const extractAnnotationSnapshots = async () => {
-  if (isCurrentPreviewPicture.value) return extractPicturePreviewSnapshots()
-  return extractVideoAnnotationSnapshots()
+const extractAnnotationSnapshots = async ({ withLabel = false } = {}) => {
+  if (isCurrentPreviewPicture.value) {
+    return extractPicturePreviewSnapshots({ withLabel })
+  }
+  return extractVideoAnnotationSnapshots({ withLabel })
 }
 
-const snapshotFilename = ({ revision, frame, index } = {}) =>
-  buildAnnotationSnapshotFilename({
-    production: currentProduction.value?.name,
-    entity: task.value?.entity_name,
-    taskType: taskTypeMap.value.get(task.value?.task_type_id)?.name,
-    revision,
-    frame,
-    index
-  })
+const snapshotIdentity = ({ revision, frame, index } = {}) => ({
+  production: currentProduction.value?.name,
+  entity: task.value?.entity_name,
+  taskType: taskTypeMap.value.get(task.value?.task_type_id)?.name,
+  revision,
+  frame,
+  index
+})
+
+const snapshotFilename = identity =>
+  buildAnnotationSnapshotFilename(snapshotIdentity(identity))
+
+const snapshotTitle = identity =>
+  buildAnnotationSnapshotTitle(snapshotIdentity(identity))
 
 // Video preview: one PNG per annotation, each captured at the
 // annotation's frame with its drawing composited on top.
-const extractVideoAnnotationSnapshots = async () => {
+const extractVideoAnnotationSnapshots = async ({ withLabel = false } = {}) => {
   const cur = currentFrame.value
   const sorted = annotations.value.sort((a, b) => a.time - b.time)
   const files = []
@@ -2845,6 +2854,7 @@ const extractVideoAnnotationSnapshots = async () => {
     )
     await extractVideoFrame(canvas, frame)
     await copyAnnotationCanvas(canvas, ann)
+    if (withLabel) drawSnapshotTitle(canvas, snapshotTitle({ revision, frame }))
     files.push(
       await getFileFromCanvas(canvas, snapshotFilename({ revision, frame }))
     )
@@ -2859,7 +2869,7 @@ const extractVideoAnnotationSnapshots = async () => {
 // preview's annotations composited on top. Briefly switches the
 // displayed picture in order to reuse the live extract/composite
 // pipeline.
-const extractPicturePreviewSnapshots = async () => {
+const extractPicturePreviewSnapshots = async ({ withLabel = false } = {}) => {
   const entity = currentEntity.value
   if (!entity) return []
   const picturePreviews = [
@@ -2885,6 +2895,12 @@ const extractPicturePreviewSnapshots = async () => {
     const canvas = document.getElementById('annotation-snapshot')
     extractPicture(canvas)
     await compositeLiveAnnotationsOntoCanvas(canvas)
+    if (withLabel) {
+      drawSnapshotTitle(
+        canvas,
+        snapshotTitle({ revision: preview.revision, index: fileIndex })
+      )
+    }
     files.push(
       await getFileFromCanvas(
         canvas,
@@ -4135,7 +4151,7 @@ defineExpose({
 })
 
 const playerProxy = {
-  extractAnnotationSnapshots: () => extractAnnotationSnapshots()
+  extractAnnotationSnapshots: options => extractAnnotationSnapshots(options)
 }
 </script>
 

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -888,6 +888,7 @@ import { usePreviewShortcuts } from '@/composables/players/previewShortcuts'
 import { usePreviewRoom } from '@/composables/previewRoom'
 import preferences from '@/lib/preferences'
 import {
+  buildAnnotationSnapshotFilename,
   isModelPreview,
   isMoviePreview,
   isPdfPreview,
@@ -1538,7 +1539,8 @@ const {
   endAnnotationSaving,
   restoreFailedAnnotations,
   confirmAnnotationsSaved,
-  copyAnnotationCanvas
+  copyAnnotationCanvas,
+  compositeLiveAnnotationsOntoCanvas
 } = annotation
 
 // FullScreen composable
@@ -2802,22 +2804,99 @@ const extractVideoFrame = (canvas, f) => {
   })
 }
 
+const extractPicture = canvas => {
+  if (!picturePlayer.value) return
+  const image = picturePlayer.value.getPictureElement()
+  if (!image) return
+  const { width, height } = picturePlayer.value.getNaturalDimensions()
+  const context = canvas.getContext('2d')
+  canvas.width = width
+  canvas.height = height
+  context.clearRect(0, 0, canvas.width, canvas.height)
+  context.drawImage(image, 0, 0, canvas.width, canvas.height)
+}
+
 const extractAnnotationSnapshots = async () => {
+  if (isCurrentPreviewPicture.value) return extractPicturePreviewSnapshots()
+  return extractVideoAnnotationSnapshots()
+}
+
+const snapshotFilename = ({ revision, frame, index } = {}) =>
+  buildAnnotationSnapshotFilename({
+    production: currentProduction.value?.name,
+    entity: task.value?.entity_name,
+    taskType: taskTypeMap.value.get(task.value?.task_type_id)?.name,
+    revision,
+    frame,
+    index
+  })
+
+// Video preview: one PNG per annotation, each captured at the
+// annotation's frame with its drawing composited on top.
+const extractVideoAnnotationSnapshots = async () => {
   const cur = currentFrame.value
   const sorted = annotations.value.sort((a, b) => a.time - b.time)
   const files = []
-  let index = 1
+  const revision = currentPreview.value?.revision
   for (const ann of sorted) {
     const canvas = document.getElementById('annotation-snapshot')
-    const filename = `annotation ${index}.png`
-    const f = roundToFrame(ann.time, fps.value) / frameDuration.value
-    await extractVideoFrame(canvas, f)
+    const frame = Math.round(
+      roundToFrame(ann.time, fps.value) / frameDuration.value
+    )
+    await extractVideoFrame(canvas, frame)
     await copyAnnotationCanvas(canvas, ann)
-    const file = await getFileFromCanvas(canvas, filename)
-    files.push(file)
-    index++
+    files.push(
+      await getFileFromCanvas(canvas, snapshotFilename({ revision, frame }))
+    )
   }
   rawPlayer.value.setCurrentFrame(cur - 1)
+  nextTick(() => clearCanvas())
+  return files
+}
+
+// Picture revisions can hold several preview files (main + extras).
+// Walk them all and emit one PNG per picture preview, with that
+// preview's annotations composited on top. Briefly switches the
+// displayed picture in order to reuse the live extract/composite
+// pipeline.
+const extractPicturePreviewSnapshots = async () => {
+  const entity = currentEntity.value
+  if (!entity) return []
+  const picturePreviews = [
+    {
+      id: entity.preview_file_id,
+      extension: entity.preview_file_extension,
+      revision: entity.preview_file_revision,
+      annotations: entity.preview_file_annotations || []
+    },
+    ...(entity.preview_file_previews || [])
+  ]
+    .map((preview, index) => ({ preview, index }))
+    .filter(({ preview }) => isPicturePreview(preview.extension))
+
+  const savedIndex = currentPreviewIndex.value
+  const files = []
+  let fileIndex = 1
+  for (const { preview, index } of picturePreviews) {
+    if (currentPreviewIndex.value !== index) {
+      currentPreviewIndex.value = index
+      await new Promise(resolve => setTimeout(resolve, 500))
+    }
+    const canvas = document.getElementById('annotation-snapshot')
+    extractPicture(canvas)
+    await compositeLiveAnnotationsOntoCanvas(canvas)
+    files.push(
+      await getFileFromCanvas(
+        canvas,
+        snapshotFilename({ revision: preview.revision, index: fileIndex })
+      )
+    )
+    fileIndex++
+  }
+  if (currentPreviewIndex.value !== savedIndex) {
+    currentPreviewIndex.value = savedIndex
+    await new Promise(resolve => setTimeout(resolve, 500))
+  }
   nextTick(() => clearCanvas())
   return files
 }

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -3703,10 +3703,6 @@ const onKeyDown = event => {
     } else {
       onNextFrameClicked()
     }
-  } else if (event.keyCode === 32) {
-    event.preventDefault()
-    event.stopPropagation()
-    onPlayPauseClicked()
   } else if (event.altKey && event.keyCode === 74) {
     event.preventDefault()
     event.stopPropagation()

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -2057,6 +2057,10 @@ defineExpose({
 
 .preview-player {
   background: $dark-grey-light;
+  // Container query anchor so child components (PlayerPlaybackBar etc.)
+  // can react to the player's own width rather than the viewport.
+  container-name: preview-player;
+  container-type: inline-size;
   display: flex;
   flex-direction: column;
   border-radius: 5px;

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -1667,6 +1667,11 @@ watch(current3DAnimation, () => {
 
 watch(currentPreview, () => {
   endAnnotationSaving()
+  // Wipe the fabric canvas before the new preview's annotations are
+  // re-loaded — otherwise switching between tasks (or between
+  // previews on the same task) leaves the previous task's strokes
+  // visible until the new video reaches frame 0.
+  clearCanvas()
   reloadAnnotations()
   isComparing.value = false
   if (isMovie.value) {
@@ -1902,6 +1907,7 @@ const playerApi = computed(() => ({
 // Expose
 
 defineExpose({
+  currentPreview,
   extractAnnotationSnapshots,
   setCurrentFrame,
   getCurrentFrame,
@@ -1909,6 +1915,7 @@ defineExpose({
   displayFirst,
   displayLast,
   focus,
+  notSaved,
   pause,
   play,
   reloadAnnotations,

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -415,6 +415,8 @@ import { getEntityPath } from '@/lib/path'
 import localPreferences from '@/lib/preferences'
 import {
   buildAnnotationSnapshotFilename,
+  buildAnnotationSnapshotTitle,
+  drawSnapshotTitle,
   isModelPreview,
   isMoviePreview,
   isPicturePreview,
@@ -1354,24 +1356,29 @@ const extractVideoFrame = (canvas, frame) => {
   })
 }
 
-const extractAnnotationSnapshots = async () => {
-  if (isPicture.value) return extractPicturePreviewSnapshots()
-  return extractVideoAnnotationSnapshots()
+const extractAnnotationSnapshots = async ({ withLabel = false } = {}) => {
+  if (isPicture.value) return extractPicturePreviewSnapshots({ withLabel })
+  return extractVideoAnnotationSnapshots({ withLabel })
 }
 
-const snapshotFilename = ({ revision, frame, index } = {}) =>
-  buildAnnotationSnapshotFilename({
-    production: currentProduction.value?.name,
-    entity: props.task?.entity_name,
-    taskType: props.taskTypeMap.get(props.task?.task_type_id)?.name,
-    revision,
-    frame,
-    index
-  })
+const snapshotIdentity = ({ revision, frame, index } = {}) => ({
+  production: currentProduction.value?.name,
+  entity: props.task?.entity_name,
+  taskType: props.taskTypeMap.get(props.task?.task_type_id)?.name,
+  revision,
+  frame,
+  index
+})
+
+const snapshotFilename = identity =>
+  buildAnnotationSnapshotFilename(snapshotIdentity(identity))
+
+const snapshotTitle = identity =>
+  buildAnnotationSnapshotTitle(snapshotIdentity(identity))
 
 // Video preview: one PNG per annotation, each captured at the
 // annotation's frame with its drawing composited on top.
-const extractVideoAnnotationSnapshots = async () => {
+const extractVideoAnnotationSnapshots = async ({ withLabel = false } = {}) => {
   const files = []
   const sortedAnnotations = annotations.value.sort((a, b) => {
     return parseInt(b.frame) < parseInt(a.frame) ? 1 : -1
@@ -1384,6 +1391,7 @@ const extractVideoAnnotationSnapshots = async () => {
     )
     await extractVideoFrame(canvas, frame)
     await copyAnnotationCanvas(canvas, annotation)
+    if (withLabel) drawSnapshotTitle(canvas, snapshotTitle({ revision, frame }))
     files.push(
       await getFileFromCanvas(canvas, snapshotFilename({ revision, frame }))
     )
@@ -1399,7 +1407,7 @@ const extractVideoAnnotationSnapshots = async () => {
 // emit one PNG per picture preview, with that preview's annotations
 // composited on top. Briefly switches the displayed preview file in
 // order to reuse the live extract/composite pipeline.
-const extractPicturePreviewSnapshots = async () => {
+const extractPicturePreviewSnapshots = async ({ withLabel = false } = {}) => {
   const savedIndex = currentIndex.value
   const picturePreviews = props.previews
     .map((preview, index) => ({ preview, index: index + 1 }))
@@ -1418,6 +1426,12 @@ const extractPicturePreviewSnapshots = async () => {
     const canvas = document.getElementById('annotation-snapshot')
     previewViewer.value.extractPicture(canvas)
     await compositeLiveAnnotationsOntoCanvas(canvas)
+    if (withLabel) {
+      drawSnapshotTitle(
+        canvas,
+        snapshotTitle({ revision: preview.revision, index })
+      )
+    }
     files.push(
       await getFileFromCanvas(
         canvas,

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -414,6 +414,7 @@ import { usePreviewShortcuts } from '@/composables/players/previewShortcuts'
 import { getEntityPath } from '@/lib/path'
 import localPreferences from '@/lib/preferences'
 import {
+  buildAnnotationSnapshotFilename,
   isModelPreview,
   isMoviePreview,
   isPicturePreview,
@@ -657,6 +658,7 @@ const {
   clearComparisonCanvas,
   copyAnnotations,
   copyAnnotationCanvas,
+  compositeLiveAnnotationsOntoCanvas,
   pasteAnnotations,
   setAnnotationDrawingMode,
   setShapeTool,
@@ -1353,25 +1355,81 @@ const extractVideoFrame = (canvas, frame) => {
 }
 
 const extractAnnotationSnapshots = async () => {
+  if (isPicture.value) return extractPicturePreviewSnapshots()
+  return extractVideoAnnotationSnapshots()
+}
+
+const snapshotFilename = ({ revision, frame, index } = {}) =>
+  buildAnnotationSnapshotFilename({
+    production: currentProduction.value?.name,
+    entity: props.task?.entity_name,
+    taskType: props.taskTypeMap.get(props.task?.task_type_id)?.name,
+    revision,
+    frame,
+    index
+  })
+
+// Video preview: one PNG per annotation, each captured at the
+// annotation's frame with its drawing composited on top.
+const extractVideoAnnotationSnapshots = async () => {
   const files = []
   const sortedAnnotations = annotations.value.sort((a, b) => {
     return parseInt(b.frame) < parseInt(a.frame) ? 1 : -1
   })
-  let index = 1
+  const revision = currentPreview.value?.revision
   for (const annotation of sortedAnnotations) {
     const canvas = document.getElementById('annotation-snapshot')
-    const filename = `annotation ${index}.png`
-    const frame = roundToFrame(annotation.time, fps.value) / frameDuration.value
+    const frame = Math.round(
+      roundToFrame(annotation.time, fps.value) / frameDuration.value
+    )
     await extractVideoFrame(canvas, frame)
     await copyAnnotationCanvas(canvas, annotation)
-    const file = await getFileFromCanvas(canvas, filename)
-    files.push(file)
-    index++
+    files.push(
+      await getFileFromCanvas(canvas, snapshotFilename({ revision, frame }))
+    )
   }
   previewViewer.value.setCurrentFrame(currentFrame.value - 1)
   nextTick(() => {
     clearCanvas()
   })
+  return files
+}
+
+// Picture revisions can hold several preview files. Walk them all and
+// emit one PNG per picture preview, with that preview's annotations
+// composited on top. Briefly switches the displayed preview file in
+// order to reuse the live extract/composite pipeline.
+const extractPicturePreviewSnapshots = async () => {
+  const savedIndex = currentIndex.value
+  const picturePreviews = props.previews
+    .map((preview, index) => ({ preview, index: index + 1 }))
+    .filter(({ preview }) => isPicturePreview(preview.extension))
+
+  const files = []
+  for (const { preview, index } of picturePreviews) {
+    if (currentIndex.value !== index) {
+      currentIndex.value = index
+      // Wait for the picture to swap and annotations to reload. The
+      // chain is async (image load -> resetPlayerPositions ->
+      // AnnotationCanvas resized -> reloadAnnotations) so a single tick
+      // isn't enough.
+      await new Promise(resolve => setTimeout(resolve, 500))
+    }
+    const canvas = document.getElementById('annotation-snapshot')
+    previewViewer.value.extractPicture(canvas)
+    await compositeLiveAnnotationsOntoCanvas(canvas)
+    files.push(
+      await getFileFromCanvas(
+        canvas,
+        snapshotFilename({ revision: preview.revision, index })
+      )
+    )
+  }
+  if (currentIndex.value !== savedIndex) {
+    currentIndex.value = savedIndex
+    await new Promise(resolve => setTimeout(resolve, 500))
+  }
+  nextTick(() => clearCanvas())
   return files
 }
 

--- a/src/components/players/viewers/PreviewViewer.vue
+++ b/src/components/players/viewers/PreviewViewer.vue
@@ -417,6 +417,18 @@ const extractFrame = (canvas, frame) => {
   context.drawImage(video, 0, 0, canvas.width, canvas.height)
 }
 
+const extractPicture = canvas => {
+  if (!pictureViewer.value) return
+  const image = pictureViewer.value.getPictureElement()
+  if (!image) return
+  const context = canvas.getContext('2d')
+  const { width, height } = pictureViewer.value.getNaturalDimensions()
+  canvas.width = width
+  canvas.height = height
+  context.clearRect(0, 0, canvas.width, canvas.height)
+  context.drawImage(image, 0, 0, canvas.width, canvas.height)
+}
+
 const resetZoom = () => {
   if (pictureViewer.value) pictureViewer.value.resetPanZoom()
   if (videoViewer.value) videoViewer.value.resetPanZoom()
@@ -481,6 +493,7 @@ defineExpose({
   setCurrentTimeRaw: setCurrentTimeRawValue,
   getCurrentTimeRaw,
   extractFrame,
+  extractPicture,
   resetZoom,
   setPanZoom,
   pauseZoom,

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -194,6 +194,9 @@
                   @clear-files="clearPreviewFiles"
                   @remove-preview="onPreviewFormRemoved"
                   @annotation-snapshots-requested="extractAnnotationSnapshots"
+                  @annotation-snapshots-with-label-requested="
+                    () => extractAnnotationSnapshots(true)
+                  "
                   v-if="isCommentingAllowed"
                 />
 
@@ -1422,11 +1425,15 @@ export default {
       this.currentFrameRaw = frame
     },
 
-    async extractAnnotationSnapshots() {
+    async extractAnnotationSnapshots(withLabel = false) {
       let previewPlayer = this.$refs['preview-player']
       if (!previewPlayer) previewPlayer = this.player
-      this.$refs['add-comment'].showAnnotationLoading()
-      const files = await previewPlayer.extractAnnotationSnapshots()
+      this.$refs['add-comment'].showAnnotationLoading(
+        withLabel ? 'label' : 'standard'
+      )
+      const files = await previewPlayer.extractAnnotationSnapshots({
+        withLabel
+      })
       this.$refs['add-comment'].hideAnnotationLoading()
       this.$refs['add-comment'].setAnnotationSnapshots(files)
       return files

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -187,6 +187,7 @@
                   :frame="currentFrame || currentFrameRaw"
                   :revision="currentRevision"
                   :is-movie="isMoviePreview"
+                  :is-picture="isPicturePreview"
                   @add-comment="addComment"
                   @add-preview="onAddPreviewClicked"
                   @file-drop="selectFile"

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -70,7 +70,7 @@
             thin
             :title="$t('main.export')"
             :actions="exportActions"
-            v-if="exportActions.length > 0"
+            v-if="inPlaylist && exportActions.length > 0"
           />
         </div>
 
@@ -439,6 +439,10 @@ export default {
     extendable: {
       type: Boolean,
       default: true
+    },
+    inPlaylist: {
+      type: Boolean,
+      default: false
     },
     isLoading: {
       type: Boolean,

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -209,14 +209,25 @@
         <div class="attachment-title" v-if="attachments.length > 0">
           {{ $t('comments.attachments') }}
         </div>
-        <div
+        <template
           :key="'attachment-' + index"
-          class="attachment-file"
-          v-for="(attach, index) in attachments"
+          v-for="(attach, index) in sortedAttachments"
         >
-          {{ shortenText(attach.get('file').name, 40) }}
-          <span @click="removeAttachment(attach)">x</span>
-        </div>
+          <div
+            class="attachment-image"
+            :title="attach.get('file').name"
+            v-if="isImageAttachment(attach)"
+          >
+            <img :src="attachmentURL(attach)" :alt="attach.get('file').name" />
+            <span class="attachment-remove" @click="removeAttachment(attach)">
+              x
+            </span>
+          </div>
+          <div class="attachment-file" :title="attach.get('file').name" v-else>
+            {{ shortenText(attach.get('file').name, 70) }}
+            <span @click="removeAttachment(attach)">x</span>
+          </div>
+        </template>
 
         <div class="flexrow button-row mt1">
           <emoji-button @select="onSelectEmoji" v-if="mode === 'status'" />
@@ -509,6 +520,20 @@ const attachments = computed({
   set: value => {
     draftComment.attachments = value
   }
+})
+
+const isImageAttachment = form => form.get('file').type.startsWith('image')
+
+const attachmentURL = form => URL.createObjectURL(form.get('file'))
+
+// Show non-image attachments first, image thumbnails last, so the
+// preview wall doesn't push lighter rows out of sight.
+const sortedAttachments = computed(() => {
+  const list = attachments.value || []
+  return [
+    ...list.filter(form => !isImageAttachment(form)),
+    ...list.filter(form => isImageAttachment(form))
+  ]
 })
 
 const checklistItems = computed({
@@ -1114,6 +1139,37 @@ article.add-comment {
   span {
     cursor: pointer;
     float: right;
+  }
+}
+
+.attachment-image {
+  display: inline-block;
+  margin: 3px;
+  position: relative;
+  vertical-align: top;
+
+  img {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    display: block;
+    max-height: 80px;
+    max-width: 120px;
+    object-fit: cover;
+  }
+
+  .attachment-remove {
+    background: rgba(0, 0, 0, 0.6);
+    border-radius: 50%;
+    color: white;
+    cursor: pointer;
+    font-size: 0.8em;
+    height: 18px;
+    line-height: 18px;
+    position: absolute;
+    right: 2px;
+    text-align: center;
+    top: 2px;
+    width: 18px;
   }
 }
 

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -328,6 +328,7 @@
       :is-loading="loading.addCommentAttachment"
       :is-error="errors.addCommentAttachment"
       :is-movie="isMovie"
+      :is-picture="isPicture"
       :title="`${task.entity_name} / ${
         taskTypeMap.get(task.task_type_id).name
       }`"
@@ -410,6 +411,10 @@ const props = defineProps({
     default: null
   },
   isMovie: {
+    type: Boolean,
+    default: false
+  },
+  isPicture: {
     type: Boolean,
     default: false
   },

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -346,6 +346,9 @@
       @cancel="onCloseCommentAttachment"
       @confirm="addCommentAttachment"
       @add-snapshots="$emit('annotation-snapshots-requested')"
+      @add-snapshots-with-label="
+        $emit('annotation-snapshots-with-label-requested')
+      "
     />
     <confirm-modal
       :active="modals.confirmFeedbackPublish"
@@ -471,6 +474,7 @@ const emit = defineEmits([
   'add-comment',
   'add-preview',
   'annotation-snapshots-requested',
+  'annotation-snapshots-with-label-requested',
   'clear-files',
   'file-drop',
   'remove-preview'
@@ -869,8 +873,8 @@ const setAnnotationSnapshots = files => {
   getAttachmentModal().addFiles(files)
 }
 
-const showAnnotationLoading = () => {
-  getAttachmentModal().showAnnotationLoading()
+const showAnnotationLoading = (kind = 'standard') => {
+  getAttachmentModal().showAnnotationLoading(kind)
 }
 
 const hideAnnotationLoading = () => {

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -1296,37 +1296,20 @@ export const useAnnotation = ({
   }
 
   // Render whatever is currently on the live fabric canvas onto the
-  // target canvas, scaling strokes to match the target dimensions.
-  // Destructive: the objects are moved out of the live canvas (callers
-  // who need the live canvas restored afterwards should reload it).
+  // target canvas. Non-destructive: it draws the live canvas's pixels
+  // straight onto the target (scaled to fit), so objects stay on the
+  // live canvas — no per-object moves and no fabric "object belongs to
+  // a different canvas" warnings.
   const compositeLiveAnnotationsOntoCanvas = canvas => {
     return new Promise(resolve => {
+      const live = fabricCanvas.value
+      if (!live) return resolve()
+      live.renderAll()
+      const source = live.lowerCanvasEl
+      if (!source) return resolve()
       const context = canvas.getContext('2d')
-      const scaleRatio = canvas.width / fabricCanvas.value.width
-      const tmpSource = document.getElementById('resize-annotation-canvas')
-      const tmpCanvas = new fabric.Canvas('resize-annotation-canvas', {
-        width: canvas.width,
-        height: canvas.height
-      })
-      fabricCanvas.value.getObjects().forEach(obj => {
-        if (obj._objects) {
-          obj._objects.forEach(obj => {
-            tmpCanvas.add(obj)
-            obj.strokeWidth = obj.strokeWidth / scaleRatio
-          })
-        } else {
-          tmpCanvas.add(obj)
-          obj.strokeWidth = obj.strokeWidth / scaleRatio
-        }
-      })
-      tmpCanvas.setZoom(scaleRatio)
-      setTimeout(() => {
-        context.drawImage(tmpSource, 0, 0, canvas.width, canvas.height)
-        setTimeout(() => {
-          tmpCanvas.dispose()
-        }, 100)
-        return resolve()
-      }, 100)
+      context.drawImage(source, 0, 0, canvas.width, canvas.height)
+      resolve()
     })
   }
 

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -18,6 +18,12 @@ import clipboard from '@/lib/clipboard'
 import { formatFullDate } from '@/lib/time'
 import localPreferences from '@/lib/preferences'
 
+/* Force scaling / rotation handles to show on grouped selections so a
+ * marquee around several annotations stays scalable / rotatable. */
+if (fabric) {
+  fabric.Group.prototype.hasControls = true
+}
+
 /* Monkey patch needed to have text background including the padding. */
 if (fabric) {
   fabric.Text.prototype.set({
@@ -131,8 +137,6 @@ export const useAnnotation = ({
   const additions = ref([])
   const deletions = ref([])
   const updates = ref([])
-  const isShowingPalette = ref(false)
-  const isShowingPencilPalette = ref(false)
   const notSaved = ref(false)
   const pencilColor = ref('#ff3860')
   const pencilWidth = ref('big')
@@ -193,15 +197,23 @@ export const useAnnotation = ({
   }
 
   const setObjectData = object => {
+    // canvasWidth / canvasHeight are the dimensions the object's left /
+    // top were authored against — never refresh them, or a later save
+    // will pair the old coords with the new (resized) canvas and the
+    // re-loaded annotation will drift on the Y axis.
     if (object.set) {
       if (!object.id) object.set('id', uuidv4())
-      object.set('canvasWidth', fabricCanvas.value.width)
-      object.set('canvasHeight', fabricCanvas.value.height)
+      if (!object.canvasWidth) {
+        object.set('canvasWidth', fabricCanvas.value.width)
+      }
+      if (!object.canvasHeight) {
+        object.set('canvasHeight', fabricCanvas.value.height)
+      }
       if (!object.createdBy) object.set('createdBy', userId.value)
     } else {
       if (!object.id) object.id = uuidv4()
-      object.canvasWidth = fabricCanvas.value.width
-      object.canvasHeight = fabricCanvas.value.height
+      if (!object.canvasWidth) object.canvasWidth = fabricCanvas.value.width
+      if (!object.canvasHeight) object.canvasHeight = fabricCanvas.value.height
       if (!object.createdBy) object.createdBy = userId.value
     }
     addSerialization(object)
@@ -703,35 +715,20 @@ export const useAnnotation = ({
 
   // Events
 
-  const onPickPencilWidth = () => {
-    isShowingPencilPalette.value = !isShowingPencilPalette.value
-  }
-
-  const onPickPencilColor = () => {
-    isShowingPalette.value = !isShowingPalette.value
-  }
-
-  const onPickTextColor = () => {
-    isShowingPalette.value = !isShowingPalette.value
-  }
-
   const onChangePencilColor = color => {
     pencilColor.value = color
     _resetColor()
-    isShowingPalette.value = false
     localPreferences.setPreference('player:pencil-color', pencilColor.value)
   }
 
   const onChangePencilWidth = pencil => {
     pencilWidth.value = pencil
     _resetPencil()
-    isShowingPalette.value = false
     localPreferences.setPreference('player:pencil-width', pencilWidth.value)
   }
 
   const onChangeTextColor = newValue => {
     textColor.value = newValue
-    isShowingPalette.value = false
     localPreferences.setPreference('player:text-color', textColor.value)
   }
 
@@ -839,9 +836,6 @@ export const useAnnotation = ({
 
   const stackAddAction = ({ target }) => {
     doneActionStack.push({ type: 'add', obj: target })
-    target.lockScalingX = true
-    target.lockScalingY = true
-    target.rotation = true
   }
 
   // After a canvas reload (e.g. Esc-exit fullscreen) the stack entry
@@ -961,20 +955,16 @@ export const useAnnotation = ({
     fabricCanvas.value.off('text:changed', onObjectModified)
     fabricCanvas.value.off('object:modified', onObjectModified)
     fabricCanvas.value.off('object:added', onObjectAdded)
-    fabricCanvas.value.off('mouse:down', onCanvasClickedInternal)
     fabricCanvas.value.off('mouse:down', initializeMouseDrawing)
     fabricCanvas.value.off('mouse:move', onCanvasMouseMovedCb)
     fabricCanvas.value.off('mouse:move', updateMousePressure)
     fabricCanvas.value.off('mouse:up', endDrawing)
     fabricCanvas.value.off('mouse:up', onCanvasReleasedCb)
-    fabricCanvas.value.off('mouse:move', onCanvasMouseMovedCb)
-    fabricCanvas.value.off('mouse:down', onCanvasClickedInternal)
     fabricCanvas.value.on('object:moved', onObjectModified)
     fabricCanvas.value.on('object:modified', onObjectModified)
     fabricCanvas.value.on('text:changed', onObjectModified)
     fabricCanvas.value.on('object:added', onObjectAdded)
     fabricCanvas.value.on('erasing:end', onObjectAdded)
-    fabricCanvas.value.on('mouse:down', onCanvasClickedInternal)
     fabricCanvas.value.on('mouse:down', initializeMouseDrawing)
     fabricCanvas.value.on('mouse:move', onCanvasMouseMovedCb)
     fabricCanvas.value.on('mouse:move', updateMousePressure)
@@ -1042,13 +1032,7 @@ export const useAnnotation = ({
       mb: false,
       mt: false
     }
-    fabric.Group.prototype.hasControls = true
     return fabricCanvas.value
-  }
-
-  const onCanvasClickedInternal = event => {
-    // This is the canvas click handler registered on the fabric canvas
-    // Different from the template @click handler
   }
 
   // Mouse pressure
@@ -1420,8 +1404,6 @@ export const useAnnotation = ({
     additions,
     deletions,
     updates,
-    isShowingPalette,
-    isShowingPencilPalette,
     notSaved,
     pencilColor,
     pencilWidth,
@@ -1462,9 +1444,6 @@ export const useAnnotation = ({
     addObjectToCanvas,
 
     // Events
-    onPickPencilWidth,
-    onPickPencilColor,
-    onPickTextColor,
     onChangePencilColor,
     onChangePencilWidth,
     onChangeTextColor,

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -1311,37 +1311,50 @@ export const useAnnotation = ({
     }, 5000)
   }
 
+  // Render whatever is currently on the live fabric canvas onto the
+  // target canvas, scaling strokes to match the target dimensions.
+  // Destructive: the objects are moved out of the live canvas (callers
+  // who need the live canvas restored afterwards should reload it).
+  const compositeLiveAnnotationsOntoCanvas = canvas => {
+    return new Promise(resolve => {
+      const context = canvas.getContext('2d')
+      const scaleRatio = canvas.width / fabricCanvas.value.width
+      const tmpSource = document.getElementById('resize-annotation-canvas')
+      const tmpCanvas = new fabric.Canvas('resize-annotation-canvas', {
+        width: canvas.width,
+        height: canvas.height
+      })
+      fabricCanvas.value.getObjects().forEach(obj => {
+        if (obj._objects) {
+          obj._objects.forEach(obj => {
+            tmpCanvas.add(obj)
+            obj.strokeWidth = obj.strokeWidth / scaleRatio
+          })
+        } else {
+          tmpCanvas.add(obj)
+          obj.strokeWidth = obj.strokeWidth / scaleRatio
+        }
+      })
+      tmpCanvas.setZoom(scaleRatio)
+      setTimeout(() => {
+        context.drawImage(tmpSource, 0, 0, canvas.width, canvas.height)
+        setTimeout(() => {
+          tmpCanvas.dispose()
+        }, 100)
+        return resolve()
+      }, 100)
+    })
+  }
+
+  // Per-annotation composite for video: clear and reload only the
+  // requested annotation onto the live canvas before compositing, so a
+  // caller iterating frame-by-frame gets one PNG per annotation.
   const copyAnnotationCanvas = (canvas, annotation) => {
     return new Promise(resolve => {
       clearCanvas()
       loadSingleAnnotation(annotation)
       setTimeout(() => {
-        const context = canvas.getContext('2d')
-        const scaleRatio = canvas.width / fabricCanvas.value.width
-        const tmpSource = document.getElementById('resize-annotation-canvas')
-        const tmpCanvas = new fabric.Canvas('resize-annotation-canvas', {
-          width: canvas.width,
-          height: canvas.height
-        })
-        fabricCanvas.value.getObjects().forEach(obj => {
-          if (obj._objects) {
-            obj._objects.forEach(obj => {
-              tmpCanvas.add(obj)
-              obj.strokeWidth = obj.strokeWidth / scaleRatio
-            })
-          } else {
-            tmpCanvas.add(obj)
-            obj.strokeWidth = obj.strokeWidth / scaleRatio
-          }
-        })
-        tmpCanvas.setZoom(scaleRatio)
-        setTimeout(() => {
-          context.drawImage(tmpSource, 0, 0, canvas.width, canvas.height)
-          setTimeout(() => {
-            tmpCanvas.dispose()
-          }, 100)
-          return resolve()
-        }, 100)
+        compositeLiveAnnotationsOntoCanvas(canvas).then(resolve)
       }, 100)
     })
   }
@@ -1506,6 +1519,7 @@ export const useAnnotation = ({
     confirmAnnotationsSaved,
     restoreFailedAnnotations,
     copyAnnotationCanvas,
+    compositeLiveAnnotationsOntoCanvas,
 
     // Setter for component-specific callbacks
     setCurrentPreviewGetter

--- a/src/lib/preview.js
+++ b/src/lib/preview.js
@@ -32,3 +32,34 @@ export const isFilePreview = extension =>
   !isPdfPreview(extension) &&
   !isMarkdownPreview(extension) &&
   !isDiffPreview(extension)
+
+// Build the .png filename for an exported annotation snapshot from a
+// task context. Sanitises each part so it's safe across filesystems,
+// lowercases the result and joins parts with underscores:
+//   `productionname_fullentityname_tasktypename_v{revision}_annotation[_{frame|index}].png`
+// Pass `frame` for video snapshots and `index` for picture batches
+// that need disambiguation.
+export const buildAnnotationSnapshotFilename = ({
+  production,
+  entity,
+  taskType,
+  revision,
+  frame,
+  index
+}) => {
+  const sanitize = part =>
+    String(part || '')
+      .replace(/[\s/\\:?<>|"*]+/g, '_')
+      .replace(/_+/g, '_')
+      .replace(/^_|_$/g, '')
+  const suffix = frame != null ? Math.round(frame) : index
+  const parts = [
+    sanitize(production),
+    sanitize(entity),
+    sanitize(taskType),
+    revision != null && revision !== '' ? `v${revision}` : '',
+    'annotation',
+    suffix != null ? String(suffix) : ''
+  ].filter(Boolean)
+  return `${parts.join('_')}.png`.toLowerCase()
+}

--- a/src/lib/preview.js
+++ b/src/lib/preview.js
@@ -63,3 +63,46 @@ export const buildAnnotationSnapshotFilename = ({
   ].filter(Boolean)
   return `${parts.join('_')}.png`.toLowerCase()
 }
+
+// Human-readable label burned into the PNG so it identifies its
+// source when viewed in isolation. Parts are kept verbatim and joined
+// with slashes for a compact "breadcrumb" look.
+export const buildAnnotationSnapshotTitle = ({
+  production,
+  entity,
+  taskType,
+  revision,
+  frame,
+  index
+}) => {
+  const suffix =
+    frame != null ? `#${Math.round(frame)}` : index != null ? `#${index}` : null
+  const parts = [
+    production,
+    entity,
+    taskType,
+    revision != null && revision !== '' ? `v${revision}` : null,
+    suffix
+  ].filter(part => part != null && String(part).length > 0)
+  return parts.join(' / ')
+}
+
+// Burn a one-line title strip into the bottom of a 2D canvas so the
+// resulting PNG still identifies its source when viewed in isolation.
+// Full-width semi-opaque black band with the text in white, sized
+// relative to the canvas so it stays readable at any resolution.
+export const drawSnapshotTitle = (canvas, text) => {
+  if (!text) return
+  const context = canvas.getContext('2d')
+  const fontSize = Math.max(14, Math.round(canvas.height * 0.025))
+  const padding = Math.round(fontSize * 0.6)
+  const stripHeight = fontSize + padding * 2
+  context.save()
+  context.fillStyle = 'rgba(0, 0, 0, 0.6)'
+  context.fillRect(0, canvas.height - stripHeight, canvas.width, stripHeight)
+  context.fillStyle = '#ffffff'
+  context.textBaseline = 'middle'
+  context.font = `${fontSize}px sans-serif`
+  context.fillText(text, padding, canvas.height - stripHeight / 2)
+  context.restore()
+}

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -727,6 +727,7 @@ export default {
     apply: 'Apply',
     archived: 'Archived',
     attach_snapshots: 'Attach snapshots from your annotation',
+    attach_snapshots_with_label: 'Attach snapshots with a label burned in',
     avatar: {
       open_page: 'Open {personName} page',
       unassign: 'Unassign {personName}'

--- a/tests/unit/composables/annotation.spec.js
+++ b/tests/unit/composables/annotation.spec.js
@@ -404,60 +404,27 @@ describe('composables/annotation', () => {
     })
   })
 
-  describe('palette toggles', () => {
-    it('onPickPencilWidth toggles the pencil palette flag', () => {
-      const { api, wrapper } = mountAnnotation()
-      expect(api.isShowingPencilPalette.value).toBe(false)
-      api.onPickPencilWidth()
-      expect(api.isShowingPencilPalette.value).toBe(true)
-      api.onPickPencilWidth()
-      expect(api.isShowingPencilPalette.value).toBe(false)
-      wrapper.unmount()
-    })
-
-    it('onPickPencilColor toggles the palette flag', () => {
-      const { api, wrapper } = mountAnnotation()
-      expect(api.isShowingPalette.value).toBe(false)
-      api.onPickPencilColor()
-      expect(api.isShowingPalette.value).toBe(true)
-      wrapper.unmount()
-    })
-
-    it('onPickTextColor toggles the palette flag', () => {
-      const { api, wrapper } = mountAnnotation()
-      api.onPickTextColor()
-      expect(api.isShowingPalette.value).toBe(true)
-      wrapper.unmount()
-    })
-  })
-
   describe('color and pencil changes', () => {
-    it('onChangePencilColor updates the color and closes the palette', () => {
+    it('onChangePencilColor updates the color', () => {
       const { api, canvas, wrapper } = mountAnnotation()
-      api.isShowingPalette.value = true
       api.onChangePencilColor('#00ff00')
       expect(api.pencilColor.value).toBe('#00ff00')
-      expect(api.isShowingPalette.value).toBe(false)
       expect(canvas.freeDrawingBrush.color).toBe('#00ff00')
       wrapper.unmount()
     })
 
-    it('onChangePencilWidth updates the width and closes the palette', () => {
+    it('onChangePencilWidth updates the width', () => {
       const { api, canvas, wrapper } = mountAnnotation()
-      api.isShowingPalette.value = true
       api.onChangePencilWidth('small')
       expect(api.pencilWidth.value).toBe('small')
-      expect(api.isShowingPalette.value).toBe(false)
       expect(canvas.freeDrawingBrush.width).toBe(2)
       wrapper.unmount()
     })
 
-    it('onChangeTextColor updates the text color and closes the palette', () => {
+    it('onChangeTextColor updates the text color', () => {
       const { api, wrapper } = mountAnnotation()
-      api.isShowingPalette.value = true
       api.onChangeTextColor('#0000ff')
       expect(api.textColor.value).toBe('#0000ff')
-      expect(api.isShowingPalette.value).toBe(false)
       wrapper.unmount()
     })
   })


### PR DESCRIPTION
## Problems

- Annotation snapshots only worked for videos, not picture revisions; exported files had unhelpful names and no source label
- TaskInfo export combobox showed outside playlists; PlaylistPlayer spacebar toggled play+pause twice
- Annotations clipped at the un-zoomed media bounds when zooming; a fresh stroke couldn't be scaled without a reload
- Task.vue's socket handler threw (PreviewPlayer no longer exposed currentPreview / notSaved); switching tasks kept the old strokes on screen
- compositeLiveAnnotationsOntoCanvas spammed fabric warnings; useAnnotation carried dead code
- Attachment modal upload control was visually inconsistent

## Solutions

- Support picture revisions in the snapshot export (one PNG per preview) + named files + an optional "with label" action that burns a breadcrumb onto the PNG
- Gate the export combobox behind an inPlaylist prop; drop the duplicate spacebar handler
- Delegate clipping to the player's outer container; stop locking scaling on new objects; refresh fabric's offset after re-anchor
- Expose currentPreview / notSaved and clear the canvas on task switch
- Composite via a direct drawImage; remove dead palette/handler code and hoist the fabric.Group patch
- Redesign the attachment modal (dropzone, stacked snapshot buttons, thumbnail attachments) and hide the timecode on narrow PreviewPlayer