### PR TITLE
[tasks] Add "Use current frame" checkbox on the task page

### DIFF
--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -142,6 +142,17 @@
                     :title="$t('tasks.hookup_playlist')"
                   />
                 </button>
+                <label
+                  class="flexrow-item pointer"
+                  v-if="isMovie && isCurrentUserManager"
+                >
+                  <input
+                    class="mr02"
+                    type="checkbox"
+                    v-model="isUseCurrentFrame"
+                  />
+                  {{ $t('tasks.use_current_frame') }}
+                </label>
                 <button
                   class="button flexrow-item mr0"
                   :class="{
@@ -1246,11 +1257,16 @@ export default {
       this.loading.setPreview = true
       this.errors.setPreview = false
       const previewId = previewPlayer.currentPreview.id
+      const frame =
+        this.isMovie && this.isUseCurrentFrame
+          ? this.currentFrame + 1
+          : undefined
       this.$store
         .dispatch('setPreview', {
           taskId: this.task.id,
           entityId: this.task.entity.id,
-          previewId
+          previewId,
+          frame
         })
         .then(() => {
           this.loading.setPreview = false


### PR DESCRIPTION
## Problems

- The task page "Set preview" button always used the default thumbnail; the "Use current frame" option only existed in the overview sidebar. Fixes #1696

## Solutions

- Add the same checkbox next to the button for movie previews and pass `frame` (current frame + 1) to the existing `setPreview` action, matching the sidebar behavior