### PR TITLE
[players] Tighten panzoom and add scrub/focus shortcuts

### DIFF
--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -104,6 +104,7 @@
               :style="{
                 opacity: overlayOpacity
               }"
+              @panzoom-ready="onComparisonPanzoomReady"
               @video-loaded="onComparisonVideoLoaded"
               v-show="isComparing && previewToCompare"
             />
@@ -1119,6 +1120,17 @@ const realignComparisonCanvas = () => {
   comparisonViewer.value?.resize()
   comparisonAnnotationCanvas.value?.updateBounds()
   loadComparisonAnnotationAtCurrentFrame()
+}
+
+// Push the main viewer's current transform onto the comparison
+// viewer once its panzoom instance is (re)bound. The comparison
+// binds lazily — on the media's load event after a revision swap —
+// so the panzoomTransform watcher (which only fires on changes) had
+// no chance to sync the fresh instance back to the main viewer.
+const onComparisonPanzoomReady = () => {
+  if (!isComparing.value) return
+  const { x, y, scale } = panzoomTransform.value
+  comparisonViewer.value?.setPanZoom(x, y, scale)
 }
 
 const onComparisonVideoLoaded = () => {

--- a/src/components/players/viewers/PreviewViewer.vue
+++ b/src/components/players/viewers/PreviewViewer.vue
@@ -44,6 +44,7 @@
       @duration-changed="duration => $emit('duration-changed', duration)"
       @frame-update="frameNumber => $emit('frame-update', frameNumber)"
       @panzoom-changed="onVideoPanzoomChanged"
+      @panzoom-ready="$emit('panzoom-ready')"
       @play-ended="$emit('play-ended')"
       @size-changed="onVideoSizeChanged"
       @video-end="$emit('video-end')"
@@ -63,6 +64,7 @@
       :preview="preview"
       @loaded="$emit('picture-loaded')"
       @panzoom-changed="onPicturePanzoomChanged"
+      @panzoom-ready="$emit('panzoom-ready')"
       @size-changed="onPictureSizeChanged"
       v-show="isPicture"
     />
@@ -229,6 +231,7 @@ const emit = defineEmits([
   'frame-update',
   'model-loaded',
   'panzoom-changed',
+  'panzoom-ready',
   'picture-loaded',
   'play-ended',
   'size-changed',

--- a/src/components/players/viewers/VideoViewer.vue
+++ b/src/components/players/viewers/VideoViewer.vue
@@ -120,6 +120,7 @@ const emit = defineEmits([
   'duration-changed',
   'frame-update',
   'panzoom-changed',
+  'panzoom-ready',
   'play-ended',
   'size-changed',
   'video-end',
@@ -440,6 +441,11 @@ const setupPanZoom = () => {
   panzoomInstance.on('zoom', emitPanZoom)
   panzoomInstance.on('pan', emitPanZoom)
   if (!panzoomActive) panzoomInstance.pause()
+  // Tell the parent that a fresh instance exists so the comparison
+  // sync can re-push the main viewer's transform — without this the
+  // comparison stays at identity after a revision swap and drifts
+  // out of sync with the main viewer.
+  emit('panzoom-ready')
 }
 
 const pausePanZoom = () => {


### PR DESCRIPTION
## Problems

- Panzoom bound against 0×0 / gutter-sized media: off-centre on slow loads,
  triggered by clicks in the area around the media, and stole the player's
  keyboard shortcuts.
- Annotation overlay spilled across PlaylistPlayer comparison viewers.
- PlaylistPlayer comparison opened with panzoom off-centre.
- PreviewPlayer fullscreen ignored browser zoom — black bar at <100 %
  (#1541).
- No keyboard scrub / focus toggle between player and comment textarea.
- Pen / touch drag along the timeline triggered Chrome's back-forward
  swipe and dropped unsaved comments (#1700).

## Solutions

- Gate panzoom binding on the media's natural size, add
  `beforeMouseDown` / `beforeWheel` guards, and set
  `disableKeyboardInteraction: true`.
- Wrap each annotation canvas in a per-viewer slot clipped at the
  viewer's edge.
- Defer MultiVideoViewer panzoom to `loadedmetadata` and reset it once
  bound.
- Read `defaultHeight` from reactive `window.innerWidth / innerHeight`.
- Shift+drag scrubs from anywhere in the player; Shift+Tab toggles focus
  with the comment textarea; nested players let the innermost handle the
  event.
- `overscroll-behavior-x: contain` on player + timeline, `touch-action:
  pan-y` on progress bars.