### PR TITLE
Fix review crashes and reduce memory build-up over long sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,14 @@ useHead({ title: computed(() => `${t('studios.title')} - Kitsu`) })
 </script>
 ```
 
+#### `defineExpose` when a parent drives the component via a ref
+
+A `<script setup>` component exposes nothing through a template ref (≠ Options API):
+
+- Parent calls `this.$refs.child.method()` / `childRef.value.method()` → method throws `TypeError`, **property write is a silent no-op**.
+- Fix: grep both ref styles and add the members to `defineExpose`.
+- If the parent only *wrote* state, prefer a watcher on the child's props and delete the ref access.
+
 ### Script setup organization
 
 Group code by role with section comments, in this order:

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -1090,11 +1090,8 @@ export default {
   },
 
   watch: {
-    displayedAssets: {
-      deep: true,
-      handler() {
-        this.$options.lineIndex = {}
-      }
+    displayedAssets() {
+      this.$options.lineIndex = {}
     },
 
     validationColumns: {

--- a/src/components/lists/EpisodeStatsList.vue
+++ b/src/components/lists/EpisodeStatsList.vue
@@ -430,14 +430,11 @@ export default {
   },
 
   watch: {
-    entries: {
-      deep: true,
-      handler() {
-        this.entries.forEach(e => {
-          const value = this.expanded[e.id] || false
-          this.expanded[e.id] = value
-        })
-      }
+    entries() {
+      this.entries.forEach(e => {
+        const value = this.expanded[e.id] || false
+        this.expanded[e.id] = value
+      })
     },
 
     isRetakes() {

--- a/src/components/mixins/task.js
+++ b/src/components/mixins/task.js
@@ -1,5 +1,3 @@
-import drafts from '@/lib/drafts'
-
 /*
  * Helpers to display task information
  */
@@ -60,15 +58,6 @@ export const taskMixin = {
       }
       if (this.$refs['add-comment-image-modal']) {
         this.$refs['add-comment-image-modal'].reset()
-      }
-    },
-
-    resetDraft() {
-      const task = this.getTask()
-      if (task && this.$refs['add-comment']) {
-        const draft = drafts.getTaskDraft(task.id)
-        this.$refs['add-comment'].text = draft?.text || ''
-        this.$refs['add-comment'].checklistItems = draft?.checklist || []
       }
     },
 

--- a/src/components/modals/EditAssetModal.vue
+++ b/src/components/modals/EditAssetModal.vue
@@ -156,13 +156,17 @@ const episodeOptions = computed(() => {
   return options
 })
 
+const focusName = () => {
+  nameField.value?.focus()
+}
+
 const validateForm = () => {
   if (isTVShow.value && !episodeField.value?.isValid) {
     episodeField.value?.focus()
     return false
   }
   if (!form.value.name) {
-    nameField.value?.focus()
+    focusName()
     return false
   }
   return true
@@ -243,7 +247,7 @@ watch(
     resetForm()
     if (active) {
       setTimeout(() => {
-        nameField.value?.focus()
+        focusName()
       }, 100)
     }
   }
@@ -258,6 +262,8 @@ onMounted(() => {
   resetForm()
   assetSuccessText.value = ''
 })
+
+defineExpose({ focusName })
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/modals/EditCommentModal.vue
+++ b/src/components/modals/EditCommentModal.vue
@@ -369,7 +369,7 @@ watch(
     })
     membersForAts.value['#'] = taskTypeOptions
   },
-  { deep: true, immediate: true }
+  { immediate: true }
 )
 
 watch(
@@ -399,7 +399,7 @@ watch(
     teamOptions.push({ isTime: true, full_name: 'frame' })
     membersForAts.value['@'] = teamOptions
   },
-  { deep: true, immediate: true }
+  { immediate: true }
 )
 </script>
 

--- a/src/components/pages/ProductionSettings.vue
+++ b/src/components/pages/ProductionSettings.vue
@@ -81,7 +81,7 @@
             {{ $t('main.add') }}
           </button>
         </div>
-        <div class="box" v-if="isEmpty(currentProduction.task_statuses)">
+        <div class="box" v-if="isEmpty(currentProduction?.task_statuses)">
           {{ $t('settings.production.empty_list') }}
         </div>
         <table class="datatable" v-else>
@@ -200,7 +200,7 @@ const taskStatus = computed(() => store.getters.taskStatus)
 const remainingTaskStatuses = computed(() =>
   taskStatus.value.filter(
     status =>
-      !currentProduction.value.task_statuses.includes(status.id) &&
+      !currentProduction.value?.task_statuses.includes(status.id) &&
       !status.for_concept
   )
 )

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -1180,7 +1180,6 @@ export default {
       this.taskComments = this.getCurrentTaskComments()
       this.taskPreviews = this.getCurrentTaskPreviews()
       this.task = this.getCurrentTask()
-      this.resetDraft()
       setTimeout(() => {
         if (this.$route.params.preview_id) {
           this.selectedPreviewId = this.$route.params.preview_id

--- a/src/components/players/annotations/SharedAnnotationOverlay.vue
+++ b/src/components/players/annotations/SharedAnnotationOverlay.vue
@@ -279,12 +279,11 @@ watch(
     () => props.isPicture,
     () => props.isPlaying
   ],
-  render,
-  { deep: true }
+  render
 )
 
-watch(() => props.movieDimensions, fitCanvasToBounds, { deep: true })
-watch(() => props.panzoomTransform, applyPanzoomTransform, { deep: true })
+watch(() => props.movieDimensions, fitCanvasToBounds)
+watch(() => props.panzoomTransform, applyPanzoomTransform)
 
 // Lifecycle
 

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -2760,11 +2760,13 @@ const saveAnnotations = () => {
   }
   if (currentPreviewIndex.value > 0) {
     const index = currentPreviewIndex.value - 1
-    const previewFile = currentEntity.value.preview_file_previews[index]
-    preview = {
-      id: previewFile.id,
-      task_id: entity.preview_file_task_id,
-      annotations: previewFile.annotations || []
+    const previewFile = currentEntity.value?.preview_file_previews?.[index]
+    if (previewFile) {
+      preview = {
+        id: previewFile.id,
+        task_id: entity.preview_file_task_id,
+        annotations: previewFile.annotations || []
+      }
     }
   }
 

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -4186,13 +4186,9 @@ watch(comparisonMode, () => {
 // its panzoom-transform prop. setComparisonPanZoom runs in silent mode
 // inside MultiVideoViewer, so the resulting panzoom-changed event is
 // suppressed and we don't get a feedback loop.
-watch(
-  panzoomTransform,
-  ({ x, y, scale }) => {
-    if (isComparing.value) setComparisonPanZoom(x, y, scale)
-  },
-  { deep: true }
-)
+watch(panzoomTransform, ({ x, y, scale }) => {
+  if (isComparing.value) setComparisonPanZoom(x, y, scale)
+})
 
 // Preserve the current entity across an entities rebuild. A task-type
 // change rebuilds the list with the same entities (the parent does it via

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -4375,6 +4375,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   endAnnotationSaving()
+  _stopPlaylistProgressUpdateLoop()
   window.removeEventListener('keydown', onKeyDown)
   window.removeEventListener('resize', onWindowResize)
   window.removeEventListener('beforeunload', onWindowsClosed)

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -2133,19 +2133,15 @@ watch(isComparisonOverlay, () => {
 // Drive the comparison viewer's underlying panzoom from the main one so
 // both stay visually synced. The annotation canvases pick up the
 // transform directly via their panzoom-transform prop.
-watch(
-  panzoomTransform,
-  transform => {
-    if (isComparing.value) {
-      comparisonViewer.value?.setPanZoom(
-        transform.x,
-        transform.y,
-        transform.scale
-      )
-    }
-  },
-  { deep: true }
-)
+watch(panzoomTransform, transform => {
+  if (isComparing.value) {
+    comparisonViewer.value?.setPanZoom(
+      transform.x,
+      transform.y,
+      transform.scale
+    )
+  }
+})
 
 watch(speed, () => {
   const rates = [0.25, 0.5, 1, 1.5, 2]

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -594,6 +594,7 @@ const revisionPreviews = useTemplateRef('revision-previews')
 let lastIndex = 1
 let scrubbing = false
 let scrubStartX = 0
+let containerResizeObserver = null
 
 // — Reactive
 
@@ -2189,10 +2190,11 @@ onMounted(() => {
   // viewer's transform through the panzoom-changed sync.
   previewViewer.value?.resumeZoom()
 
-  new ResizeObserver(() => {
+  containerResizeObserver = new ResizeObserver(() => {
     resetPlayerPositions()
     if (isPicture.value || isMovie.value) loadAnnotation()
-  }).observe(container.value)
+  })
+  containerResizeObserver.observe(container.value)
 
   window.addEventListener('resize', onWindowResize)
   // Capture phase so Shift+Tab is intercepted before the textarea's
@@ -2216,6 +2218,8 @@ onBeforeUnmount(() => {
   )
   document.removeEventListener('mousemove', onScrubMove)
   document.removeEventListener('mouseup', onScrubEnd)
+  containerResizeObserver?.disconnect()
+  containerResizeObserver = null
 })
 
 // Player API (passed to TaskInfo via :player prop)

--- a/src/components/players/progress/PlaylistProgress.vue
+++ b/src/components/players/progress/PlaylistProgress.vue
@@ -150,6 +150,8 @@ const playlistProgressWidget = ref(null)
 const progressDragging = ref(false)
 const width = ref(0)
 
+let playlistResizeObserver = null
+
 const getClientX = event =>
   event.touches?.[0]?.clientX ??
   event.changedTouches?.[0]?.clientX ??
@@ -356,7 +358,8 @@ onMounted(() => {
   domEvents.forEach(([type, listener]) =>
     document.addEventListener(type, listener)
   )
-  new ResizeObserver(resetWidth).observe(playlistProgressWidget.value)
+  playlistResizeObserver = new ResizeObserver(resetWidth)
+  playlistResizeObserver.observe(playlistProgressWidget.value)
   resetWidth()
 })
 
@@ -364,6 +367,8 @@ onBeforeUnmount(() => {
   domEvents.forEach(([type, listener]) =>
     document.removeEventListener(type, listener)
   )
+  playlistResizeObserver?.disconnect()
+  playlistResizeObserver = null
 })
 </script>
 

--- a/src/components/players/progress/PlaylistProgress.vue
+++ b/src/components/players/progress/PlaylistProgress.vue
@@ -336,7 +336,7 @@ watch(
   () => {
     if (props.previewId) {
       const preview = props.playlistShotPosition[hoverFrame.value]
-      if (preview.extension === 'mp4') {
+      if (preview?.extension === 'mp4') {
         isTileLoading.value = true
         const img = new Image()
         img.src = tilePath.value

--- a/src/components/players/viewers/MultiVideoViewer.vue
+++ b/src/components/players/viewers/MultiVideoViewer.vue
@@ -129,6 +129,7 @@ const nextPlayer = shallowRef(undefined)
 // Non-reactive locals (instance-private state previously stashed on $options)
 let containerResizeObserver = null
 let currentTimeRaw = 0
+let isSeeking = false
 let firstPanZoom = null
 let panzoomInstances = []
 let playLoop = null
@@ -507,10 +508,18 @@ const _setCurrentTime = newTime => {
 }
 
 const runSetCurrentTime = currentTime => {
+  // onTimeUpdate emits frame-update, which PlaylistPlayer can answer with
+  // another seek: ignore those re-entrant calls so the loop can't recurse.
+  if (isSeeking) return
   if (currentPlayer.value && currentPlayer.value.currentTime !== currentTime) {
-    // tweaks needed because the html video player is messy with frames
-    currentPlayer.value.currentTime = currentTime + 0.001
-    onTimeUpdate()
+    isSeeking = true
+    try {
+      // tweaks needed because the html video player is messy with frames
+      currentPlayer.value.currentTime = currentTime + 0.001
+      onTimeUpdate()
+    } finally {
+      isSeeking = false
+    }
   }
 }
 

--- a/src/components/players/viewers/MultiVideoViewer.vue
+++ b/src/components/players/viewers/MultiVideoViewer.vue
@@ -264,6 +264,7 @@ const getMoviePath = entity => {
     let previewId
     if (
       props.currentPreviewIndex === 0 ||
+      !entity.preview_file_previews ||
       props.currentPreviewIndex > entity.preview_file_previews.length
     ) {
       previewId = entity.preview_file_id

--- a/src/components/players/viewers/SoundViewer.vue
+++ b/src/components/players/viewers/SoundViewer.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup>
-import { onMounted, ref, watch } from 'vue'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import WaveSurfer from 'wavesurfer.js'
 
 import Spinner from '@/components/widgets/Spinner.vue'
@@ -83,6 +83,11 @@ watch(
     }
   }
 )
+
+onBeforeUnmount(() => {
+  wavesurfer?.destroy()
+  wavesurfer = null
+})
 
 defineExpose({ play, pause })
 </script>

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1034,7 +1034,6 @@ export default {
         this.setOtherPreviews()
         this.currentPreviewPath = this.getOriginalPath()
         this.currentPreviewDlPath = this.getOriginalDlPath()
-        this.resetDraft()
         this.$nextTick(() => {
           this.$refs['preview-player']?.focus()
         })

--- a/src/components/widgets/ComboboxStyled.vue
+++ b/src/components/widgets/ComboboxStyled.vue
@@ -190,7 +190,7 @@ watch(
       selectedOption.value = option || props.options[0]
     }
   },
-  { deep: true, immediate: true }
+  { immediate: true }
 )
 
 watch(showList, () => {

--- a/src/components/widgets/PeopleField.vue
+++ b/src/components/widgets/PeopleField.vue
@@ -133,8 +133,7 @@ watch(
       : null
     items.value = props.people
     index.value = buildNameIndex(props.people)
-  },
-  { deep: true }
+  }
 )
 
 watch(

--- a/src/composables/atMentions.js
+++ b/src/composables/atMentions.js
@@ -34,7 +34,7 @@ export const useAtMentionsMembers = (teamGetter, taskTypesGetter) => {
       })
       membersForAts['#'] = taskTypeOptions
     },
-    { deep: true, immediate: true }
+    { immediate: true }
   )
 
   watch(
@@ -68,7 +68,7 @@ export const useAtMentionsMembers = (teamGetter, taskTypesGetter) => {
       })
       membersForAts['@'] = teamOptions
     },
-    { deep: true, immediate: true }
+    { immediate: true }
   )
 
   return { membersForAts, atOptionsFilter }

--- a/src/directives/resizable-column.js
+++ b/src/directives/resizable-column.js
@@ -19,27 +19,40 @@ export default {
 
         const setListeners = (item, div) => {
           let pageX, curCol, curColWidth
-          div.addEventListener('mousedown', function (e) {
+
+          const onMouseMove = e => {
+            if (curCol) {
+              const diffX = e.pageX - pageX
+              const newWidth = curColWidth + diffX + 'px'
+              curCol.style.minWidth = newWidth
+              curCol.style.width = newWidth
+              localStorage.setItem(`${el.id}-${item.textContent}`, newWidth)
+            }
+          }
+
+          const onMouseDown = e => {
             curCol = e.target.parentElement
             pageX = e.pageX
             curColWidth = curCol.offsetWidth
+            document.addEventListener('mousemove', onMouseMove)
+          }
 
-            document.addEventListener('mousemove', function (e) {
-              if (curCol) {
-                const diffX = e.pageX - pageX
-                const newWidth = curColWidth + diffX + 'px'
-                curCol.style.minWidth = newWidth
-                curCol.style.width = newWidth
-                localStorage.setItem(`${el.id}-${item.textContent}`, newWidth)
-              }
-            })
-          })
-
-          document.addEventListener('mouseup', function (e) {
+          const onMouseUp = () => {
             curCol = undefined
             pageX = undefined
             curColWidth = undefined
-            document.onmousemove = null
+            document.removeEventListener('mousemove', onMouseMove)
+          }
+
+          div.addEventListener('mousedown', onMouseDown)
+          document.addEventListener('mouseup', onMouseUp)
+
+          // The directive re-runs for each new thead, so track the
+          // document-level listeners and let the unmounted hook detach them.
+          el._columnResizeCleanups = el._columnResizeCleanups || []
+          el._columnResizeCleanups.push(() => {
+            document.removeEventListener('mousemove', onMouseMove)
+            document.removeEventListener('mouseup', onMouseUp)
           })
         }
 
@@ -56,6 +69,12 @@ export default {
             item.style.width = width
           }
         })
+      },
+      unmounted(el) {
+        if (el._columnResizeCleanups) {
+          el._columnResizeCleanups.forEach(cleanup => cleanup())
+          el._columnResizeCleanups = null
+        }
       }
     })
   }

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -19,7 +19,7 @@ export const sanitize = (html, options) => {
     allowedImageTag: true,
     ...options
   }
-  let allowedTags = sanitizeHTML.defaults.allowedTags
+  let allowedTags = [...sanitizeHTML.defaults.allowedTags]
   if (!options.allowedLinkTag) {
     allowedTags = allowedTags.filter(tag => tag !== 'a')
   }

--- a/src/store/modules/people.js
+++ b/src/store/modules/people.js
@@ -711,7 +711,8 @@ const mutations = {
     cache.peopleIndex = buildPeopleIndex(cache.people)
     if (state.peopleSearchText) {
       const keywords = getKeyWords(state.peopleSearchText)
-      state.displayedPeople = indexSearch(cache.peopleIndex, keywords)
+      state.displayedPeople =
+        indexSearch(cache.peopleIndex, keywords) || cache.people
     } else {
       state.displayedPeople = cache.people
     }
@@ -742,7 +743,8 @@ const mutations = {
         cache.peopleIndex = buildPeopleIndex(cache.people)
         if (state.peopleSearchText) {
           const keywords = getKeyWords(state.peopleSearchText)
-          state.displayedPeople = indexSearch(cache.peopleIndex, keywords)
+          state.displayedPeople =
+            indexSearch(cache.peopleIndex, keywords) || cache.people
         } else {
           state.displayedPeople = cache.people
         }

--- a/tests/unit/store/people.spec.js
+++ b/tests/unit/store/people.spec.js
@@ -1,0 +1,51 @@
+import { vi } from 'vitest'
+
+// Importing the people module transitively pulls in the root store
+// (lib/models → timezone → @/store); stub it so no Vuex store is built.
+vi.mock('@/store', () => ({ default: {} }))
+
+import store from '@/store/modules/people'
+
+describe('People store', () => {
+  describe('Mutations', () => {
+    let state
+
+    beforeEach(() => {
+      store.cache.people = [
+        { id: 'person-1', name: 'John Doe', email: 'john.doe@example.com' },
+        { id: 'person-2', name: 'Jane Roe', email: 'jane.roe@example.com' }
+      ]
+      store.cache.peopleIndex = {}
+      store.cache.personMap = new Map()
+      store.cache.guests = []
+      state = {
+        displayedPeople: [],
+        guests: [],
+        peopleSearchText: '',
+        personMapVersion: 0
+      }
+    })
+
+    // A filter-only search (e.g. `department=animation`) reduces to zero
+    // keywords, so indexSearch returns null. The mutation must fall back to
+    // the full list rather than leave displayedPeople null.
+    test('DELETE_PEOPLE_END keeps displayedPeople an array with a filter search', () => {
+      state.peopleSearchText = 'department=animation'
+      store.mutations.DELETE_PEOPLE_END(state)
+      expect(Array.isArray(state.displayedPeople)).toBe(true)
+      expect(state.displayedPeople).toEqual(store.cache.people)
+    })
+
+    test('EDIT_PEOPLE_END keeps displayedPeople an array with a filter search', () => {
+      state.peopleSearchText = 'department=animation'
+      store.mutations.EDIT_PEOPLE_END(state, {
+        id: 'person-1',
+        first_name: 'John',
+        last_name: 'Doe',
+        email: 'john.doe@example.com'
+      })
+      expect(Array.isArray(state.displayedPeople)).toBe(true)
+      expect(state.displayedPeople).toEqual(store.cache.people)
+    })
+  })
+})


### PR DESCRIPTION
**Problem**

- The preview and playlist players could crash during normal review, interrupting the session:
  - while navigating frames in the comparison/multi-video player,
  - when opening an entity that has no preview yet,
  - when hovering the playlist progress bar over a shot with no preview.
- On the People page, editing or deleting a person while a filter-only search (e.g., `department=animation`) was active emptied or broke the list.
- After viewing certain comments, links, and formatting in later comments could be stripped incorrectly, because one comment's sanitization rules leaked into the next.
- When creating an asset with "confirm and stay", an unwanted error message appears.
- During long review sessions, memory and background work kept building up: players, the sound waveform, the playlist progress bar, and resizable table columns never released their resources when closed, so the app got progressively heavier.
- Some unused internal code remained on the task screens.

**Solution**

Stability & correctness:
- The preview and playlist players no longer crash in the cases above; missing previews are handled gracefully, and frame navigation can't get stuck in a loop.
- Editing or deleting a person under a filter-only search keeps the list intact (with tests covering both cases).
- Comment formatting is now isolated per comment, so links and styling stay consistent from one comment to the next.
- The asset name field focuses automatically again when the modal opens.

Performance & lighter sessions:
- Players, the sound waveform, the playlist progress bar, and resizable columns now release their listeners and observers when closed, so long review sessions stay light and don't accumulate background work.

Cleanup:
- Removed dead code from the task screens and documented a migration gotcha for contributors.
