### PR TITLE
[players] Show the audio file name in the playlist player

### DIFF
--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -290,6 +290,7 @@
         <sound-viewer
           ref="sound-player"
           class="sound-player"
+          :file-name="currentPreviewFileName"
           :preview-url="currentPreviewDlPath"
           :full-screen="fullScreen"
           @play-ended="pause"
@@ -1262,6 +1263,19 @@ const currentPreview = computed(() => {
     }
   }
   return entity.preview_file_previews?.[currentPreviewIndex.value - 1]
+})
+
+// The main preview entity fields don't carry original_name: look it up in
+// the full preview_files payload so reviewers see which file is playing.
+const currentPreviewFileName = computed(() => {
+  const preview = currentPreview.value
+  if (!preview) return ''
+  const originalName =
+    preview.original_name ||
+    Object.values(currentEntity.value?.preview_files || {})
+      .flat()
+      .find(previewFile => previewFile.id === preview.id)?.original_name
+  return originalName ? `${originalName}.${preview.extension}` : ''
 })
 
 const currentEntityPreviewLength = computed(() => {


### PR DESCRIPTION
## Problems

- When a revision holds several files, the playlist player gave no way to know which audio file was playing — SoundViewer supports a `file-name` prop but the playlist never passed it (remaining part of #1517, mp3 playback itself was fixed in 0.20.0). Fixes #1517

## Solutions

- Pass the current preview's `original_name.extension` to the sound viewer, resolving the main preview's name from the `preview_files` payload since entity-level fields don't carry it