### PR TITLE
[episodes] Fix stats total row ignoring the only-running filter

### DIFF
--- a/src/components/lists/EpisodeStatsList.vue
+++ b/src/components/lists/EpisodeStatsList.vue
@@ -221,7 +221,8 @@ import { mapGetters } from 'vuex'
 import { entityListMixin } from '@/components/mixins/entity_list'
 import { range } from '@/lib/time'
 import {
-  getChartColors,
+  aggregateRetakeStats,
+  aggregateStats,
   getChartData,
   getChartRetakeCount,
   getRetakeChartData
@@ -316,6 +317,18 @@ export default {
 
     isRetakes() {
       return this.dataMode === 'retakes'
+    },
+
+    // The "all" row aggregates the displayed entries only, so it stays
+    // consistent when episodes are filtered (e.g. "only running").
+    displayedEntriesStats() {
+      const entryIds = this.entries.map(entry => entry.id)
+      return { all: aggregateStats(this.episodeStats, entryIds) }
+    },
+
+    displayedEntriesRetakeStats() {
+      const entryIds = this.entries.map(entry => entry.id)
+      return { all: aggregateRetakeStats(this.episodeRetakeStats, entryIds) }
     }
   },
 
@@ -324,20 +337,21 @@ export default {
       if (this.isRetakes) {
         return ['#ff3860', '#6f727a', '#22d160']
       } else {
-        return getChartColors(this.episodeStats, entryId, columnId)
+        return this.chartData(entryId, columnId).map(data => data[2])
       }
     },
 
     chartData(entryId, columnId, dataType = 'count') {
       if (this.isRetakes) {
-        return getRetakeChartData(
-          this.episodeRetakeStats,
-          entryId,
-          columnId,
-          dataType
-        )
+        const stats =
+          entryId === 'all'
+            ? this.displayedEntriesRetakeStats
+            : this.episodeRetakeStats
+        return getRetakeChartData(stats, entryId, columnId, dataType)
       } else {
-        return getChartData(this.episodeStats, entryId, columnId, dataType)
+        const stats =
+          entryId === 'all' ? this.displayedEntriesStats : this.episodeStats
+        return getChartData(stats, entryId, columnId, dataType)
       }
     },
 

--- a/src/lib/stats.js
+++ b/src/lib/stats.js
@@ -186,6 +186,63 @@ const computeTaskResult = (
   }
 }
 
+// Aggregate the per-entry stats of the given entries into a single bucket
+// shaped like an entry (used for the "all" row when entries are filtered).
+export const aggregateStats = (mainStats, entryIds) => {
+  const result = {}
+  entryIds.forEach(entryId => {
+    const entryStats = mainStats[entryId]
+    if (!entryStats) return
+    Object.keys(entryStats).forEach(columnId => {
+      if (!result[columnId]) result[columnId] = {}
+      const columnStats = entryStats[columnId]
+      Object.keys(columnStats).forEach(taskStatusId => {
+        const data = columnStats[taskStatusId]
+        const target = result[columnId][taskStatusId]
+        if (!target) {
+          result[columnId][taskStatusId] = { ...data }
+        } else {
+          target.count += data.count || 0
+          target.frames += data.frames || 0
+          target.drawings += data.drawings || 0
+        }
+      })
+    })
+  })
+  return result
+}
+
+// Same as aggregateStats for retake stats (retake / done / other buckets).
+export const aggregateRetakeStats = (retakeStats, entryIds) => {
+  const result = {}
+  entryIds.forEach(entryId => {
+    const entryStats = retakeStats[entryId]
+    if (!entryStats) return
+    Object.keys(entryStats).forEach(columnId => {
+      if (!result[columnId]) {
+        result[columnId] = {
+          max_retake_count: 0,
+          retake: { count: 0, frames: 0, drawings: 0 },
+          done: { count: 0, frames: 0, drawings: 0 },
+          other: { count: 0, frames: 0, drawings: 0 }
+        }
+      }
+      const columnStats = entryStats[columnId]
+      const target = result[columnId]
+      target.max_retake_count = Math.max(
+        target.max_retake_count,
+        columnStats.max_retake_count || 0
+      )
+      ;['retake', 'done', 'other'].forEach(key => {
+        ;['count', 'frames', 'drawings'].forEach(field => {
+          target[key][field] += columnStats[key]?.[field] || 0
+        })
+      })
+    })
+  })
+  return result
+}
+
 export const getPercentage = (value, total) => {
   let percent = 0
   if (total > 0) {

--- a/tests/unit/lib/stats.spec.js
+++ b/tests/unit/lib/stats.spec.js
@@ -1,4 +1,6 @@
 import {
+  aggregateRetakeStats,
+  aggregateStats,
   computeStats,
   getChartData,
   getChartColors,
@@ -182,5 +184,49 @@ describe('lib/stats', () => {
     expect(getPercentage(1, 3)).toEqual('33.33')
     expect(getPercentage(0, 0)).toEqual('0.00')
     expect(getPercentage(0, 100)).toEqual('0.00')
+  })
+
+  it('aggregateStats', () => {
+    const aggregated = aggregateStats(expectedStatResult, ['sequence-1'])
+    expect(aggregated).toEqual(expectedStatResult['sequence-1'])
+    const all = aggregateStats(expectedStatResult, [
+      'sequence-1',
+      'sequence-2'
+    ])
+    expect(all.all).toEqual(expectedStatResult.all.all)
+    expect(aggregateStats(expectedStatResult, ['missing'])).toEqual({})
+  })
+
+  it('aggregateRetakeStats', () => {
+    const retakeStats = {
+      'episode-1': {
+        all: {
+          max_retake_count: 2,
+          retake: { count: 1, frames: 10, drawings: 0 },
+          done: { count: 2, frames: 20, drawings: 0 },
+          other: { count: 3, frames: 30, drawings: 0 },
+          evolution: {}
+        }
+      },
+      'episode-2': {
+        all: {
+          max_retake_count: 4,
+          retake: { count: 10, frames: 100, drawings: 0 },
+          done: { count: 20, frames: 200, drawings: 0 },
+          other: { count: 30, frames: 300, drawings: 0 },
+          evolution: {}
+        }
+      }
+    }
+    const aggregated = aggregateRetakeStats(retakeStats, [
+      'episode-1',
+      'episode-2'
+    ])
+    expect(aggregated.all.max_retake_count).toEqual(4)
+    expect(aggregated.all.retake).toEqual({ count: 11, frames: 110, drawings: 0 })
+    expect(aggregated.all.done).toEqual({ count: 22, frames: 220, drawings: 0 })
+    expect(aggregated.all.other).toEqual({ count: 33, frames: 330, drawings: 0 })
+    const partial = aggregateRetakeStats(retakeStats, ['episode-1'])
+    expect(partial.all.retake.count).toEqual(1)
   })
 })


### PR DESCRIPTION
## Problems

- On Episode Stats, the "All episodes" row read the precomputed server-side `all` bucket, so switching to "only running" filtered the rows but never the totals. Fixes #1859

## Solutions

- Aggregate the total row client-side from the displayed episodes (new `aggregateStats`/`aggregateRetakeStats` helpers in `lib/stats`, covered by unit tests)