### PR TITLE
[productions] Add single-preview-per-revision option

### DIFF
--- a/src/components/pages/ProjectTemplateSettings.vue
+++ b/src/components/pages/ProjectTemplateSettings.vue
@@ -121,6 +121,10 @@
                 v-model="params.is_set_preview_automated"
               />
               <combobox-boolean
+                :label="$t('productions.fields.is_single_preview_per_revision')"
+                v-model="params.is_single_preview_per_revision"
+              />
+              <combobox-boolean
                 :label="$t('productions.fields.is_publish_default')"
                 v-model="params.is_publish_default_for_artists"
               />
@@ -403,6 +407,7 @@ const params = ref({
   is_clients_isolated: 'false',
   is_preview_download_allowed: 'false',
   is_set_preview_automated: 'false',
+  is_single_preview_per_revision: 'false',
   is_publish_default_for_artists: 'false',
   max_retakes: 0
 })
@@ -464,6 +469,9 @@ const loadTemplateData = async () => {
       ? 'true'
       : 'false',
     is_set_preview_automated: tmpl.is_set_preview_automated ? 'true' : 'false',
+    is_single_preview_per_revision: tmpl.is_single_preview_per_revision
+      ? 'true'
+      : 'false',
     is_publish_default_for_artists: tmpl.is_publish_default_for_artists
       ? 'true'
       : 'false',
@@ -512,6 +520,8 @@ const saveParameters = async () => {
         params.value.is_preview_download_allowed === 'true',
       is_set_preview_automated:
         params.value.is_set_preview_automated === 'true',
+      is_single_preview_per_revision:
+        params.value.is_single_preview_per_revision === 'true',
       is_publish_default_for_artists:
         params.value.is_publish_default_for_artists === 'true'
     })

--- a/src/components/pages/production/ProductionParameters.vue
+++ b/src/components/pages/production/ProductionParameters.vue
@@ -128,6 +128,12 @@
           v-if="currentProduction && currentProduction.id"
         />
         <combobox-boolean
+          :label="$t('productions.fields.is_single_preview_per_revision')"
+          @enter="runConfirmation"
+          v-model="form.is_single_preview_per_revision"
+          v-if="currentProduction && currentProduction.id"
+        />
+        <combobox-boolean
           :label="$t('productions.fields.is_publish_default')"
           @enter="runConfirmation"
           v-model="form.is_publish_default_for_artists"
@@ -212,6 +218,7 @@ const emptyForm = () => ({
   is_clients_isolated: 'false',
   is_preview_download_allowed: 'false',
   is_set_preview_automated: 'false',
+  is_single_preview_per_revision: 'false',
   is_publish_default_for_artists: 'false',
   fps: '',
   ratio: '',
@@ -268,6 +275,9 @@ const resetForm = () => {
         ? 'true'
         : 'false',
       is_set_preview_automated: production.is_set_preview_automated
+        ? 'true'
+        : 'false',
+      is_single_preview_per_revision: production.is_single_preview_per_revision
         ? 'true'
         : 'false',
       is_publish_default_for_artists: production.is_publish_default_for_artists

--- a/src/components/players/bars/BrowsingBar.vue
+++ b/src/components/players/bars/BrowsingBar.vue
@@ -31,7 +31,7 @@
       icon="plus"
       :title="$t('playlists.actions.files_add')"
       @click="$emit('add-preview-clicked')"
-      v-if="(isAssigned || !readOnly) && !fullScreen"
+      v-if="(isAssigned || !readOnly) && !fullScreen && allowExtraPreview"
     />
 
     <button-simple
@@ -52,6 +52,10 @@ import { computed } from 'vue'
 import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 
 const props = defineProps({
+  allowExtraPreview: {
+    type: Boolean,
+    default: true
+  },
   currentIndex: {
     type: Number,
     default: 0

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -266,6 +266,7 @@
           ></div>
 
           <browsing-bar
+            :allow-extra-preview="allowExtraPreview"
             :current-index="currentIndex"
             :previews="previews"
             :read-only="readOnly"
@@ -749,6 +750,10 @@ if (props.entityPreviewFiles) {
 
 const currentProduction = computed(() =>
   productionMap.value.get(props.task.project_id)
+)
+
+const allowExtraPreview = computed(
+  () => !currentProduction.value?.is_single_preview_per_revision
 )
 
 const marginBottom = computed(() => {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1382,6 +1382,7 @@ export default {
       is_preview_download_allowed: 'Allow artists to download previews',
       is_publish_default: 'Set comment widget for artists on publish mode by default',
       is_set_preview_automated: 'Set new preview as entity thumbnail automatically',
+      is_single_preview_per_revision: 'Allow only one preview file per revision',
       max_retakes: 'Maximum number of retakes',
       name: 'Name',
       nb_episodes: 'Number of episodes',

--- a/src/store/api/productions.js
+++ b/src/store/api/productions.js
@@ -35,7 +35,8 @@ export default {
       'is_clients_isolated',
       'is_preview_download_allowed',
       'is_set_preview_automated',
-      'is_publish_default_for_artists'
+      'is_publish_default_for_artists',
+      'is_single_preview_per_revision'
     ]
     const { id, ...data } = production
     BOOLEAN_FIELDS.forEach(field => {

--- a/src/store/api/projecttemplates.js
+++ b/src/store/api/projecttemplates.js
@@ -23,7 +23,8 @@ export default {
       is_clients_isolated: template.is_clients_isolated,
       is_preview_download_allowed: template.is_preview_download_allowed,
       is_set_preview_automated: template.is_set_preview_automated,
-      is_publish_default_for_artists: template.is_publish_default_for_artists
+      is_publish_default_for_artists: template.is_publish_default_for_artists,
+      is_single_preview_per_revision: template.is_single_preview_per_revision
     }
     return client.ppost('/api/data/project-templates', data)
   },
@@ -42,7 +43,8 @@ export default {
       is_clients_isolated: template.is_clients_isolated,
       is_preview_download_allowed: template.is_preview_download_allowed,
       is_set_preview_automated: template.is_set_preview_automated,
-      is_publish_default_for_artists: template.is_publish_default_for_artists
+      is_publish_default_for_artists: template.is_publish_default_for_artists,
+      is_single_preview_per_revision: template.is_single_preview_per_revision
     }
     return client.pput(`/api/data/project-templates/${template.id}`, data)
   },


### PR DESCRIPTION
**Problem**
- The new `is_single_preview_per_revision` project option has no UI, and artists can still trigger the add-extra-preview action on projects that forbid it.

**Solution**
- Expose the option as a toggle in production parameters and project template settings, and pass it through the project/template store APIs.
- Hide the add-extra-preview button in the preview player when the option is enabled.