### PR TITLE
[players] Gate wheel zoom behind Ctrl

### DIFF
--- a/src/components/players/annotations/AnnotationCanvas.vue
+++ b/src/components/players/annotations/AnnotationCanvas.vue
@@ -153,6 +153,9 @@ const createFabric = () => {
 // zoom-by-wheel. preventDefault stops the page from scrolling.
 const onWheel = event => {
   if (!props.wheelTarget) return
+  // Zoom is a Ctrl+wheel gesture: let plain wheels bubble so the
+  // surrounding widgets/page keep scrolling.
+  if (!event.ctrlKey) return
   event.preventDefault()
   const forwarded = new WheelEvent('wheel', {
     bubbles: true,

--- a/src/components/players/progress/VideoProgress.vue
+++ b/src/components/players/progress/VideoProgress.vue
@@ -24,7 +24,7 @@
             }
           : { 'background-image': frameTicksGradient }
       "
-      @wheel.prevent="onWheelZoom"
+      @wheel="onWheelZoom"
       @mouseenter="isFrameNumberVisible = true"
       @mouseleave="isFrameNumberVisible = false"
       @touchstart="isFrameNumberVisible = true"
@@ -255,6 +255,10 @@ const clampViewStart = start =>
   Math.min(Math.max(start, 0), props.nbFrames - visibleFrames.value)
 
 const onWheelZoom = event => {
+  // Zoom is a Ctrl+wheel gesture (map-style): a plain wheel keeps
+  // scrolling the surrounding widgets/page.
+  if (!event.ctrlKey) return
+  event.preventDefault()
   if (props.empty || !props.nbFrames) return
   const anchorFrame = xToFrame(getClientX(event) - getProgressLeft())
   const factor = event.deltaY < 0 ? 1.25 : 1 / 1.25

--- a/src/components/players/viewers/MultiVideoViewer.vue
+++ b/src/components/players/viewers/MultiVideoViewer.vue
@@ -1,5 +1,9 @@
 <template>
-  <div ref="container" class="video-wrapper filler flexrow-item">
+  <div
+    ref="container"
+    class="video-wrapper filler flexrow-item"
+    @wheel="swallowBrowserZoom"
+  >
     <div class="video-loader" v-show="isLoading">
       <spinner class="mt2" style="color: white" />
     </div>
@@ -49,6 +53,7 @@ import {
 } from 'vue'
 import { useStore } from 'vuex'
 
+import { swallowBrowserZoom } from '@/lib/players/wheel'
 import { floorToFrame, roundToFrame } from '@/lib/video'
 import {
   createFrameRenderer,
@@ -189,7 +194,9 @@ const setupPanZoom = () => {
     maxZoom: 5,
     minZoom: 0.5,
     beforeMouseDown: e => e.target !== displayCanvasRef.value,
-    beforeWheel: e => e.target !== displayCanvasRef.value,
+    // Zoom is a Ctrl+wheel gesture: a plain wheel keeps scrolling the
+    // surrounding widgets/page.
+    beforeWheel: e => !e.ctrlKey || e.target !== displayCanvasRef.value,
     disableKeyboardInteraction: true
   })
   PANZOOM_EVENTS.forEach(name => {

--- a/src/components/players/viewers/PictureViewer.vue
+++ b/src/components/players/viewers/PictureViewer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="container" class="picture-player">
+  <div ref="container" class="picture-player" @wheel="swallowBrowserZoom">
     <div
       ref="pictureWrapper"
       class="picture-wrapper"
@@ -31,6 +31,7 @@
 import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import createPanzoom from 'panzoom'
 
+import { swallowBrowserZoom } from '@/lib/players/wheel'
 import { isPicturePreview } from '@/lib/preview'
 
 import Spinner from '@/components/widgets/Spinner.vue'
@@ -322,7 +323,9 @@ const setupPanZoom = () => {
     minZoom: 1,
     smoothScroll: false,
     beforeMouseDown: e => e.target !== target,
-    beforeWheel: e => e.target !== target,
+    // Zoom is a Ctrl+wheel gesture: a plain wheel keeps scrolling the
+    // surrounding widgets/page.
+    beforeWheel: e => !e.ctrlKey || e.target !== target,
     // panzoom otherwise puts tabindex=0 on the owner and steals arrow
     // keys / +/- to pan and zoom — those shortcuts are owned by the
     // player (frame stepping, annotation navigation), so disable them.

--- a/src/components/players/viewers/VideoViewer.vue
+++ b/src/components/players/viewers/VideoViewer.vue
@@ -7,6 +7,7 @@
       'border-top-right-radius': isRoundedTopBorder ? '10px' : ''
     }"
     @click="$emit('click')"
+    @wheel="swallowBrowserZoom"
   >
     <div
       class="video-wrapper"
@@ -45,6 +46,7 @@ import {
   createFrameRenderer,
   supportsVideoFrameCallback
 } from '@/lib/players/frameRenderer'
+import { swallowBrowserZoom } from '@/lib/players/wheel'
 import { formatFrame } from '@/lib/video'
 
 import Spinner from '@/components/widgets/Spinner.vue'
@@ -542,7 +544,9 @@ const setupPanZoom = () => {
     minZoom: 1,
     smoothScroll: false,
     beforeMouseDown: e => e.target !== displayCanvas.value,
-    beforeWheel: e => e.target !== displayCanvas.value,
+    // Zoom is a Ctrl+wheel gesture: a plain wheel keeps scrolling the
+    // surrounding widgets/page.
+    beforeWheel: e => !e.ctrlKey || e.target !== displayCanvas.value,
     // panzoom otherwise puts tabindex=0 on the owner and steals arrow
     // keys / +/- to pan and zoom — those shortcuts are owned by the
     // player (frame stepping, annotation navigation), so disable them.

--- a/src/lib/players/wheel.js
+++ b/src/lib/players/wheel.js
@@ -1,0 +1,6 @@
+// Swallow Ctrl+wheel inside player surfaces so the browser page zoom
+// never fires there — the players own that gesture (panzoom / timeline
+// zoom). Plain wheels are left alone and keep scrolling the page.
+export const swallowBrowserZoom = event => {
+  if (event.ctrlKey) event.preventDefault()
+}


### PR DESCRIPTION
## Problems

- #2048 was merged from a head that missed its last two commits: plain wheel over the timeline and the players still zooms, conflicting with surrounding widget/page scrolling.

## Solutions

- Cherry-pick the two missing commits: timeline zoom and every player wheel zoom (panzoom `beforeWheel` + the annotation overlay wheel forwarder) now require Ctrl+wheel, map-style; a plain wheel scrolls normally.