### PR TITLE
[previews] Display revision numbers with project padding

### DIFF
--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -422,6 +422,7 @@ import { mapGetters, mapActions } from 'vuex'
 
 import drafts from '@/lib/drafts'
 import { getTaskEntityPath, getTaskEntitiesPath } from '@/lib/path'
+import { formatRevision } from '@/lib/preview'
 import { getTaskTypePriorityOfProd } from '@/lib/productions'
 import { sortPeople } from '@/lib/sorting'
 
@@ -615,7 +616,7 @@ export default {
         .sort((a, b) => b.revision - a.revision)
         .map(preview => {
           return {
-            label: `v${preview.revision}`,
+            label: formatRevision(preview.revision, this.currentProduction),
             value: preview.id
           }
         })

--- a/src/components/pages/production/ProductionParameters.vue
+++ b/src/components/pages/production/ProductionParameters.vue
@@ -147,6 +147,16 @@
           v-model="form.max_retakes"
           v-if="currentProduction && currentProduction.id"
         />
+        <text-field
+          type="number"
+          :step="1"
+          :min="0"
+          :max="8"
+          :label="$t('productions.fields.revision_padding')"
+          @enter="runConfirmation"
+          v-model="form.revision_padding"
+          v-if="currentProduction && currentProduction.id"
+        />
         <div v-if="currentProduction && currentProduction.id">
           <label class="label">{{ $t('productions.picture') }}</label>
           <file-upload
@@ -215,6 +225,7 @@ const emptyForm = () => ({
   nb_episodes: 0,
   episode_span: 0,
   max_retakes: 0,
+  revision_padding: 0,
   is_clients_isolated: 'false',
   is_preview_download_allowed: 'false',
   is_set_preview_automated: 'false',
@@ -269,6 +280,7 @@ const resetForm = () => {
       episode_span: production.episode_span,
       fps: production.fps,
       max_retakes: production.max_retakes,
+      revision_padding: production.revision_padding,
       nb_episodes: production.nb_episodes,
       is_clients_isolated: production.is_clients_isolated ? 'true' : 'false',
       is_preview_download_allowed: production.is_preview_download_allowed

--- a/src/components/players/bars/PreviewsPerTaskType.vue
+++ b/src/components/players/bars/PreviewsPerTaskType.vue
@@ -32,6 +32,7 @@ import { firstBy } from 'thenby'
 import { ref, computed, watch, onMounted } from 'vue'
 import { useStore } from 'vuex'
 
+import { formatRevision } from '@/lib/preview'
 import editStore from '@/store/modules/edits'
 
 import ComboboxStyled from '@/components/widgets/ComboboxStyled.vue'
@@ -54,6 +55,7 @@ const emit = defineEmits(['preview-changed'])
 const taskMap = computed(() => store.getters.taskMap)
 const taskTypeMap = computed(() => store.getters.taskTypeMap)
 const taskStatusMap = computed(() => store.getters.taskStatusMap)
+const currentProduction = computed(() => store.getters.currentProduction)
 
 const taskTypeId = ref(null)
 const previewFileId = ref(props.entity.preview_file_id)
@@ -73,7 +75,7 @@ const taskTypeOptions = computed(() => {
 const previewFileOptions = computed(() => {
   const previewFiles = props.entity.preview_files[taskTypeId.value] || []
   return previewFiles.map(previewFile => ({
-    label: `v${previewFile.revision}`,
+    label: formatRevision(previewFile.revision, currentProduction.value),
     value: previewFile.id
   }))
 })

--- a/src/components/players/players/PlaylistedEntity.vue
+++ b/src/components/players/players/PlaylistedEntity.vue
@@ -95,6 +95,8 @@ import { firstBy } from 'thenby'
 import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { useStore } from 'vuex'
 
+import { formatRevision } from '@/lib/preview'
+
 import Combobox from '@/components/widgets/Combobox.vue'
 import LightEntityThumbnail from '@/components/widgets/LightEntityThumbnail.vue'
 import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
@@ -143,12 +145,13 @@ const playlistEntryMap = computed(() => store.getters.playlistEntryMap)
 const taskMap = computed(() => store.getters.taskMap)
 const taskStatusMap = computed(() => store.getters.taskStatusMap)
 const taskTypeMap = computed(() => store.getters.taskTypeMap)
+const currentProduction = computed(() => store.getters.currentProduction)
 
 const previewFileOptions = computed(() => {
   if (props.readOnly) return []
   const files = previewFiles.value[taskTypeId.value] || []
   return files.map(previewFile => ({
-    label: `v${previewFile.revision}`,
+    label: formatRevision(previewFile.revision, currentProduction.value),
     value: previewFile.id
   }))
 })

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -438,6 +438,7 @@ import {
   buildAnnotationSnapshotFilename,
   buildAnnotationSnapshotTitle,
   drawSnapshotTitle,
+  formatRevision,
   isModelPreview,
   isMoviePreview,
   isPicturePreview,
@@ -748,6 +749,9 @@ const {
   entityPreviewFiles: computed(() => props.entityPreviewFiles),
   currentPreview,
   taskTypeMap: computed(() => props.taskTypeMap),
+  currentProduction: computed(() =>
+    productionMap.value.get(props.task.project_id)
+  ),
   t
 })
 
@@ -859,7 +863,7 @@ const lastPreviewFileOptions = computed(() => {
     .sort((a, b) => b.revision - a.revision)
     .map(preview => ({
       value: preview.id,
-      label: `v${preview.revision}`,
+      label: formatRevision(preview.revision, currentProduction.value),
       validation_status: preview.validation_status
     }))
 })

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -379,6 +379,7 @@ import {
   getTaskPath
 } from '@/lib/path'
 import preferences from '@/lib/preferences'
+import { formatRevision } from '@/lib/preview'
 import { getTaskTypeStyle } from '@/lib/render'
 import { sortPeople, sortTaskNames } from '@/lib/sorting'
 import stringHelpers from '@/lib/string'
@@ -912,7 +913,7 @@ export default {
         .sort((a, b) => b.revision - a.revision)
         .map(preview => ({
           value: preview.id,
-          label: `v${preview.revision}`,
+          label: formatRevision(preview.revision, this.currentProduction),
           validation_status: preview.validation_status
         }))
     },
@@ -1472,7 +1473,7 @@ export default {
                   const checked = item.checked ? 'x' : ' '
                   const revision =
                     item.revision > -1
-                      ? `(v${item.revision} - ${formatFrame(item.frame)}) `
+                      ? `(${formatRevision(item.revision, this.currentProduction)} - ${formatFrame(item.frame)}) `
                       : ''
                   return `[${checked}] ${revision}${item.text}`
                 })

--- a/src/components/widgets/PreviewRow.vue
+++ b/src/components/widgets/PreviewRow.vue
@@ -13,6 +13,9 @@
 
 <script setup>
 import { computed } from 'vue'
+import { useStore } from 'vuex'
+
+import { formatRevision } from '@/lib/preview'
 
 import ButtonLink from '@/components/widgets/ButtonLink.vue'
 
@@ -31,10 +34,11 @@ const props = defineProps({
   }
 })
 
-const label = computed(() => {
-  const label = `v${props.preview.revision}`
-  return label
-})
+const store = useStore()
+
+const label = computed(() =>
+  formatRevision(props.preview.revision, store.getters.currentProduction)
+)
 </script>
 
 <style lang="scss" scoped>

--- a/src/composables/players/comparison.js
+++ b/src/composables/players/comparison.js
@@ -10,10 +10,13 @@
  */
 import { computed, nextTick, ref } from 'vue'
 
+import { formatRevision } from '@/lib/preview'
+
 export const useComparison = ({
   entityPreviewFiles,
   currentPreview,
   taskTypeMap,
+  currentProduction,
   t
 }) => {
   // State
@@ -90,7 +93,7 @@ export const useComparison = ({
     const files = entityPreviewFiles.value?.[taskTypeId.value]
     if (!files || files.length === 0) return []
     return files.map(file => ({
-      label: `v${file.revision}`,
+      label: formatRevision(file.revision, currentProduction?.value),
       value: file.id
     }))
   })

--- a/src/lib/preview.js
+++ b/src/lib/preview.js
@@ -33,6 +33,18 @@ export const isFilePreview = extension =>
   !isMarkdownPreview(extension) &&
   !isDiffPreview(extension)
 
+// Format a preview revision for display, applying the project's
+// revision padding (a display-only setting; Zou stores the bare
+// integer). `revision_padding` is the minimum number of digits:
+// 0 (default) means no padding, 3 turns 0 -> "v000", 42 -> "v042",
+// while a wider number is never truncated (1001 -> "v1001"). A missing
+// revision yields an empty string.
+export const formatRevision = (revision, project) => {
+  if (revision == null || revision === '') return ''
+  const padding = project?.revision_padding || 0
+  return `v${String(revision).padStart(padding, '0')}`
+}
+
 // Build the .png filename for an exported annotation snapshot from a
 // task context. Sanitises each part so it's safe across filesystems,
 // lowercases the result and joins parts with underscores:

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1395,6 +1395,7 @@ export default {
       homepage: 'Homepage (first page displayed)',
       ratio: 'Ratio',
       resolution: 'Resolution',
+      revision_padding: 'Revision number padding (0 = no padding)',
       start_date: 'Start date',
       status: 'Status',
       style: 'Style',

--- a/tests/unit/lib/preview.spec.js
+++ b/tests/unit/lib/preview.spec.js
@@ -1,0 +1,27 @@
+import { formatRevision } from '@/lib/preview'
+
+describe('lib/preview', () => {
+  describe('formatRevision', () => {
+    it('pads the revision to the project padding width', () => {
+      const project = { revision_padding: 3 }
+      expect(formatRevision(0, project)).toEqual('v000')
+      expect(formatRevision(42, project)).toEqual('v042')
+    })
+
+    it('never truncates a revision wider than the padding', () => {
+      expect(formatRevision(1001, { revision_padding: 3 })).toEqual('v1001')
+    })
+
+    it('falls back to no padding when the project has none', () => {
+      expect(formatRevision(2, { revision_padding: 0 })).toEqual('v2')
+      expect(formatRevision(2, {})).toEqual('v2')
+      expect(formatRevision(2, undefined)).toEqual('v2')
+    })
+
+    it('returns an empty string for a missing revision', () => {
+      expect(formatRevision(null, { revision_padding: 3 })).toEqual('')
+      expect(formatRevision(undefined, { revision_padding: 3 })).toEqual('')
+      expect(formatRevision('', { revision_padding: 3 })).toEqual('')
+    })
+  })
+})


### PR DESCRIPTION
## Problems

- Preview revision labels are hardcoded as `v{n}` and ignore any per-project padding, so a zero-padded nomenclature (`v000`) can't be shown.

## Solutions

- Add a `formatRevision(revision, project)` helper and route all preview-revision labels through it (task view, players, comparison bar, sidebar, preview row).
- Add a "Revision number padding" field to the production parameters.