### PR TITLE
[players] Add annotation onion skin

### DIFF
--- a/src/components/players/annotations/AnnotationCanvas.vue
+++ b/src/components/players/annotations/AnnotationCanvas.vue
@@ -97,6 +97,18 @@ const updateBounds = () => {
   canvas?.calcOffset()
 }
 
+// Opening the dev console moves the media without resizing the observed
+// elements (the ResizeObserver stays silent). resize fires, but the media's
+// final rect settles a frame later, so recompute now AND after the next frame.
+// Opening the dev console moves the media without resizing the observed
+// elements, so the ResizeObserver stays silent. window / visualViewport resize
+// do fire, but the media's final rect only settles after the dock animation,
+// so recompute immediately and once more after it has settled.
+const onViewportResize = () => {
+  updateBounds()
+  setTimeout(updateBounds, 250)
+}
+
 const observe = el => el && resizeObserver?.observe(el)
 const unobserve = el => el && resizeObserver?.unobserve(el)
 
@@ -164,10 +176,14 @@ onMounted(() => {
   resizeObserver = new ResizeObserver(updateBounds)
   observe(props.mediaElement)
   observe(clip.value?.parentElement)
+  window.addEventListener('resize', onViewportResize)
+  window.visualViewport?.addEventListener('resize', onViewportResize)
   updateBounds()
 })
 
 onBeforeUnmount(() => {
+  window.removeEventListener('resize', onViewportResize)
+  window.visualViewport?.removeEventListener('resize', onViewportResize)
   resizeObserver?.disconnect()
   resizeObserver = null
   fabricCanvas.value?.dispose()

--- a/src/components/players/bars/OnionSkinPicker.vue
+++ b/src/components/players/bars/OnionSkinPicker.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="onion-wrapper">
+    <button
+      type="button"
+      class="button onion-trigger"
+      :class="{ active: isOn }"
+      :title="$t('playlists.actions.onion_skin')"
+      @click="togglePalette"
+    >
+      <layers-icon class="icon" />
+    </button>
+    <div v-show="isOpen" class="onion-palette">
+      <span class="onion-label">{{ $t('playlists.actions.onion_skin') }}</span>
+      <div class="onion-options">
+        <button
+          type="button"
+          class="onion-option"
+          :class="{ active: !isOn }"
+          :title="$t('playlists.actions.onion_skin_off')"
+          @click="onPicked(false, frames)"
+        >
+          {{ $t('playlists.actions.onion_skin_off') }}
+        </button>
+        <button
+          v-for="n in 5"
+          :key="n"
+          type="button"
+          class="onion-option"
+          :class="{ active: isOn && frames === n }"
+          :title="`${n}`"
+          @click="onPicked(true, n)"
+        >
+          {{ n }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { LayersIcon } from 'lucide-vue-next'
+import { computed, ref } from 'vue'
+
+const props = defineProps({
+  frames: {
+    type: Number,
+    default: 2
+  },
+  isOn: {
+    type: Boolean,
+    default: false
+  },
+  modelValue: {
+    // When the parent passes a Boolean here, the picker is
+    // controlled — open/close decisions go through update:model-value
+    // so siblings can be coordinated (one panel open at a time).
+    // Leaving it undefined falls back to internal state.
+    type: Boolean,
+    default: undefined
+  }
+})
+
+const emit = defineEmits(['change', 'update:model-value'])
+
+const internalOpen = ref(false)
+const isControlled = () => props.modelValue !== undefined
+const isOpen = computed(() =>
+  isControlled() ? props.modelValue : internalOpen.value
+)
+
+const setOpen = value => {
+  if (isControlled()) emit('update:model-value', value)
+  else internalOpen.value = value
+}
+
+const togglePalette = () => {
+  setOpen(!isOpen.value)
+}
+
+const onPicked = (enabled, frames) => {
+  emit('change', { enabled, frames })
+  setOpen(false)
+}
+</script>
+
+<style lang="scss" scoped>
+.onion-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+// The annotation bar (.buttons :deep(.button)) already supplies the
+// background / hover / active icon colour; we only add the pressed inset
+// shadow so the active state matches the other toggles (ButtonSimple).
+.onion-trigger.active {
+  box-shadow: inset 0 0 2px 2px var(--box-shadow);
+}
+
+.onion-trigger .icon {
+  height: 1.2rem;
+  width: 1.2rem;
+}
+
+.onion-palette {
+  background-color: $dark-grey-light;
+  border-radius: 5px;
+  bottom: calc(100% + 0.2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  left: 50%;
+  padding: 0.5rem;
+  position: absolute;
+  transform: translateX(-50%);
+  z-index: 900;
+}
+
+.preview .onion-palette {
+  background-color: $dark-grey;
+}
+
+.onion-label {
+  color: $light-grey-2;
+  font-size: 0.7rem;
+  text-align: center;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.onion-options {
+  display: flex;
+  flex-direction: row;
+  gap: 0.25rem;
+}
+
+.onion-option {
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  color: white;
+  cursor: pointer;
+  font-size: 0.85rem;
+  min-width: 1.6rem;
+  padding: 0.3rem 0.4rem;
+  transition: background-color 0.15s ease;
+}
+
+.onion-option:hover {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.onion-option.active {
+  background-color: $dark-grey-strong;
+  color: $white;
+}
+</style>

--- a/src/components/players/bars/PlayerAnnotationBar.vue
+++ b/src/components/players/bars/PlayerAnnotationBar.vue
@@ -33,6 +33,14 @@
       v-if="(!light || fullScreen) && !isConcept"
     />
 
+    <onion-skin-picker
+      v-bind="pickerState('onion')"
+      :is-on="isOnionSkinOn"
+      :frames="onionSkinFrames"
+      @change="onOnionChange"
+      v-if="isMovie && (!light || fullScreen) && !isConcept"
+    />
+
     <transition name="slide">
       <div class="annotation-tools" v-show="isTyping && (!light || fullScreen)">
         <color-picker
@@ -222,6 +230,7 @@ import { ref } from 'vue'
 import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import ColorPicker from '@/components/players/bars/ColorPicker.vue'
 import ComboboxStyled from '@/components/widgets/ComboboxStyled.vue'
+import OnionSkinPicker from '@/components/players/bars/OnionSkinPicker.vue'
 import PencilPicker from '@/components/players/bars/PencilPicker.vue'
 import ShapePicker from '@/components/players/bars/ShapePicker.vue'
 
@@ -339,6 +348,15 @@ const isLaserModeOn = defineModel('isLaserModeOn', { default: undefined })
 const isEraserModeOn = defineModel('isEraserModeOn', { default: undefined })
 const isShapeMode = defineModel('isShapeMode', { default: undefined })
 const currentShape = defineModel('currentShape', { default: undefined })
+const isOnionSkinOn = defineModel('isOnionSkinOn', { default: false })
+const onionSkinFrames = defineModel('onionSkinFrames', { default: 2 })
+
+// The picker emits a combined { enabled, frames } so the on/off state and
+// the span stay in sync (picking a number turns it on, "Off" disables it).
+const onOnionChange = ({ enabled, frames }) => {
+  isOnionSkinOn.value = enabled
+  onionSkinFrames.value = frames
+}
 
 // Tracks which picker dropdown is currently open. Each picker is
 // driven through v-model so opening one closes the others — only

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -377,6 +377,18 @@
           :class="{ 'side-by-side': isSideBySideComparison }"
         >
           <annotation-canvas
+            ref="onion-annotation-canvas"
+            canvas-id="playlist-annotation-canvas-onion"
+            :media-element="mainContentAnchorEl"
+            :panzoom-transform="panzoomTransform"
+            :interactive="false"
+            :static="true"
+            @resized="refreshOnionSkin"
+            v-show="
+              isCurrentPreviewMovie && isAnnotationsDisplayed && isOnionSkinOn
+            "
+          />
+          <annotation-canvas
             ref="main-annotation-canvas"
             canvas-id="playlist-annotation-canvas"
             :cursor="annotationCursor"
@@ -653,6 +665,8 @@
         v-model:is-environment-skybox="isEnvironmentSkybox"
         v-model:is-eraser-mode-on="isEraserModeOn"
         v-model:is-laser-mode-on="isLaserModeOn"
+        v-model:is-onion-skin-on="isOnionSkinOn"
+        v-model:onion-skin-frames="onionSkinFrames"
         v-model:is-shape-mode="isShapeMode"
         v-model:is-wireframe="isWireframe"
         @annotation-displayed-clicked="
@@ -909,6 +923,7 @@ import { useFullScreen } from '@/composables/fullScreen'
 import { useAnnotation } from '@/composables/players/annotation'
 import { useAnnotationBroadcast } from '@/composables/players/annotationBroadcast'
 import { useAnnotationCursor } from '@/composables/players/annotationCursor'
+import { useOnionSkin } from '@/composables/players/onionSkin'
 import { usePlaylistComparison } from '@/composables/players/playlistComparison'
 import { usePreviewShortcuts } from '@/composables/players/previewShortcuts'
 import { usePreviewRoom } from '@/composables/previewRoom'
@@ -1031,6 +1046,7 @@ const header = useTemplateRef('header')
 const buttonBar = useTemplateRef('button-bar')
 const videoContainer = useTemplateRef('video-container')
 const mainAnnotationCanvas = useTemplateRef('main-annotation-canvas')
+const onionAnnotationCanvas = useTemplateRef('onion-annotation-canvas')
 const mainContentAnchor = useTemplateRef('main-content-anchor')
 // canvasWrapper points to the AnnotationCanvas's overlay div so the
 // composable's legacy paths (addText, showCanvas) keep working with the
@@ -1533,6 +1549,7 @@ const { postAnnotationAddition, postAnnotationDeletion, postAnnotationUpdate } =
 const annotation = useAnnotation({
   mainCanvasComponent: mainAnnotationCanvas,
   comparisonCanvasComponent: comparisonAnnotationCanvas,
+  onionCanvasComponent: onionAnnotationCanvas,
   canvasWrapper,
   annotations,
   isCurrentUserArtist,
@@ -1571,6 +1588,8 @@ const {
   loadSingleAnnotation,
   loadSingleAnnotationComparison,
   clearComparisonCanvas,
+  loadOnionSkin,
+  clearOnionCanvas,
   currentShape,
   isShapeMode,
   isEraserModeOn,
@@ -1598,6 +1617,21 @@ const {
   copyAnnotationCanvas,
   compositeLiveAnnotationsOntoCanvas
 } = annotation
+
+// Onion skin: ghost the annotations of nearby frames. Persisted like the
+// other player preferences.
+const isOnionSkinOn = ref(
+  preferences.getBoolPreference('player:onionSkinEnabled')
+)
+const onionSkinFrames = ref(
+  Number(preferences.getPreference('player:onionSkinFrames')) || 2
+)
+watch(isOnionSkinOn, value =>
+  preferences.setPreference('player:onionSkinEnabled', value)
+)
+watch(onionSkinFrames, value =>
+  preferences.setPreference('player:onionSkinFrames', value)
+)
 
 // FullScreen composable
 
@@ -2789,6 +2823,23 @@ const getAnnotation = time => {
   annotations.value = []
   return null
 }
+
+// frameNumber is round(currentTimeRaw / frameDuration) - 1, but the
+// annotation lookup (getAnnotation(frame * frameDuration)) works on the raw
+// frame index — so the onion must be centred one frame higher, matching the
+// frame the current annotation actually sits on.
+const onionCurrentFrame = computed(() => frameNumber.value + 1)
+
+const { refresh: refreshOnionSkin } = useOnionSkin({
+  isOn: isOnionSkinOn,
+  frames: onionSkinFrames,
+  currentFrame: onionCurrentFrame,
+  nbFrames,
+  annotations,
+  getAnnotationAtFrame: frame => getAnnotation(frame * frameDuration.value),
+  loadOnionSkin,
+  clearOnionCanvas
+})
 
 const onMetadataLoaded = () => {
   nextTick(() => {

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -2868,8 +2868,16 @@ const onContainerMouseDown = event => {
   // focused textarea — Shift+Tab then thinks the user is "in the
   // comment block" and ping-pongs them back to the player.
   if (event.button === 0) container.value?.focus()
-  if (!isCurrentPreviewMovie.value || !event.shiftKey || event.button !== 0)
+  const isDrawingTool =
+    isDrawing.value || isShapeMode.value || isEraserModeOn.value
+  if (
+    !isCurrentPreviewMovie.value ||
+    !event.shiftKey ||
+    event.button !== 0 ||
+    isDrawingTool
+  ) {
     return
+  }
   event.preventDefault()
   event.stopPropagation()
   scrubbing = true

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -1821,7 +1821,16 @@ const onContainerMouseDown = event => {
   // focused textarea — Shift+Tab then thinks the user is "in the
   // comment block" and ping-pongs them back to the player.
   if (event.button === 0) container.value?.focus()
-  if (!isMovie.value || !event.shiftKey || event.button !== 0) return
+  const isDrawingTool =
+    isDrawing.value || isShapeMode.value || isEraserModeOn.value
+  if (
+    !isMovie.value ||
+    !event.shiftKey ||
+    event.button !== 0 ||
+    isDrawingTool
+  ) {
+    return
+  }
   event.preventDefault()
   event.stopPropagation()
   scrubbing = true

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -12,6 +12,21 @@
             :class="{ 'side-by-side': isSideBySideComparison }"
           >
             <annotation-canvas
+              ref="onion-annotation-canvas"
+              :canvas-id="`${canvasId}-onion`"
+              :media-element="mainMediaElement"
+              :panzoom-transform="panzoomTransform"
+              :interactive="false"
+              :static="true"
+              v-show="
+                isAnnotationsDisplayed &&
+                isOnionSkinOn &&
+                isMovie &&
+                mainMediaElement
+              "
+              @resized="refreshOnionSkin"
+            />
+            <annotation-canvas
               ref="main-annotation-canvas"
               :canvas-id="canvasId"
               :cursor="annotationCursor"
@@ -231,6 +246,8 @@
             v-model:current-shape="currentShape"
             v-model:is-environment-skybox="isEnvironmentSkybox"
             v-model:is-eraser-mode-on="isEraserModeOn"
+            v-model:is-onion-skin-on="isOnionSkinOn"
+            v-model:onion-skin-frames="onionSkinFrames"
             v-model:is-shape-mode="isShapeMode"
             v-model:is-wireframe="isWireframe"
             @annotation-displayed-clicked="onAnnotationDisplayedClicked"
@@ -429,6 +446,7 @@ import { usePanzoomSync } from '@/composables/panzoom'
 import { useAnnotation } from '@/composables/players/annotation'
 import { useAnnotationCursor } from '@/composables/players/annotationCursor'
 import { useComparison } from '@/composables/players/comparison'
+import { useOnionSkin } from '@/composables/players/onionSkin'
 import { usePreviewShortcuts } from '@/composables/players/previewShortcuts'
 import { getEntityPath } from '@/lib/path'
 import localPreferences from '@/lib/preferences'
@@ -555,6 +573,7 @@ const mainAnnotationCanvas = useTemplateRef('main-annotation-canvas')
 const comparisonAnnotationCanvas = useTemplateRef(
   'comparison-annotation-canvas'
 )
+const onionAnnotationCanvas = useTemplateRef('onion-annotation-canvas')
 const previewViewer = useTemplateRef('preview-viewer')
 const comparisonViewer = useTemplateRef('comparison-preview-viewer')
 const previewContainer = useTemplateRef('preview-container')
@@ -643,6 +662,7 @@ const isOverlayInteractive = computed(() => !isAltHeld.value)
 const annotation = useAnnotation({
   mainCanvasComponent: mainAnnotationCanvas,
   comparisonCanvasComponent: comparisonAnnotationCanvas,
+  onionCanvasComponent: onionAnnotationCanvas,
   canvasWrapper,
   annotations,
   isCurrentUserArtist,
@@ -683,6 +703,8 @@ const {
   redoLastAction,
   clearCanvas,
   clearComparisonCanvas,
+  loadOnionSkin,
+  clearOnionCanvas,
   copyAnnotations,
   copyAnnotationCanvas,
   compositeLiveAnnotationsOntoCanvas,
@@ -695,6 +717,21 @@ const {
   restoreFailedAnnotations,
   toggleShapeMode
 } = annotation
+
+// Onion skin: ghost the annotations of nearby frames. Persisted like the
+// other player preferences.
+const isOnionSkinOn = ref(
+  localPreferences.getBoolPreference('player:onionSkinEnabled')
+)
+const onionSkinFrames = ref(
+  Number(localPreferences.getPreference('player:onionSkinFrames')) || 2
+)
+watch(isOnionSkinOn, value =>
+  localPreferences.setPreference('player:onionSkinEnabled', value)
+)
+watch(onionSkinFrames, value =>
+  localPreferences.setPreference('player:onionSkinFrames', value)
+)
 
 // Computed
 
@@ -1348,6 +1385,17 @@ const getAnnotation = time => {
     return annotations.value.find(annotation => annotation.time === 0)
   }
 }
+
+const { refresh: refreshOnionSkin } = useOnionSkin({
+  isOn: isOnionSkinOn,
+  frames: onionSkinFrames,
+  currentFrame,
+  nbFrames,
+  annotations,
+  getAnnotationAtFrame: frame => getAnnotation(frame * frameDuration.value),
+  loadOnionSkin,
+  clearOnionCanvas
+})
 
 const getSortedAnnotations = () => {
   const anns = annotations.value

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -1296,25 +1296,33 @@ export const useAnnotation = ({
     }
   }
 
-  // Render ghost annotations onto the read-only onion canvas. `ghosts` is an
-  // array of { annotation, opacity }. Objects are built sequentially (creation
-  // is async); a newer load or a clear bumps onionLoadToken and aborts the
-  // in-flight one so late adds never repopulate a cleared canvas.
+  // Add one ghost annotation's objects at the given opacity. Sequential
+  // because object creation is async and addObjectToCanvas mutates shared
+  // state (so it can't run in parallel).
+  const renderOnionGhost = async (canvas, { annotation, opacity }) => {
+    for (const obj of annotation.drawing.objects) {
+      const built = await addObjectToCanvas(annotation, obj, canvas)
+      built?.set('opacity', opacity)
+    }
+  }
+
+  // Paint the ghosts (each { annotation, opacity }) onto the read-only onion
+  // canvas. Newest load wins: ghosts are skipped once a fresher load or a
+  // clear has bumped onionLoadToken, so a superseded load never repopulates a
+  // canvas meant for another frame.
   const loadOnionSkin = async ghosts => {
     const canvas = fabricCanvasOnion.value
+    // A 0×0 canvas (not laid out yet) would scale every object to nothing.
     if (!canvas || !canvas.width || !canvas.height) return
-    onionLoadToken++
-    const token = onionLoadToken
+    const token = ++onionLoadToken
     canvas.clear()
-    for (const { annotation, opacity } of ghosts) {
-      for (const obj of annotation.drawing.objects) {
-        if (token !== onionLoadToken) return
-        const built = await addObjectToCanvas(annotation, obj, canvas)
-        if (built) built.set('opacity', opacity)
-      }
+    for (const ghost of ghosts) {
+      if (token !== onionLoadToken) return
+      await renderOnionGhost(canvas, ghost)
     }
-    if (token !== onionLoadToken) return
-    if (isFabricReady(canvas)) canvas.requestRenderAll()
+    if (token === onionLoadToken && isFabricReady(canvas)) {
+      canvas.requestRenderAll()
+    }
   }
 
   // Clipboard

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -125,6 +125,7 @@ if (PSStroke) {
 export const useAnnotation = ({
   mainCanvasComponent,
   comparisonCanvasComponent,
+  onionCanvasComponent,
   canvasWrapper,
   annotations,
   isCurrentUserArtist,
@@ -148,6 +149,7 @@ export const useAnnotation = ({
   // writable refs.
   const fabricCanvas = ref(null)
   const fabricCanvasComparison = ref(null)
+  const fabricCanvasOnion = ref(null)
   const lastAnnotationTime = ref('')
   const additions = ref([])
   const deletions = ref([])
@@ -177,6 +179,7 @@ export const useAnnotation = ({
   // Bumped on every comparison-canvas clear so an in-flight async load can tell
   // it was superseded and stop repopulating a canvas meant to be cleared.
   let comparisonLoadToken = 0
+  let onionLoadToken = 0
   let annotatedPreview = null
   let annotationToSave = null
   let pendingSave = null
@@ -1286,6 +1289,34 @@ export const useAnnotation = ({
     }
   }
 
+  const clearOnionCanvas = () => {
+    onionLoadToken++
+    if (isFabricReady(fabricCanvasOnion.value)) {
+      fabricCanvasOnion.value.clear()
+    }
+  }
+
+  // Render ghost annotations onto the read-only onion canvas. `ghosts` is an
+  // array of { annotation, opacity }. Objects are built sequentially (creation
+  // is async); a newer load or a clear bumps onionLoadToken and aborts the
+  // in-flight one so late adds never repopulate a cleared canvas.
+  const loadOnionSkin = async ghosts => {
+    const canvas = fabricCanvasOnion.value
+    if (!canvas || !canvas.width || !canvas.height) return
+    onionLoadToken++
+    const token = onionLoadToken
+    canvas.clear()
+    for (const { annotation, opacity } of ghosts) {
+      for (const obj of annotation.drawing.objects) {
+        if (token !== onionLoadToken) return
+        const built = await addObjectToCanvas(annotation, obj, canvas)
+        if (built) built.set('opacity', opacity)
+      }
+    }
+    if (token !== onionLoadToken) return
+    if (isFabricReady(canvas)) canvas.requestRenderAll()
+  }
+
   // Clipboard
 
   const copyAnnotations = () => {
@@ -1507,11 +1538,21 @@ export const useAnnotation = ({
       { immediate: true, flush: 'sync' }
     )
   }
+  if (onionCanvasComponent) {
+    watch(
+      () => onionCanvasComponent.value?.canvas || null,
+      canvas => {
+        fabricCanvasOnion.value = canvas
+      },
+      { immediate: true, flush: 'sync' }
+    )
+  }
 
   return {
     // State
     fabricCanvas,
     fabricCanvasComparison,
+    fabricCanvasOnion,
     lastAnnotationTime,
     additions,
     deletions,
@@ -1601,6 +1642,8 @@ export const useAnnotation = ({
     isEmptyCanvas,
     clearCanvas,
     clearComparisonCanvas,
+    loadOnionSkin,
+    clearOnionCanvas,
     copyAnnotations,
     pasteAnnotations,
     applyGroupChanges,

--- a/src/composables/players/onionSkin.js
+++ b/src/composables/players/onionSkin.js
@@ -1,0 +1,54 @@
+/*
+ * Onion skin orchestration.
+ *
+ * Watches the current frame and the onion settings, computes the ghost
+ * annotations (neighbouring annotated frames + their fade opacity via the pure
+ * helpers in @/lib/players/onionSkin) and pushes them to the read-only onion
+ * canvas owned by the annotation composable.
+ */
+import { watch } from 'vue'
+
+import { onionOpacity, selectOnionNeighbors } from '@/lib/players/onionSkin'
+
+/*
+ * @param {Object} options
+ * @param {import('vue').Ref<boolean>} options.isOn
+ * @param {import('vue').Ref<number>} options.frames - span 1..5
+ * @param {import('vue').Ref<number>} options.currentFrame
+ * @param {import('vue').Ref<number>} options.nbFrames
+ * @param {import('vue').Ref<Array>} options.annotations - re-render when it changes
+ * @param {Function} options.getAnnotationAtFrame - (frame) => annotation | null
+ * @param {Function} options.loadOnionSkin - (ghosts) => Promise, ghosts = [{annotation, opacity}]
+ * @param {Function} options.clearOnionCanvas - () => void
+ */
+export const useOnionSkin = ({
+  isOn,
+  frames,
+  currentFrame,
+  nbFrames,
+  annotations,
+  getAnnotationAtFrame,
+  loadOnionSkin,
+  clearOnionCanvas
+}) => {
+  const refresh = () => {
+    if (!isOn.value) {
+      clearOnionCanvas()
+      return
+    }
+    const ghosts = selectOnionNeighbors(
+      currentFrame.value,
+      frames.value,
+      getAnnotationAtFrame,
+      nbFrames.value
+    ).map(({ annotation, distance }) => ({
+      annotation,
+      opacity: onionOpacity(distance, frames.value)
+    }))
+    loadOnionSkin(ghosts)
+  }
+
+  watch([isOn, frames, currentFrame, annotations], refresh, { immediate: true })
+
+  return { refresh }
+}

--- a/src/lib/players/onionSkin.js
+++ b/src/lib/players/onionSkin.js
@@ -1,0 +1,55 @@
+/*
+ * Onion skin helpers.
+ *
+ * Pure logic for the annotation onion skin: pick the neighbouring annotated
+ * frames around the current frame and compute each ghost's opacity from its
+ * distance. No Vue / no canvas here so it stays unit-testable.
+ */
+
+export const ONION_MIN_OPACITY = 0.1
+export const ONION_MAX_OPACITY = 0.55
+
+/*
+ * Opacity of a ghost annotation `distance` frames away from the current frame,
+ * for a span of `n` frames on each side. Linear fade from ONION_MAX_OPACITY at
+ * distance 1, floored at ONION_MIN_OPACITY so the farthest ghost stays faintly
+ * visible. Returns 0 for invalid inputs.
+ */
+export const onionOpacity = (distance, n) => {
+  if (distance < 1 || n < 1) return 0
+  const step = (ONION_MAX_OPACITY - ONION_MIN_OPACITY) / n
+  const opacity = ONION_MAX_OPACITY - (distance - 1) * step
+  return Math.max(ONION_MIN_OPACITY, Math.min(ONION_MAX_OPACITY, opacity))
+}
+
+/*
+ * Neighbours to ghost around `currentFrame`: up to `n` frames before and after
+ * that actually carry an annotation, clamped to [0, nbFrames - 1]. The current
+ * frame itself is never included (it holds the editable annotation).
+ *
+ * `getAnnotationAtFrame(frame)` returns the annotation on that frame, or a
+ * falsy value when none. `nbFrames` is optional; when omitted only the lower
+ * bound (>= 0) is enforced.
+ *
+ * Returns [{ annotation, distance, frame }], nearest distances first.
+ */
+export const selectOnionNeighbors = (
+  currentFrame,
+  n,
+  getAnnotationAtFrame,
+  nbFrames
+) => {
+  const inRange = frame =>
+    frame >= 0 && (nbFrames == null || frame <= nbFrames - 1)
+  return Array.from({ length: Math.max(0, n) }, (_, i) => i + 1)
+    .flatMap(distance =>
+      [currentFrame - distance, currentFrame + distance]
+        .filter(inRange)
+        .map(frame => ({
+          frame,
+          distance,
+          annotation: getAnnotationAtFrame(frame)
+        }))
+    )
+    .filter(entry => entry.annotation)
+}

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1265,6 +1265,8 @@ export default {
       annotation_small: 'Small',
       annotation_tiny: 'Tiny',
       annotation_zoom_pan: 'Reset zoom',
+      onion_skin: 'Onion skin frames',
+      onion_skin_off: 'Off',
       change_task_type: 'Change task type',
       current_time: 'Position in the video',
       comments: 'Show/Hide comments',

--- a/tests/unit/composables/onionSkin.spec.js
+++ b/tests/unit/composables/onionSkin.spec.js
@@ -1,0 +1,79 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent, nextTick, ref } from 'vue'
+
+import { useOnionSkin } from '@/composables/players/onionSkin'
+
+const ghost = id => ({ id, drawing: { objects: [] } })
+
+const mountOnion = (overrides = {}) => {
+  const isOn = overrides.isOn ?? ref(false)
+  const frames = overrides.frames ?? ref(2)
+  const currentFrame = overrides.currentFrame ?? ref(10)
+  const nbFrames = overrides.nbFrames ?? ref(100)
+  const annotations = overrides.annotations ?? ref([])
+  // Annotations on frames 9 and 11 by default.
+  const annotated = overrides.annotated ?? { 9: ghost('a9'), 11: ghost('a11') }
+  const getAnnotationAtFrame = frame => annotated[frame] || null
+  const loadOnionSkin = vi.fn()
+  const clearOnionCanvas = vi.fn()
+
+  let api
+  const Comp = defineComponent({
+    setup() {
+      api = useOnionSkin({
+        isOn,
+        frames,
+        currentFrame,
+        nbFrames,
+        annotations,
+        getAnnotationAtFrame,
+        loadOnionSkin,
+        clearOnionCanvas
+      })
+      return () => null
+    }
+  })
+  const wrapper = mount(Comp)
+  return { wrapper, api, isOn, frames, currentFrame, loadOnionSkin, clearOnionCanvas }
+}
+
+describe('composables/onionSkin', () => {
+  it('clears the onion canvas while disabled', () => {
+    const { clearOnionCanvas, loadOnionSkin, wrapper } = mountOnion({
+      isOn: ref(false)
+    })
+    expect(clearOnionCanvas).toHaveBeenCalled()
+    expect(loadOnionSkin).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('loads ghosts (nearest first) with fading opacity when enabled', () => {
+    const { loadOnionSkin, wrapper } = mountOnion({ isOn: ref(true) })
+    expect(loadOnionSkin).toHaveBeenCalledTimes(1)
+    const ghosts = loadOnionSkin.mock.calls.at(-1)[0]
+    expect(ghosts.map(g => g.annotation.id)).toEqual(['a9', 'a11'])
+    expect(ghosts.every(g => g.opacity > 0 && g.opacity <= 1)).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('re-renders when the current frame changes', async () => {
+    const isOn = ref(true)
+    const currentFrame = ref(10)
+    const { loadOnionSkin, wrapper } = mountOnion({ isOn, currentFrame })
+    loadOnionSkin.mockClear()
+    currentFrame.value = 50
+    await nextTick()
+    expect(loadOnionSkin).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+
+  it('clears when toggled off', async () => {
+    const isOn = ref(true)
+    const { clearOnionCanvas, isOn: onRef, wrapper } = mountOnion({ isOn })
+    clearOnionCanvas.mockClear()
+    onRef.value = false
+    await nextTick()
+    expect(clearOnionCanvas).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+})

--- a/tests/unit/lib/onionSkin.spec.js
+++ b/tests/unit/lib/onionSkin.spec.js
@@ -1,0 +1,71 @@
+import {
+  ONION_MAX_OPACITY,
+  ONION_MIN_OPACITY,
+  onionOpacity,
+  selectOnionNeighbors
+} from '@/lib/players/onionSkin'
+
+describe('lib/players/onionSkin', () => {
+  describe('onionOpacity', () => {
+    it('returns the max opacity for the nearest neighbour', () => {
+      expect(onionOpacity(1, 5)).toBe(ONION_MAX_OPACITY)
+    })
+
+    it('fades with distance', () => {
+      expect(onionOpacity(2, 5)).toBeLessThan(onionOpacity(1, 5))
+      expect(onionOpacity(3, 5)).toBeLessThan(onionOpacity(2, 5))
+    })
+
+    it('never drops below the min opacity', () => {
+      expect(onionOpacity(5, 5)).toBeGreaterThanOrEqual(ONION_MIN_OPACITY)
+      expect(onionOpacity(99, 5)).toBe(ONION_MIN_OPACITY)
+    })
+
+    it('returns 0 for invalid inputs', () => {
+      expect(onionOpacity(0, 5)).toBe(0)
+      expect(onionOpacity(1, 0)).toBe(0)
+    })
+  })
+
+  describe('selectOnionNeighbors', () => {
+    // Annotations on frames 8, 9, 11, 13; current frame 10.
+    const annotated = { 8: { id: 'a8' }, 9: { id: 'a9' }, 11: { id: 'a11' }, 13: { id: 'a13' } }
+    const getAt = frame => annotated[frame] || null
+
+    it('collects annotated frames within n before and after, nearest first', () => {
+      const result = selectOnionNeighbors(10, 2, getAt, 100)
+      expect(result).toEqual([
+        { frame: 9, distance: 1, annotation: { id: 'a9' } },
+        { frame: 11, distance: 1, annotation: { id: 'a11' } },
+        { frame: 8, distance: 2, annotation: { id: 'a8' } }
+      ])
+    })
+
+    it('excludes the current frame', () => {
+      const result = selectOnionNeighbors(9, 1, getAt, 100)
+      expect(result.every(entry => entry.frame !== 9)).toBe(true)
+    })
+
+    it('skips frames without an annotation', () => {
+      // frame 12 has no annotation, frame 13 does (distance 3)
+      const result = selectOnionNeighbors(10, 3, getAt, 100)
+      const frames = result.map(entry => entry.frame)
+      expect(frames).toContain(13)
+      expect(frames).not.toContain(12)
+    })
+
+    it('clamps to the lower bound', () => {
+      const result = selectOnionNeighbors(0, 5, getAt, 100)
+      expect(result.every(entry => entry.frame >= 0)).toBe(true)
+    })
+
+    it('clamps to the upper bound (nbFrames)', () => {
+      const result = selectOnionNeighbors(13, 5, getAt, 14)
+      expect(result.every(entry => entry.frame <= 13)).toBe(true)
+    })
+
+    it('returns nothing for n = 0', () => {
+      expect(selectOnionNeighbors(10, 0, getAt, 100)).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Problems

- Reviewers and artists can't see the annotations of neighbouring frames while navigating or drawing.
- Shift+drag triggered the scrub gesture even while a drawing tool was active.
- The annotation overlay drifted off the media on viewport/layout changes.

## Solutions

- Add an opt-in onion skin: ghost the annotations of the 1–5 frames before and after the current one, faded by distance, on a read-only canvas layer; movie-only, persisted, toggled from a Layers picker in the annotation bar. Wired into the preview and playlist players, reusing the existing read-only render path.
- Ignore Shift+drag scrubbing while a drawing tool is active.
- Re-glue the annotation overlay to the media on viewport changes.
