### PR TITLE
[shots] Fix Sequence Stats displaying empty on first load

### DIFF
--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -83,6 +83,16 @@ const cache = {
   result: []
 }
 
+// Callbacks of loadShots calls made while another load was in flight.
+// They run once that load settles, so callers never see an empty cache.
+let pendingLoadShotsCallbacks = []
+
+const flushPendingLoadShotsCallbacks = err => {
+  const callbacks = pendingLoadShotsCallbacks
+  pendingLoadShotsCallbacks = []
+  callbacks.forEach(callback => callback(err))
+}
+
 const helpers = {
   getCurrentProduction() {
     return productionsStore.getters.currentProduction(productionsStore.state)
@@ -426,7 +436,12 @@ const actions = {
     }
 
     if (state.isShotsLoading) {
-      if (callback) return callback()
+      return new Promise(resolve => {
+        pendingLoadShotsCallbacks.push(err => {
+          if (callback) callback(err)
+          resolve()
+        })
+      })
     }
 
     commit(LOAD_SHOTS_START)
@@ -457,11 +472,13 @@ const actions = {
           commit(END_SHOTS_LOADING)
         }
         if (callback) callback()
+        flushPendingLoadShotsCallbacks()
       })
       .catch(err => {
         commit(LOAD_SHOTS_ERROR)
         console.error(err)
         if (callback) callback(err)
+        flushPendingLoadShotsCallbacks(err)
       })
   },
 

--- a/tests/unit/store/shots.spec.js
+++ b/tests/unit/store/shots.spec.js
@@ -1,0 +1,56 @@
+import { vi } from 'vitest'
+
+// Importing the shots module transitively pulls in the root store
+// (lib/models → timezone → @/store); stub it so no Vuex store is built.
+vi.mock('@/store', () => ({ default: {} }))
+vi.mock('@/store/api/shots', () => ({
+  default: { getShots: vi.fn() }
+}))
+
+import shotsApi from '@/store/api/shots'
+import shotsStore from '@/store/modules/shots'
+
+describe('Shots store', () => {
+  describe('loadShots while a load is in flight', () => {
+    const rootGetters = {
+      currentProduction: { id: 'production-1' },
+      currentEpisode: null,
+      episodes: [],
+      userFilters: {},
+      userFilterGroups: {},
+      taskTypeMap: new Map(),
+      taskMap: new Map(),
+      personMap: new Map(),
+      isTVShow: false
+    }
+
+    test('queued callbacks run once the in-flight load settles', async () => {
+      let resolveGetShots
+      shotsApi.getShots.mockReturnValue(
+        new Promise(resolve => {
+          resolveGetShots = resolve
+        })
+      )
+
+      const state = { isShotsLoading: false }
+      const context = {
+        state,
+        commit: vi.fn(),
+        dispatch: vi.fn().mockResolvedValue(),
+        rootGetters
+      }
+
+      const firstLoad = shotsStore.actions.loadShots(context)
+      state.isShotsLoading = true
+
+      const queuedCallback = vi.fn()
+      const secondLoad = shotsStore.actions.loadShots(context, queuedCallback)
+      expect(queuedCallback).not.toHaveBeenCalled()
+
+      resolveGetShots([])
+      await firstLoad
+      await secondLoad
+      expect(queuedCallback).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Problems

- Opening Sequence Stats while shots were still loading (e.g. coming from the Shots landing page) computed stats on an empty shot cache and never recomputed, leaving the page empty until a manual refresh. Fixes #1900

## Solutions

- `loadShots` now queues callbacks made during an in-flight load (and returns a promise for await callers) and runs them once that load settles, instead of invoking them immediately on the empty cache