### PR TITLE
[players] Reset pan/zoom and load sub-preview annotations on preview switch

### DIFF
--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -2865,6 +2865,32 @@ const ensureEntityAnnotationsLoaded = entity => {
     })
 }
 
+// Load annotations for the *current* preview, whether it is the entity's
+// main preview (index 0) or one of its sub-previews (index > 0). Annotations
+// live on the entity for the main preview and on the sub-preview object
+// otherwise; both are stripped from the playlist payload and fetched here.
+const ensureCurrentPreviewAnnotations = () => {
+  const entity = currentEntity.value
+  const preview = currentPreview.value
+  if (!entity || !preview?.id) return Promise.resolve([])
+  const index = currentPreviewIndex.value
+  const target =
+    index === 0 ? entity : entity.preview_file_previews?.[index - 1]
+  const key = index === 0 ? 'preview_file_annotations' : 'annotations'
+  if (!target) return Promise.resolve([])
+  if (target[key] !== undefined) return Promise.resolve(target[key])
+  return store
+    .dispatch('loadPreviewFileAnnotations', preview.id)
+    .then(loaded => {
+      if (target[key] === undefined) target[key] = loaded || []
+      return target[key]
+    })
+    .catch(() => {
+      if (target[key] === undefined) target[key] = []
+      return target[key]
+    })
+}
+
 const prefetchAnnotationsAround = index => {
   const start = Math.max(0, index - ANNOTATION_PREFETCH_RADIUS)
   const end = Math.min(
@@ -3433,6 +3459,8 @@ const changePreviewFile = (entity, previewFile, previousPreviewFileId) => {
     previousPreviewFileId
   })
   clearCanvas()
+  resetPanZoom()
+  panzoomTransform.value = { x: 0, y: 0, scale: 1 }
 }
 
 const onEntityDropped = info => {
@@ -4228,6 +4256,7 @@ watch(currentPreviewIndex, () => {
   })
   if (currentPreview.value) {
     resetPanZoom()
+    panzoomTransform.value = { x: 0, y: 0, scale: 1 }
     movieDimensions.value = {
       width: currentPreview.value.width,
       height: currentPreview.value.height
@@ -4265,6 +4294,7 @@ watch(playingEntityIndex, () => {
         resetCanvas()
       }
       resetPanZoom()
+      panzoomTransform.value = { x: 0, y: 0, scale: 1 }
       resetCanvasVisibility()
     })
   })
@@ -4394,10 +4424,8 @@ watch(
   previewFileId => {
     prefetchAnnotationsAround(playingEntityIndex.value)
     if (!previewFileId) return
-    const entity = currentEntity.value
-    if (!entity || entity.preview_file_annotations !== undefined) return
     const token = ++annotationLoadToken
-    ensureEntityAnnotationsLoaded(entity).then(loaded => {
+    ensureCurrentPreviewAnnotations().then(loaded => {
       if (token !== annotationLoadToken) return
       if (currentPreview.value?.id !== previewFileId) return
       annotations.value = loaded || []

--- a/src/components/players/players/SharedPlaylistPlayer.vue
+++ b/src/components/players/players/SharedPlaylistPlayer.vue
@@ -792,6 +792,18 @@ watch(isEntitiesHidden, hidden => {
 
 watch(playingEntityIndex, () => nextTick(scrollPlayingEntityIntoView))
 
+// Reset pan/zoom whenever the displayed preview changes (entity or
+// sub-preview) so annotations stay aligned with the freshly-reset media.
+watch(
+  () => currentPreview.value?.id,
+  () =>
+    nextTick(() => {
+      const target = isMovie.value ? rawPlayer.value : picturePlayer.value
+      target?.resetPanZoom?.()
+      resetPanzoomTransform()
+    })
+)
+
 // Lifecycle
 
 onMounted(() => {


### PR DESCRIPTION
## Problems

- **Pan/zoom not reset for annotations on switch.** Switching entity, sub-preview or version reset the viewer's pan/zoom but not `panzoomTransform`, which drives `AnnotationCanvas`. `resetPanZoom()` resets the viewer silently (`PictureViewer.setPanZoom` runs with `silent=true`, emitting no `panzoom-changed`), so the annotation transform kept the previous pan/zoom and annotations were left offset/zoomed.
- **Sub-previews no longer loaded their annotations** (regression from moving annotations out of the playlist payload): the on-demand loader only handled the entity's main preview.

## Solutions

- Reset `panzoomTransform` alongside `resetPanZoom()` in the `currentPreviewIndex` and `playingEntityIndex` watchers and in `changePreviewFile` (version switch); add a `currentPreview.id` reset watcher in `SharedPlaylistPlayer`.
- Generalise the lazy loader (`ensureCurrentPreviewAnnotations`) to load the current preview's annotations whether it is the main preview or a sub-preview. The guest player keeps annotations inline, so it is unaffected by the regression.