### PR TITLE
[players][budget] Shared playlist player parity + budget fixes

### DIFF
--- a/src/components/pages/SharedPlaylistIdentityCard.vue
+++ b/src/components/pages/SharedPlaylistIdentityCard.vue
@@ -9,6 +9,7 @@
     </div>
     <form class="identity-form" @submit.prevent="onSubmit">
       <text-field
+        ref="nameField"
         :label="$t('share.your_name')"
         :placeholder="$t('share.name_placeholder')"
         v-model.trim="guestName"
@@ -27,12 +28,16 @@
 </template>
 
 <script setup>
+import { onMounted, useTemplateRef } from 'vue'
+
 import TextField from '@/components/widgets/TextField.vue'
 
 defineProps({
   errorMessage: { type: String, default: '' },
   playlistName: { type: String, required: true }
 })
+
+const nameField = useTemplateRef('nameField')
 
 const guestName = defineModel('guestName', {
   type: String,
@@ -45,6 +50,8 @@ const onSubmit = () => {
   if (!guestName.value) return
   emit('submit')
 }
+
+onMounted(() => nameField.value?.focus())
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/pages/budget/Budget.vue
+++ b/src/components/pages/budget/Budget.vue
@@ -217,15 +217,18 @@ export default {
     ...mapGetters(['currentProduction', 'departmentMap', 'personMap']),
 
     monthsBetweenStartAndNow() {
+      // Split the timeline on calendar months, not on the day of the month:
+      // the current month always belongs to the real costs section, whatever
+      // the production start day is.
       return this.getMonthsBetweenDates(
         this.currentProduction.start_date,
-        moment().format('YYYY-MM-DD')
+        moment().endOf('month').format('YYYY-MM-DD')
       )
     },
 
     monthsBetweenNowAndEnd() {
       return this.getMonthsBetweenDates(
-        moment().add(1, 'month').format('YYYY-MM-DD'),
+        moment().add(1, 'month').startOf('month').format('YYYY-MM-DD'),
         this.currentProduction.end_date
       )
     },

--- a/src/components/pages/budget/BudgetList.vue
+++ b/src/components/pages/budget/BudgetList.vue
@@ -543,11 +543,21 @@ export default {
       preferences.setObjectPreference(key, this.collapsedDepartments)
     },
 
-    /* It sets an salary exception for a person, for a given month. */
+    /* It sets a salary exception for a person, for a given month. An empty,
+     * zero or negative value clears the override instead: the month falls
+     * back to the computed salary rather than storing a 0 exception (which
+     * the backend would drop anyway).
+     */
     addPersonException({ personEntry, month, value }) {
-      value = parseInt(value)
+      const monthKey = month.format('YYYY-MM')
       const exceptions = personEntry.exceptions || {}
-      exceptions[month.format('YYYY-MM')] = value
+      const amount = parseInt(value)
+      if (value == null || value === '' || isNaN(amount) || amount <= 0) {
+        delete exceptions[monthKey]
+      } else {
+        exceptions[monthKey] = amount
+      }
+      personEntry.exceptions = exceptions
       const budgetEntry = {
         id: personEntry.budget_entry_id,
         ...personEntry,

--- a/src/components/pages/budget/BudgetPersonRow.vue
+++ b/src/components/pages/budget/BudgetPersonRow.vue
@@ -36,6 +36,7 @@
       <td
         :key="personEntry.id + '-' + month"
         class="costs"
+        :class="{ negative: isOverEstimate(month) }"
         v-for="month in monthsBetweenStartAndNow"
       >
         {{ personExpense?.[month.format('YYYY-MM')]?.toLocaleString() }}
@@ -64,21 +65,37 @@
         ? monthsBetweenNowAndEnd
         : monthsBetweenProductionDates"
     >
-      <input
-        class="input-editor"
-        type="number"
-        min="0"
-        step="1"
-        :value="getMonthCost(personEntry, month)"
-        @change="
-          $emit('add-person-exception', {
-            personEntry,
-            month,
-            value: $event.target.value
-          })
-        "
+      <div
+        class="cell-editor"
         v-if="personEntry.monthCosts[month.format('YYYY-MM')]"
-      />
+      >
+        <button
+          class="clear-exception"
+          type="button"
+          :title="$t('budget.clear_exception')"
+          @click="
+            $emit('add-person-exception', { personEntry, month, value: null })
+          "
+          v-if="hasException(personEntry, month)"
+        >
+          <x-icon :size="12" />
+        </button>
+        <input
+          class="input-editor"
+          :class="{ 'has-exception': hasException(personEntry, month) }"
+          type="number"
+          min="0"
+          step="1"
+          :value="getMonthCost(personEntry, month)"
+          @change="
+            $emit('add-person-exception', {
+              personEntry,
+              month,
+              value: $event.target.value
+            })
+          "
+        />
+      </div>
       <span v-else>&nbsp;</span>
     </td>
     <td class="total-cost remaining-previsional" v-if="isShowingExpenses">
@@ -108,6 +125,7 @@
 </template>
 
 <script setup>
+import { XIcon } from 'lucide-vue-next'
 import { computed, defineProps } from 'vue'
 
 import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
@@ -205,6 +223,24 @@ const getMonthCost = (personEntry, month) => {
     parseInt(personEntry.monthCosts[monthKey]) ||
     0
   )
+}
+
+/* It tells whether the person has an explicit salary override for the given
+ * month, as opposed to the salary computed from the daily rate.
+ */
+const hasException = (personEntry, month) => {
+  const monthKey = typeof month === 'string' ? month : month.format('YYYY-MM')
+  return personEntry.exceptions?.[monthKey] != null
+}
+
+/* It tells whether the real cost spent for the given month went over the
+ * estimated cost, so the cell can be flagged when showing real costs.
+ */
+const isOverEstimate = month => {
+  const monthKey = typeof month === 'string' ? month : month.format('YYYY-MM')
+  const realCost = personExpense.value?.[monthKey]
+  if (realCost == null) return false
+  return realCost > getMonthCost(props.personEntry, monthKey)
 }
 </script>
 

--- a/src/components/pages/budget/budget.scss
+++ b/src/components/pages/budget/budget.scss
@@ -1,12 +1,11 @@
 @use '@/variables.scss';
 
-$green: #00B242;
-$dark-grey-light: #3D4048;
-$dark-grey-2: #36393F;
-$light-grey: #CCC;
-$light-grey-light: #DDD;
-$red: #FF3860;
-
+$green: #00b242;
+$dark-grey-light: #3d4048;
+$dark-grey-2: #36393f;
+$light-grey: #ccc;
+$light-grey-light: #ddd;
+$red: #ff3860;
 
 th.month {
   text-align: center;
@@ -91,9 +90,35 @@ td.datatable-row-header.name {
   }
 }
 
+.cell-editor {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
 .input-editor {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   text-align: right;
+
+  &.has-exception {
+    font-weight: bold;
+  }
+}
+
+.clear-exception {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+
+  &:hover {
+    color: $red;
+  }
 }
 
 .cost-column {
@@ -106,7 +131,7 @@ td.datatable-row-header.name {
 }
 
 .negative {
-    color: $red;
+  color: $red;
 }
 
 input[type='number']::-webkit-outer-spin-button,

--- a/src/components/players/annotations/SharedAnnotationOverlay.vue
+++ b/src/components/players/annotations/SharedAnnotationOverlay.vue
@@ -1,6 +1,8 @@
 <template>
-  <div class="annotation-overlay" ref="wrapper" :style="overlayStyle">
-    <canvas :id="canvasId" />
+  <div class="annotation-overlay" ref="wrapper" :style="wrapperStyle">
+    <div class="annotation-surface" :style="surfaceStyle">
+      <canvas :id="canvasId" />
+    </div>
     <div class="annotation-toolbar" v-if="isEditable">
       <button
         type="button"
@@ -9,7 +11,7 @@
         :title="$t('playlists.actions.annotation_draw')"
         @click="annotation.setTool('pen')"
       >
-        <pen-tool-icon :size="14" />
+        <pencil-icon :size="14" />
       </button>
       <button
         type="button"
@@ -75,12 +77,12 @@ import {
   ArrowUpRightIcon,
   CircleIcon,
   CornerLeftDownIcon,
-  PenToolIcon,
+  PencilIcon,
   RectangleHorizontalIcon,
   SaveIcon,
   Trash2Icon
 } from 'lucide-vue-next'
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useStore } from 'vuex'
 
 import { useSharedAnnotationCanvas } from '@/composables/players/sharedAnnotation'
@@ -134,6 +136,39 @@ const videoBounds = computed(() => {
   if (!mw || !mh) {
     return { width: cw, height: ch, left: 0, top: 0 }
   }
+
+  // Pictures: mirror the studio player's sizing — the image is centered and
+  // never upscaled beyond its natural size, so the overlay box matches the
+  // actually displayed <img>. A plain contain-fit (used for movies) would
+  // upscale small images and misalign the annotations on top of them.
+  if (props.isPicture) {
+    const ratio = mw / mh
+    let width = ratio ? ch * ratio : cw
+    let height = ratio ? Math.round(cw / ratio) : ch
+    let left = 0
+    let top = 0
+    if (cw > mw) {
+      left = Math.round((cw - mw) / 2)
+      width = mw
+    } else if (cw > width) {
+      left = Math.round((cw - width) / 2)
+    } else {
+      width = cw
+    }
+    if (ch > mh) {
+      top = Math.round((ch - mh) / 2)
+      height = mh
+    } else if (ch > height) {
+      top = Math.round((ch - height) / 2)
+    } else {
+      height = ch
+      width = Math.round(height * ratio)
+      left = Math.round((cw - width) / 2)
+    }
+    return { width, height, left, top }
+  }
+
+  // Movies: contain-fit — matches the canvas, which fills the container.
   const containerRatio = cw / ch
   const movieRatio = mw / mh
   let displayedW
@@ -153,7 +188,8 @@ const videoBounds = computed(() => {
   }
 })
 
-const overlayStyle = computed(() => {
+// The wrapper is pinned (un-transformed) to the displayed media box.
+const wrapperStyle = computed(() => {
   const bounds = videoBounds.value
   if (!bounds.width || !bounds.height) {
     return { display: 'none' }
@@ -161,9 +197,21 @@ const overlayStyle = computed(() => {
   return {
     height: `${bounds.height}px`,
     left: `${bounds.left}px`,
-    pointerEvents: props.isEditable ? 'auto' : 'none',
     top: `${bounds.top}px`,
     width: `${bounds.width}px`
+  }
+})
+
+// Panzoom is applied here as a CSS transform (mirrors the studio
+// AnnotationCanvas) instead of fabric's setViewportTransform: a CSS
+// transform scales with the page under browser zoom and stays aligned
+// with the media, whereas fabric's retina-scaled viewport drifts when
+// devicePixelRatio changes.
+const surfaceStyle = computed(() => {
+  const { x = 0, y = 0, scale = 1 } = props.panzoomTransform || {}
+  return {
+    pointerEvents: props.isEditable ? 'auto' : 'none',
+    transform: `translate(${x}px, ${y}px) scale(${scale})`
   }
 })
 
@@ -214,15 +262,31 @@ const fitCanvasToBounds = () => {
   const bounds = videoBounds.value
   if (bounds.width <= 0 || bounds.height <= 0) return
   annotation.setCanvasSize(bounds.width, bounds.height)
+  // Refresh fabric's cached canvas offset so freshly drawn strokes land
+  // under the cursor (a stale offset shifts pointer coordinates).
+  annotation.getCanvas()?.calcOffset()
   render()
 }
 
-const applyPanzoomTransform = () => {
-  const fabricCanvas = annotation.getCanvas()
-  if (!fabricCanvas) return
-  const { x = 0, y = 0, scale = 1 } = props.panzoomTransform || {}
-  fabricCanvas.setViewportTransform([scale, 0, 0, scale, x, y])
-  fabricCanvas.requestRenderAll()
+const refreshLayout = () => {
+  measureContainer()
+  fitCanvasToBounds()
+}
+
+// Browser zoom (a devicePixelRatio change) and dev-console docking move
+// the media without resizing the observed elements, so the ResizeObserver
+// stays silent. window / visualViewport resize do fire, so recompute on
+// them — immediately and once more after the layout settles.
+const onViewportResize = () => {
+  refreshLayout()
+  setTimeout(refreshLayout, 250)
+}
+
+// The panzoom transform is now applied via CSS (surfaceStyle); we only
+// refresh fabric's cached offset so pointer coordinates stay accurate
+// while drawing on a zoomed/panned view.
+const refreshCanvasOffset = () => {
+  nextTick(() => annotation.getCanvas()?.calcOffset())
 }
 
 const save = async () => {
@@ -249,8 +313,9 @@ const save = async () => {
       }
     })
     emit('saved', updated.annotations || [])
-  } catch {
-    // Silent failure for now; toolbar stays so the user can retry.
+  } catch (error) {
+    // Keep the toolbar so the user can retry; surface the failure for logs.
+    console.error('Failed to save shared playlist annotations', error)
   }
   isSaving.value = false
 }
@@ -282,8 +347,8 @@ watch(
   render
 )
 
-watch(() => props.movieDimensions, fitCanvasToBounds)
-watch(() => props.panzoomTransform, applyPanzoomTransform)
+watch(() => props.movieDimensions, refreshLayout)
+watch(() => props.panzoomTransform, refreshCanvasOffset)
 
 // Lifecycle
 
@@ -293,20 +358,19 @@ onMounted(() => {
   annotation.setUserId(props.guestId)
   annotation.setTime(currentTime.value, props.currentFrame)
   annotation.setDrawingMode(!!props.isEditable)
-  measureContainer()
-  fitCanvasToBounds()
-  applyPanzoomTransform()
+  refreshLayout()
+  window.addEventListener('resize', onViewportResize)
+  window.visualViewport?.addEventListener('resize', onViewportResize)
   const target = wrapper.value?.parentElement
   if (typeof ResizeObserver !== 'undefined' && target) {
-    resizeObserver = new ResizeObserver(() => {
-      measureContainer()
-      fitCanvasToBounds()
-    })
+    resizeObserver = new ResizeObserver(refreshLayout)
     resizeObserver.observe(target)
   }
 })
 
 onBeforeUnmount(() => {
+  window.removeEventListener('resize', onViewportResize)
+  window.visualViewport?.removeEventListener('resize', onViewportResize)
   resizeObserver?.disconnect()
   resizeObserver = null
   annotation.dispose()
@@ -323,7 +387,23 @@ defineExpose({
 <style lang="scss" scoped>
 .annotation-overlay {
   position: absolute;
-  z-index: 5;
+  // Above the media viewers (PictureViewer / MultiVideoViewer are z-index
+  // 300); mirrors the non-shared AnnotationCanvas. The wrapper itself never
+  // captures pointer events — the surface re-enables them while editing and
+  // the toolbar is always interactive — so clicks pass through to the media.
+  pointer-events: none;
+  z-index: 500;
+}
+
+.annotation-surface {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  // Panzoom is applied here as a CSS transform (see surfaceStyle) so it
+  // scales with the page under browser zoom and stays aligned with media.
+  transform-origin: 0 0;
+  width: 100%;
 
   canvas {
     display: block;

--- a/src/components/players/bars/SharedPlaylistButtonBar.vue
+++ b/src/components/players/bars/SharedPlaylistButtonBar.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="playlist-footer flexrow">
-    <div class="flexrow flexrow-item" v-if="isMovie || isSound">
+    <div class="flexrow flexrow-item" v-if="isMovie || isSound || isPicture">
       <button-simple
         class="playlist-button flexrow-item"
         icon="play"
@@ -14,6 +14,29 @@
         :title="$t('playlists.actions.pause')"
         @click="$emit('pause')"
         v-else
+      />
+    </div>
+
+    <div
+      class="flexrow flexrow-item sub-preview-nav"
+      v-if="entityPreviewLength > 1"
+    >
+      <button-simple
+        class="playlist-button flexrow-item"
+        icon="left"
+        :title="$t('playlists.actions.files_previous')"
+        :disabled="isPlaying"
+        @click="$emit('previous-preview')"
+      />
+      <span class="flexrow-item nowrap sub-preview-position">
+        {{ currentPreviewIndex + 1 }} / {{ entityPreviewLength }}
+      </span>
+      <button-simple
+        class="playlist-button flexrow-item"
+        icon="right"
+        :title="$t('playlists.actions.files_next')"
+        :disabled="isPlaying"
+        @click="$emit('next-preview')"
       />
     </div>
 
@@ -81,10 +104,9 @@
     />
     <button-simple
       class="playlist-button flexrow-item"
-      :active="isZoomEnabled"
       icon="loupe"
       :title="$t('playlists.actions.annotation_zoom_pan')"
-      @click="isZoomEnabled = !isZoomEnabled"
+      @click="$emit('reset-zoom')"
       v-if="isMovie || isPicture"
     />
     <button-simple
@@ -111,7 +133,9 @@ import ButtonSound from '@/components/widgets/ButtonSound.vue'
 defineProps({
   canComment: { type: Boolean, default: false },
   currentFrameDisplay: { type: String, default: '' },
+  currentPreviewIndex: { type: Number, default: 0 },
   currentTimeFormatted: { type: String, default: '' },
+  entityPreviewLength: { type: Number, default: 0 },
   guestId: { type: String, default: '' },
   isFullScreen: { type: Boolean, default: false },
   isMovie: { type: Boolean, default: false },
@@ -123,7 +147,15 @@ defineProps({
   token: { type: String, default: '' }
 })
 
-defineEmits(['pause', 'play', 'toggle-full-screen', 'toggle-sound'])
+defineEmits([
+  'next-preview',
+  'pause',
+  'play',
+  'previous-preview',
+  'reset-zoom',
+  'toggle-full-screen',
+  'toggle-sound'
+])
 
 const isAnnotating = defineModel('isAnnotating', {
   type: Boolean,
@@ -140,10 +172,6 @@ const isEntitiesHidden = defineModel('isEntitiesHidden', {
 const isHd = defineModel('isHd', { type: Boolean, default: true })
 const isMuted = defineModel('isMuted', { type: Boolean, default: false })
 const isRepeating = defineModel('isRepeating', {
-  type: Boolean,
-  default: false
-})
-const isZoomEnabled = defineModel('isZoomEnabled', {
   type: Boolean,
   default: false
 })
@@ -191,6 +219,12 @@ const volume = defineModel('volume', { type: Number, default: 100 })
   color: rgba(244, 245, 250, 0.6);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.02em;
+}
+
+.sub-preview-position {
+  color: rgba(244, 245, 250, 0.6);
+  font-variant-numeric: tabular-nums;
+  padding: 0 0.3em;
 }
 
 @media screen and (max-width: 768px) {

--- a/src/components/players/players/PlaylistedEntity.vue
+++ b/src/components/players/players/PlaylistedEntity.vue
@@ -5,12 +5,13 @@
         'playlisted-entity': true,
         playing: isPlaying
       }"
+      @click.prevent="onPlayClick"
     >
-      <div class="thumbnail-wrapper" @click.prevent="onPlayClick">
+      <div class="thumbnail-wrapper">
         <span
           class="remove-button flexrow-item"
           :title="$t('playlists.remove')"
-          @click.prevent="onRemoveClick"
+          @click.stop.prevent="onRemoveClick"
           v-if="!readOnly && (isCurrentUserManager || isCurrentUserSupervisor)"
         >
           <x-icon />
@@ -33,13 +34,16 @@
             : 'none',
           'padding-bottom': '5px'
         }"
-        @click.prevent="onPlayClick"
       >
         {{ entity.parent_name }} / {{ entity.name }}
       </div>
 
       <template v-if="!readOnly">
-        <div class="preview-choice" v-if="taskTypeOptions.length > 0">
+        <div
+          class="preview-choice"
+          @click.stop
+          v-if="taskTypeOptions.length > 0"
+        >
           <combobox
             :thin="true"
             :width="150"

--- a/src/components/players/players/SharedPlaylistPlayer.vue
+++ b/src/components/players/players/SharedPlaylistPlayer.vue
@@ -30,6 +30,7 @@
             @frame-update="onFrameUpdate"
             @max-duration-update="onMaxDurationUpdate"
             @panzoom-changed="onPanzoomChanged"
+            @panzoom-ready="onPanzoomReady"
             @play-next="onPlayNext"
             @video-loaded="onVideoLoaded"
             v-show="isMovie && !loading"
@@ -38,7 +39,7 @@
           <picture-viewer
             ref="picturePlayer"
             :big="true"
-            :default-height="600"
+            :default-height="pictureHeight"
             :full-screen="false"
             :light="false"
             :margin-bottom="0"
@@ -46,6 +47,7 @@
             :preview="currentPreview"
             :url-prefix="sharedApiPrefix"
             high-quality
+            @panzoom-changed="onPanzoomChanged"
             v-show="isPicture && !loading"
           />
 
@@ -160,7 +162,9 @@
     <shared-playlist-button-bar
       :can-comment="canComment"
       :current-frame-display="currentFrameDisplay"
+      :current-preview-index="currentPreviewIndex"
       :current-time-formatted="currentTimeFormatted"
+      :entity-preview-length="currentEntityPreviewLength"
       :guest-id="guestId"
       :is-full-screen="isFullScreen"
       :is-movie="isMovie"
@@ -176,10 +180,12 @@
       v-model:is-hd="isHd"
       v-model:is-muted="isMuted"
       v-model:is-repeating="isRepeating"
-      v-model:is-zoom-enabled="isZoomEnabled"
       v-model:volume="volume"
+      @next-preview="onNextPreviewClicked"
       @pause="pause"
       @play="play"
+      @previous-preview="onPreviousPreviewClicked"
+      @reset-zoom="onResetZoom"
       @toggle-full-screen="toggleFullScreen"
       @toggle-sound="onToggleSoundClicked"
     />
@@ -245,6 +251,7 @@ import { useStore } from 'vuex'
 import darkTimesliderUrl from '@/assets/background/video-timeslider-dark.png'
 import { usePanzoomSync } from '@/composables/panzoom'
 import { isAltLetter } from '@/composables/players/previewShortcuts'
+import { mergeAnnotationsByFrame } from '@/lib/players/annotation'
 import {
   isDiffPreview,
   isMarkdownPreview,
@@ -293,6 +300,11 @@ const { panzoomTransform, onPanzoomChanged, resetPanzoomTransform } =
   usePanzoomSync()
 
 const container = ref(null)
+const videoContainer = ref(null)
+// Height available for the picture viewer: it must fill the same area the
+// annotation overlay fits into (the whole .video-container), otherwise a
+// fixed height left the image small and pushed annotations below it.
+const pictureHeight = ref(600)
 const currentFrameNumber = ref(0)
 const currentPlaylistProgress = ref(0)
 const currentPreviewIndex = ref(0)
@@ -307,7 +319,6 @@ const isHd = ref(true)
 const isMuted = ref(false)
 const isPlaying = ref(false)
 const isRepeating = ref(false)
-const isZoomEnabled = ref(false)
 const maxDuration = ref(0)
 const movieDimensions = ref({ width: 0, height: 0 })
 const picturePlayer = ref(null)
@@ -321,6 +332,9 @@ const volume = ref(100)
 // Tracks whether the very first entity has been auto-loaded after mount.
 // Plain `let` (not ref) — only used by the watchers below.
 let firstEntityLoaded = false
+
+// requestAnimationFrame id for the picture playback timer (null when idle).
+let picturePlayFrame = null
 
 // Computed
 
@@ -376,9 +390,28 @@ const currentPreview = computed(() => {
   return entity.preview_file_previews?.[currentPreviewIndex.value - 1]
 })
 
-const currentAnnotations = computed(
-  () => currentPreview.value?.annotations || []
-)
+// Legacy annotations store unrounded times, so the same frame can exist as
+// several entries; the players only ever match the first one, which hides
+// the others (and makes a newly drawn+saved annotation look lost when an
+// old entry sits on the same frame). Merge them onto the frame grid, exactly
+// like the studio PreviewPlayer, so old + new annotations all render.
+const currentAnnotations = computed(() => {
+  const anns = (currentPreview.value?.annotations || []).filter(
+    a => a.time >= 0
+  )
+  return mergeAnnotationsByFrame(anns, fps.value).sort(
+    (a, b) => a.time - b.time
+  )
+})
+
+// Number of preview files attached to the current entity (main preview +
+// its alternate previews / sub-previews). Used to drive the sub-preview
+// navigation just like the studio player.
+const currentEntityPreviewLength = computed(() => {
+  const entity = currentEntity.value
+  if (!entity?.preview_file_previews) return 0
+  return entity.preview_file_previews.length + 1
+})
 
 const extension = computed(() => currentPreview.value?.extension || '')
 const isMovie = computed(() => isMoviePreview(extension.value))
@@ -508,16 +541,83 @@ const entityListForProgress = computed(
 const play = () => {
   isPlaying.value = true
   if (isSound.value) soundPlayer.value?.play()
+  else if (isPicture.value) playPicture()
   else rawPlayer.value?.play()
 }
 
 const pause = () => {
   isPlaying.value = false
+  stopPicturePlayback()
   if (isSound.value) soundPlayer.value?.pause()
   else rawPlayer.value?.pause()
 }
 
 const togglePlay = () => (isPlaying.value ? pause() : play())
+
+// Picture playback: the picture viewer (not MultiVideoViewer, which is
+// movie-only) shows the image, and a timer advances the playlist after the
+// image's frame budget elapses — mirroring the studio player's playPicture.
+// Matches playlistFrameData's defaultPictureFrames so a picture is shown for
+// the same span the playlist-progress bar allots to it.
+const pictureFrameCount = () => Math.round(2 * fps.value)
+
+const stopPicturePlayback = () => {
+  if (picturePlayFrame !== null) cancelAnimationFrame(picturePlayFrame)
+  picturePlayFrame = null
+}
+
+const playPicture = () => {
+  stopPicturePlayback()
+  const total = pictureFrameCount()
+  let startFrame = currentFrameNumber.value
+  if (startFrame >= total - 1) startFrame = 0
+  const baseline = performance.now() - (startFrame / fps.value) * 1000
+  const step = () => {
+    if (!isPlaying.value || !isPicture.value) return
+    const frame = Math.floor(
+      ((performance.now() - baseline) / 1000) * fps.value
+    )
+    if (frame >= total) {
+      advancePlaylist()
+      return
+    }
+    onFrameUpdate(frame)
+    picturePlayFrame = requestAnimationFrame(step)
+  }
+  picturePlayFrame = requestAnimationFrame(step)
+}
+
+// Play whatever preview is currently selected, by type. Used when stepping
+// to the next sub-preview of the same entity during playback (a movie
+// sub-preview is a different file, so it must be (re)loaded first).
+const playCurrentPreview = () => {
+  if (!isPlaying.value) return
+  if (isSound.value) soundPlayer.value?.play()
+  else if (isPicture.value) playPicture()
+  else {
+    rawPlayer.value?.loadEntity(playingEntityIndex.value, 0)
+    nextTick(() => rawPlayer.value?.play())
+  }
+}
+
+// Advance playback: step through the current entity's sub-previews one by
+// one, then move to the next entity. Used when a movie ends or an image's
+// display time elapses.
+const advancePlaylist = () => {
+  const previewCount = Math.max(currentEntityPreviewLength.value, 1)
+  if (currentPreviewIndex.value < previewCount - 1) {
+    currentPreviewIndex.value += 1
+    currentFrameNumber.value = 0
+    nextTick(playCurrentPreview)
+    return
+  }
+  const next = playingEntityIndex.value + 1
+  if (next >= entityList.value.length) {
+    pause()
+    return
+  }
+  selectEntity(next)
+}
 
 const selectEntity = index => {
   if (index < 0 || index >= entityList.value.length) return
@@ -545,6 +645,38 @@ const selectEntity = index => {
 
 const previousEntity = () => selectEntity(playingEntityIndex.value - 1)
 const nextEntity = () => selectEntity(playingEntityIndex.value + 1)
+
+// Functions — sub-previews & zoom
+
+const onPreviousPreviewClicked = () => {
+  const length = currentEntityPreviewLength.value
+  if (length <= 1) return
+  const index = currentPreviewIndex.value - 1
+  currentPreviewIndex.value = index < 0 ? length - 1 : index
+}
+
+const onNextPreviewClicked = () => {
+  const length = currentEntityPreviewLength.value
+  if (length <= 1) return
+  const index = currentPreviewIndex.value + 1
+  currentPreviewIndex.value = index > length - 1 ? 0 : index
+}
+
+// The movie viewer creates its panzoom instance paused (panzoomActive
+// starts false in MultiVideoViewer); like the studio player we resume it
+// as soon as the instance is ready so pan/zoom is always available. The
+// picture viewer is live by default and needs no resume.
+const onPanzoomReady = () => {
+  rawPlayer.value?.resumePanZoom?.()
+}
+
+// The "loupe" button mirrors the studio player: it resets the zoom rather
+// than toggling a mode (pan/zoom on the media stays available at all times).
+const onResetZoom = () => {
+  rawPlayer.value?.resetPanZoom?.()
+  picturePlayer.value?.resetPanZoom?.()
+  resetPanzoomTransform()
+}
 
 const goPreviousFrame = () => {
   if (!rawPlayer.value) return
@@ -631,9 +763,9 @@ const onProgressPlaylistChanged = frameNumber => {
 
 const onPlayNext = () => {
   if (!isPlaying.value) return
-  const isLast = playingEntityIndex.value >= entityList.value.length - 1
-  if (isLast) isPlaying.value = false
-  else rawPlayer.value?.playNext()
+  // Step through sub-previews first, then the next entity (handles images
+  // too, which MultiVideoViewer's own playNext would skip).
+  advancePlaylist()
 }
 
 const onVideoLoaded = () => {
@@ -642,6 +774,10 @@ const onVideoLoaded = () => {
     width: dimensions.width || 0,
     height: dimensions.height || 0
   }
+  // Push the initial frame so the video-progress cursor sits on frame 1 and
+  // the annotation overlay renders the first frame's annotations right away
+  // (the viewer doesn't emit a frame-update until playback starts).
+  if (!isPlaying.value) onFrameUpdate(0)
 }
 
 const onMaxDurationUpdate = duration => {
@@ -701,6 +837,11 @@ const triggerPlayerResize = () => {
     rawPlayer.value?.resetHeight?.()
     window.dispatchEvent(new Event('resize'))
   }, 50)
+}
+
+const updatePictureHeight = () => {
+  const el = videoContainer.value
+  if (el?.clientHeight) pictureHeight.value = el.clientHeight
 }
 
 // Functions — keyboard
@@ -775,17 +916,6 @@ watch(volume, newVolume => {
   nextTick(() => rawPlayer.value?.setVolume(newVolume))
 })
 
-watch(isZoomEnabled, enabled => {
-  const target = isMovie.value ? rawPlayer.value : picturePlayer.value
-  if (enabled) {
-    target?.resumePanZoom?.()
-  } else {
-    target?.pausePanZoom?.()
-    target?.resetPanZoom?.()
-    resetPanzoomTransform()
-  }
-})
-
 watch(isCommentsHidden, triggerPlayerResize)
 
 watch(isEntitiesHidden, hidden => {
@@ -809,16 +939,25 @@ watch(
 
 // Lifecycle
 
+let pictureResizeObserver = null
+
 onMounted(() => {
   window.addEventListener('keydown', onKeyDown, false)
   document.addEventListener('fullscreenchange', onFullScreenChange)
   document.addEventListener('webkitfullscreenchange', onFullScreenChange)
+  updatePictureHeight()
+  if (window.ResizeObserver && videoContainer.value) {
+    pictureResizeObserver = new ResizeObserver(updatePictureHeight)
+    pictureResizeObserver.observe(videoContainer.value)
+  }
 })
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeyDown)
   document.removeEventListener('fullscreenchange', onFullScreenChange)
   document.removeEventListener('webkitfullscreenchange', onFullScreenChange)
+  pictureResizeObserver?.disconnect()
+  stopPicturePlayback()
 })
 </script>
 
@@ -958,6 +1097,7 @@ onBeforeUnmount(() => {
     border: 1px solid var(--border-soft);
     border-radius: 12px;
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+    cursor: pointer;
     padding: 0.4em;
     position: relative;
     transition:
@@ -1048,6 +1188,12 @@ onBeforeUnmount(() => {
   margin-right: 0;
   max-height: 100%;
   max-width: 100%;
+  // The movie canvas centers via `margin: auto`, which doesn't apply to an
+  // inline canvas on desktop (only the mobile media query made the wrapper a
+  // flex box), so the video stuck to the left. Center it here too.
+  align-items: center;
+  display: flex;
+  justify-content: center;
 }
 
 .video-container {
@@ -1088,29 +1234,6 @@ onBeforeUnmount(() => {
   box-shadow: 0 0 0 2px rgba(255, 87, 140, 0.25);
 }
 
-.shared-player :deep(.entity-status) {
-  border-right: 1px solid rgba(255, 255, 255, 0.12);
-  height: 14px;
-  opacity: 0.55;
-  transition:
-    opacity 0.2s ease,
-    height 0.2s ease;
-
-  &:hover {
-    opacity: 0.95;
-  }
-
-  span {
-    background: var(--surface-raised);
-    border: 1px solid var(--border-strong);
-    border-radius: 8px;
-    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
-    color: var(--text);
-    font-size: 0.8em;
-    padding: 0.25em 0.6em;
-  }
-}
-
 .shared-player :deep(.frame-number) {
   background: var(--surface-raised);
   border: 1px solid var(--border-strong);
@@ -1131,25 +1254,11 @@ onBeforeUnmount(() => {
   background: var(--accent);
 }
 
+// Use the PlaylistProgress component's own styling (same look as the studio
+// player); only keep the layout bit so the bar isn't squeezed in the guest's
+// flex column.
 .shared-player :deep(.playlist-progress) {
-  background: #08080c !important;
-  border-bottom: 1px solid var(--border-soft) !important;
-  border-top: 1px solid var(--border-soft) !important;
   flex-shrink: 0;
-  height: 14px;
-  transition: height 0.2s ease-in-out;
-
-  &:hover {
-    height: 14px;
-  }
-}
-
-.shared-player :deep(.playlist-progress-position) {
-  border-left: 3px solid var(--accent);
-  border-radius: 0;
-  box-shadow: 0 0 10px rgba(124, 92, 255, 0.6);
-  height: 14px;
-  top: 0;
 }
 
 // Responsive

--- a/src/composables/players/sharedAnnotation.js
+++ b/src/composables/players/sharedAnnotation.js
@@ -9,6 +9,7 @@
  */
 import { ref, shallowRef } from 'vue'
 
+import { CURSOR_PENCIL } from '@/composables/players/annotationCursor'
 import {
   DEFAULT_PENCIL_COLOR,
   DEFAULT_PENCIL_WIDTH,
@@ -100,6 +101,16 @@ export const useSharedAnnotationCanvas = () => {
     const penActive = isDrawing.value && currentTool.value === 'pen'
     fabricCanvas.isDrawingMode = penActive
     fabricCanvas.skipTargetFind = !isDrawing.value
+    // Cursor parity with the studio annotation tool: pencil while drawing,
+    // crosshair for the shape tools, default otherwise.
+    const cursor = !isDrawing.value
+      ? 'default'
+      : currentTool.value === 'pen'
+        ? CURSOR_PENCIL
+        : 'crosshair'
+    fabricCanvas.freeDrawingCursor = cursor
+    fabricCanvas.defaultCursor = cursor
+    fabricCanvas.hoverCursor = cursor
   }
 
   const setDrawingMode = enabled => {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -145,6 +145,7 @@ export default {
     analytics: 'Budget Analytics',
     cash_evolution: 'Expense evolution',
     cash_repartition: 'Expense repartition',
+    clear_exception: "Clear this month's salary override",
     cost: 'Cost',
     costs: 'Real Costs',
     departments: 'Departments',


### PR DESCRIPTION
## Problems

- Shared (guest) playlist player diverged from the studio: tool cursor/draw icon, zoom button, sub-preview access and playback, image-shot playback, annotations following pan/zoom on images, browser-zoom alignment, first-load annotations/cursor, and only part of the playlisted-entity card was clickable.
- A newly saved guest annotation looked lost when a legacy (unrounded-time) annotation already sat on the same frame.
- Budget page mishandled exception clearing, the current month, and over-budget display.

## Solutions

- Align the shared playlist player with the studio: per-tool cursor + pencil icon, reset-zoom button (movie panzoom resumed on ready), sub-preview navigation + per-sub-preview playback, image-shot playback via the picture viewer, CSS-transform annotation overlay (fixes image pan/zoom and browser-zoom drift), studio picture sizing, initial frame push on load, fully clickable playlisted entity, component-native playlist-progress styling, and login name-field autofocus.
- Merge legacy unrounded-time annotations onto the frame grid so old and newly saved annotations all render.
- Budget: fix exception clearing, current-month handling, and over-budget display.