### PR TITLE
[tasks] Add button to create all missing task types

### DIFF
--- a/src/components/mixins/entities.js
+++ b/src/components/mixins/entities.js
@@ -300,6 +300,30 @@ export const entitiesMixin = {
         })
     },
 
+    confirmCreateAllMissingTasks({ missingTaskTypeIds, selectionOnly }) {
+      this.errors.creatingTasks = false
+      this.loading.creatingAllTasks = true
+      const createForTaskType = taskTypeId =>
+        this.createTasks({
+          type: `${this.type}s`,
+          task_type_id: taskTypeId,
+          project_id: this.currentProduction.id,
+          selectionOnly
+        })
+      func
+        .runPromiseMapAsSeries(missingTaskTypeIds, createForTaskType)
+        .then(() => {
+          this.reset()
+          this.hideCreateTasksModal()
+          this.loading.creatingAllTasks = false
+        })
+        .catch(err => {
+          this.errors.creatingTasks = true
+          this.loading.creatingAllTasks = false
+          console.error(err)
+        })
+    },
+
     runTasksCreation(form, selectionOnly) {
       this.errors.creatingTasks = false
       return this.createTasks({

--- a/src/components/modals/CreateTasksModal.vue
+++ b/src/components/modals/CreateTasksModal.vue
@@ -46,6 +46,24 @@
               button: true,
               'flexrow-item': true,
               'is-primary': true,
+              'is-loading': isLoadingAll,
+              'is-disabled': missingTaskTypes.length === 0
+            }"
+            @click="confirmAllMissingClicked"
+          >
+            {{
+              missingTaskTypes.length > 0
+                ? $t('tasks.create_tasks_all_missing', {
+                    count: missingTaskTypes.length
+                  })
+                : $t('tasks.create_tasks_all_missing_empty')
+            }}
+          </a>
+          <a
+            :class="{
+              button: true,
+              'flexrow-item': true,
+              'is-primary': true,
               'is-loading': isLoadingStay
             }"
             @click="confirmAndStayClicked"
@@ -96,12 +114,18 @@ const props = defineProps({
   errorText: { type: String, default: '' },
   isError: { type: Boolean, default: false },
   isLoading: { type: Boolean, default: false },
+  isLoadingAll: { type: Boolean, default: false },
   isLoadingStay: { type: Boolean, default: false },
   text: { type: String, default: '' },
   title: { type: String, default: '' }
 })
 
-const emit = defineEmits(['cancel', 'confirm', 'confirm-and-stay'])
+const emit = defineEmits([
+  'cancel',
+  'confirm',
+  'confirm-all-missing',
+  'confirm-and-stay'
+])
 
 useModal(toRef(props, 'active'), emit)
 
@@ -125,6 +149,29 @@ const productionShotTaskTypes = computed(
   () => store.getters.productionShotTaskTypes
 )
 
+const assetValidationColumns = computed(
+  () => store.getters.assetValidationColumns
+)
+const editValidationColumns = computed(
+  () => store.getters.editValidationColumns
+)
+const episodeValidationColumns = computed(
+  () => store.getters.episodeValidationColumns
+)
+const sequenceValidationColumns = computed(
+  () => store.getters.sequenceValidationColumns
+)
+const shotValidationColumns = computed(
+  () => store.getters.shotValidationColumns
+)
+
+const missingTaskTypes = computed(() => {
+  const shownColumns = new Set(getApplicableValidationColumns())
+  return getApplicableTaskTypes().filter(
+    taskType => !shownColumns.has(taskType.id)
+  )
+})
+
 const selectionOptions = computed(() => [
   { label: t('tasks.for_selection'), value: 'true' },
   { label: t('tasks.for_project'), value: 'false' }
@@ -140,6 +187,16 @@ const getApplicableTaskTypes = () => {
   return []
 }
 
+const getApplicableValidationColumns = () => {
+  const path = route.path
+  if (path.includes('assets')) return assetValidationColumns.value
+  if (path.includes('shots')) return shotValidationColumns.value
+  if (path.includes('sequences')) return sequenceValidationColumns.value
+  if (path.includes('edits')) return editValidationColumns.value
+  if (path.includes('episodes')) return episodeValidationColumns.value
+  return []
+}
+
 const buildPayload = () => ({
   form: form.value,
   selectionOnly: selectionOnly.value === 'true'
@@ -151,6 +208,14 @@ const confirmClicked = () => {
 
 const confirmAndStayClicked = () => {
   emit('confirm-and-stay', buildPayload())
+}
+
+const confirmAllMissingClicked = () => {
+  if (missingTaskTypes.value.length === 0) return
+  emit('confirm-all-missing', {
+    missingTaskTypeIds: missingTaskTypes.value.map(taskType => taskType.id),
+    selectionOnly: selectionOnly.value === 'true'
+  })
 }
 
 onMounted(() => {

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -210,12 +210,14 @@
       :active="modals.isCreateTasksDisplayed"
       :is-loading="loading.creatingTasks"
       :is-loading-stay="loading.creatingTasksStay"
+      :is-loading-all="loading.creatingAllTasks"
       :is-error="errors.creatingTasks"
       :title="$t('tasks.create_tasks_asset')"
       :text="$t('tasks.create_tasks_asset_explaination')"
       :error-text="$t('tasks.create_tasks_asset_failed')"
       @confirm="confirmCreateTasks"
       @confirm-and-stay="confirmCreateTasksAndStay"
+      @confirm-all-missing="confirmCreateAllMissingTasks"
       @cancel="hideCreateTasksModal"
     />
 
@@ -358,6 +360,7 @@ export default {
         addThumbnails: false,
         creatingTasks: false,
         creatingTasksStay: false,
+        creatingAllTasks: false,
         deleteAllTasks: false,
         deleteMetadata: false,
         delete: false,

--- a/src/components/pages/Edits.vue
+++ b/src/components/pages/Edits.vue
@@ -203,6 +203,7 @@
       :active="modals.isCreateTasksDisplayed"
       :is-loading="loading.creatingTasks"
       :is-loading-stay="loading.creatingTasksStay"
+      :is-loading-all="loading.creatingAllTasks"
       :is-error="errors.creatingTasks"
       :title="$t('tasks.create_tasks_edit')"
       :text="$t('tasks.create_tasks_edit_explaination')"
@@ -210,6 +211,7 @@
       @cancel="hideCreateTasksModal"
       @confirm="confirmCreateTasks"
       @confirm-and-stay="confirmCreateTasksAndStay"
+      @confirm-all-missing="confirmCreateAllMissingTasks"
     />
 
     <add-metadata-modal
@@ -348,6 +350,7 @@ export default {
         addThumbnails: false,
         creatingTasks: false,
         creatingTasksStay: false,
+        creatingAllTasks: false,
         deleteAllTasks: false,
         deleteMetadata: false,
         edit: false,

--- a/src/components/pages/Episodes.vue
+++ b/src/components/pages/Episodes.vue
@@ -133,6 +133,7 @@
       :active="modals.isCreateTasksDisplayed"
       :is-loading="loading.creatingTasks"
       :is-loading-stay="loading.creatingTasksStay"
+      :is-loading-all="loading.creatingAllTasks"
       :is-error="errors.creatingTasks"
       :title="$t('tasks.create_tasks_episode')"
       :text="$t('tasks.create_tasks_episode_explaination')"
@@ -140,6 +141,7 @@
       @cancel="hideCreateTasksModal"
       @confirm="confirmCreateTasks"
       @confirm-and-stay="confirmCreateTasksAndStay"
+      @confirm-all-missing="confirmCreateAllMissingTasks"
     />
 
     <add-metadata-modal
@@ -283,6 +285,7 @@ export default {
         addThumbnails: false,
         creatingTasks: false,
         creatingTasksStay: false,
+        creatingAllTasks: false,
         del: false,
         deleteAllTasks: false,
         deleteMetadata: false,

--- a/src/components/pages/Sequences.vue
+++ b/src/components/pages/Sequences.vue
@@ -134,6 +134,7 @@
       :active="modals.isCreateTasksDisplayed"
       :is-loading="loading.creatingTasks"
       :is-loading-stay="loading.creatingTasksStay"
+      :is-loading-all="loading.creatingAllTasks"
       :is-error="errors.creatingTasks"
       :title="$t('tasks.create_tasks_sequence')"
       :text="$t('tasks.create_tasks_sequence_explaination')"
@@ -141,6 +142,7 @@
       @cancel="hideCreateTasksModal"
       @confirm="confirmCreateTasks"
       @confirm-and-stay="confirmCreateTasksAndStay"
+      @confirm-all-missing="confirmCreateAllMissingTasks"
     />
 
     <add-metadata-modal
@@ -283,6 +285,7 @@ export default {
         addThumbnails: false,
         creatingTasks: false,
         creatingTasksStay: false,
+        creatingAllTasks: false,
         del: false,
         deleteAllTasks: false,
         deleteMetadata: false,

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -243,6 +243,7 @@
       :active="modals.isCreateTasksDisplayed"
       :is-loading="loading.creatingTasks"
       :is-loading-stay="loading.creatingTasksStay"
+      :is-loading-all="loading.creatingAllTasks"
       :is-error="errors.creatingTasks"
       :title="$t('tasks.create_tasks_shot')"
       :text="$t('tasks.create_tasks_shot_explaination')"
@@ -250,6 +251,7 @@
       @cancel="hideCreateTasksModal"
       @confirm="confirmCreateTasks"
       @confirm-and-stay="confirmCreateTasksAndStay"
+      @confirm-all-missing="confirmCreateAllMissingTasks"
     />
 
     <add-metadata-modal
@@ -421,6 +423,7 @@ export default {
         addThumbnails: false,
         creatingTasks: false,
         creatingTasksStay: false,
+        creatingAllTasks: false,
         deleteAllTasks: false,
         deleteMetadata: false,
         edit: false,

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1982,6 +1982,8 @@ export default {
     comment_image: 'Attach files',
     create_for_selection: 'Create a task for each empty cell',
     create_tasks: 'Add tasks',
+    create_tasks_all_missing: 'Add all missing ({count})',
+    create_tasks_all_missing_empty: 'Add all missing',
     create_tasks_disclaimer: 'If your task type is missing, verify it is listed in the Task Types section of the production settings.',
     create_tasks_shot: 'Add tasks for current shots',
     create_tasks_shot_explaination: 'You are about to create a new task for each shot of the current production for the given task type. Do you want to continue?',


### PR DESCRIPTION
Add an "Add all missing" button to the create-tasks modal on the shot, asset, sequence, episode and edit list pages. It creates tasks for every production task type that is not yet shown as a column on the table, respecting the existing for-selection/for-project toggle. The button shows the missing count and is disabled when nothing is missing.

Problem — On the shot/asset/sequence/episode/edit list pages, the "Add tasks" modal adds task type columns one at a time; when a production gains several new task types you must re-open and add each manually.

Solution — An "Add all missing" button that creates tasks for every applicable production task type not already a column. Shows the count, disabled when none missing, respects the for-selection/for-project toggle. No backend changes — loops the existing createTasks; columns appear via NEW_TASK_END.
