### PR TITLE
[players] Make preview height independent of viewport width

### DIFF
--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -826,11 +826,9 @@ const marginBottom = computed(() => {
 // physical pixels and ignores zoom, so a 75 % zoomed-out fullscreen
 // player used to leave a black bar at the bottom — see issue #1541.
 const windowHeight = ref(window.innerHeight)
-const windowWidth = ref(window.innerWidth)
 
 const onWindowResize = () => {
   windowHeight.value = window.innerHeight
-  windowWidth.value = window.innerWidth
 }
 
 const defaultHeight = computed(() => {
@@ -839,9 +837,7 @@ const defaultHeight = computed(() => {
   }
   let bigHeight = windowHeight.value > 800 ? 470 : 300
   if (isMovie.value) bigHeight = windowHeight.value > 800 ? 442 : 272
-  return windowWidth.value > 1300 && (!props.light || props.big)
-    ? bigHeight
-    : 200
+  return !props.light || props.big ? bigHeight : 200
 })
 
 const fps = computed(


### PR DESCRIPTION
## Problems

- The preview player height was gated on `windowWidth > 1300`, collapsing it to 200px on OS-scaled / high-DPI displays whose CSS viewport is under 1300px (e.g. a 1920x1200 panel at 150% scaling reports 1280px). Enlarging the preview then did almost nothing, while the same content on a 1920x1080 screen at 100% worked — the "resizing inconsistent across screen sizes" of #2056.

## Solutions

- Drop the viewport-width gate (and the now-unused `windowWidth` ref): the preview height follows available vertical space, not width. The `windowHeight > 800` threshold and the compact light-mode (200px) are unchanged.

Fix #2056