### PR TITLE
[plugins] Fix vertically misaligned frontend plugin iframe

### DIFF
--- a/src/components/pages/Plugin.vue
+++ b/src/components/pages/Plugin.vue
@@ -1,8 +1,5 @@
 <template>
-  <div class="plugin-page">
-    <h1>Plugin</h1>
-    {{ plugin?.name }}
-
+  <div class="plugin-page page fixed-page">
     <iframe
       class="plugin-iframe"
       :src="pluginUrl"
@@ -73,13 +70,15 @@ useHead({
 
 <style lang="scss" scoped>
 .plugin-page {
-  padding-top: 20px;
+  padding-left: 0;
+  padding-right: 0;
+  padding-bottom: 0;
 }
 
 .plugin-iframe {
   background-color: $white;
+  flex: 1;
   width: 100%;
-  height: calc(100vh - 68px);
   border: none;
   padding: 0;
   margin: 0;


### PR DESCRIPTION
## Problems

- The plugin page floated in normal flow with a hardcoded `calc(100vh - 68px)` height, so on production plugins the iframe started under the navbar and left a white strip at the bottom. Fixes #2067

## Solutions

- Use the standard `page fixed-page` layout and let the iframe flex-fill the remaining height; drop the leftover "Plugin" debug heading