### PR TITLE
feat: add OIDC SSO login button

### DIFF
--- a/src/components/pages/Login.vue
+++ b/src/components/pages/Login.vue
@@ -26,6 +26,19 @@
               </a>
             </p>
           </div>
+          <div class="field" v-if="mainConfig?.oidc_enabled">
+            <p class="control">
+              <a
+                class="button is-fullwidth"
+                :class="{
+                  'is-loading': isLoginLoading
+                }"
+                href="/api/auth/oidc/login"
+              >
+                {{ loginOIDCButtonInfo }}
+              </a>
+            </p>
+          </div>
           <div class="field mt2">
             <p class="control has-icon">
               <input
@@ -155,6 +168,16 @@ export default {
         })
       } else {
         return this.$t('login.saml')
+      }
+    },
+
+    loginOIDCButtonInfo() {
+      if (this.mainConfig?.oidc_idp_name) {
+        return this.$t('login.login_with_oidc', {
+          oidc_idp_name: this.mainConfig.oidc_idp_name
+        })
+      } else {
+        return this.$t('login.login_oidc')
       }
     }
   },

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -377,6 +377,8 @@
       "login_server_failed": "Der opstod en serverfejl under login.",
       "login_with_saml": "SSO-login med {saml_idp_name}.",
       "login_saml": "SSO-login",
+      "login_with_oidc": "SSO login with {oidc_idp_name}",
+      "login_oidc": "SSO login",
       "reset_password_inactive": "Nulstilling af din adgangskode mislykkedes. Brugeren med denne e-mail er inaktiv.",
       "set_password_title": "Velkommen til Kitsu!",
       "set_password": "Indstil din adgangskode",

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -714,6 +714,8 @@ export default {
     },
     login_with_saml: 'SSO login with {saml_idp_name}',
     login_saml: 'SSO login',
