### PR TITLE
[players] Stop playing the previous build when switching playlists

### DIFF
--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -4453,6 +4453,13 @@ watch(
       if (room.value?.people?.includes(user.value?.id)) leaveRoom()
       closeRoom(oldPlaylist.id)
     }
+    // Leave the previous playlist's build playback, otherwise its movie
+    // keeps playing over the newly selected playlist.
+    if (isFullMode.value) {
+      fullPlaylistPlayer.value?.pause()
+      isFullMode.value = false
+    }
+    fullPlayingPath = ''
     endAnnotationSaving()
     room.value.id = props.playlist?.id
     room.value.localId = uuidv4()


### PR DESCRIPTION
## Problems

- After playing a playlist build, selecting another playlist kept playing the previous build's movie — full mode was never reset on playlist change. Fixes #1575

## Solutions

- In the playlist watcher, pause the build player, leave full mode and clear the cached build path when navigating to a different playlist