### PR TITLE
[players] Render video viewers through a canvas pipeline

### DIFF
--- a/src/components/modals/ViewPlaylistModal.vue
+++ b/src/components/modals/ViewPlaylistModal.vue
@@ -188,6 +188,13 @@ const convertEntityToPlaylistFormat = entityInfo => {
     name: entity.name,
     nb_frames:
       entityInfo.nb_frames || entity.nb_frames || DEFAULT_NB_FRAMES_PICTURE,
+    // Per-entity fps: an entity can override the production fps via
+    // data.fps. Carried here so the player uses the right rate (same
+    // enrichment as the Playlist page).
+    fps:
+      parseFloat(entity.data?.fps) ||
+      parseFloat(currentProduction.value?.fps) ||
+      25,
     parent_name:
       entity.sequence_name || entity.episode_name || entity.asset_type_name,
     preview_files: entityInfo.preview_files,

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -648,6 +648,7 @@ export default {
       currentSort: 'updated_at',
       currentEntitiesMap: {},
       currentEntitiesList: [],
+      entitiesAddedWhilePanelOpen: false,
       entityLoading: {},
       isAddingEntity: false,
       isListToggled: false,
@@ -1228,6 +1229,7 @@ export default {
 
     addEntityToPlaylist(entity) {
       this.setSilent()
+      this.entitiesAddedWhilePanelOpen = true
       const playlist = this.currentPlaylist
       this.addEntity(entity, playlist).then(() => {
         this.clearSilent()
@@ -1386,6 +1388,7 @@ export default {
         playlist = this.currentPlaylist
       }
       if (entities && entities.length > 0) {
+        this.entitiesAddedWhilePanelOpen = true
         const entity = entities.pop()
         this.addEntity(entity, playlist).then(() => {
           this.addEntities(entities, callback, playlist)
@@ -1560,7 +1563,10 @@ export default {
 
     toggleAddEntities() {
       if (this.isAddingEntity) {
-        this.resetPlaylist()
+        // Only rebuild the playlist when entities were actually added —
+        // closing an untouched panel otherwise reloads the whole player.
+        if (this.entitiesAddedWhilePanelOpen) this.resetPlaylist()
+        this.entitiesAddedWhilePanelOpen = false
       }
       this.isAddingEntity = !this.isAddingEntity
     },

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -3606,10 +3606,12 @@ const onEntitiesWheel = event => {
 }
 
 const onProgressPlaylistChanged = frameNumberValue => {
+  // The strip playhead is only driven by time-update while playing;
+  // reflect paused clicks/drags immediately in every mode.
+  const time = frameNumberValue / fps.value
+  playlistProgress.value = time
   if (isFullMode.value) {
-    const time = frameNumberValue / fps.value
     fullPlaylistPlayer.value.currentTime = time
-    playlistProgress.value = time
   }
   const pos = playlistShotPosition.value[frameNumberValue]
   if (!pos) return

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -1404,7 +1404,8 @@ const mainContentAnchorEl = computed(() => mainContentAnchor.value || null)
 // active picture switches (entity change, revision change, …).
 const mainMediaElement = computed(() => {
   if (isCurrentPreviewMovie.value) {
-    return rawPlayer.value?.currentPlayer || null
+    // Use the visible canvas surface so wheel events reach the painted element.
+    return rawPlayer.value?.getDisplaySurface?.() || null
   }
   if (isCurrentPreviewPicture.value) {
     currentPreview.value // dependency trigger
@@ -2127,7 +2128,8 @@ const updateComparisonAnchor = () => {
   const anchor = comparisonContentAnchor.value
   const container = videoContainer.value
   if (!player || !anchor || !container) return
-  const playerEl = player.$el
+  // The display canvas is already aspect-fitted, so the ratio math mostly no-ops.
+  const playerEl = player.getDisplaySurface?.() || player.$el
   const ratio = player.getVideoRatio()
   const fullWidth = playerEl.offsetWidth
   const fullHeight = playerEl.offsetHeight

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -3680,17 +3680,32 @@ const loadWaveForm = () => {
   }
 }
 
-const resetHandles = entity => {
-  if (!['shot', 'edit', 'episode'].includes(props.playlist?.for_entity)) return
-  entity = entity || currentEntity.value
+// Handles straight from the entity's source data — the handleIn /
+// handleOut refs and the global nbFrames may still reflect the previous
+// entity right after a switch.
+const getEntityHandles = entity => {
+  if (!['shot', 'edit', 'episode'].includes(props.playlist?.for_entity)) {
+    return { handleIn: 0, handleOut: 0 }
+  }
   const entityMapByType = {
     edit: editMap.value,
     episode: episodeMap.value,
     shot: shotMap.value
   }
   const source = entityMapByType[props.playlist.for_entity]?.get(entity?.id)
-  handleIn.value = source?.data?.handle_in || 0
-  handleOut.value = source?.data?.handle_out || nbFrames.value
+  return {
+    handleIn: source?.data?.handle_in || 0,
+    handleOut: source?.data?.handle_out || 0
+  }
+}
+
+const resetHandles = entity => {
+  if (!['shot', 'edit', 'episode'].includes(props.playlist?.for_entity)) return
+  entity = entity || currentEntity.value
+  const { handleIn: entityHandleIn, handleOut: entityHandleOut } =
+    getEntityHandles(entity)
+  handleIn.value = entityHandleIn
+  handleOut.value = entityHandleOut || nbFrames.value
 }
 
 const resetPlaylistFrameData = () => {
@@ -3942,7 +3957,24 @@ const onKeyDown = event => {
     } else if (event.altKey) {
       onPlayPreviousEntityClicked()
       nextTick(() => {
-        rawPlayer.value?.setCurrentFrame(nbFrames.value - 1)
+        // Land on the last playable frame of the entity we just switched
+        // to, computed from its own data: the global nbFrames still
+        // reflects the previous entity at this tick (metadata not loaded
+        // yet), and the entity's handle-out bounds the playable range.
+        const entity = currentEntity.value
+        const entityFps = parseFloat(entity?.fps) || fps.value
+        let lastFrame =
+          Math.round((entity?.preview_file_duration || 0) * entityFps) - 1
+        const handleOutFrame = getEntityHandles(entity).handleOut
+        if (handleOutFrame > 0 && handleOutFrame < lastFrame) {
+          lastFrame = handleOutFrame
+        }
+        lastFrame = Math.max(lastFrame, 0)
+        rawPlayer.value?.setCurrentFrame(lastFrame)
+        // The strip indicator is only driven by time-update while
+        // playing; reposition it on this paused jump.
+        playlistProgress.value =
+          (entity?.start_duration || 0) + lastFrame / entityFps
         if (isFullMode.value && currentEntity.value) {
           const time =
             currentEntity.value.start_duration +
@@ -3967,7 +3999,14 @@ const onKeyDown = event => {
     } else if (event.altKey) {
       onPlayNextEntityClicked()
       nextTick(() => {
-        rawPlayer.value?.setCurrentFrame(0)
+        // Mirror of Alt+Left: land on the entity's handle-in (or frame
+        // 0) and reposition the paused strip indicator.
+        const entity = currentEntity.value
+        const entityFps = parseFloat(entity?.fps) || fps.value
+        const firstFrame = Math.max(getEntityHandles(entity).handleIn, 0)
+        rawPlayer.value?.setCurrentFrame(firstFrame)
+        playlistProgress.value =
+          (entity?.start_duration || 0) + firstFrame / entityFps
       })
     } else {
       onNextFrameClicked()

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -1183,8 +1183,26 @@ const realignComparisonCanvas = () => {
 // no chance to sync the fresh instance back to the main viewer.
 const onComparisonPanzoomReady = () => {
   if (!isComparing.value) return
-  const { x, y, scale } = panzoomTransform.value
-  comparisonViewer.value?.setPanZoom(x, y, scale)
+  const pushTransform = () => {
+    if (!isComparing.value) return
+    const { x, y, scale } = panzoomTransform.value
+    comparisonViewer.value?.setPanZoom(x, y, scale)
+  }
+  // The comparison geometry is only final once the 0.3s side-by-side
+  // layout transition settles (same constraint as realignComparisonCanvas
+  // below): a push clamped against mid-transition bounds sticks — the
+  // transform watcher only fires on changes. Track the transition frame
+  // by frame so the comparison follows the geometry instead of jumping
+  // once at the end.
+  const startedAt = performance.now()
+  const track = () => {
+    if (!isComparing.value) return
+    pushTransform()
+    if (performance.now() - startedAt < RESIZE_DELAY + 100) {
+      requestAnimationFrame(track)
+    }
+  }
+  track()
 }
 
 const onComparisonVideoLoaded = () => {

--- a/src/components/players/progress/PlaylistProgress.vue
+++ b/src/components/players/progress/PlaylistProgress.vue
@@ -39,6 +39,7 @@
     >
       <div
         class="entity-status"
+        :class="{ current: isCurrentEntity(entity) }"
         :key="`progress-entity-${entity.id}`"
         :style="{
           left: getEntityPosition(entity) + '%',
@@ -63,10 +64,17 @@
         </span>
       </div>
       <span
+        class="playlist-progress-elapsed"
+        :style="{
+          width: (100 * playlistProgress) / playlistDuration + '%'
+        }"
+      >
+      </span>
+      <span
         class="playlist-progress-position"
         :style="{
           left:
-            'calc(' + (100 * playlistProgress) / playlistDuration + '% - 3px)'
+            'calc(' + (100 * playlistProgress) / playlistDuration + '% - 1px)'
         }"
         @mouseenter="isFrameNumberVisible = true"
         @mouseleave="isFrameNumberVisible = false"
@@ -318,6 +326,19 @@ const getFullEntityName = entity => {
   return `${entity.parent_name} / ${entity.name}`.replaceAll(' ', ' ')
 }
 
+const currentEntityIndex = computed(() => {
+  const time = props.playlistProgress
+  return props.entityList.findIndex((entity, index) => {
+    const start = entity.start_duration - props.frameDuration
+    const next = props.entityList[index + 1]
+    const end = next ? next.start_duration - props.frameDuration : Infinity
+    return time >= start && time < end
+  })
+})
+
+const isCurrentEntity = entity =>
+  props.entityList[currentEntityIndex.value]?.id === entity.id
+
 const domEvents = [
   ['mousemove', doProgressDrag],
   ['touchmove', doProgressDrag],
@@ -411,13 +432,38 @@ onBeforeUnmount(() => {
   touch-action: pan-y;
 }
 
-.playlist-progress-position {
-  border-left: 5px solid $green;
+// Translucent veil over the already-played part of the strip, so the
+// position reads at a glance without hiding the status colors.
+.playlist-progress-elapsed {
+  background: rgba(255, 255, 255, 0.16);
+  height: 100%;
+  left: 0;
+  pointer-events: none;
   position: absolute;
-  height: 6px;
-  border-radius: 50%;
+  top: 0;
   z-index: 3;
-  top: -2px;
+}
+
+.playlist-progress-position {
+  background: $white;
+  box-shadow: 0 0 3px rgba(0, 0, 0, 0.7);
+  height: 24px;
+  position: absolute;
+  top: -3px;
+  width: 2px;
+  z-index: 4;
+
+  // Small grab handle on top of the playhead line.
+  &::before {
+    background: $white;
+    border-radius: 2px;
+    content: '';
+    height: 5px;
+    left: -2px;
+    position: absolute;
+    top: 0;
+    width: 6px;
+  }
 }
 
 .frame-number-rail {
@@ -436,22 +482,35 @@ onBeforeUnmount(() => {
 
 .entity-status {
   border-left: 0;
-  border-right: 3px solid $dark-grey;
+  border-right: 2px solid $dark-grey;
   position: absolute;
   bottom: 0;
-  transition: height 0.3s ease-in-out;
-  height: 16px;
+  transition:
+    height 0.3s ease-in-out,
+    opacity 0.2s ease-in-out;
+  height: 14px;
   z-index: 2;
-  opacity: 0.4;
+  opacity: 0.55;
 
   span {
     background: $dark-grey;
     border-radius: 5px;
+    // The segment constrains the tooltip's width: without nowrap a long
+    // name wraps inside a narrow segment and spills over the timeline.
+    white-space: nowrap;
+    bottom: calc(100% + 6px);
     color: $white;
     display: none;
     padding: 0.2em 0.5em;
     position: absolute;
-    top: -30px;
+    z-index: 5;
+  }
+
+  // The currently-playing entity stands out: full status color, full
+  // strip height.
+  &.current {
+    height: 18px;
+    opacity: 1;
   }
 
   &:hover {

--- a/src/components/players/progress/PlaylistProgress.vue
+++ b/src/components/players/progress/PlaylistProgress.vue
@@ -37,27 +37,21 @@
       "
       v-show="entityList.length > 1 && playlistDuration > 0"
     >
+      <!-- Hover visibility is owned by the wrapper: per-child enter/leave
+           handlers flicker the thumbnail when the cursor crosses segment
+           boundaries while still inside the bar. -->
       <div
         class="entity-status"
-        :class="{ current: isCurrentEntity(entity) }"
-        :key="`progress-entity-${entity.id}`"
+        :class="{ current: index === currentEntityIndex }"
+        :key="`progress-entity-${entity.id}-${entity.preview_file_id}`"
         :style="{
           left: getEntityPosition(entity) + '%',
           width: getEntityWidth(entity) + '%',
           'background-color': getEntityColor(entity)
         }"
-        @mouseenter="isFrameNumberVisible = true"
-        @mouseleave="isFrameNumberVisible = false"
-        @touchend="isFrameNumberVisible = false"
-        @touchcancel="isFrameNumberVisible = false"
         @mousedown="startPlaylistProgressDrag"
-        @touchstart="
-          () => {
-            startPlaylistProgressDrag()
-            isFrameNumberVisible = true
-          }
-        "
-        v-for="entity in entityList"
+        @touchstart="startPlaylistProgressDrag"
+        v-for="(entity, index) in entityList"
       >
         <span>
           {{ getFullEntityName(entity) }}
@@ -76,11 +70,6 @@
           left:
             'calc(' + (100 * playlistProgress) / playlistDuration + '% - 1px)'
         }"
-        @mouseenter="isFrameNumberVisible = true"
-        @mouseleave="isFrameNumberVisible = false"
-        @touchstart="isFrameNumberVisible = true"
-        @touchend="isFrameNumberVisible = false"
-        @touchcancel="isFrameNumberVisible = false"
       >
       </span>
     </div>
@@ -89,6 +78,13 @@
 
 <script setup>
 import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+
+import {
+  getTileCellIndex,
+  getTileGeometry,
+  TILE_CELL_HEIGHT,
+  TILE_COLUMNS
+} from '@/lib/players/tiles'
 
 import Spinner from '@/components/widgets/Spinner.vue'
 
@@ -152,7 +148,6 @@ const emit = defineEmits([
 const frameNumberLeftPosition = ref(0)
 const hoverFrame = ref(0)
 const isFrameNumberVisible = ref(false)
-const isTileLoading = ref(false)
 const playlistProgressDragging = ref(false)
 const playlistProgressWidget = ref(null)
 const progressDragging = ref(false)
@@ -165,20 +160,16 @@ const getClientX = event =>
   event.changedTouches?.[0]?.clientX ??
   event.clientX
 
-const tilePath = computed(
-  () =>
-    `${props.urlPrefix || '/api'}/movies/tiles/preview-files/${props.previewId}.png`
-)
-
 const frameNumberStyle = computed(() => {
-  const frameHeight = 100
+  const frameHeight = TILE_CELL_HEIGHT
   const height = frameHeight + 30
   let frameWidth = 150
   const preview = props.playlistShotPosition[hoverFrame.value]
   if (!preview) return {}
   if (preview.extension === 'mp4') {
-    const ratio = preview.width / preview.height
-    frameWidth = Math.ceil(frameHeight * ratio)
+    frameWidth =
+      tileGeometries.value.get(preview.id)?.cellWidth ??
+      Math.ceil(frameHeight * (preview.width / preview.height))
   } else if (preview.extension === 'png') {
     frameWidth = 150
   }
@@ -245,6 +236,16 @@ const doProgressDrag = event => {
   ) {
     const { frameNumber } = getPlaylistMouseFrame(event)
     hoverFrame.value = frameNumber + 1
+    // Kick the sprite load for the hovered preview even while the
+    // spinner is shown (the tile span itself is v-if'd out then).
+    const preview = props.playlistShotPosition[hoverFrame.value]
+    if (preview?.extension === 'mp4') {
+      const base = props.urlPrefix || '/api'
+      ensureTileGeometry(
+        preview.id,
+        `${base}/movies/tiles/preview-files/${preview.id}.png`
+      )
+    }
     const allDuration = Math.round(props.playlistDuration * props.fps)
     frameNumberLeftPosition.value = (width.value / allDuration) * frameNumber
     if (playlistProgressDragging.value) {
@@ -258,6 +259,31 @@ const onPlaylistProgressClicked = event => {
   emit('progress-playlist-changed', frameNumber)
 }
 
+// Measured sprite geometries per preview id — recomputing the cell width
+// from stored dimensions drifts from the file the sprite was built from
+// (source ratio ≠ production ratio, renormalisations).
+const tileGeometries = ref(new Map())
+
+const ensureTileGeometry = (id, tilePathUrl) => {
+  if (tileGeometries.value.has(id)) return tileGeometries.value.get(id)
+  tileGeometries.value.set(id, null)
+  getTileGeometry(tilePathUrl).then(geometry => {
+    if (!geometry) return
+    const next = new Map(tileGeometries.value)
+    next.set(id, geometry)
+    tileGeometries.value = next
+  })
+  return null
+}
+
+// The hovered preview's sprite is still loading/measuring: show the
+// spinner instead of a black not-yet-loaded background.
+const isTileLoading = computed(() => {
+  const preview = props.playlistShotPosition[hoverFrame.value]
+  if (!preview || preview.extension !== 'mp4') return false
+  return !tileGeometries.value.get(preview.id)
+})
+
 const getFrameBackgroundStyle = frame => {
   if (!frame || !props.playlistShotPosition[frame]) return {}
   const {
@@ -268,12 +294,6 @@ const getFrameBackgroundStyle = frame => {
   } = props.playlistShotPosition[frame]
 
   frame = frame - props.playlistShotPosition[frame].start * props.fps
-  if (props.nbFrames >= 3840) {
-    frame = Math.ceil(frame / Math.ceil(props.nbFrames / 3840))
-  }
-  const frameX = frame % 8
-  const frameY = Math.floor(frame / 8)
-  const frameHeight = 100
   const base = props.urlPrefix || '/api'
 
   if (extension === 'png') {
@@ -284,13 +304,18 @@ const getFrameBackgroundStyle = frame => {
       width: '150px'
     }
   } else if (extension === 'mp4') {
-    const ratio = pw / ph
-    const frameWidth = Math.ceil(frameHeight * ratio)
     const tp = `${base}/movies/tiles/preview-files/${id}.png`
+    const geometry = ensureTileGeometry(id, tp)
+    const frameWidth =
+      geometry?.cellWidth ?? Math.ceil(TILE_CELL_HEIGHT * (pw / ph))
+    const cellCount = geometry?.cellCount ?? 3840
+    const cell = getTileCellIndex(frame, props.nbFrames, cellCount)
+    const frameX = cell % TILE_COLUMNS
+    const frameY = Math.floor(cell / TILE_COLUMNS)
     return {
       background: `url(${tp})`,
       'background-position': `-${frameX * frameWidth}px -${
-        frameY * frameHeight
+        frameY * TILE_CELL_HEIGHT
       }px`,
       width: `${frameWidth}px`
     }
@@ -336,9 +361,6 @@ const currentEntityIndex = computed(() => {
   })
 })
 
-const isCurrentEntity = entity =>
-  props.entityList[currentEntityIndex.value]?.id === entity.id
-
 const domEvents = [
   ['mousemove', doProgressDrag],
   ['touchmove', doProgressDrag],
@@ -351,24 +373,6 @@ const domEvents = [
   ['touchend', stopPlaylistProgressDrag],
   ['touchcancel', stopPlaylistProgressDrag]
 ]
-
-watch(
-  () => props.previewId,
-  () => {
-    if (props.previewId) {
-      const preview = props.playlistShotPosition[hoverFrame.value]
-      if (preview?.extension === 'mp4') {
-        isTileLoading.value = true
-        const img = new Image()
-        img.src = tilePath.value
-        img.onload = () => {
-          isTileLoading.value = false
-        }
-      }
-    }
-  },
-  { immediate: true }
-)
 
 watch(
   () => props.entityList,
@@ -398,6 +402,10 @@ onBeforeUnmount(() => {
   background: $black;
   border-radius: 5px;
   color: $white;
+  // The thumbnail can overlap the bar (top: 16px when not fullscreen);
+  // without this the cursor "enters" it, fires the bar's mouseleave and
+  // the thumbnail flickers in a show/hide loop.
+  pointer-events: none;
   position: absolute;
   padding: 0.3em;
   text-align: center;
@@ -447,9 +455,12 @@ onBeforeUnmount(() => {
 .playlist-progress-position {
   background: $white;
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.7);
-  height: 24px;
+  // Flush with the bar bottom: overflowing below made the hover
+  // thumbnail flicker on the bar's last pixel row.
+  height: 22px;
+  pointer-events: none;
   position: absolute;
-  top: -3px;
+  top: -4px;
   width: 2px;
   z-index: 4;
 

--- a/src/components/players/progress/VideoProgress.vue
+++ b/src/components/players/progress/VideoProgress.vue
@@ -104,6 +104,13 @@
 <script setup>
 import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 
+import {
+  getTileCellIndex,
+  getTileGeometry,
+  TILE_CELL_HEIGHT,
+  TILE_COLUMNS
+} from '@/lib/players/tiles'
+
 const props = defineProps({
   annotations: {
     default: () => [],
@@ -174,6 +181,7 @@ const hoverFrame = ref(0)
 const isFrameNumberVisible = ref(false)
 const progress = ref(null)
 const progressDragging = ref(false)
+const tileGeometry = ref(null)
 const width = ref(0)
 
 // Mouse scratch state; not reactive — written from event handlers, never read by template
@@ -207,9 +215,10 @@ const handleInWidth = computed(
 )
 
 const frameNumberStyle = computed(() => {
-  const frameHeight = 100
+  const frameHeight = TILE_CELL_HEIGHT
   const height = frameHeight + 30
-  const frameWidth = Math.ceil(frameHeight * videoRatio.value)
+  const frameWidth =
+    tileGeometry.value?.cellWidth ?? Math.ceil(frameHeight * videoRatio.value)
   const w = frameWidth + 10
   const left = Math.min(
     Math.max(frameNumberLeftPosition.value - frameWidth / 2, 0),
@@ -230,6 +239,23 @@ const onWindowResize = () => {
     width.value = coords.width
   }
 }
+
+watch(
+  () => props.previewId,
+  () => {
+    tileGeometry.value = null
+    if (!props.previewId) return
+    const previewId = props.previewId
+    const base = props.urlPrefix || '/api'
+    getTileGeometry(`${base}/movies/tiles/preview-files/${previewId}.png`).then(
+      geometry => {
+        // Guard against a preview switch racing the load.
+        if (props.previewId === previewId) tileGeometry.value = geometry
+      }
+    )
+  },
+  { immediate: true }
+)
 
 const getAnnotationPosition = annotation => {
   if (props.nbFrames === 0) return 0
@@ -350,20 +376,22 @@ const emitProgressEvent = (event, annotation) => {
 const getFrameBackgroundStyle = frame => {
   if (!frame) return {}
   const previewId = props.previewId
-  frame = frame - 1
-  if (props.nbFrames >= 3840) {
-    frame = Math.ceil(frame / Math.ceil(props.nbFrames / 3840))
-  }
-  const frameX = frame % 8
-  const frameY = Math.floor(frame / 8)
-  const frameHeight = 100
-  const frameWidth = Math.ceil(frameHeight * videoRatio.value)
   const base = props.urlPrefix || '/api'
   const tilePath = `${base}/movies/tiles/preview-files/${previewId}.png`
+  // Measured sprite geometry beats recomputing the cell width from the
+  // preview's stored dimensions, which drift from the file the sprite
+  // was built from (source ratio ≠ production ratio, renormalisations).
+  const geometry = tileGeometry.value
+  const frameWidth =
+    geometry?.cellWidth ?? Math.ceil(TILE_CELL_HEIGHT * videoRatio.value)
+  const cellCount = geometry?.cellCount ?? 3840
+  const cell = getTileCellIndex(frame - 1, props.nbFrames, cellCount)
+  const frameX = cell % TILE_COLUMNS
+  const frameY = Math.floor(cell / TILE_COLUMNS)
   return {
     background: `url(${tilePath})`,
     'background-position': `-${frameX * frameWidth}px -${
-      frameY * frameHeight
+      frameY * TILE_CELL_HEIGHT
     }px`,
     width: `${frameWidth}px`
   }

--- a/src/components/players/progress/VideoProgress.vue
+++ b/src/components/players/progress/VideoProgress.vue
@@ -1,5 +1,19 @@
 <template>
   <div class="unselectable">
+    <!-- Zoom mini-map: the full clip, with the visible window. -->
+    <div
+      class="timeline-minimap"
+      v-if="zoomLevel > 1"
+      @mousedown="startMinimapDrag"
+    >
+      <span
+        class="minimap-window"
+        :style="{
+          left: (100 * viewStartFrame) / nbFrames + '%',
+          width: 100 / zoomLevel + '%'
+        }"
+      ></span>
+    </div>
     <div
       class="progress-wrapper"
       :style="
@@ -10,6 +24,7 @@
             }
           : { 'background-image': frameTicksGradient }
       "
+      @wheel.prevent="onWheelZoom"
       @mouseenter="isFrameNumberVisible = true"
       @mouseleave="isFrameNumberVisible = false"
       @touchstart="isFrameNumberVisible = true"
@@ -32,9 +47,7 @@
       <span
         class="handle-out"
         :class="{ dragging: handleOutDragging }"
-        :style="{
-          width: frameSize * (nbFrames - handleOut) + 'px'
-        }"
+        :style="{ width: handleOutWidth }"
         @mousedown="startHandleOutDrag"
         @touchstart="startHandleOutDrag"
         v-if="handleOut >= 0 && !isFullMode && !empty"
@@ -58,7 +71,7 @@
         class="annotation-mark"
         :style="{
           left: getAnnotationPosition(annotation) + 'px',
-          width: Math.max(frameSize - 1, 5) + 'px'
+          width: Math.max(effectiveFrameSize - 1, 5) + 'px'
         }"
         @mouseenter="isFrameNumberVisible = true"
         @mouseleave="isFrameNumberVisible = false"
@@ -75,7 +88,7 @@
         class="annotation-mark comparison-mark"
         :style="{
           left: getAnnotationPosition(annotation) + 'px',
-          width: Math.max(frameSize - 1, 5) + 'px'
+          width: Math.max(effectiveFrameSize - 1, 5) + 'px'
         }"
         @mouseenter="isFrameNumberVisible = true"
         @mouseleave="isFrameNumberVisible = false"
@@ -212,16 +225,87 @@ const backgroundSize = computed(() => {
 // stretched texture blurred as soon as the clip had few frames. Stripes
 // are dropped when frames get too dense to read.
 const frameTicksGradient = computed(() => {
-  const size = frameSize.value
+  const size = effectiveFrameSize.value
   if (!size || size < 3) return 'none'
+  // Anchor the stripe phase on the view window so frames keep their
+  // shade while panning/zooming.
+  const phase = -(viewStartFrame.value % 2) * size
   return (
-    'repeating-linear-gradient(to right, ' +
-    `rgb(54, 57, 63) 0, rgb(54, 57, 63) ${size}px, ` +
-    `rgb(84, 89, 98) ${size}px, rgb(84, 89, 98) ${2 * size}px)`
+    `repeating-linear-gradient(to right, ` +
+    `rgb(54, 57, 63) ${phase}px, rgb(54, 57, 63) ${phase + size}px, ` +
+    `rgb(84, 89, 98) ${phase + size}px, rgb(84, 89, 98) ${phase + 2 * size}px)`
   )
 })
 
-const frameSize = computed(() => width.value / props.nbFrames)
+// — Timeline zoom: the bar shows a [viewStartFrame, viewStartFrame +
+// nbFrames / zoomLevel] window of the clip. Every on-screen position
+// goes through frameToX / xToFrame so marks, handles, fill, clicks and
+// stripes share one mapping. zoomLevel 1 = the whole clip (status quo).
+const zoomLevel = ref(1)
+const viewStartFrame = ref(0)
+
+const visibleFrames = computed(() => props.nbFrames / zoomLevel.value)
+const effectiveFrameSize = computed(() => width.value / visibleFrames.value)
+
+const frameToX = frame =>
+  (frame - viewStartFrame.value) * effectiveFrameSize.value
+const xToFrame = x => viewStartFrame.value + x / effectiveFrameSize.value
+
+const clampViewStart = start =>
+  Math.min(Math.max(start, 0), props.nbFrames - visibleFrames.value)
+
+const onWheelZoom = event => {
+  if (props.empty || !props.nbFrames) return
+  const anchorFrame = xToFrame(getClientX(event) - getProgressLeft())
+  const factor = event.deltaY < 0 ? 1.25 : 1 / 1.25
+  // Never zoom past ~8 visible frames, never below the full clip.
+  const maxZoom = Math.max(props.nbFrames / 8, 1)
+  zoomLevel.value = Math.min(Math.max(zoomLevel.value * factor, 1), maxZoom)
+  if (zoomLevel.value === 1) {
+    viewStartFrame.value = 0
+    return
+  }
+  // Keep the frame under the cursor stationary while zooming.
+  const cursorX = getClientX(event) - getProgressLeft()
+  viewStartFrame.value = clampViewStart(
+    anchorFrame - cursorX / effectiveFrameSize.value
+  )
+}
+
+let minimapDragging = false
+
+const startMinimapDrag = event => {
+  minimapDragging = true
+  panMinimap(event)
+  const move = e => panMinimap(e)
+  const up = () => {
+    minimapDragging = false
+    document.removeEventListener('mousemove', move)
+    document.removeEventListener('mouseup', up)
+  }
+  document.addEventListener('mousemove', move)
+  document.addEventListener('mouseup', up)
+}
+
+const panMinimap = event => {
+  if (!minimapDragging || !width.value) return
+  const x = getClientX(event) - getProgressLeft()
+  const centerFrame = (x / width.value) * props.nbFrames
+  viewStartFrame.value = clampViewStart(centerFrame - visibleFrames.value / 2)
+}
+
+const getProgressLeft = () => {
+  if (!progress.value) return 0
+  const left = progress.value.getBoundingClientRect().left
+  if (
+    left === 0 &&
+    !props.isFullScreen &&
+    progress.value.parentElement.offsetParent
+  ) {
+    return progress.value.parentElement.offsetParent.offsetLeft
+  }
+  return left
+}
 
 const videoRatio = computed(() =>
   props.movieDimensions.width
@@ -230,7 +314,15 @@ const videoRatio = computed(() =>
 )
 
 const handleInWidth = computed(
-  () => Math.max(frameSize.value * props.handleIn, 0) + 'px'
+  () => Math.min(Math.max(frameToX(props.handleIn), 0), width.value || 0) + 'px'
+)
+
+const handleOutWidth = computed(
+  () =>
+    Math.min(
+      Math.max((width.value || 0) - frameToX(props.handleOut), 0),
+      width.value || 0
+    ) + 'px'
 )
 
 const frameNumberStyle = computed(() => {
@@ -279,13 +371,19 @@ watch(
 const getAnnotationPosition = annotation => {
   if (props.nbFrames === 0) return 0
   const frameNumber = Math.round(annotation.time / props.frameDuration)
-  return frameNumber * frameSize.value
+  return frameToX(frameNumber)
 }
 
+// Remember the last frame pushed by the parent so the fill can be
+// recomputed when the zoom window moves.
+let lastProgressFrame = 0
+
 const updateProgressBar = frameNumber => {
+  lastProgressFrame = frameNumber
+  const relative = frameNumber - viewStartFrame.value
   progress.value.value = props.empty
-    ? frameNumber * props.frameDuration
-    : (frameNumber + 1) * props.frameDuration
+    ? relative * props.frameDuration
+    : (relative + 1) * props.frameDuration
 }
 
 const startProgressDrag = () => {
@@ -334,12 +432,13 @@ const getMouseFrame = (event, annotation) => {
   }
   let position = getClientX(event) - left
   if (position > width.value) position = width.value - 1
-  const ratio = position / width.value
   // Clicking an annotation marker must land on that annotation's exact
   // frame so the annotation loads — not the pixel the cursor hit, which can
   // be a frame off and make the annotation lookup miss. Bar clicks (no
-  // annotation) still map to the click position.
-  let duration = annotation ? annotation.time : videoDuration.value * ratio
+  // annotation) map the click position through the zoom window.
+  let duration = annotation
+    ? annotation.time
+    : xToFrame(position) * props.frameDuration
   if (duration < 0) duration = 0
 
   const isChromium = !!window.chrome
@@ -369,7 +468,7 @@ const doProgressDrag = event => {
     currentMouseFrame = getMouseFrame(event)
     const { frameNumber } = currentMouseFrame
     hoverFrame.value = frameNumber + 1
-    frameNumberLeftPosition.value = (width.value / props.nbFrames) * frameNumber
+    frameNumberLeftPosition.value = frameToX(frameNumber)
     if (progressDragging.value) {
       emit('progress-changed', frameNumber)
     } else if (handleInDragging.value) {
@@ -456,6 +555,24 @@ watch(videoDuration, () => {
   updateProgressBar(0)
 })
 
+// Keep the fill consistent when the zoom window changes: the bar's max
+// becomes the visible duration and the fill is recomputed against the
+// last frame the parent pushed.
+watch([zoomLevel, viewStartFrame], () => {
+  if (!progress.value) return
+  progress.value.setAttribute('max', visibleFrames.value * props.frameDuration)
+  updateProgressBar(lastProgressFrame)
+})
+
+// A new preview means a new timeline: drop the zoom.
+watch(
+  () => props.previewId,
+  () => {
+    zoomLevel.value = 1
+    viewStartFrame.value = 0
+  }
+)
+
 onBeforeUnmount(() => {
   domEvents.forEach(([type, listener]) =>
     document.removeEventListener(type, listener)
@@ -481,9 +598,27 @@ defineExpose({ updateProgressBar })
   }
 }
 
+.timeline-minimap {
+  background: rgb(40, 42, 47);
+  cursor: grab;
+  height: 6px;
+  position: relative;
+  width: 100%;
+
+  .minimap-window {
+    background: rgba(255, 255, 255, 0.35);
+    border-radius: 2px;
+    height: 100%;
+    position: absolute;
+    top: 0;
+  }
+}
+
 .progress-wrapper {
   background: $grey;
   background-repeat: repeat-x;
+  // Zoomed views position marks/handles outside the window: clip them.
+  overflow: hidden;
   border: 0;
   cursor: pointer;
   flex-shrink: 0;

--- a/src/components/players/progress/VideoProgress.vue
+++ b/src/components/players/progress/VideoProgress.vue
@@ -2,12 +2,14 @@
   <div class="unselectable">
     <div
       class="progress-wrapper"
-      :style="{
-        'background-size': backgroundSize,
-        ...(backgroundUrl
-          ? { 'background-image': `url(${backgroundUrl})` }
-          : {})
-      }"
+      :style="
+        backgroundUrl
+          ? {
+              'background-size': backgroundSize,
+              'background-image': `url(${backgroundUrl})`
+            }
+          : { 'background-image': frameTicksGradient }
+      "
       @mouseenter="isFrameNumberVisible = true"
       @mouseleave="isFrameNumberVisible = false"
       @touchstart="isFrameNumberVisible = true"
@@ -16,19 +18,20 @@
     >
       <span
         class="handle-in"
-        :style="{
-          width: handleInWidth,
-          'padding-right': handleIn > 1 ? '5px' : 0
-        }"
+        :class="{ dragging: handleInDragging }"
+        :style="{ width: handleInWidth }"
         @mousedown="startHandleInDrag"
         @touchstart="startHandleInDrag"
         v-if="handleIn >= 0 && !isFullMode && !empty"
       >
-        {{ handleIn !== 0 ? handleIn + 1 : '' }}
+        <span class="handle-frame" v-if="handleIn !== 0">
+          {{ handleIn + 1 }}
+        </span>
       </span>
 
       <span
         class="handle-out"
+        :class="{ dragging: handleOutDragging }"
         :style="{
           width: frameSize * (nbFrames - handleOut) + 'px'
         }"
@@ -36,7 +39,9 @@
         @touchstart="startHandleOutDrag"
         v-if="handleOut >= 0 && !isFullMode && !empty"
       >
-        {{ handleOut + 1 }}
+        <span class="handle-frame">
+          {{ handleOut + 1 }}
+        </span>
       </span>
 
       <progress
@@ -200,6 +205,20 @@ const backgroundSize = computed(() => {
   } else {
     return '300%'
   }
+})
+
+// Alternating frame stripes generated at the exact frame size, using the
+// two colors sampled from the legacy player-timeslider.png — the
+// stretched texture blurred as soon as the clip had few frames. Stripes
+// are dropped when frames get too dense to read.
+const frameTicksGradient = computed(() => {
+  const size = frameSize.value
+  if (!size || size < 3) return 'none'
+  return (
+    'repeating-linear-gradient(to right, ' +
+    `rgb(54, 57, 63) 0, rgb(54, 57, 63) ${size}px, ` +
+    `rgb(84, 89, 98) ${size}px, rgb(84, 89, 98) ${2 * size}px)`
+  )
 })
 
 const frameSize = computed(() => width.value / props.nbFrames)
@@ -464,7 +483,6 @@ defineExpose({ updateProgressBar })
 
 .progress-wrapper {
   background: $grey;
-  background-image: url('../../../assets/background/player-timeslider.png');
   background-repeat: repeat-x;
   border: 0;
   cursor: pointer;
@@ -539,56 +557,93 @@ progress {
   }
 }
 
-.handle-in {
-  background: $black;
-  color: $grey;
+// Trim handles, NLE-bracket style: a thick vertical bar with top and
+// bottom lips marking the in/out bounds, the excluded zones lightly
+// veiled so the timeline stays readable, frame numbers always visible.
+.handle-in,
+.handle-out {
+  background: rgba(0, 0, 0, 0.45);
   display: inline-block;
   height: 28px;
-  left: 0;
-  opacity: 0.9;
-  padding-top: 3px;
   position: absolute;
   z-index: 100;
-  text-align: right;
+
+  // Same number presentation as the legacy handles: vertically centered
+  // in the veiled zone, next to the bracket.
+  .handle-frame {
+    color: $grey;
+    font-variant-numeric: tabular-nums;
+    line-height: 28px;
+    position: absolute;
+    top: 0;
+    z-index: 130;
+  }
+
+  // The bracket: vertical bar + top/bottom lips pointing inward,
+  // drawn as solid blocks (borders got visually truncated).
+  &::after {
+    background: $dark-purple;
+    content: ' ';
+    cursor: ew-resize;
+    bottom: 0;
+    position: absolute;
+    top: 0;
+    transition: width 0.1s ease-in-out;
+    width: 4px;
+    z-index: 120;
+  }
+
+  &::before {
+    background:
+      linear-gradient($dark-purple, $dark-purple) top / 100% 4px no-repeat,
+      linear-gradient($dark-purple, $dark-purple) bottom / 100% 4px no-repeat;
+    bottom: 0;
+    content: ' ';
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: 9px;
+    z-index: 120;
+  }
+
+  &:hover,
+  &.dragging {
+    &::after {
+      width: 6px;
+    }
+  }
 }
 
-.handle-in::after {
-  bottom: 0;
-  background: $dark-purple;
-  content: ' ';
-  cursor: pointer;
-  height: 34px;
-  position: absolute;
-  right: -5px;
-  top: -2px;
-  width: 5px;
-  z-index: 120;
+.handle-in {
+  left: 0;
+
+  .handle-frame {
+    right: 8px;
+  }
+
+  &::after {
+    right: -4px;
+  }
+
+  &::before {
+    right: -9px;
+  }
 }
 
 .handle-out {
-  background: $black;
-  color: $grey;
-  display: inline-block;
-  height: 28px;
-  overflow: hidden;
-  padding-left: 10px;
-  padding-top: 3px;
-  position: absolute;
-  opacity: 0.9;
+  overflow: visible;
   right: 0;
-  z-index: 100;
-}
 
-.handle-out::before {
-  bottom: 0;
-  background: $dark-purple;
-  content: ' ';
-  cursor: pointer;
-  height: 34px;
-  left: 0;
-  position: absolute;
-  top: -2px;
-  width: 5px;
-  z-index: 120;
+  .handle-frame {
+    left: 8px;
+  }
+
+  &::after {
+    left: -4px;
+  }
+
+  &::before {
+    left: -9px;
+  }
 }
 </style>

--- a/src/components/players/viewers/MultiVideoViewer.vue
+++ b/src/components/players/viewers/MultiVideoViewer.vue
@@ -5,16 +5,21 @@
     </div>
     <video
       ref="player1"
+      class="playlist-movie-decoder"
       preload="auto"
+      playsinline
       :muted="muted"
       @ended="$emit('play-next')"
     />
     <video
       ref="player2"
+      class="playlist-movie-decoder"
       preload="auto"
+      playsinline
       :muted="muted"
       @ended="$emit('play-next')"
     />
+    <canvas ref="displayCanvas" class="playlist-movie" />
   </div>
 </template>
 
@@ -45,6 +50,10 @@ import {
 import { useStore } from 'vuex'
 
 import { floorToFrame, roundToFrame } from '@/lib/video'
+import {
+  createFrameRenderer,
+  supportsVideoFrameCallback
+} from '@/lib/players/frameRenderer'
 
 import Spinner from '@/components/widgets/Spinner.vue'
 
@@ -120,9 +129,10 @@ const emit = defineEmits([
 const containerRef = useTemplateRef('container')
 const player1Ref = useTemplateRef('player1')
 const player2Ref = useTemplateRef('player2')
+const displayCanvasRef = useTemplateRef('displayCanvas')
 
 const currentIndex = ref(0)
-const currentPlayer = shallowRef(undefined)
+const currentPlayer = shallowRef(null)
 const isLoading = ref(true)
 const isPlaying = ref(false)
 const nextPlayer = shallowRef(undefined)
@@ -133,10 +143,13 @@ let currentTimeRaw = 0
 let isSeeking = false
 let firstPanZoom = null
 let panzoomInstances = []
-let playLoop = null
+let renderer = null
+let renderLoopHandle = null
+let renderLoopIsRvfc = false
+let renderLoopPlayer = null
+let renderLoopGeneration = 0
 let lastEmittedFrame = null
 let rate = 1
-let secondPanZoom = null
 let silent = false
 let showLoadingTimer = null
 // Track whether the panzoom should be active across instance
@@ -165,68 +178,91 @@ const frameDuration = computed(
 
 const PANZOOM_EVENTS = ['zoom', 'pan', 'panend', 'transform']
 
-// Setup is deferred until each video's metadata loads, since panzoom's
-// bounds clamp computed against a 0×0 target leaves the media off-
-// centre as soon as the parent applies a transform — most visibly the
-// comparison viewer drifting when the user first opens the panel.
-const setupPlayer1PanZoom = () => {
-  if (!props.panzoom || !player1Ref.value) return
+// Setup is deferred until the canvas has metadata so the bounds
+// clamp doesn't compute against a 0×0 target.
+const setupPanZoom = () => {
+  if (!props.panzoom || !displayCanvasRef.value) return
   firstPanZoom?.dispose()
-  // panzoom listens on the target's parentElement, which stretches
-  // with the surrounding flex layout and leaves gutters on the sides
-  // of the video. Skip events whose target isn't the video itself so
-  // clicks / wheel in the gutter don't trigger pan or zoom.
-  firstPanZoom = createPanzoom(player1Ref.value, {
+  firstPanZoom = createPanzoom(displayCanvasRef.value, {
     bounds: true,
     boundsPadding: 0.2,
     maxZoom: 5,
     minZoom: 0.5,
-    beforeMouseDown: e => e.target !== player1Ref.value,
-    beforeWheel: e => e.target !== player1Ref.value,
-    // panzoom otherwise puts tabindex=0 on the owner and steals arrow
-    // keys / +/- — those shortcuts belong to the playlist player
-    // (next/previous entity, frame stepping).
+    beforeMouseDown: e => e.target !== displayCanvasRef.value,
+    beforeWheel: e => e.target !== displayCanvasRef.value,
     disableKeyboardInteraction: true
   })
   PANZOOM_EVENTS.forEach(name => {
-    firstPanZoom.on(name, () => {
-      if (currentPlayer.value !== player1Ref.value) return
-      emitPanZoomChanged(firstPanZoom)
-    })
+    firstPanZoom.on(name, () => emitPanZoomChanged(firstPanZoom))
   })
   if (!panzoomActive) firstPanZoom.pause()
-  refreshPanzoomInstances()
-  // Tell the parent that a fresh instance exists, so it can re-push
-  // the comparison sync transform that arrived earlier (while the
-  // panzoom didn't exist yet and the setPanZoom call was a no-op).
-  emit('panzoom-ready')
-}
-
-const setupPlayer2PanZoom = () => {
-  if (!props.panzoom || !player2Ref.value) return
-  secondPanZoom?.dispose()
-  secondPanZoom = createPanzoom(player2Ref.value, {
-    bounds: true,
-    boundsPadding: 0.2,
-    maxZoom: 3,
-    minZoom: 0.5,
-    beforeMouseDown: e => e.target !== player2Ref.value,
-    beforeWheel: e => e.target !== player2Ref.value,
-    disableKeyboardInteraction: true
-  })
-  PANZOOM_EVENTS.forEach(name => {
-    secondPanZoom.on(name, () => {
-      if (currentPlayer.value !== player2Ref.value) return
-      emitPanZoomChanged(secondPanZoom)
-    })
-  })
-  if (!panzoomActive) secondPanZoom.pause()
   refreshPanzoomInstances()
   emit('panzoom-ready')
 }
 
 const refreshPanzoomInstances = () => {
-  panzoomInstances = [firstPanZoom, secondPanZoom].filter(Boolean)
+  panzoomInstances = [firstPanZoom].filter(Boolean)
+}
+
+const getDisplaySurface = () => displayCanvasRef.value
+
+const resizeRenderer = () => {
+  if (!renderer || !currentPlayer.value) return
+  // Keep the renderer's default source on the active decoder so a
+  // no-argument drawFrame() can never paint the inactive player.
+  renderer.video = currentPlayer.value
+  renderer.resize(
+    currentPlayer.value.videoWidth,
+    currentPlayer.value.videoHeight
+  )
+  renderer.drawFrame(currentPlayer.value)
+}
+
+const startRenderLoop = () => {
+  stopRenderLoop()
+  const player = currentPlayer.value
+  if (!player) return
+  renderLoopPlayer = player
+  renderLoopGeneration++
+  const generation = renderLoopGeneration
+  if (supportsVideoFrameCallback()) {
+    renderLoopIsRvfc = true
+    const tick = () => {
+      if (renderLoopGeneration !== generation) return
+      renderer?.drawFrame(player)
+      if (isPlaying.value && props.name === 'main') {
+        updateTime(player.currentTime)
+      }
+      renderLoopHandle = player.requestVideoFrameCallback(tick)
+    }
+    renderLoopHandle = player.requestVideoFrameCallback(tick)
+  } else {
+    renderLoopIsRvfc = false
+    let lastDrawnTime = -1
+    const tick = () => {
+      if (renderLoopGeneration !== generation) return
+      if (player.currentTime !== lastDrawnTime) {
+        lastDrawnTime = player.currentTime
+        renderer?.drawFrame(player)
+        if (isPlaying.value && props.name === 'main') {
+          updateTime(player.currentTime)
+        }
+      }
+      renderLoopHandle = requestAnimationFrame(tick)
+    }
+    renderLoopHandle = requestAnimationFrame(tick)
+  }
+}
+
+const stopRenderLoop = () => {
+  if (renderLoopHandle === null) return
+  if (renderLoopIsRvfc) {
+    renderLoopPlayer?.cancelVideoFrameCallback?.(renderLoopHandle)
+  } else {
+    cancelAnimationFrame(renderLoopHandle)
+  }
+  renderLoopHandle = null
+  renderLoopPlayer = null
 }
 
 const emitPanZoomChanged = panzoomInstance => {
@@ -301,12 +337,12 @@ const clear = () => {
 
 const resetHeight = () => {
   nextTick(() => {
-    if (currentPlayer.value) currentPlayer.value.style.height = '0px'
-    if (nextPlayer.value) nextPlayer.value.style.height = '0px'
+    if (displayCanvasRef.value) displayCanvasRef.value.style.height = '0px'
     if (containerRef.value) {
       const height = containerRef.value.offsetHeight
-      if (currentPlayer.value) currentPlayer.value.style.height = `${height}px`
-      if (nextPlayer.value) nextPlayer.value.style.height = `${height}px`
+      if (displayCanvasRef.value) {
+        displayCanvasRef.value.style.height = `${height}px`
+      }
     }
   })
 }
@@ -385,11 +421,16 @@ const loadEntity = (index = 0, currentTime = 0, silentLoad = false) => {
     } else if (nextPlayer.value) {
       nextPlayer.value.src = ''
     }
-    currentPlayer.value.style.display = 'block'
-    nextPlayer.value.style.display = 'none'
     resetHeight()
 
     setSpeed(rate)
+    if (!renderer && displayCanvasRef.value) {
+      renderer = createFrameRenderer(
+        displayCanvasRef.value,
+        currentPlayer.value
+      )
+    }
+    startRenderLoop()
     _setCurrentTime(currentTime)
     if (!silentLoad) {
       emit('entity-change', currentIndex.value)
@@ -411,7 +452,6 @@ const pause = () => {
       currentPlayer.value.currentTime / frameDuration.value
     )
     emit('frame-update', frameNumber)
-    cancelAnimationFrame(playLoop)
   }
   isPlaying.value = false
 }
@@ -423,26 +463,11 @@ const play = () => {
     entity = props.entities[currentIndex.value]
     if (entity.preview_file_id) {
       if (currentPlayer.value) {
-        if (props.name === 'main') {
-          runEmitTimeUpdateLoop()
-        }
         currentPlayer.value.play()
       }
       isPlaying.value = true
     }
   }
-}
-
-const runEmitTimeUpdateLoop = () => {
-  cancelAnimationFrame(playLoop)
-  lastEmittedFrame = null
-  // requestAnimationFrame (not setInterval) so the emitted time is smooth and
-  // tab-throttle friendly; frame-update is deduplicated to the frame value.
-  const update = () => {
-    if (currentPlayer.value) updateTime(currentPlayer.value.currentTime)
-    playLoop = requestAnimationFrame(update)
-  }
-  playLoop = requestAnimationFrame(update)
 }
 
 const playNext = handleIn => {
@@ -459,12 +484,10 @@ const playNext = handleIn => {
     currentIndex.value = nextIndex
     emit('entity-change', currentIndex.value)
 
-    if (currentPlayer.value) currentPlayer.value.style.display = 'none'
     if (nextPlayer.value) {
       nextPlayer.value.currentTime = handleIn
         ? handleIn * frameDuration.value
         : 0
-      nextPlayer.value.style.display = 'block'
       nextPlayer.value.play()
     }
 
@@ -553,6 +576,8 @@ const switchPlayers = () => {
   }
   resetHeight()
   setSpeed(rate)
+  resizeRenderer()
+  startRenderLoop()
 }
 
 const updateTime = time => {
@@ -569,8 +594,10 @@ const updateTime = time => {
 
 const updateMaxDuration = () => {
   if (currentPlayer.value) {
+    resizeRenderer()
     emit('max-duration-update', currentPlayer.value.duration)
     emit('video-loaded')
+    if (renderLoopHandle === null) startRenderLoop()
   }
 }
 
@@ -694,10 +721,9 @@ watch(
 onMounted(() => {
   resetHeight()
   player1Ref.value.addEventListener('loadedmetadata', emitLoadedEvent)
-  // Defer panzoom binding until each video has metadata so the bounds
+  // Defer panzoom binding until metadata loads so the bounds
   // clamp doesn't compute against a 0×0 target.
-  player1Ref.value.addEventListener('loadedmetadata', setupPlayer1PanZoom)
-  player2Ref.value.addEventListener('loadedmetadata', setupPlayer2PanZoom)
+  player1Ref.value.addEventListener('loadedmetadata', setupPanZoom)
   window.addEventListener('resize', resetHeight)
   if (typeof ResizeObserver !== 'undefined' && containerRef.value) {
     containerResizeObserver = new ResizeObserver(() => {
@@ -711,23 +737,22 @@ onMounted(() => {
 
   // Cached-video case: metadata may already be present, in which case
   // the load events above won't fire.
-  if (player1Ref.value.readyState >= 1) setupPlayer1PanZoom()
-  if (player2Ref.value.readyState >= 1) setupPlayer2PanZoom()
+  if (player1Ref.value.readyState >= 1) setupPanZoom()
 })
 
 onBeforeUnmount(() => {
-  cancelAnimationFrame(playLoop)
+  stopRenderLoop()
+  renderer?.dispose()
+  renderer = null
   window.removeEventListener('resize', resetHeight)
   containerResizeObserver?.disconnect()
   player1Ref.value?.removeEventListener('loadedmetadata', emitLoadedEvent)
-  player1Ref.value?.removeEventListener('loadedmetadata', setupPlayer1PanZoom)
-  player2Ref.value?.removeEventListener('loadedmetadata', setupPlayer2PanZoom)
+  player1Ref.value?.removeEventListener('loadedmetadata', setupPanZoom)
 
   unbindLoadingHandlers(player1Ref.value)
   unbindLoadingHandlers(player2Ref.value)
 
   firstPanZoom?.dispose()
-  secondPanZoom?.dispose()
 })
 
 // Expose public surface for parent components ($refs['raw-player'])
@@ -766,7 +791,8 @@ defineExpose({
   pausePanZoom,
   resetPanZoom,
   resumePanZoom,
-  setPanZoom
+  setPanZoom,
+  getDisplaySurface
 })
 </script>
 
@@ -776,8 +802,17 @@ defineExpose({
   position: relative;
   overflow: hidden;
 
-  video {
+  .playlist-movie-decoder {
+    // Not display:none — some browsers suspend decoding entirely.
+    position: absolute;
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  canvas.playlist-movie {
     margin: auto;
+    max-width: 100%;
+    object-fit: contain;
   }
 }
 
@@ -787,7 +822,7 @@ defineExpose({
     display: flex;
     justify-content: center;
 
-    video {
+    canvas.playlist-movie {
       margin: 0 auto;
     }
   }

--- a/src/components/players/viewers/PreviewViewer.vue
+++ b/src/components/players/viewers/PreviewViewer.vue
@@ -381,7 +381,10 @@ const resize = () => {
 }
 
 const currentMediaElement = computed(() => {
-  if (isMovie.value) return videoViewer.value?.video || null
+  // The visible surface: AnnotationCanvas aligns its bounds (and the
+  // wheel forwarder dispatches) on it. The hidden decoder <video> has
+  // no reliable bbox under visibility:hidden.
+  if (isMovie.value) return videoViewer.value?.getDisplaySurface() || null
   if (isPicture.value) return pictureViewer.value?.visibleImage || null
   return null
 })

--- a/src/components/players/viewers/VideoViewer.vue
+++ b/src/components/players/viewers/VideoViewer.vue
@@ -358,8 +358,12 @@ const emitFrameSignals = playerTime => {
 }
 
 // One continuous loop, play AND pause: a paused seek still presents a
-// new frame, and that presentation is exactly when to repaint and
-// announce the frame.
+// new frame, and that presentation is exactly when to repaint. EMITTING
+// stays playback-only though — paused frame context is owned by the
+// parent (pause / goNextFrame / progress clicks emit the prop-frame
+// convention), and the loop's getFrameFromPlayer numbers use the
+// playback convention; feeding those to setVideoFrameContext during a
+// paused seek shifts the UI off the clicked frame.
 const startRenderLoop = () => {
   stopRenderLoop()
   if (supportsVideoFrameCallback()) {
@@ -370,7 +374,9 @@ const startRenderLoop = () => {
       lastMediaTime = metadata.mediaTime
       currentTimeRaw.value = metadata.mediaTime
       renderer?.drawFrame()
-      emitFrameSignals(playerTimeFromMediaTime(metadata.mediaTime))
+      if (!video.value.paused) {
+        emitFrameSignals(playerTimeFromMediaTime(metadata.mediaTime))
+      }
       renderLoopHandle = video.value.requestVideoFrameCallback(tick)
     }
     renderLoopHandle = video.value.requestVideoFrameCallback(tick)
@@ -385,7 +391,9 @@ const startRenderLoop = () => {
         lastDrawnTime = video.value.currentTime
         currentTimeRaw.value = lastDrawnTime
         renderer?.drawFrame()
-        emitFrameSignals(lastDrawnTime)
+        if (!video.value.paused) {
+          emitFrameSignals(lastDrawnTime)
+        }
       }
       renderLoopHandle = requestAnimationFrame(tick)
     }

--- a/src/components/players/viewers/VideoViewer.vue
+++ b/src/components/players/viewers/VideoViewer.vue
@@ -800,7 +800,12 @@ defineExpose({
 
 canvas.annotation-movie {
   // Same sizing behavior as the old <video>: resetSize() drives the CSS
-  // height, the intrinsic bitmap ratio drives the width.
-  object-fit: inherit;
+  // height, the intrinsic bitmap ratio drives the width. Bulma's reset
+  // (img, video, … { max-width: 100% }) clamped the old <video> when a
+  // comparison slot got narrower than the computed width, but canvas is
+  // not covered by it — re-apply the clamp, and letterbox the bitmap
+  // instead of stretching it when the clamp kicks in.
+  max-width: 100%;
+  object-fit: contain;
 }
 </style>

--- a/src/components/players/viewers/VideoViewer.vue
+++ b/src/components/players/viewers/VideoViewer.vue
@@ -272,6 +272,10 @@ const runSetCurrentTime = () => {
 }
 
 const setCurrentTime = currentTime => {
+  // Scrubbing queues a seek per mousemove; only the latest target
+  // matters, and every landed seek now costs a decode + a canvas paint.
+  // Drop the stale backlog instead of replaying the whole trail.
+  currentTimeCalls.length = 0
   currentTimeCalls.push(currentTime)
   runSetCurrentTime()
 }

--- a/src/components/players/viewers/VideoViewer.vue
+++ b/src/components/players/viewers/VideoViewer.vue
@@ -571,6 +571,9 @@ watch(
   () => {
     hasPaintedVideoFrame = false
     lastMediaTime = 0
+    // Allow the first frame-update of the new preview even when it lands
+    // on the same frame number the previous clip stopped at.
+    lastEmittedFrame = null
     paintPosterFallback()
     resetPanZoom()
     pause()

--- a/src/components/players/viewers/VideoViewer.vue
+++ b/src/components/players/viewers/VideoViewer.vue
@@ -20,13 +20,18 @@
       </div>
       <video
         ref="movie"
-        class="annotation-movie"
+        class="annotation-movie-decoder"
         :src="moviePath"
         :poster="posterPath"
         preload="auto"
         type="video/mp4"
-        v-show="!isLoading"
+        playsinline
       ></video>
+      <canvas
+        ref="displayCanvas"
+        class="annotation-movie"
+        v-show="!isLoading"
+      ></canvas>
     </div>
   </div>
 </template>
@@ -36,6 +41,10 @@ import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import createPanzoom from 'panzoom'
 import { useStore } from 'vuex'
 
+import {
+  createFrameRenderer,
+  supportsVideoFrameCallback
+} from '@/lib/players/frameRenderer'
 import { formatFrame } from '@/lib/video'
 
 import Spinner from '@/components/widgets/Spinner.vue'
@@ -132,6 +141,7 @@ const store = useStore()
 
 const container = ref(null)
 const currentTimeRaw = ref(0)
+const displayCanvas = ref(null)
 const isLoading = ref(false)
 const movie = ref(null)
 const videoDuration = ref(0)
@@ -146,10 +156,20 @@ let panzoomSilent = false
 // finally exists.
 let panzoomActive = false
 let currentTimeCalls = []
-let playLoop = null
 let lastEmittedFrame = null
 let isPlaying = false
 let previousDimensions = null
+
+let renderer = null
+let renderLoopHandle = null
+let renderLoopIsRvfc = false
+// mediaTime of the last frame the browser actually presented. The
+// source of truth for emitted times/frames (currentTime lies during
+// decode latency, which is the whole point of this pipeline).
+let lastMediaTime = 0
+// iOS Safari may not decode any frame before a user gesture: paint the
+// poster so the canvas isn't black until the first rVFC tick.
+let hasPaintedVideoFrame = false
 
 const currentProduction = computed(() => store.getters.currentProduction)
 
@@ -260,8 +280,8 @@ const resetSize = () => {
   const { height: initialHeight } = getDimensions()
   if (initialHeight > 0) {
     container.value.style.height = props.defaultHeight + 'px'
-    video.value.style.height = initialHeight + 'px'
-    const videoPosition = video.value.getBoundingClientRect()
+    displayCanvas.value.style.height = initialHeight + 'px'
+    const videoPosition = displayCanvas.value.getBoundingClientRect()
     const containerPosition = container.value.getBoundingClientRect()
     const top = videoPosition.top - containerPosition.top
     const left = videoPosition.left - containerPosition.left
@@ -289,6 +309,12 @@ const mountVideo = () => {
   videoDuration.value = video.value.duration
   isLoading.value = false
   emit('duration-changed', videoDuration.value)
+  if (!renderer && displayCanvas.value) {
+    renderer = createFrameRenderer(displayCanvas.value, video.value)
+  }
+  resizeRenderer()
+  if (renderLoopHandle === null) startRenderLoop()
+  paintPosterFallback()
   resetSize()
   setTimeout(() => {
     resetSize()
@@ -302,8 +328,19 @@ const configureVideo = () => {
   }
 }
 
+// rVFC mediaTime is the frame's PRESENTATION time (its start boundary),
+// while every consumer is calibrated on the mid-frame currentTime that
+// frameToTime() seeks produce. Re-center so all emitted values stay
+// bit-identical to the old pipeline.
+const playerTimeFromMediaTime = mediaTime => mediaTime + frameDuration.value / 2
+
 const getFrameFromPlayer = () => {
-  const raw = video.value ? video.value.currentTime : 0
+  const raw =
+    lastMediaTime > 0
+      ? playerTimeFromMediaTime(lastMediaTime)
+      : video.value
+        ? video.value.currentTime
+        : 0
   if (raw === 0) return 0
   let frame = Math.ceil(raw / frameDuration.value) + 1
   frame = Number(frame.toPrecision(4))
@@ -311,22 +348,76 @@ const getFrameFromPlayer = () => {
   return frame
 }
 
-const runEmitTimeUpdateLoop = () => {
-  cancelAnimationFrame(playLoop)
-  lastEmittedFrame = null
-  // requestAnimationFrame for a smooth time signal; frame-update is deduped.
-  const update = () => {
-    if (video.value) {
-      emit('time-update', video.value.currentTime)
-      const frame = getFrameFromPlayer()
-      if (frame !== lastEmittedFrame) {
-        lastEmittedFrame = frame
-        emit('frame-update', frame)
-      }
-    }
-    playLoop = requestAnimationFrame(update)
+const emitFrameSignals = playerTime => {
+  emit('time-update', playerTime)
+  const frame = getFrameFromPlayer()
+  if (frame !== lastEmittedFrame) {
+    lastEmittedFrame = frame
+    emit('frame-update', frame)
   }
-  playLoop = requestAnimationFrame(update)
+}
+
+// One continuous loop, play AND pause: a paused seek still presents a
+// new frame, and that presentation is exactly when to repaint and
+// announce the frame.
+const startRenderLoop = () => {
+  stopRenderLoop()
+  if (supportsVideoFrameCallback()) {
+    renderLoopIsRvfc = true
+    const tick = (now, metadata) => {
+      if (!video.value) return
+      hasPaintedVideoFrame = true
+      lastMediaTime = metadata.mediaTime
+      currentTimeRaw.value = metadata.mediaTime
+      renderer?.drawFrame()
+      emitFrameSignals(playerTimeFromMediaTime(metadata.mediaTime))
+      renderLoopHandle = video.value.requestVideoFrameCallback(tick)
+    }
+    renderLoopHandle = video.value.requestVideoFrameCallback(tick)
+  } else {
+    // Fallback (no rVFC): poll currentTime at rAF cadence. Same
+    // accuracy as the old pipeline — no worse, just not better.
+    renderLoopIsRvfc = false
+    let lastDrawnTime = -1
+    const tick = () => {
+      if (video.value && video.value.currentTime !== lastDrawnTime) {
+        hasPaintedVideoFrame = true
+        lastDrawnTime = video.value.currentTime
+        currentTimeRaw.value = lastDrawnTime
+        renderer?.drawFrame()
+        emitFrameSignals(lastDrawnTime)
+      }
+      renderLoopHandle = requestAnimationFrame(tick)
+    }
+    renderLoopHandle = requestAnimationFrame(tick)
+  }
+}
+
+const stopRenderLoop = () => {
+  if (renderLoopHandle === null) return
+  if (renderLoopIsRvfc) {
+    video.value?.cancelVideoFrameCallback?.(renderLoopHandle)
+  } else {
+    cancelAnimationFrame(renderLoopHandle)
+  }
+  renderLoopHandle = null
+}
+
+const getDisplaySurface = () => displayCanvas.value
+
+const resizeRenderer = () => {
+  if (!renderer || !video.value) return
+  renderer.resize(video.value.videoWidth, video.value.videoHeight)
+  renderer.drawFrame()
+}
+
+const paintPosterFallback = () => {
+  if (hasPaintedVideoFrame || !renderer || !posterPath.value) return
+  const poster = new Image()
+  poster.onload = () => {
+    if (!hasPaintedVideoFrame) renderer?.drawFrame(poster)
+  }
+  poster.src = posterPath.value
 }
 
 const play = () => {
@@ -338,14 +429,10 @@ const play = () => {
     setCurrentTime(0)
   }
   video.value.play()
-  if (props.name.indexOf('comparison') < 0) {
-    runEmitTimeUpdateLoop()
-  }
 }
 
 const pause = () => {
   video.value.pause()
-  cancelAnimationFrame(playLoop)
   video.value.currentTime = frameToTime(props.currentFrame)
   emit('frame-update', props.currentFrame)
 }
@@ -372,7 +459,6 @@ const goNextFrame = () => {
 
 const onVideoEnd = () => {
   isPlaying = false
-  cancelAnimationFrame(playLoop)
   // a queued 'ended' event can fire after unmount, once the ref is nulled
   if (!video.value) return
   if (props.isRepeating) {
@@ -417,34 +503,34 @@ const emitPanZoom = () => {
   emit('panzoom-changed', { x, y, scale, source: 'movie' })
 }
 
-// Bind panzoom to the <video> rather than the wrapping container: the
-// video is flex-centered inside the wrapper, so scaling the wrapper
-// multiplies the centering offset and the video drifts relative to the
+// Bind panzoom to the canvas rather than the wrapping container: the
+// canvas is flex-centered inside the wrapper, so scaling the wrapper
+// multiplies the centering offset and the canvas drifts relative to the
 // AnnotationCanvas overlay (which applies the same transform from its
 // own top-left origin). Setup is deferred until metadata is loaded so
 // panzoom's bounds clamp doesn't compute against a 0×0 target — that
-// raced the load on slow connections and left the video off-centre.
+// raced the load on slow connections and left the canvas off-centre.
 const setupPanZoom = () => {
-  if (!props.panzoom || !movie.value) return
+  if (!props.panzoom || !displayCanvas.value) return
   if (panzoomInstance) {
     panzoomInstance.dispose()
     panzoomInstance = null
   }
-  // panzoom listens on `movie.parentElement` (.video-wrapper), which
+  // panzoom listens on `displayCanvas.parentElement` (.video-wrapper), which
   // is forced to 100% of the viewer and leaves gutters on the sides
-  // of the video. Without these guards a click / wheel in the gutter
+  // of the canvas. Without these guards a click / wheel in the gutter
   // would still trigger pan or zoom. Ignore any event whose target
-  // isn't the video itself. The AnnotationCanvas wheel forwarder
-  // dispatches on movie.value directly, so wheel-from-overlay (zoom
+  // isn't the canvas itself. The AnnotationCanvas wheel forwarder
+  // dispatches on displayCanvas.value directly, so wheel-from-overlay (zoom
   // while drawing) keeps working.
-  panzoomInstance = createPanzoom(movie.value, {
+  panzoomInstance = createPanzoom(displayCanvas.value, {
     bounds: true,
     boundsPadding: 0.2,
     maxZoom: 5,
     minZoom: 1,
     smoothScroll: false,
-    beforeMouseDown: e => e.target !== movie.value,
-    beforeWheel: e => e.target !== movie.value,
+    beforeMouseDown: e => e.target !== displayCanvas.value,
+    beforeWheel: e => e.target !== displayCanvas.value,
     // panzoom otherwise puts tabindex=0 on the owner and steals arrow
     // keys / +/- to pan and zoom — those shortcuts are owned by the
     // player (frame stepping, annotation navigation), so disable them.
@@ -483,6 +569,9 @@ const setVolume = volume => {
 watch(
   () => props.preview,
   () => {
+    hasPaintedVideoFrame = false
+    lastMediaTime = 0
+    paintPosterFallback()
     resetPanZoom()
     pause()
     nextTick(() => {
@@ -556,7 +645,10 @@ onMounted(() => {
         setupPanZoom()
       }
       video.value.addEventListener('focus', e => e.target.blur())
-      video.value.addEventListener('resize', resetSize)
+      video.value.addEventListener('resize', () => {
+        resizeRenderer()
+        resetSize()
+      })
 
       video.value.addEventListener('loadedmetadata', () => {
         if (!video.value) return
@@ -606,6 +698,9 @@ onMounted(() => {
 onBeforeUnmount(() => {
   if (video.value) video.value.onended = null
   pause()
+  stopRenderLoop()
+  renderer?.dispose()
+  renderer = null
   window.removeEventListener('resize', onWindowResize)
   panzoomInstance?.dispose()
 })
@@ -634,7 +729,8 @@ defineExpose({
   resumePanZoom,
   setSpeed,
   setVolume,
-  resetSize
+  resetSize,
+  getDisplaySurface
 })
 </script>
 
@@ -680,7 +776,16 @@ defineExpose({
   position: relative;
 }
 
-video {
+.annotation-movie-decoder {
+  // Not display:none — some browsers suspend decoding entirely.
+  position: absolute;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+canvas.annotation-movie {
+  // Same sizing behavior as the old <video>: resetSize() drives the CSS
+  // height, the intrinsic bitmap ratio drives the width.
   object-fit: inherit;
 }
 </style>

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -141,6 +141,7 @@
                     :entity-preview-files="taskEntityPreviews"
                     :entity-type="entityType"
                     :extra-wide="isExtraWide"
+                    :fps="currentFps"
                     :is-assigned="isAssigned"
                     :last-preview-files="taskPreviews"
                     :light="!isWide"
@@ -810,10 +811,6 @@ export default {
           visible: !this.withActions && !this.isCurrentUserClient
         }
       ].filter(action => action.visible !== false)
-    },
-
-    currentFps() {
-      return parseInt(this.productionMap.get(this.task.project_id)?.fps) || 25
     },
 
     currentRevision() {

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -839,6 +839,13 @@ export const useAnnotation = ({
     if (silentAnnotation) return
     let o = obj.target ? obj.target : obj.targets[0]
     o = setObjectData(o)
+    // The finalized stroke can lose the brush's round caps under
+    // fabric 7 (the live brush preview had them). Force them like the
+    // reload path (addObjectToCanvas) already does.
+    if (o.set && (o.type === 'PSStroke' || o.type === 'path')) {
+      o.set('strokeLineCap', 'round')
+      o.set('strokeLineJoin', 'round')
+    }
     if (isLaserModeOn.value) {
       // Laser strokes fade out locally and are broadcast as ephemeral
       // events; they are intentionally not added to the additions stack.

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -1407,13 +1407,19 @@ export const useAnnotation = ({
 
   const fadeObject = obj => {
     if (!obj) return
-    obj.animate('opacity', '0', {
-      duration: 1500,
-      onChange: fabricCanvas.value.renderAll.bind(fabricCanvas.value),
-      onComplete: () => {
-        fabricCanvas.value.remove(obj)
+    // fabric v6+ animate() only accepts the object form — the legacy
+    // ('opacity', '0', options) signature silently does nothing, which
+    // left laser strokes on the canvas forever.
+    obj.animate(
+      { opacity: 0 },
+      {
+        duration: 1500,
+        onChange: fabricCanvas.value.renderAll.bind(fabricCanvas.value),
+        onComplete: () => {
+          fabricCanvas.value.remove(obj)
+        }
       }
-    })
+    )
   }
 
   // Saving

--- a/src/composables/players/previewShortcuts.js
+++ b/src/composables/players/previewShortcuts.js
@@ -77,10 +77,14 @@ export const usePreviewShortcuts = handlers => {
         handlers.onDelete?.()
         break
       case 'ArrowLeft':
-        handlers.onPrevFrame?.()
+        // Modified arrows belong to surface-specific handlers bound on
+        // the same window target (playlist entity navigation on Alt,
+        // entity reorder on Ctrl+Shift) — stepping a frame on top of
+        // them overwrote their seek.
+        if (!alt && !mod) handlers.onPrevFrame?.()
         break
       case 'ArrowRight':
-        handlers.onNextFrame?.()
+        if (!alt && !mod) handlers.onNextFrame?.()
         break
       case 'Home':
         pauseEvent(event)

--- a/src/lib/players/frameRenderer.js
+++ b/src/lib/players/frameRenderer.js
@@ -11,7 +11,13 @@ export class Canvas2DFrameRenderer {
   constructor(canvas, video) {
     this.canvas = canvas
     this.video = video
-    this.context = canvas.getContext('2d', { alpha: false })
+    // alpha:false skips per-pixel compositing; desynchronized lets the
+    // browser present paints without waiting for the compositor frame,
+    // which keeps scrubbing responsive while the pointer is dragging.
+    this.context = canvas.getContext('2d', {
+      alpha: false,
+      desynchronized: true
+    })
   }
 
   // Internal bitmap resolution (native video size), not the CSS size.

--- a/src/lib/players/frameRenderer.js
+++ b/src/lib/players/frameRenderer.js
@@ -1,0 +1,50 @@
+/*
+ * Frame-painting backends for the canvas video pipeline.
+ *
+ * The visible <canvas> in VideoViewer is painted from a hidden <video>
+ * on every requestVideoFrameCallback tick. v1 ships a single Canvas2D
+ * backend; `createFrameRenderer` is the seam where a WebGL backend
+ * (LUTs, scopes) will plug in without re-migrating the component.
+ */
+
+export class Canvas2DFrameRenderer {
+  constructor(canvas, video) {
+    this.canvas = canvas
+    this.video = video
+    this.context = canvas.getContext('2d', { alpha: false })
+  }
+
+  // Internal bitmap resolution (native video size), not the CSS size.
+  resize(width, height) {
+    if (!this.canvas || !width || !height) return
+    // Reassigning canvas.width/height clears the bitmap; skip when unchanged.
+    if (this.canvas.width !== width) this.canvas.width = width
+    if (this.canvas.height !== height) this.canvas.height = height
+  }
+
+  // Paints the current frame of the hidden video — or any drawImage
+  // source (the poster <img> before the first decoded frame).
+  drawFrame(source = this.video) {
+    if (!this.context || !source) return
+    this.context.drawImage(source, 0, 0, this.canvas.width, this.canvas.height)
+  }
+
+  dispose() {
+    if (this.canvas) {
+      // Zero the bitmap so the browser can reclaim the backing store
+      // right away instead of waiting for GC.
+      this.canvas.width = 0
+      this.canvas.height = 0
+    }
+    this.context = null
+    this.video = null
+    this.canvas = null
+  }
+}
+
+export const createFrameRenderer = (canvas, video) =>
+  new Canvas2DFrameRenderer(canvas, video)
+
+export const supportsVideoFrameCallback = () =>
+  typeof HTMLVideoElement !== 'undefined' &&
+  'requestVideoFrameCallback' in HTMLVideoElement.prototype

--- a/src/lib/players/tiles.js
+++ b/src/lib/players/tiles.js
@@ -1,0 +1,62 @@
+/*
+ * Tile-sprite geometry helpers for the progress-bar hover thumbnails.
+ *
+ * Zou builds one PNG sprite per movie preview: 8 columns of 100px-high
+ * cells, cell width = ceil(100 × display aspect ratio of the normalized
+ * movie), at most 480 rows (longer movies are subsampled by ffmpeg's
+ * select filter, keeping one frame in ceil(nbFrames / 3840)).
+ *
+ * Recomputing the cell width client-side from the preview's stored
+ * dimensions drifts whenever the stored dimensions disagree with the
+ * file the sprite was actually built from (source ratio ≠ production
+ * ratio, renormalisations after a resolution change, DAR metadata).
+ * Measuring the sprite itself gives the exact geometry by construction.
+ */
+
+export const TILE_COLUMNS = 8
+export const TILE_CELL_HEIGHT = 100
+
+const tileGeometryCache = new Map()
+
+/**
+ * Resolve the real geometry of a tile sprite. Resolves null when the
+ * image cannot be loaded (broken preview, no tile yet). Results are
+ * memoized per URL; failures are evicted so a later retry can succeed.
+ */
+export const getTileGeometry = url => {
+  if (tileGeometryCache.has(url)) return tileGeometryCache.get(url)
+  const promise = new Promise(resolve => {
+    const image = new Image()
+    image.onload = () => {
+      const rows = Math.max(
+        Math.round(image.naturalHeight / TILE_CELL_HEIGHT),
+        1
+      )
+      resolve({
+        cellWidth: image.naturalWidth / TILE_COLUMNS,
+        rows,
+        cellCount: rows * TILE_COLUMNS
+      })
+    }
+    image.onerror = () => {
+      tileGeometryCache.delete(url)
+      resolve(null)
+    }
+    image.src = url
+  })
+  tileGeometryCache.set(url, promise)
+  return promise
+}
+
+/**
+ * Map a (0-based) frame to its cell index, mirroring ffmpeg's
+ * select='not(mod(n,k))' subsampling: the kept frame for n is
+ * floor(n / k), clamped to the sprite.
+ */
+export const getTileCellIndex = (frame, nbFrames, cellCount) => {
+  let index = frame
+  if (nbFrames > cellCount) {
+    index = Math.floor(frame / Math.ceil(nbFrames / cellCount))
+  }
+  return Math.min(Math.max(index, 0), cellCount - 1)
+}

--- a/tests/unit/composables/annotation.spec.js
+++ b/tests/unit/composables/annotation.spec.js
@@ -1229,6 +1229,29 @@ describe('composables/annotation', () => {
     })
   })
 
+  describe('fadeObject — laser stroke fade-out', () => {
+    it('uses the fabric v6+ object-form animate signature', () => {
+      // The legacy ('opacity', '0', options) form silently no-ops on
+      // fabric 6/7, leaving laser strokes on the canvas forever.
+      const canvas = createFakeCanvas()
+      const { api, wrapper } = mountAnnotation({ canvas })
+      const obj = { animate: vi.fn() }
+      api.fadeObject(obj)
+      expect(obj.animate).toHaveBeenCalledWith(
+        { opacity: 0 },
+        expect.objectContaining({
+          duration: expect.any(Number),
+          onChange: expect.any(Function),
+          onComplete: expect.any(Function)
+        })
+      )
+      // The completion callback removes the faded stroke from the canvas.
+      obj.animate.mock.calls[0][1].onComplete()
+      expect(canvas.remove).toHaveBeenCalledWith(obj)
+      wrapper.unmount()
+    })
+  })
+
   describe('loadSingleAnnotation — cancellation on clear', () => {
     it('drops in-flight object loads when the canvas is cleared', async () => {
       // Fast navigation: frame A's strokes are still deserializing when the

--- a/tests/unit/composables/previewShortcuts.spec.js
+++ b/tests/unit/composables/previewShortcuts.spec.js
@@ -109,6 +109,20 @@ describe('composables/previewShortcuts', () => {
       wrapper.unmount()
     })
 
+    it('ignores modified arrows — Alt/Ctrl combos belong to surface handlers', () => {
+      // PlaylistPlayer binds Alt+Arrow (entity navigation) and
+      // Ctrl+Shift+Arrow (entity reorder) on the same window target;
+      // stepping a frame on top of those overwrote their seek.
+      const { handlers, wrapper } = mountShortcuts()
+      dispatchKeydown({ key: 'ArrowLeft', altKey: true })
+      dispatchKeydown({ key: 'ArrowRight', altKey: true })
+      dispatchKeydown({ key: 'ArrowLeft', ctrlKey: true, shiftKey: true })
+      dispatchKeydown({ key: 'ArrowRight', metaKey: true })
+      expect(handlers.onPrevFrame).not.toHaveBeenCalled()
+      expect(handlers.onNextFrame).not.toHaveBeenCalled()
+      wrapper.unmount()
+    })
+
     it('keeps stepping frames on auto-repeat so holding an arrow scrubs the video', () => {
       const { handlers, wrapper } = mountShortcuts()
       dispatchKeydown({ key: 'ArrowRight', repeat: true })

--- a/tests/unit/lib/frameRenderer.spec.js
+++ b/tests/unit/lib/frameRenderer.spec.js
@@ -1,0 +1,89 @@
+import {
+  Canvas2DFrameRenderer,
+  createFrameRenderer,
+  supportsVideoFrameCallback
+} from '@/lib/players/frameRenderer'
+
+const createFakeCanvas = () => {
+  const context = {
+    drawImage: vi.fn()
+  }
+  const canvas = {
+    width: 0,
+    height: 0,
+    getContext: vi.fn(() => context)
+  }
+  return { canvas, context }
+}
+
+const createFakeVideo = () => ({ videoWidth: 1920, videoHeight: 1080 })
+
+describe('lib/players/frameRenderer', () => {
+  describe('Canvas2DFrameRenderer', () => {
+    it('acquires an opaque 2d context on construction', () => {
+      const { canvas } = createFakeCanvas()
+      new Canvas2DFrameRenderer(canvas, createFakeVideo())
+      expect(canvas.getContext).toHaveBeenCalledWith('2d', { alpha: false })
+    })
+
+    it('resize sets the internal bitmap resolution', () => {
+      const { canvas } = createFakeCanvas()
+      const renderer = new Canvas2DFrameRenderer(canvas, createFakeVideo())
+      renderer.resize(1920, 1080)
+      expect(canvas.width).toBe(1920)
+      expect(canvas.height).toBe(1080)
+    })
+
+    it('resize ignores falsy dimensions (metadata not loaded yet)', () => {
+      const { canvas } = createFakeCanvas()
+      const renderer = new Canvas2DFrameRenderer(canvas, createFakeVideo())
+      canvas.width = 640
+      canvas.height = 360
+      renderer.resize(0, 0)
+      expect(canvas.width).toBe(640)
+      expect(canvas.height).toBe(360)
+    })
+
+    it('drawFrame paints the video over the full bitmap', () => {
+      const { canvas, context } = createFakeCanvas()
+      const video = createFakeVideo()
+      const renderer = new Canvas2DFrameRenderer(canvas, video)
+      renderer.resize(1920, 1080)
+      renderer.drawFrame()
+      expect(context.drawImage).toHaveBeenCalledWith(video, 0, 0, 1920, 1080)
+    })
+
+    it('drawFrame accepts an alternate source (poster image)', () => {
+      const { canvas, context } = createFakeCanvas()
+      const renderer = new Canvas2DFrameRenderer(canvas, createFakeVideo())
+      renderer.resize(1920, 1080)
+      const poster = { src: 'poster.png' }
+      renderer.drawFrame(poster)
+      expect(context.drawImage).toHaveBeenCalledWith(poster, 0, 0, 1920, 1080)
+    })
+
+    it('is inert after dispose (no throw, no draw)', () => {
+      const { canvas, context } = createFakeCanvas()
+      const renderer = new Canvas2DFrameRenderer(canvas, createFakeVideo())
+      renderer.dispose()
+      expect(() => renderer.drawFrame()).not.toThrow()
+      expect(() => renderer.resize(10, 10)).not.toThrow()
+      expect(() => renderer.dispose()).not.toThrow()
+      expect(context.drawImage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('createFrameRenderer', () => {
+    it('returns a Canvas2DFrameRenderer (v1 has a single backend)', () => {
+      const { canvas } = createFakeCanvas()
+      const renderer = createFrameRenderer(canvas, createFakeVideo())
+      expect(renderer).toBeInstanceOf(Canvas2DFrameRenderer)
+    })
+  })
+
+  describe('supportsVideoFrameCallback', () => {
+    it('returns a boolean and false under jsdom', () => {
+      expect(supportsVideoFrameCallback()).toBe(false)
+    })
+  })
+})

--- a/tests/unit/lib/frameRenderer.spec.js
+++ b/tests/unit/lib/frameRenderer.spec.js
@@ -20,10 +20,13 @@ const createFakeVideo = () => ({ videoWidth: 1920, videoHeight: 1080 })
 
 describe('lib/players/frameRenderer', () => {
   describe('Canvas2DFrameRenderer', () => {
-    it('acquires an opaque 2d context on construction', () => {
+    it('acquires an opaque desynchronized 2d context on construction', () => {
       const { canvas } = createFakeCanvas()
       new Canvas2DFrameRenderer(canvas, createFakeVideo())
-      expect(canvas.getContext).toHaveBeenCalledWith('2d', { alpha: false })
+      expect(canvas.getContext).toHaveBeenCalledWith('2d', {
+        alpha: false,
+        desynchronized: true
+      })
     })
 
     it('resize sets the internal bitmap resolution', () => {

--- a/tests/unit/lib/tiles.spec.js
+++ b/tests/unit/lib/tiles.spec.js
@@ -1,0 +1,75 @@
+import {
+  getTileCellIndex,
+  getTileGeometry,
+  TILE_CELL_HEIGHT,
+  TILE_COLUMNS
+} from '@/lib/players/tiles'
+
+describe('lib/players/tiles', () => {
+  describe('getTileCellIndex', () => {
+    it('maps frames one-to-one when the sprite holds every frame', () => {
+      expect(getTileCellIndex(0, 100, 3840)).toBe(0)
+      expect(getTileCellIndex(41, 100, 3840)).toBe(41)
+    })
+
+    it('mirrors ffmpeg subsampling (floor, not ceil) on long movies', () => {
+      // 7000 frames in a 3840-cell sprite: k = ceil(7000/3840) = 2,
+      // ffmpeg keeps frames 0, 2, 4… so frame 11 lives in cell 5.
+      expect(getTileCellIndex(11, 7000, 3840)).toBe(5)
+      expect(getTileCellIndex(10, 7000, 3840)).toBe(5)
+      expect(getTileCellIndex(12, 7000, 3840)).toBe(6)
+    })
+
+    it('clamps to the sprite bounds', () => {
+      expect(getTileCellIndex(-3, 100, 3840)).toBe(0)
+      expect(getTileCellIndex(99999, 7000, 3840)).toBe(3839)
+    })
+  })
+
+  describe('getTileGeometry', () => {
+    let originalImage
+
+    beforeEach(() => {
+      originalImage = globalThis.Image
+    })
+
+    afterEach(() => {
+      globalThis.Image = originalImage
+    })
+
+    const installImageMock = ({ width, height, fail = false }) => {
+      globalThis.Image = class {
+        set src(_) {
+          this.naturalWidth = width
+          this.naturalHeight = height
+          setTimeout(() => (fail ? this.onerror?.() : this.onload?.()))
+        }
+      }
+    }
+
+    it('measures the sprite cells from the natural image size', async () => {
+      installImageMock({ width: 1424, height: 4200 })
+      const geometry = await getTileGeometry('/tiles/measured.png')
+      expect(geometry.cellWidth).toBe(1424 / TILE_COLUMNS)
+      expect(geometry.rows).toBe(4200 / TILE_CELL_HEIGHT)
+      expect(geometry.cellCount).toBe((4200 / TILE_CELL_HEIGHT) * 8)
+    })
+
+    it('memoizes per URL', async () => {
+      installImageMock({ width: 800, height: 100 })
+      const first = await getTileGeometry('/tiles/cached.png')
+      installImageMock({ width: 1600, height: 200 })
+      const second = await getTileGeometry('/tiles/cached.png')
+      expect(second).toBe(first)
+    })
+
+    it('resolves null on load failure and allows a retry', async () => {
+      installImageMock({ width: 0, height: 0, fail: true })
+      expect(await getTileGeometry('/tiles/broken.png')).toBeNull()
+      installImageMock({ width: 800, height: 100 })
+      const retried = await getTileGeometry('/tiles/broken.png')
+      expect(retried).not.toBeNull()
+      expect(retried.cellWidth).toBe(100)
+    })
+  })
+})

--- a/tests/unit/players/multivideoviewer.spec.js
+++ b/tests/unit/players/multivideoviewer.spec.js
@@ -1,0 +1,165 @@
+import { mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+
+import MultiVideoViewer from '@/components/players/viewers/MultiVideoViewer.vue'
+
+// jsdom has no 2d context nor rVFC: both are stubbed here.
+const fakeContext = { drawImage: vi.fn() }
+
+// Collects rVFC callbacks per video so tests can fire ticks manually.
+let rvfcCallbacks
+let rvfcCancelled
+
+const installRvfcMock = () => {
+  rvfcCallbacks = []
+  rvfcCancelled = []
+  HTMLVideoElement.prototype.requestVideoFrameCallback = function (cb) {
+    rvfcCallbacks.push({ video: this, cb })
+    return rvfcCallbacks.length
+  }
+  HTMLVideoElement.prototype.cancelVideoFrameCallback = function (handle) {
+    rvfcCancelled.push(handle)
+  }
+}
+
+const removeRvfcMock = () => {
+  delete HTMLVideoElement.prototype.requestVideoFrameCallback
+  delete HTMLVideoElement.prototype.cancelVideoFrameCallback
+}
+
+const mountViewer = () => {
+  const store = createStore({
+    getters: { currentProduction: () => ({ fps: '25' }) }
+  })
+  return mount(MultiVideoViewer, {
+    props: {
+      entities: [
+        { id: 'e1', preview_file_id: 'p1', preview_file_extension: 'mp4', fps: 25 },
+        { id: 'e2', preview_file_id: 'p2', preview_file_extension: 'mp4', fps: 25 }
+      ],
+      name: 'main'
+    },
+    global: {
+      mocks: { $t: key => key },
+      plugins: [store]
+    }
+  })
+}
+
+describe('players/MultiVideoViewer (canvas pipeline)', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      fakeContext
+    )
+    fakeContext.drawImage.mockClear()
+    HTMLMediaElement.prototype.load = vi.fn()
+    installRvfcMock()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    removeRvfcMock()
+    delete HTMLMediaElement.prototype.load
+  })
+
+  it('renders one visible canvas and two hidden decoder videos', () => {
+    const wrapper = mountViewer()
+    const canvas = wrapper.find('canvas.playlist-movie')
+    const videos = wrapper.findAll('video.playlist-movie-decoder')
+    expect(canvas.exists()).toBe(true)
+    expect(videos.length).toBe(2)
+    wrapper.unmount()
+  })
+
+  it('keeps the full exposed surface plus getDisplaySurface', () => {
+    const wrapper = mountViewer()
+    const exposed = [
+      'currentIndex',
+      'currentPlayer',
+      'isPlaying',
+      'loadEntity',
+      'loadNextEntity',
+      'reloadCurrentEntity',
+      'pause',
+      'play',
+      'playNext',
+      'getCurrentFrame',
+      'getCurrentTime',
+      'getCurrentTimeRaw',
+      'goNextFrame',
+      'goPreviousFrame',
+      'setCurrentFrame',
+      'setCurrentTimeRaw',
+      'setSpeed',
+      'setVolume',
+      'getNaturalDimensions',
+      'getVideoRatio',
+      'clear',
+      'resetHeight',
+      'pausePanZoom',
+      'resetPanZoom',
+      'resumePanZoom',
+      'setPanZoom',
+      'getDisplaySurface'
+    ]
+    exposed.forEach(name => {
+      expect(wrapper.vm[name], `missing exposed: ${name}`).toBeDefined()
+    })
+    expect(wrapper.vm.getDisplaySurface()).toBe(
+      wrapper.find('canvas').element
+    )
+    wrapper.unmount()
+  })
+
+  it('paints from the active player and re-arms the loop on switch', async () => {
+    const wrapper = mountViewer()
+    wrapper.vm.loadEntity(0)
+    await wrapper.vm.$nextTick()
+
+    // Fire the latest rVFC tick for the current active player
+    const firstCallCount = rvfcCallbacks.length
+    expect(firstCallCount).toBeGreaterThan(0)
+
+    const { cb: tick1 } = rvfcCallbacks[firstCallCount - 1]
+    tick1()
+    expect(fakeContext.drawImage).toHaveBeenCalled()
+
+    fakeContext.drawImage.mockClear()
+
+    // Load entity 1 — re-arms on a new registration
+    wrapper.vm.loadEntity(1)
+    await wrapper.vm.$nextTick()
+
+    // A NEW rVFC registration should have happened
+    expect(rvfcCallbacks.length).toBeGreaterThan(firstCallCount)
+
+    // Firing the stale old tick must NOT paint (stale-player guard)
+    const staleCount = rvfcCallbacks.length
+    tick1()
+    expect(fakeContext.drawImage).not.toHaveBeenCalled()
+
+    // Firing the new tick DOES paint
+    const { cb: tick2 } = rvfcCallbacks[staleCount - 1]
+    tick2()
+    expect(fakeContext.drawImage).toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('does not emit frame-update from ticks while paused', async () => {
+    const wrapper = mountViewer()
+    wrapper.vm.loadEntity(0)
+    await wrapper.vm.$nextTick()
+
+    expect(rvfcCallbacks.length).toBeGreaterThan(0)
+    const countBefore = (wrapper.emitted('frame-update') || []).length
+
+    const { cb: tick } = rvfcCallbacks[rvfcCallbacks.length - 1]
+    tick()
+
+    const countAfter = (wrapper.emitted('frame-update') || []).length
+    expect(countAfter).toBe(countBefore)
+
+    wrapper.unmount()
+  })
+})

--- a/tests/unit/players/videoviewer.spec.js
+++ b/tests/unit/players/videoviewer.spec.js
@@ -1,0 +1,147 @@
+import { mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+
+import VideoViewer from '@/components/players/viewers/VideoViewer.vue'
+
+// jsdom has no 2d context nor rVFC: both are stubbed here.
+const fakeContext = { drawImage: vi.fn() }
+
+// Collects rVFC callbacks so tests can fire ticks manually.
+let rvfcCallbacks
+let rvfcCancelled
+
+const installRvfcMock = () => {
+  rvfcCallbacks = []
+  rvfcCancelled = []
+  HTMLVideoElement.prototype.requestVideoFrameCallback = function (cb) {
+    rvfcCallbacks.push(cb)
+    return rvfcCallbacks.length
+  }
+  HTMLVideoElement.prototype.cancelVideoFrameCallback = function (handle) {
+    rvfcCancelled.push(handle)
+  }
+}
+
+const removeRvfcMock = () => {
+  delete HTMLVideoElement.prototype.requestVideoFrameCallback
+  delete HTMLVideoElement.prototype.cancelVideoFrameCallback
+}
+
+const mountViewer = () => {
+  const store = createStore({
+    getters: { currentProduction: () => ({ fps: '25' }) }
+  })
+  return mount(VideoViewer, {
+    props: {
+      preview: { id: 'preview-1', extension: 'mp4' },
+      fps: 25,
+      nbFrames: 100
+    },
+    global: {
+      mocks: { $t: key => key },
+      plugins: [store]
+    }
+  })
+}
+
+describe('players/VideoViewer (canvas pipeline)', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+      fakeContext
+    )
+    fakeContext.drawImage.mockClear()
+    installRvfcMock()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    removeRvfcMock()
+  })
+
+  it('renders a visible canvas and a hidden decoder video', () => {
+    const wrapper = mountViewer()
+    const canvas = wrapper.find('canvas.annotation-movie')
+    const video = wrapper.find('video.annotation-movie-decoder')
+    expect(canvas.exists()).toBe(true)
+    expect(video.exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('keeps the full exposed surface plus getDisplaySurface', () => {
+    const wrapper = mountViewer()
+    const exposed = [
+      'currentTimeRaw',
+      'video',
+      'formatFrame',
+      'getNaturalDimensions',
+      'getDimensions',
+      'getLastPushedCurrentTime',
+      'setCurrentFrame',
+      'setCurrentTimeRaw',
+      'setCurrentTime',
+      'configureVideo',
+      'mountVideo',
+      'getFrameFromPlayer',
+      'play',
+      'pause',
+      'toggleMute',
+      'goPreviousFrame',
+      'goNextFrame',
+      'resetPanZoom',
+      'setPanZoom',
+      'pausePanZoom',
+      'resumePanZoom',
+      'setSpeed',
+      'setVolume',
+      'resetSize',
+      'getDisplaySurface'
+    ]
+    exposed.forEach(name => {
+      expect(wrapper.vm[name], `missing exposed: ${name}`).toBeDefined()
+    })
+    expect(wrapper.vm.getDisplaySurface()).toBe(
+      wrapper.find('canvas').element
+    )
+    wrapper.unmount()
+  })
+
+  it('starts the rVFC loop on loadedmetadata and paints + emits per tick', async () => {
+    const wrapper = mountViewer()
+    // Wait for the setTimeout(0) in onMounted to complete
+    await new Promise(resolve => setTimeout(resolve))
+    const video = wrapper.find('video').element
+    await video.dispatchEvent(new Event('loadedmetadata'))
+    expect(rvfcCallbacks.length).toBeGreaterThan(0)
+
+    // Fire a tick: frame 10 at 25fps starts at mediaTime 0.4.
+    const tick = rvfcCallbacks[rvfcCallbacks.length - 1]
+    tick(performance.now(), { mediaTime: 0.4 })
+    expect(fakeContext.drawImage).toHaveBeenCalled()
+    const timeUpdates = wrapper.emitted('time-update')
+    const frameUpdates = wrapper.emitted('frame-update')
+    expect(timeUpdates.length).toBeGreaterThan(0)
+    // mediaTime re-centered to the mid-frame convention: 0.4 + 0.02.
+    expect(timeUpdates.at(-1)[0]).toBeCloseTo(0.42, 5)
+    expect(frameUpdates.length).toBeGreaterThan(0)
+    // Same number the currentTime-based formula produced for this frame.
+    expect(frameUpdates.at(-1)[0]).toBe(12)
+
+    // A second tick on the SAME frame must not re-emit frame-update.
+    const frameCount = frameUpdates.length
+    const tick2 = rvfcCallbacks[rvfcCallbacks.length - 1]
+    tick2(performance.now(), { mediaTime: 0.4 })
+    expect(wrapper.emitted('frame-update').length).toBe(frameCount)
+    wrapper.unmount()
+  })
+
+  it('cancels the rVFC loop and disposes the renderer on unmount', async () => {
+    const wrapper = mountViewer()
+    // Wait for the setTimeout(0) in onMounted to complete
+    await new Promise(resolve => setTimeout(resolve))
+    const video = wrapper.find('video').element
+    await video.dispatchEvent(new Event('loadedmetadata'))
+    wrapper.unmount()
+    // The handle cancelled must be the most recently scheduled one.
+    expect(rvfcCancelled).toContain(rvfcCallbacks.length)
+  })
+})

--- a/tests/unit/players/videoviewer.spec.js
+++ b/tests/unit/players/videoviewer.spec.js
@@ -105,13 +105,18 @@ describe('players/VideoViewer (canvas pipeline)', () => {
     wrapper.unmount()
   })
 
-  it('starts the rVFC loop on loadedmetadata and paints + emits per tick', async () => {
+  it('starts the rVFC loop on loadedmetadata and paints + emits per tick while playing', async () => {
     const wrapper = mountViewer()
     // Wait for the setTimeout(0) in onMounted to complete
     await new Promise(resolve => setTimeout(resolve))
     const video = wrapper.find('video').element
     await video.dispatchEvent(new Event('loadedmetadata'))
     expect(rvfcCallbacks.length).toBeGreaterThan(0)
+    // Emissions are playback-only; jsdom videos are paused by default.
+    Object.defineProperty(video, 'paused', {
+      value: false,
+      configurable: true
+    })
 
     // Fire a tick: frame 10 at 25fps starts at mediaTime 0.4.
     const tick = rvfcCallbacks[rvfcCallbacks.length - 1]
@@ -131,6 +136,24 @@ describe('players/VideoViewer (canvas pipeline)', () => {
     const tick2 = rvfcCallbacks[rvfcCallbacks.length - 1]
     tick2(performance.now(), { mediaTime: 0.4 })
     expect(wrapper.emitted('frame-update').length).toBe(frameCount)
+    wrapper.unmount()
+  })
+
+  it('paints but does not emit frames on paused seeks', async () => {
+    // Regression: paused frame context is owned by the parent (prop-frame
+    // convention). A paused seek emitting playback-convention numbers fed
+    // setVideoFrameContext values shifted from the clicked frame, so
+    // progress clicks and arrow steps landed on the wrong frame.
+    const wrapper = mountViewer()
+    await new Promise(resolve => setTimeout(resolve))
+    const video = wrapper.find('video').element
+    await video.dispatchEvent(new Event('loadedmetadata'))
+    // jsdom videos are paused by default.
+    const tick = rvfcCallbacks[rvfcCallbacks.length - 1]
+    tick(performance.now(), { mediaTime: 0.4 })
+    expect(fakeContext.drawImage).toHaveBeenCalled()
+    expect(wrapper.emitted('frame-update')).toBeUndefined()
+    expect(wrapper.emitted('time-update')).toBeUndefined()
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## Problems

- Paused seeks could paint a different frame than the one announced — the historical source of off-by-one annotation placements.
- The visible `<video>` elements blocked any per-pixel display work (LUTs) and forced the playlist player to juggle element visibility.
- QA surfaced old player bugs: entity fps ignored on two surfaces (12fps duplicates), laser strokes never fading, stroke caps lost, tile thumbnails drifting, Alt+arrow navigation double-handled.

## Solutions

- Decode in hidden `<video>` elements, paint through a visible canvas on every `requestVideoFrameCallback` tick, in `VideoViewer` and `MultiVideoViewer`; `frameRenderer.js` is the seam for a future WebGL/LUT backend. Overlays, wheel and comparison anchor on the canvas.
- Fix the surfaced bugs: per-entity fps everywhere, laser fade, round caps, measured tile-sprite geometry, single-handled Alt+arrow, no playlist reload on untouched add panel close.
- Restyle the playlist progress strip and the trim handles; generate timeline stripes at exact frame size; add wheel zoom with a mini-map to the timeline for long clips.
- Gates: 936 unit tests, prod build, full manual QA.
