### PR TITLE
[entities] Add display toggle to show full task type names

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -25,7 +25,10 @@
         @toggle-stick="metadataStickColumnClicked($event)"
       />
 
-      <table class="datatable multi-section">
+      <table
+        class="datatable multi-section"
+        :class="{ 'expand-task-types': displaySettings.fullTaskTypeNames }"
+      >
         <thead class="datatable-head" v-columns-resizable id="datatable-asset">
           <tr>
             <th
@@ -1192,6 +1195,18 @@ td.ready-for {
   max-width: 150px;
   width: 150px;
   margin-right: 1em;
+}
+
+.expand-task-types :deep(.validation-cell) {
+  width: auto;
+  min-width: 150px;
+  max-width: none;
+}
+
+.expand-task-types :deep(.task-type-name) {
+  max-width: none;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 .hidden-validation-cell {

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -25,7 +25,10 @@
         @toggle-stick="metadataStickColumnClicked($event)"
       />
 
-      <table class="datatable">
+      <table
+        class="datatable"
+        :class="{ 'expand-task-types': displaySettings.fullTaskTypeNames }"
+      >
         <thead class="datatable-head" id="datatable-edit" v-columns-resizable>
           <tr>
             <th scope="col" class="episode" ref="th-episode" v-if="isTVShow">
@@ -897,6 +900,18 @@ thead .name.edit-name {
   min-width: 150px;
   max-width: 150px;
   width: 150px;
+}
+
+.expand-task-types :deep(.validation-cell) {
+  width: auto;
+  min-width: 150px;
+  max-width: none;
+}
+
+.expand-task-types :deep(.task-type-name) {
+  max-width: none;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 .estimation,

--- a/src/components/lists/EpisodeList.vue
+++ b/src/components/lists/EpisodeList.vue
@@ -25,7 +25,10 @@
         @toggle-stick="metadataStickColumnClicked($event)"
       />
 
-      <table class="datatable">
+      <table
+        class="datatable"
+        :class="{ 'expand-task-types': displaySettings.fullTaskTypeNames }"
+      >
         <thead
           class="datatable-head"
           id="datatable-episode"
@@ -823,6 +826,18 @@ thead .name.episode-name {
   min-width: 150px;
   max-width: 150px;
   width: 150px;
+}
+
+.expand-task-types :deep(.validation-cell) {
+  width: auto;
+  min-width: 150px;
+  max-width: none;
+}
+
+.expand-task-types :deep(.task-type-name) {
+  max-width: none;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 .estimation,

--- a/src/components/lists/SequenceList.vue
+++ b/src/components/lists/SequenceList.vue
@@ -23,7 +23,10 @@
         @toggle-stick="metadataStickColumnClicked($event)"
       />
 
-      <table class="datatable">
+      <table
+        class="datatable"
+        :class="{ 'expand-task-types': displaySettings.fullTaskTypeNames }"
+      >
         <thead
           class="datatable-head"
           id="datatable-sequence"
@@ -761,6 +764,18 @@ thead .name.sequence-name {
   min-width: 150px;
   max-width: 150px;
   width: 150px;
+}
+
+.expand-task-types :deep(.validation-cell) {
+  width: auto;
+  min-width: 150px;
+  max-width: none;
+}
+
+.expand-task-types :deep(.task-type-name) {
+  max-width: none;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 .estimation,

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -25,7 +25,10 @@
         @toggle-stick="metadataStickColumnClicked($event)"
       />
 
-      <table class="datatable multi-section">
+      <table
+        class="datatable multi-section"
+        :class="{ 'expand-task-types': displaySettings.fullTaskTypeNames }"
+      >
         <thead class="datatable-head" id="datatable-shot" v-columns-resizable>
           <tr>
             <th
@@ -1315,6 +1318,18 @@ thead .name.shot-name {
   min-width: 150px;
   max-width: 150px;
   width: 150px;
+}
+
+.expand-task-types :deep(.validation-cell) {
+  width: auto;
+  min-width: 150px;
+  max-width: none;
+}
+
+.expand-task-types :deep(.task-type-name) {
+  max-width: none;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 .frames {

--- a/src/components/mixins/entities.js
+++ b/src/components/mixins/entities.js
@@ -13,6 +13,7 @@ export const entitiesMixin = {
       displaySettings: {
         bigThumbnails: false,
         contactSheetMode: false,
+        fullTaskTypeNames: false,
         showAssignations: true,
         showInfos: true
       },

--- a/src/components/widgets/ComboboxDisplayOptions.vue
+++ b/src/components/widgets/ComboboxDisplayOptions.vue
@@ -53,6 +53,11 @@ const options = computed(() => {
       value: 'contactSheetMode'
     },
     {
+      label: t('tasks.full_task_type_names'),
+      value: 'fullTaskTypeNames',
+      when: !isTaskType
+    },
+    {
       label: t('shots.show_timecode'),
       value: 'inOutTimecode',
       when: props.type === 'shot'

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -2032,6 +2032,7 @@ export default {
     full_screen: 'Display in full screen',
     for_selection: 'For current list and filters',
     for_project: 'For production',
+    full_task_type_names: 'Show full task type names',
     hide_assignations: 'Hide assignments',
     hide_infos: 'Hide additional information',
     hookup_playlist: 'Generate a hook-up playlist',


### PR DESCRIPTION
Add a "Show full task type names" option to the display settings on the shot, asset, sequence, episode and edit list pages. When enabled, each task type column auto-expands to fit its full name on one line instead of the fixed-width truncated (ellipsis) header. Off by default; persisted per entity type via the existing display_settings preference.
