### PR TITLE
[players] Fix annotation alignment, sync and comparison rendering

### DIFF
--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -2416,9 +2416,16 @@ const onFrameUpdate = frame => {
       }
     }
   }
-  if (isCurrentPreviewMovie.value && wavesurfer && isWaveformDisplayed.value) {
-    const position = currentTimeRaw.value / maxDurationRaw.value
-    wavesurfer.seekTo(position)
+  if (
+    isCurrentPreviewMovie.value &&
+    wavesurfer &&
+    isWaveformDisplayed.value &&
+    maxDurationRaw.value > 0
+  ) {
+    // Guard the divisor: while a playlist reset is in flight the next
+    // media's duration isn't known yet (maxDurationRaw is 0), and seeking
+    // to a non-finite position throws in WaveSurfer's currentTime setter.
+    wavesurfer.seekTo(currentTimeRaw.value / maxDurationRaw.value)
   }
   nextTick(() => {
     const actions = onNextTimeUpdateActions.value

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -979,6 +979,7 @@ const props = defineProps({
 // Emits
 
 const emit = defineEmits([
+  'annotation-changed',
   'edit-clicked',
   'entity-to-add',
   'new-entity-dropped',
@@ -3777,11 +3778,15 @@ const onPreviewFileAnnotationUpdate = eventData => {
         currentPreview.value?.id === eventData.preview_file_id &&
         !isWriting(eventData.updated_at)
       ) {
-        const isAnnotationSizeChanged =
-          annotations.value.length !== preview.annotations.length
         annotations.value = preview.annotations
+        // Reload on every update, not only when the number of annotated frames
+        // changes: adding or moving a stroke on a frame that is already
+        // annotated leaves the entry count unchanged, so gating on it dropped
+        // those updates outside a review room (the "syncs once then stops"
+        // bug). In a live room the boolean skips the canvas reload — the live
+        // broadcast already painted it.
         const isLiveRoom = !room.value?.people?.length
-        if (isAnnotationSizeChanged) reloadAnnotations(isLiveRoom)
+        reloadAnnotations(isLiveRoom)
       }
     })
 }

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -421,10 +421,10 @@
     <div
       id="sound-container"
       :style="{
-        height: isWaveformDisplayed ? '60px' : '0px',
+        height: isWaveformDisplayed && isCurrentPreviewMovie ? '60px' : '0px',
         width: '100%'
       }"
-      v-show="isWaveformDisplayed"
+      v-show="isWaveformDisplayed && isCurrentPreviewMovie"
     >
       <div id="waveform"></div>
     </div>
@@ -3196,7 +3196,7 @@ const resetHeight = () => {
     if (playlistProgressRef.value?.$el) {
       height -= playlistProgressRef.value.$el.offsetHeight
     }
-    if (isWaveformDisplayed.value) height -= 60
+    if (isWaveformDisplayed.value && isCurrentPreviewMovie.value) height -= 60
 
     if (videoContainer.value) videoContainer.value.style.height = `${height}px`
     if (taskInfoRef.value?.$el && !isCommentsHidden.value) {

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -1747,7 +1747,7 @@ watch(previewToCompareId, () => {
     if (comparisonViewer.value) comparisonViewer.value.pause()
     previewToCompare.value = resolvePreviewToCompare(previewToCompareId.value)
     if (isComparing.value) {
-      setCurrentFrame(currentFrame.value - 1)
+      syncComparisonViewer()
       setTimeout(() => {
         syncComparisonViewer()
       }, SYNC_DELAY)

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -33,6 +33,7 @@
               !isComparisonOverlay
             "
             @click="onCanvasClicked"
+            @resized="onComparisonCanvasResized"
           />
           <div class="viewers">
             <preview-viewer
@@ -87,7 +88,7 @@
               :style="{
                 opacity: overlayOpacity
               }"
-              @video-loaded="syncComparisonViewer"
+              @video-loaded="onComparisonVideoLoaded"
               v-show="isComparing && previewToCompare"
             />
           </div>
@@ -1036,6 +1037,38 @@ const syncComparisonViewer = () => {
   }
 }
 
+const loadComparisonAnnotationAtCurrentFrame = () => {
+  if (!isComparing.value || isComparisonOverlay.value) return
+  if (isMovie.value) {
+    loadComparisonAnnotation(currentFrame.value * frameDuration.value)
+  } else if (isPicture.value) {
+    loadComparisonAnnotation(0)
+  }
+}
+
+const realignComparisonCanvas = () => {
+  previewViewer.value?.resize()
+  comparisonViewer.value?.resize()
+  comparisonAnnotationCanvas.value?.updateBounds()
+  loadComparisonAnnotationAtCurrentFrame()
+}
+
+const onComparisonVideoLoaded = () => {
+  syncComparisonViewer()
+  // The comparison canvas position and size are derived from the
+  // comparison media element's on-screen rect, which is only final once
+  // the 0.3s side-by-side layout transition has settled — and the
+  // comparison viewer's left edge depends on the main viewer's width.
+  // Draw once after RESIZE_DELAY rather than on nextTick: painting before
+  // the transition settles places the annotation at a mid-transition
+  // position, so it visibly jumps when corrected.
+  setTimeout(realignComparisonCanvas, RESIZE_DELAY)
+}
+
+const onComparisonCanvasResized = () => {
+  loadComparisonAnnotationAtCurrentFrame()
+}
+
 const onProgressChanged = frame => {
   reloadAnnotations()
   if (currentFrame.value !== frame) {
@@ -1752,9 +1785,7 @@ watch(previewToCompareId, () => {
         syncComparisonViewer()
       }, SYNC_DELAY)
       pause()
-      if (isMovie.value) {
-        loadComparisonAnnotation(currentTime.value)
-      } else if (isPicture.value) {
+      if (isPicture.value) {
         loadComparisonAnnotation(0)
       }
     }

--- a/src/components/players/viewers/SoundViewer.vue
+++ b/src/components/players/viewers/SoundViewer.vue
@@ -12,7 +12,7 @@
     <div class="file-name" v-show="!isLoading">
       {{ fileName }}
     </div>
-    <div id="waveform"></div>
+    <div ref="waveform" class="waveform"></div>
   </div>
 </template>
 
@@ -39,6 +39,10 @@ const props = defineProps({
 
 const emit = defineEmits(['play-ended'])
 
+// A template ref, not a global '#waveform' id: PreviewPlayer mounts a
+// main and a comparison PreviewViewer, each with its own SoundViewer, so
+// an id selector would bind every WaveSurfer instance to the first match.
+const waveform = ref(null)
 const isLoading = ref(false)
 let wavesurfer = null
 
@@ -53,7 +57,7 @@ const pause = () => {
 onMounted(() => {
   isLoading.value = true
   wavesurfer = WaveSurfer.create({
-    container: '#waveform',
+    container: waveform.value,
     waveColor: '#00B242',
     progressColor: '#008732',
     height: props.defaultHeight
@@ -103,7 +107,7 @@ defineExpose({ play, pause })
   color: white;
 }
 
-#waveform {
+.waveform {
   flex: 1;
   margin: auto;
 }

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1741,8 +1741,14 @@ export default {
           }).then(() => {
             if (!previewPlayer.notSaved) {
               this.taskPreviews = this.getTaskPreviews(this.task.id)
-              previewPlayer.reloadAnnotations()
-              previewPlayer.loadAnnotation()
+              // Wait for the refreshed previews prop to propagate to the
+              // player before reloading — otherwise reloadAnnotations
+              // reads the stale currentPreview and the remote drawing
+              // never shows up outside a review room.
+              this.$nextTick(() => {
+                previewPlayer.reloadAnnotations()
+                previewPlayer.loadAnnotation()
+              })
             }
           })
         }

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -1211,8 +1211,14 @@ export const useAnnotation = ({
 
   // Saving
 
+  // Guards against a freshly-saved annotation being immediately reloaded by
+  // the socket echo of our own save (which would clear + reload the canvas and
+  // drop strokes drawn since). isWriting() compares this against the event's
+  // UTC updated_at, so it must be UTC too — the previous `moment().add(2,'h')`
+  // only landed on UTC by accident in a UTC+2 zone, and elsewhere it either
+  // blocked remote updates for ~2h or never guarded at all.
   const markLastAnnotationTime = () => {
-    const time = moment().add(2, 'hour').add(6, 'seconds')
+    const time = moment.utc().add(6, 'seconds')
     lastAnnotationTime.value = formatFullDate(time).replace(' ', 'T')
   }
 

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -735,11 +735,11 @@ export const useAnnotation = ({
   const _resetPencil = () => {
     if (!fabricCanvas.value) return
     const converter = {
-      huge: 15,
-      big: 10,
-      medium: 5,
-      small: 2,
-      tiny: 1
+      huge: 30,
+      big: 20,
+      medium: 10,
+      small: 4,
+      tiny: 2
     }
     const strokeWidth = converter[pencilWidth.value]
     fabricCanvas.value.freeDrawingBrush.width = strokeWidth
@@ -1015,7 +1015,10 @@ export const useAnnotation = ({
     })
 
     fabricCanvas.value.freeDrawingBrush.color = pencilColor.value
-    fabricCanvas.value.freeDrawingBrush.width = 4
+    // Apply the selected pencil width rather than a hardcoded value — the
+    // drawing-mode toggle (setAnnotationDrawingMode) doesn't reset the brush,
+    // so a hardcoded width here stuck every freehand stroke at that size.
+    _resetPencil()
 
     fabric.Group.prototype._controlsVisibility = {
       tl: false,

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -161,6 +161,9 @@ export const useAnnotation = ({
   const doneActionStack = []
   const undoneActionStack = []
   let silentAnnotation = false
+  // Bumped on every comparison-canvas clear so an in-flight async load can tell
+  // it was superseded and stop repopulating a canvas meant to be cleared.
+  let comparisonLoadToken = 0
   let annotatedPreview = null
   let annotationToSave = null
   let pendingSave = null
@@ -523,10 +526,20 @@ export const useAnnotation = ({
     })
   }
 
-  const loadSingleAnnotationComparison = annotation => {
-    annotation.drawing.objects.forEach(obj => {
-      addObjectToCanvas(annotation, obj, fabricCanvasComparison.value)
-    })
+  const loadSingleAnnotationComparison = async annotation => {
+    const canvas = fabricCanvasComparison.value
+    // The comparison viewer mounts at 0x0 and only gets its real size once the
+    // side-by-side layout settles. Painting before then places every object at
+    // scale 0; onComparisonCanvasResized reloads once it has a size.
+    if (!canvas || !canvas.width || !canvas.height) return
+    // Adding PSStrokes / shapes is async, so load sequentially and bail if a
+    // clear (or newer load) superseded us — otherwise late adds repopulate a
+    // canvas that was just cleared, leaving an incomplete/garbled overlay.
+    const token = comparisonLoadToken
+    for (const obj of annotation.drawing.objects) {
+      if (token !== comparisonLoadToken) return
+      await addObjectToCanvas(annotation, obj, canvas)
+    }
   }
 
   const addObjectToCanvas = async (annotation, obj, canvas = null) => {
@@ -1140,6 +1153,9 @@ export const useAnnotation = ({
   }
 
   const clearComparisonCanvas = () => {
+    // Cancel any in-flight comparison load so its remaining async adds don't
+    // land after this clear.
+    comparisonLoadToken++
     if (isFabricReady(fabricCanvasComparison.value)) {
       fabricCanvasComparison.value.clear()
     }

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -12,6 +12,7 @@ import {
   SHAPE_WIDTHS,
   attachShapeDrawing,
   buildReadOnlyShape,
+  getAnnotationContainMapping,
   lockBrushToFirstPointer
 } from '@/lib/annotation'
 import clipboard from '@/lib/clipboard'
@@ -532,38 +533,26 @@ export const useAnnotation = ({
     if (getObjectById(obj.id) && !canvas) return
     if (!canvas) canvas = fabricCanvas.value
     let path, shape, text, psstroke
-    let scaleMultiplierX = 1
-    let scaleMultiplierY = 1
-    if (annotation?.width) {
-      scaleMultiplierX = canvas.width / annotation.width
-      scaleMultiplierY = canvas.width / annotation.width
-    }
-    if (annotation?.height) {
-      scaleMultiplierY = canvas.height / annotation.height
-    }
-    const canvasWidth = obj.canvasWidth || annotation.width
-    const canvasHeight = obj.canvasHeight
-
-    if (canvasWidth) {
-      scaleMultiplierX = canvas.width / canvasWidth
-      scaleMultiplierY = canvas.width / canvasWidth
-    }
-    if (canvasHeight) {
-      scaleMultiplierY = canvas.height / canvasHeight
-    }
+    const canvasWidth = obj.canvasWidth || annotation?.width
+    const canvasHeight = obj.canvasHeight || annotation?.height
+    const { scale, offsetX, offsetY } = getAnnotationContainMapping(
+      canvas,
+      canvasWidth,
+      canvasHeight
+    )
 
     const base = {
       id: obj.id,
       fill: 'transparent',
-      left: obj.left * scaleMultiplierX,
-      top: obj.top * scaleMultiplierY,
+      left: obj.left * scale + offsetX,
+      top: obj.top * scale + offsetY,
       stroke: obj.stroke,
       strokeWidth: obj.strokeWidth,
       radius: obj.radius,
       width: obj.width,
       height: obj.height,
-      scaleX: obj.scaleX * scaleMultiplierX,
-      scaleY: obj.scaleY * scaleMultiplierY,
+      scaleX: obj.scaleX * scale,
+      scaleY: obj.scaleY * scale,
       angle: obj.angle,
       scale: obj.scale,
       editable: !isCurrentUserArtist.value,
@@ -571,16 +560,10 @@ export const useAnnotation = ({
     }
 
     if (obj.type === 'path') {
-      let strokeMultiplier = 1
-      if (obj.canvasWidth) {
-        strokeMultiplier = canvasWidth / canvas.width
-      }
-      if (canvas.width < 420) strokeMultiplier /= 2
       path = new fabric.Path(obj.path, {
         ...base
       })
       path.set('id', obj.id)
-      path.set('strokeWidth', obj.strokeWidth * strokeMultiplier)
       path.set('canvasWidth', canvasWidth)
       path.set('canvasHeight', canvasHeight)
       addSerialization(path)
@@ -602,8 +585,8 @@ export const useAnnotation = ({
       text = new fabric.IText(obj.text, {
         ...base,
         fill: obj.fill,
-        left: obj.left * scaleMultiplierX,
-        top: obj.top * scaleMultiplierY,
+        left: obj.left * scale + offsetX,
+        top: obj.top * scale + offsetY,
         fontFamily: obj.fontFamily,
         fontSize: obj.fontSize,
         backgroundColor: 'rgba(255,255,255, 0.8)',
@@ -629,22 +612,20 @@ export const useAnnotation = ({
       silentAnnotation = false
     } else if (obj.type === 'PSStroke') {
       if (obj.canvasWidth) {
-        let strokeMultiplier = canvasWidth / canvas.width
-        if (canvas.width < 420) strokeMultiplier /= 2
         psstroke = await deserializePSBrush(obj)
         psstroke.set('id', obj.id)
-        psstroke.set('strokeWidth', obj.strokeWidth * strokeMultiplier)
+        psstroke.set('strokeWidth', obj.strokeWidth)
         psstroke.set('canvasWidth', canvasWidth)
         psstroke.set('canvasHeight', canvasHeight)
-        psstroke.set('scaleX', obj.scaleX * scaleMultiplierX)
-        psstroke.set('scaleY', obj.scaleY * scaleMultiplierY)
-        psstroke.set('left', obj.left * scaleMultiplierX)
-        psstroke.set('top', obj.top * scaleMultiplierY)
+        psstroke.set('scaleX', obj.scaleX * scale)
+        psstroke.set('scaleY', obj.scaleY * scale)
+        psstroke.set('left', obj.left * scale + offsetX)
+        psstroke.set('top', obj.top * scale + offsetY)
         psstroke.set('radius', obj.radius)
         psstroke.set('width', obj.width)
         psstroke.set('height', obj.height)
-        psstroke.set('scaleX', obj.scaleX * scaleMultiplierX)
-        psstroke.set('scaleY', obj.scaleY * scaleMultiplierY)
+        psstroke.set('scaleX', obj.scaleX * scale)
+        psstroke.set('scaleY', obj.scaleY * scale)
         psstroke.set('angle', obj.angle)
         psstroke.set('scale', obj.scale)
         psstroke.set('editable', !isCurrentUserArtist.value)

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -13,7 +13,8 @@ import {
   attachShapeDrawing,
   buildReadOnlyShape,
   getAnnotationContainMapping,
-  lockBrushToFirstPointer
+  lockBrushToFirstPointer,
+  normalizeSerializedAnnotation
 } from '@/lib/annotation'
 import clipboard from '@/lib/clipboard'
 import { formatFullDate } from '@/lib/time'
@@ -192,7 +193,7 @@ export const useAnnotation = ({
       result.angle = this.angle
       result.scale = this.scale
       result.createdBy = this.createdBy
-      return result
+      return normalizeSerializedAnnotation(this, result)
     }
     return object
   }

--- a/src/lib/annotation.js
+++ b/src/lib/annotation.js
@@ -132,7 +132,7 @@ export const addSerialization = object => {
     result.angle = this.angle
     result.scale = this.scale
     result.createdBy = this.createdBy
-    return result
+    return normalizeSerializedAnnotation(this, result)
   }
   return object
 }
@@ -562,6 +562,30 @@ export const getAnnotationContainMapping = (canvas, refWidth, refHeight) => {
     return { scale: canvas.width / refWidth, offsetX: 0, offsetY: 0 }
   }
   return { scale: 1, offsetX: 0, offsetY: 0 }
+}
+
+// serialize() reads the fabric object's live left/top/scale, which the load
+// transform scaled to the *current* canvas. Persisting those against the
+// stored canvasWidth/Height — a different frame — made every resize+save cycle
+// re-multiply the coordinates (annotations drifting badly after drawing in
+// fullscreen). Invert the load transform on the object's own canvas so the
+// stored form is always expressed in its canvasWidth reference frame and
+// round-trips stably. No-op for objects drawn at the current size (scale 1) and
+// for objects not attached to a canvas.
+export const normalizeSerializedAnnotation = (object, result) => {
+  const canvas = object.canvas
+  if (!canvas || !object.canvasWidth) return result
+  const { scale, offsetX, offsetY } = getAnnotationContainMapping(
+    canvas,
+    object.canvasWidth,
+    object.canvasHeight
+  )
+  if (!scale) return result
+  result.left = (result.left - offsetX) / scale
+  result.top = (result.top - offsetY) / scale
+  result.scaleX = result.scaleX / scale
+  result.scaleY = result.scaleY / scale
+  return result
 }
 
 export const buildReadOnlyShape = async (annotation, obj, canvas) => {

--- a/src/lib/annotation.js
+++ b/src/lib/annotation.js
@@ -542,27 +542,38 @@ export const deserializePSStroke = obj =>
  * Promise because PSStroke deserialisation is async.
  * -----------------------------------------------------------------------*/
 
+// Maps coordinates authored on a canvas of `refWidth × refHeight` onto the
+// current `canvas` the way object-fit:contain lays media out: one uniform scale
+// plus centering. The media element is always sized to its natural aspect
+// ratio, so the authoring canvas shares that aspect — a single factor (rather
+// than separate X/Y) keeps annotations aligned and undistorted even when the
+// current box aspect differs (comparison halves the width, fullscreen enlarges
+// it). Falls back to a width-only scale when the reference height is unknown.
+export const getAnnotationContainMapping = (canvas, refWidth, refHeight) => {
+  if (refWidth && refHeight) {
+    const scale = Math.min(canvas.width / refWidth, canvas.height / refHeight)
+    return {
+      scale,
+      offsetX: (canvas.width - refWidth * scale) / 2,
+      offsetY: (canvas.height - refHeight * scale) / 2
+    }
+  }
+  if (refWidth) {
+    return { scale: canvas.width / refWidth, offsetX: 0, offsetY: 0 }
+  }
+  return { scale: 1, offsetX: 0, offsetY: 0 }
+}
+
 export const buildReadOnlyShape = async (annotation, obj, canvas) => {
   if (!obj || !obj.type) return null
 
-  let scaleMultiplierX = 1
-  let scaleMultiplierY = 1
-  if (annotation?.width) {
-    scaleMultiplierX = canvas.width / annotation.width
-    scaleMultiplierY = canvas.width / annotation.width
-  }
-  if (annotation?.height) {
-    scaleMultiplierY = canvas.height / annotation.height
-  }
-  const canvasWidth = obj.canvasWidth || annotation.width
-  const canvasHeight = obj.canvasHeight
-  if (canvasWidth) {
-    scaleMultiplierX = canvas.width / canvasWidth
-    scaleMultiplierY = canvas.width / canvasWidth
-  }
-  if (canvasHeight) {
-    scaleMultiplierY = canvas.height / canvasHeight
-  }
+  const canvasWidth = obj.canvasWidth || annotation?.width
+  const canvasHeight = obj.canvasHeight || annotation?.height
+  const { scale, offsetX, offsetY } = getAnnotationContainMapping(
+    canvas,
+    canvasWidth,
+    canvasHeight
+  )
 
   const base = {
     angle: obj.angle || 0,
@@ -570,24 +581,20 @@ export const buildReadOnlyShape = async (annotation, obj, canvas) => {
     fill: obj.fill || 'transparent',
     height: obj.height,
     hoverCursor: 'default',
-    left: (obj.left || 0) * scaleMultiplierX,
+    left: (obj.left || 0) * scale + offsetX,
     radius: obj.radius,
-    scaleX: (obj.scaleX || 1) * scaleMultiplierX,
-    scaleY: (obj.scaleY || 1) * scaleMultiplierY,
+    scaleX: (obj.scaleX || 1) * scale,
+    scaleY: (obj.scaleY || 1) * scale,
     selectable: false,
     stroke: obj.stroke,
     strokeWidth: obj.strokeWidth || 1,
-    top: (obj.top || 0) * scaleMultiplierY,
+    top: (obj.top || 0) * scale + offsetY,
     width: obj.width
   }
 
   if (obj.type === 'path') {
-    let strokeMultiplier = 1
-    if (obj.canvasWidth) strokeMultiplier = canvasWidth / canvas.width
-    if (canvas.width < 420) strokeMultiplier /= 2
     const path = new fabric.Path(obj.path, base)
     path.set('id', obj.id)
-    path.set('strokeWidth', obj.strokeWidth * strokeMultiplier)
     path.set('canvasWidth', canvasWidth)
     path.set('canvasHeight', canvasHeight)
     addSerialization(path)
@@ -597,9 +604,6 @@ export const buildReadOnlyShape = async (annotation, obj, canvas) => {
   if (obj.type === 'PSStroke') {
     const stroke = await deserializePSStroke(obj)
     if (!stroke) return null
-    let strokeMultiplier = 1
-    if (obj.canvasWidth) strokeMultiplier = canvasWidth / canvas.width
-    if (canvas.width < 420) strokeMultiplier /= 2
     stroke.set({
       id: obj.id,
       angle: base.angle,
@@ -611,7 +615,7 @@ export const buildReadOnlyShape = async (annotation, obj, canvas) => {
       scaleY: base.scaleY,
       selectable: false,
       stroke: base.stroke,
-      strokeWidth: (obj.strokeWidth || 1) * strokeMultiplier,
+      strokeWidth: obj.strokeWidth || 1,
       top: base.top,
       canvasWidth,
       canvasHeight


### PR DESCRIPTION
## Problems

- Annotations drifted and distorted when the player aspect changed (split-view, fullscreen) and got corrupted across resize/save cycles.
- Realtime annotation sync outside review rooms stopped after the first stroke on a frame.
- Comparison was broken: it didn't load the compared annotations on open, switching target nudged the frame, and picture annotations loaded incomplete.
- The sound waveform didn't render with multiple viewers.

## Solutions

- Uniform contain-scale with centering, normalized on save so annotations round-trip stably.
- Reload on every valid update with a UTC drawing guard so remote updates aren't blocked.
- Load compared annotations on open, drop the frame nudge, and skip/cancel-guard comparison loads until the canvas is sized.
- Fix waveform rendering with multiple viewers.