+    login_with_oidc: 'SSO login with {oidc_idp_name}',
+    login_oidc: 'SSO login',
   },
 
   logs: {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -377,6 +377,8 @@
       "login_server_failed": "Se ha producido un error en el servidor al iniciar sesión.",
       "login_with_saml": "Inicio de sesión SSO con {saml_idp_name}",
       "login_saml": "Inicio de sesión SSO",
+      "login_with_oidc": "SSO login with {oidc_idp_name}",
+      "login_oidc": "SSO login",
       "reset_password_inactive": "No se ha podido restablecer la contraseña. El usuario con este correo electrónico está inactivo.",
       "set_password_title": "¡Bienvenido a Kitsu!",
       "set_password": "Establezca su contraseña",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -377,6 +377,8 @@
       "login_server_failed": "هنگام ورود به سیستم یک خطای سرور رخ داد.",
       "login_with_saml": "ورود SSO با {saml_idp_name}",
       "login_saml": "ورود به سیستم SSO",
+      "login_with_oidc": "SSO login with {oidc_idp_name}",
+      "login_oidc": "SSO login",
       "reset_password_inactive": "بازنشانی رمز عبور ناموفق بود. کاربری با این ایمیل غیرفعال است.",
       "set_password_title": "به کیتسو خوش آمدید!",
       "set_password": "رمز عبور خود را تنظیم کنید",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -377,6 +377,8 @@
       "login_server_failed": "Une erreur de serveur s'est produite lors de la connexion.",
       "login_with_saml": "Connexion SSO avec {saml_idp_name}",
       "login_saml": "Connexion SSO",
+      "login_with_oidc": "SSO login with {oidc_idp_name}",
+      "login_oidc": "SSO login",
       "reset_password_inactive": "La réinitialisation de votre mot de passe a échoué. L'utilisateur ayant cet email est inactif.",
       "set_password_title": "Bienvenue sur Kitsu !",
       "set_password": "Définissez votre mot de passe",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -377,6 +377,8 @@
       "login_server_failed": "ログイン中にサーバーエラーが発生しました。",
       "login_with_saml": "{saml_idp_name} で SSO ログイン",
       "login_saml": "SSO ログイン",
+      "login_with_oidc": "SSO login with {oidc_idp_name}",
+      "login_oidc": "SSO login",
       "reset_password_inactive": "パスワードのリセットに失敗しました。この電子メールを持つユーザーはアクティブではありません。",
       "set_password_title": "キツへようこそ！",
       "set_password": "パスワードの設定",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -377,6 +377,8 @@
       "login_server_failed": "로그인하는 동안 서버 오류가 발생했습니다.",
       "login_with_saml": "{saml_idp_name}으로 SSO 로그인",
       "login_saml": "SSO 로그인",
+      "login_with_oidc": "SSO login with {oidc_idp_name}",
+      "login_oidc": "SSO login",
       "reset_password_inactive": "비밀번호를 재설정하지 못했습니다. 이 이메일을 받은 사용자가 비활성 상태입니다.",
       "set_password_title": "키츠에 오신 것을 환영합니다!",
       "set_password": "비밀번호 설정",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -377,6 +377,8 @@
       "login_server_failed": "Er is een serverfout opgetreden tijdens het aanmelden.",
       "login_with_saml": "SSO aanmelding met {saml_idp_name}",
       "login_saml": "SSO aanmelding",
+      "login_with_oidc": "SSO login with {oidc_idp_name}",
+      "login_oidc": "SSO login",
       "reset_password_inactive": "Uw wachtwoord opnieuw instellen is mislukt. De gebruiker met dit e-mailadres is inactief.",
       "set_password_title": "Welkom bij Kitsu!",
       "set_password": "Wachtwoord instellen",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -377,6 +377,8 @@
       "login_server_failed": "Ocorreu um erro no servidor ao fazer o login.",
       "login_with_saml": "Login SSO com {saml_idp_name}",
       "login_saml": "Login SSO",
+      "login_with_oidc": "SSO login with {oidc_idp_name}",
+      "login_oidc": "SSO login",
       "reset_password_inactive": "A redefinição de sua senha falhou. O usuário com esse e-mail está inativo.",
       "set_password_title": "Bem-vindo à Kitsu!",
       "set_password": "Defina sua senha",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -377,6 +377,8 @@
       "login_server_failed": "Произошла ошибка сервера при входе.",
       "login_with_saml": "SSO вход через {saml_idp_name}",
       "login_saml": "SSO вход",
+      "login_with_oidc": "SSO login with {oidc_idp_name}",
+      "login_oidc": "SSO login",
       "reset_password_inactive": "Сброс пароля не удался. Пользователь с таким электронным адресом неактивен.",
       "set_password_title": "Добро пожаловать в Кицу!",
       "set_password": "Установите пароль",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -377,6 +377,8 @@
       "login_server_failed": "登录时发生服务器错误。",
       "login_with_saml": "使用 {saml_idp_name} 进行 SSO 登录",
       "login_saml": "SSO 登录",
+      "login_with_oidc": "SSO login with {oidc_idp_name}",
+      "login_oidc": "SSO login",
       "reset_password_inactive": "重设密码失败。使用此电子邮件的用户处于非活动状态。",
       "set_password_title": "欢迎来到 Kitsu！",
       "set_password": "设置密码",

--- a/src/locales/zh_tw.json
+++ b/src/locales/zh_tw.json
@@ -377,6 +377,8 @@
       "login_server_failed": "登入時發生伺服器錯誤。",
       "login_with_saml": "使用 {saml_idp_name} 進行 SSO 登入",
       "login_saml": "SSO 登入",
+      "login_with_oidc": "SSO login with {oidc_idp_name}",
+      "login_oidc": "SSO login",
       "reset_password_inactive": "重設密碼失敗。使用此電子郵件的使用者已停止活動。",
       "set_password_title": "歡迎來到 Kitsu！",
       "set_password": "設定您的密碼",


### PR DESCRIPTION
## What
Shows a "Login with <provider>" button on the login page when OIDC is enabled in the backend config, mirroring the existing SAML button.

## Changes
- `Login.vue`: button guarded by `mainConfig.oidc_enabled` linking to `/api/auth/oidc/login`, with a `loginOIDCButtonInfo` computed label
- i18n: add `login_with_oidc` / `login_oidc` keys across locales

## Companion PR
Frontend half - requires the Zou backend PR cgwire/zou#1107 (OIDC routes + `oidc_enabled` / `oidc_idp_name` config flags). Merge together.