### PR TITLE
[episodes] Fix assets not fetched on first load for TV Shows without episodes

### DIFF
--- a/src/store/modules/episodes.js
+++ b/src/store/modules/episodes.js
@@ -807,13 +807,14 @@ const mutations = {
     state.displayedEpisodes = state.episodes
     state.displayedEpisodesLength = state.episodes.length
 
-    // Set currentEpisode
-    if (state.episodes.length > 0) {
-      if (routeEpisodeId === 'all') {
-        state.currentEpisode = { id: 'all' }
-      } else if (routeEpisodeId === 'main') {
-        state.currentEpisode = { id: 'main' }
-      } else if (routeEpisodeId) {
+    // Set currentEpisode. The 'all' and 'main' pseudo-episodes are valid
+    // even when the production has no episodes.
+    if (routeEpisodeId === 'all') {
+      state.currentEpisode = { id: 'all' }
+    } else if (routeEpisodeId === 'main') {
+      state.currentEpisode = { id: 'main' }
+    } else if (state.episodes.length > 0) {
+      if (routeEpisodeId) {
         state.currentEpisode = cache.episodeMap.get(routeEpisodeId)
       }
       if (!state.currentEpisode) {

--- a/tests/unit/store/episodes.spec.js
+++ b/tests/unit/store/episodes.spec.js
@@ -1,0 +1,33 @@
+import { vi } from 'vitest'
+
+// Importing the episodes module transitively pulls in the root store
+// (lib/models → timezone → @/store); stub it so no Vuex store is built.
+vi.mock('@/store', () => ({ default: {} }))
+
+import episodesStore from '@/store/modules/episodes'
+import { LOAD_EPISODES_END } from '@/store/mutation-types'
+
+describe('Episodes store', () => {
+  describe('LOAD_EPISODES_END with no episodes', () => {
+    test.each(['all', 'main'])(
+      'resolves the %s pseudo-episode from the route',
+      routeEpisodeId => {
+        const state = { episodes: [] }
+        episodesStore.mutations[LOAD_EPISODES_END](state, {
+          episodes: [],
+          routeEpisodeId
+        })
+        expect(state.currentEpisode).toEqual({ id: routeEpisodeId })
+      }
+    )
+
+    test('keeps currentEpisode null without a route episode', () => {
+      const state = { episodes: [] }
+      episodesStore.mutations[LOAD_EPISODES_END](state, {
+        episodes: [],
+        routeEpisodeId: undefined
+      })
+      expect(state.currentEpisode).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Problems

- On a TV Show with no episodes, loading `/episodes/all/assets` directly fetched nothing: `LOAD_EPISODES_END` forced `currentEpisode` to null when the episode list was empty, so `loadAssets` bailed out with an empty result. Fixes #1948

## Solutions

- Resolve the `all`/`main` pseudo-episodes from the route even when the production has no episodes; they don't require real episodes to exist