### PR TITLE
[assets] Fix CSV import duplicate check missing unloaded assets

### DIFF
--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -482,20 +482,23 @@ export default {
     },
 
     filteredAssets() {
+      // Build the lookup from the full asset cache, not the paginated
+      // display list, so the import duplicate check sees every asset.
+      // The cache Map is not reactive: depend on displayedAssets (updated
+      // by the same mutations) to invalidate this computed.
+      this.displayedAssets // eslint-disable-line no-unused-expressions
       const assets = {}
-      this.displayedAssetsByType.forEach(type => {
-        type.forEach(item => {
-          let assetKey = ''
-          if (
-            this.isTVShow &&
-            item.episode_id &&
-            this.episodeMap.has(item.episode_id)
-          ) {
-            assetKey += this.episodeMap.get(item.episode_id).name
-          }
-          assetKey += `${item.asset_type_name}${item.name}`
-          assets[assetKey] = true
-        })
+      this.assetMap.forEach(item => {
+        let assetKey = ''
+        if (
+          this.isTVShow &&
+          item.episode_id &&
+          this.episodeMap.has(item.episode_id)
+        ) {
+          assetKey += this.episodeMap.get(item.episode_id).name
+        }
+        assetKey += `${item.asset_type_name}${item.name}`
+        assets[assetKey] = true
       })
       return assets
     },


### PR DESCRIPTION
## Problems

- The CSV import "already imported" indicator compared names against the paginated display list, so assets not yet scrolled into view were flagged as new. Fixes #927

## Solutions

- Build the lookup from the full asset cache (`assetMap`), keeping a reactive dependency on `displayedAssets` for invalidation since the cache Map lives outside the store state