### PR TITLE
[schedule] Show hours unit when durations are formatted in hours

### DIFF
--- a/src/components/mixins/format.js
+++ b/src/components/mixins/format.js
@@ -16,6 +16,12 @@ export const formatListMixin = {
 
     isDurationInHours() {
       return this.organisation.format_duration_in_hours
+    },
+
+    durationUnit() {
+      return this.isDurationInHours
+        ? this.$t('schedule.hours')
+        : this.$t('schedule.md')
     }
   },
 

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -396,7 +396,7 @@
                 :step="0.01"
                 placeholder="0.00"
                 type="number"
-                :unit-label="$t('schedule.md')"
+                :unit-label="durationUnit"
                 v-model="assignments.task.estimation"
               />
             </div>
@@ -2139,7 +2139,7 @@ export default {
                   null,
                   null,
                   null,
-                  `${task.entity.name} (${duration}md)`
+                  `${task.entity.name} (${duration}${this.durationUnit})`
                 ])
 
                 // fill task timebar
@@ -2149,7 +2149,7 @@ export default {
                 const endIndex = dates.indexOf(end_date)
                 for (let i = startIndex; i > -1 && i <= endIndex; i++) {
                   const cell = row.getCell(datesColumn + i)
-                  cell.note = `${task.entity.name}\n${start_date} - ${end_date}\n${duration} ${this.$t('schedule.md')}`
+                  cell.note = `${task.entity.name}\n${start_date} - ${end_date}\n${duration} ${this.durationUnit}`
                   cell.fill = {
                     type: 'pattern',
                     pattern: 'solid',

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -29,7 +29,7 @@
             </button>
           </div>
           <span class="total-value" v-if="!hideManDays">
-            {{ formatDuration(totalManDays) }} {{ $t('schedule.md') }}
+            {{ formatDuration(totalManDays) }} {{ durationUnit }}
           </span>
         </div>
 
@@ -128,7 +128,7 @@
                   !rootElement.avatar && rootElement.editable && !hideManDays
                 "
               >
-                {{ $t('schedule.md') }}
+                {{ durationUnit }}
               </span>
               <span
                 class="man-days-unit flexrow-item"
@@ -137,7 +137,7 @@
                 "
               >
                 {{ formatDuration(rootElement.man_days) }}
-                {{ $t('schedule.md') }}
+                {{ durationUnit }}
               </span>
             </div>
 
@@ -229,11 +229,11 @@
                         "
                         :value="formatDuration(childElement.man_days, false)"
                       />
-                      {{ $t('schedule.md') }}
+                      {{ durationUnit }}
                     </span>
                     <span class="man-days-unit flexrow-item" v-else>
                       {{ formatDuration(childElement.man_days) }}
-                      {{ $t('schedule.md') }}
+                      {{ durationUnit }}
                     </span>
                   </div>
                 </div>
@@ -948,6 +948,10 @@ const taskStatuses = computed(() => store.getters.taskStatuses)
 const isDurationInHours = computed(() => {
   return organisation.value.format_duration_in_hours
 })
+
+const durationUnit = computed(() =>
+  isDurationInHours.value ? t('schedule.hours') : t('schedule.md')
+)
 
 const formatDuration = (minutes, toLocale = true) => {
   if (!minutes) {
@@ -2017,7 +2021,7 @@ const timebarSubchildTitle = task => {
   const duration = isRealSchedule.value
     ? formatDuration(task.duration)
     : formatDuration(task.estimation)
-  return `${name} (${startDate} - ${endDate}) ${duration} ${t('schedule.md')}`
+  return `${name} (${startDate} - ${endDate}) ${duration} ${durationUnit.value}`
 }
 
 const getTimebarLeft = timeElement => {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1788,6 +1788,7 @@ export default {
     title_main: 'Main Schedule',
     overall_man_days: 'Person-days',
     md: 'md',
+    hours: 'h',
     today: 'Today',
     zoom_level: 'Zoom level',
     milestone: {


### PR DESCRIPTION
## Problems

- The schedule unit label stays "md" when the organisation displays durations in hours (values convert, the unit does not). Fixes #1910

## Solutions

- Add a `durationUnit` computed (Schedule widget + format mixin) returning "h" or "md", used everywhere `schedule.md` was hardcoded