### PR TITLE
[players] Player fixes: panzoom alignment, annotation clipping, frame controls

### DIFF
--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -1778,6 +1778,14 @@ watch(currentPreview, () => {
   clearCanvas()
   reloadAnnotations()
   isComparing.value = false
+  // Reset the frame bookkeeping synchronously. onPreviewLoaded() also
+  // sets frame 0, but only once the media-load event fires; until then
+  // currentFrame still holds the previous preview's playhead, so a
+  // single-frame shortcut (arrow keys) advances from the stale frame
+  // even though the timeline already shows frame 0.
+  currentFrame.value = 0
+  currentTimeRaw.value = 0
+  currentTime.value = formatTime(0, fps.value)
   if (isMovie.value) {
     configureVideo()
     pause()

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -1034,6 +1034,20 @@ const goNextFrame = () => {
   syncComparisonViewer()
 }
 
+const goToFirstFrame = () => {
+  if (!isMovie.value) return
+  clearCanvas()
+  setCurrentFrame(0)
+  syncComparisonViewer()
+}
+
+const goToLastFrame = () => {
+  if (!isMovie.value) return
+  clearCanvas()
+  setCurrentFrame(nbFrames.value - 1)
+  syncComparisonViewer()
+}
+
 const goPreviousDrawing = () => {
   jumpToAnnotationFrame(getPreviousAnnotationTime(currentTimeRaw.value))
 }
@@ -1557,6 +1571,8 @@ const { isAltHeld } = usePreviewShortcuts({
   onDelete: () => deleteSelection(),
   onPrevFrame: () => goPreviousFrame(),
   onNextFrame: () => goNextFrame(),
+  onFirstFrame: () => goToFirstFrame(),
+  onLastFrame: () => goToLastFrame(),
   onPlayPause: () => {
     // Don't toggle play/pause while a shared playlist modal is open.
     const playlistModal = document.getElementById('temp-playlist-modal')

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -7,40 +7,48 @@
           :style="{ cursor: annotationCursor || null }"
           ref="preview-container"
         >
-          <annotation-canvas
-            ref="main-annotation-canvas"
-            :canvas-id="canvasId"
-            :cursor="annotationCursor"
-            :media-element="mainMediaElement"
-            :panzoom-transform="panzoomTransform"
-            :interactive="isOverlayInteractive"
-            :wheel-target="mainMediaElement"
-            v-show="
-              isAnnotationsDisplayed &&
-              (isMovie || isPicture) &&
-              mainMediaElement
-            "
-            @click="onCanvasClicked"
-            @resized="onMainCanvasResized"
-          />
-          <annotation-canvas
-            ref="comparison-annotation-canvas"
-            :canvas-id="`${canvasId}-comparison`"
-            :media-element="comparisonMediaElement"
-            :panzoom-transform="panzoomTransform"
-            :interactive="false"
-            :static="true"
-            v-show="
-              isAnnotationsDisplayed &&
-              isComparing &&
-              previewToCompare &&
-              !isComparisonOverlay &&
-              (isMovie || isPicture) &&
-              comparisonMediaElement
-            "
-            @click="onCanvasClicked"
-            @resized="onComparisonCanvasResized"
-          />
+          <div
+            class="annotation-slot"
+            :class="{ 'side-by-side': isSideBySideComparison }"
+          >
+            <annotation-canvas
+              ref="main-annotation-canvas"
+              :canvas-id="canvasId"
+              :cursor="annotationCursor"
+              :media-element="mainMediaElement"
+              :panzoom-transform="panzoomTransform"
+              :interactive="isOverlayInteractive"
+              :wheel-target="mainMediaElement"
+              v-show="
+                isAnnotationsDisplayed &&
+                (isMovie || isPicture) &&
+                mainMediaElement
+              "
+              @click="onCanvasClicked"
+              @resized="onMainCanvasResized"
+            />
+          </div>
+          <div
+            class="annotation-slot comparison-slot"
+            v-if="isSideBySideComparison"
+          >
+            <annotation-canvas
+              ref="comparison-annotation-canvas"
+              :canvas-id="`${canvasId}-comparison`"
+              :media-element="comparisonMediaElement"
+              :panzoom-transform="panzoomTransform"
+              :interactive="false"
+              :static="true"
+              v-show="
+                isAnnotationsDisplayed &&
+                previewToCompare &&
+                (isMovie || isPicture) &&
+                comparisonMediaElement
+              "
+              @click="onCanvasClicked"
+              @resized="onComparisonCanvasResized"
+            />
+          </div>
           <div class="viewers">
             <preview-viewer
               ref="preview-viewer"
@@ -754,6 +762,13 @@ const currentProduction = computed(() =>
 
 const allowExtraPreview = computed(
   () => !currentProduction.value?.is_single_preview_per_revision
+)
+
+// Side-by-side is the only layout where each viewer occupies a distinct
+// slot in the container; in overlay mode they stack and the comparison
+// annotation canvas is hidden anyway.
+const isSideBySideComparison = computed(
+  () => isComparing.value && !isComparisonOverlay.value
 )
 
 const marginBottom = computed(() => {
@@ -2244,6 +2259,32 @@ defineExpose({
 
 .comparison-preview-viewer {
   z-index: 2;
+}
+
+// Per-viewer annotation slot. The annotation canvases used to sit
+// directly under .preview-container, so a panned overlay in one viewer
+// could only be clipped at the outermost container — in side-by-side
+// comparison mode that meant it spilled into the other viewer. Each
+// slot now covers just its viewer's screen area and clips at that edge.
+// pointer-events stays open so the canvas inside can still receive
+// drawing input; empty slot space falls through to the viewer beneath.
+.annotation-slot {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  pointer-events: none;
+
+  &.side-by-side {
+    width: 50%;
+  }
+}
+
+.comparison-slot {
+  left: 50%;
+  width: 50%;
 }
 
 .separator {

--- a/src/components/players/viewers/PictureViewer.vue
+++ b/src/components/players/viewers/PictureViewer.vue
@@ -250,7 +250,15 @@ const endLoading = () => {
     isLoading.value = false
   }
   emit('loaded')
-  nextTick(resetPicture)
+  nextTick(() => {
+    resetPicture()
+    // Bind (or rebind) panzoom only once the visible image has actual
+    // pixel dimensions. Wiring it on an unsized img leaves panzoom's
+    // bounds clamp computing against a 0×0 bbox, so the next pan / zoom
+    // / cross-viewer sync ends up off-centre — which is what users on
+    // slow connections were observing.
+    if (visibleImage.value?.complete) setupPanZoom()
+  })
 }
 
 const emitPanZoom = pz => {
@@ -394,7 +402,11 @@ watch(
 // stay bound to the previous img and lose sync with the displayed
 // one.
 watch(visibleImage, () => {
-  setupPanZoom()
+  // Wait for the new visible image to be loaded before binding panzoom;
+  // endLoading will rebind once its load event fires. Binding now would
+  // recreate the instance against an unsized target and leave the
+  // picture off-centre on slow loads.
+  if (visibleImage.value?.complete) setupPanZoom()
 })
 
 // Lifecycle
@@ -411,7 +423,9 @@ onMounted(() => {
   pictureGif.value.addEventListener('load', endLoading)
   window.addEventListener('resize', resetPicture)
   setPicturePath()
-  setupPanZoom()
+  // Cached-image case: load may have fired before the listener was
+  // attached. For uncached images the bind happens later in endLoading.
+  if (visibleImage.value?.complete) setupPanZoom()
 })
 
 onBeforeUnmount(() => {

--- a/src/components/players/viewers/VideoViewer.vue
+++ b/src/components/players/viewers/VideoViewer.vue
@@ -136,6 +136,13 @@ const videoDuration = ref(0)
 
 let panzoomInstance = null
 let panzoomSilent = false
+// Track whether the panzoom should be active across instance
+// recreations. The instance is only built after the video metadata
+// loads (so its bounds clamp doesn't race a 0×0 target), which can
+// happen after PreviewPlayer already called resumeZoom() at mount —
+// so we remember that intent here and apply it when the instance
+// finally exists.
+let panzoomActive = false
 let currentTimeCalls = []
 let playLoop = null
 let isPlaying = false
@@ -397,12 +404,39 @@ const emitPanZoom = () => {
   emit('panzoom-changed', { x, y, scale, source: 'movie' })
 }
 
+// Bind panzoom to the <video> rather than the wrapping container: the
+// video is flex-centered inside the wrapper, so scaling the wrapper
+// multiplies the centering offset and the video drifts relative to the
+// AnnotationCanvas overlay (which applies the same transform from its
+// own top-left origin). Setup is deferred until metadata is loaded so
+// panzoom's bounds clamp doesn't compute against a 0×0 target — that
+// raced the load on slow connections and left the video off-centre.
+const setupPanZoom = () => {
+  if (!props.panzoom || !movie.value) return
+  if (panzoomInstance) {
+    panzoomInstance.dispose()
+    panzoomInstance = null
+  }
+  panzoomInstance = createPanzoom(movie.value, {
+    bounds: true,
+    boundsPadding: 0.2,
+    maxZoom: 5,
+    minZoom: 1,
+    smoothScroll: false
+  })
+  panzoomInstance.on('zoom', emitPanZoom)
+  panzoomInstance.on('pan', emitPanZoom)
+  if (!panzoomActive) panzoomInstance.pause()
+}
+
 const pausePanZoom = () => {
-  if (panzoomInstance) panzoomInstance.pause()
+  panzoomActive = false
+  panzoomInstance?.pause()
 }
 
 const resumePanZoom = () => {
-  if (panzoomInstance) panzoomInstance.resume()
+  panzoomActive = true
+  panzoomInstance?.resume()
 }
 
 const setSpeed = rate => {
@@ -488,6 +522,7 @@ onMounted(() => {
           video.value.currentTime = 0
         })
         emit('video-loaded')
+        setupPanZoom()
       }
       video.value.addEventListener('focus', e => e.target.blur())
       video.value.addEventListener('resize', resetSize)
@@ -499,6 +534,7 @@ onMounted(() => {
         setCurrentTime(0)
         setCurrentTimeRaw(0)
         emit('video-loaded')
+        setupPanZoom()
       })
 
       video.value.addEventListener('canplay', () => {
@@ -534,24 +570,6 @@ onMounted(() => {
       window.addEventListener('resize', onWindowResize)
     }
   }, 0)
-
-  if (props.panzoom) {
-    // Attach panzoom to the <video> element rather than the wrapping
-    // container: the video is flex-centered inside the wrapper, so
-    // scaling the wrapper multiplies the centering offset and the
-    // video drifts relative to the AnnotationCanvas overlay (which
-    // applies the same transform from its own top-left origin).
-    panzoomInstance = createPanzoom(movie.value, {
-      bounds: true,
-      boundsPadding: 0.2,
-      maxZoom: 5,
-      minZoom: 1,
-      smoothScroll: false
-    })
-    panzoomInstance.on('zoom', emitPanZoom)
-    panzoomInstance.on('pan', emitPanZoom)
-    pausePanZoom()
-  }
 })
 
 onBeforeUnmount(() => {

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -24,12 +24,12 @@
             :font-size="12"
             :person="comment.person"
             :is-link="!isCurrentUserClient"
-            v-if="!isCurrentUserClient || isAuthorClient"
+            v-if="comment.person?.id"
           />
           <people-name
             class="flexrow-item strong"
             :person="comment.person"
-            v-if="!isCurrentUserClient || isAuthorClient"
+            v-if="comment.person?.id"
           />
           <div class="filler"></div>
           <span class="flexrow-item date" :title="fullDate">
@@ -161,11 +161,7 @@
                 v-for="replyComment in comment.replies || []"
               >
                 <div class="flexrow">
-                  <template
-                    v-if="
-                      !isCurrentUserClient || isReplyAuthorClient(replyComment)
-                    "
-                  >
+                  <template v-if="replyComment.person?.id">
                     <people-avatar
                       class="flexrow-item"
                       :size="18"
@@ -749,11 +745,6 @@ const isAuthorClient = computed(() => {
     personMap.value.get(props.comment.person_id) || props.comment.person
   return author?.role === 'client'
 })
-
-const isReplyAuthorClient = reply => {
-  const author = personMap.value.get(reply.person_id) || reply.person
-  return author?.role === 'client'
-}
 
 const shortenText = (text, length) => {
   return stringHelpers.shortenText(text, length)

--- a/src/composables/players/previewShortcuts.js
+++ b/src/composables/players/previewShortcuts.js
@@ -25,6 +25,8 @@ const isTypingTarget = target => ['INPUT', 'TEXTAREA'].includes(target?.tagName)
  * @param {Function} [handlers.onDelete]
  * @param {Function} [handlers.onPrevFrame]
  * @param {Function} [handlers.onNextFrame]
+ * @param {Function} [handlers.onFirstFrame]
+ * @param {Function} [handlers.onLastFrame]
  * @param {Function} [handlers.onPlayPause]
  * @param {Function} [handlers.onPrevAnnotation]
  * @param {Function} [handlers.onNextAnnotation]
@@ -76,6 +78,14 @@ export const usePreviewShortcuts = handlers => {
         break
       case 'ArrowRight':
         handlers.onNextFrame?.()
+        break
+      case 'Home':
+        pauseEvent(event)
+        handlers.onFirstFrame?.()
+        break
+      case 'End':
+        pauseEvent(event)
+        handlers.onLastFrame?.()
         break
       case ' ':
         pauseEvent(event)

--- a/tests/unit/composables/previewShortcuts.spec.js
+++ b/tests/unit/composables/previewShortcuts.spec.js
@@ -14,6 +14,8 @@ const mountShortcuts = (handlerOverrides = {}) => {
     onDelete: vi.fn(),
     onPrevFrame: vi.fn(),
     onNextFrame: vi.fn(),
+    onFirstFrame: vi.fn(),
+    onLastFrame: vi.fn(),
     onPlayPause: vi.fn(),
     onPrevAnnotation: vi.fn(),
     onNextAnnotation: vi.fn(),
@@ -104,6 +106,17 @@ describe('composables/previewShortcuts', () => {
       dispatchKeydown({ key: 'ArrowRight' })
       expect(handlers.onPrevFrame).toHaveBeenCalledTimes(1)
       expect(handlers.onNextFrame).toHaveBeenCalledTimes(1)
+      wrapper.unmount()
+    })
+
+    it('Home and End jump to the first / last frame and suppress page scroll', () => {
+      const { handlers, wrapper } = mountShortcuts()
+      const home = dispatchKeydown({ key: 'Home' })
+      const end = dispatchKeydown({ key: 'End' })
+      expect(handlers.onFirstFrame).toHaveBeenCalledTimes(1)
+      expect(handlers.onLastFrame).toHaveBeenCalledTimes(1)
+      expect(home.defaultPrevented).toBe(true)
+      expect(end.defaultPrevented).toBe(true)
       wrapper.unmount()
     })
 


### PR DESCRIPTION
## Problems

- Panzoom was instantiated before the image / video had loaded, so on
  slow connections the bounds clamp computed against a 0×0 element and
  the media appeared off-centre.
- In side-by-side comparison, a panned annotation overlay spilled into
  the other viewer because clipping only happened at the outer
  container.
- Switching preview left the previous playhead in `currentFrame`, so
  a single-frame shortcut advanced from the stale frame even though
  the timeline showed frame 0.
- No keyboard shortcut to jump to the very first or last frame of a
  movie.
- Shared playlist comments did not show the author's studio name,
  making it hard to tell which studio left feedback.

## Solutions

- Defer panzoom setup until the media's load event; VideoViewer
  remembers the pause / resume intent across the deferred setup.
- Wrap each annotation canvas in a per-viewer `.annotation-slot` that
  covers only its viewer's area and clips at that edge.
- Reset `currentFrame`, `currentTimeRaw` and `currentTime`
  synchronously when the preview changes, before the next load event.
- Add Home / End shortcuts that jump to the first / last frame.
- Surface the comment author's studio name in shared playlist
  comments.