### PR TITLE
[topbar] Fix episode combobox desync on frontend plugin pages

### DIFF
--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -389,6 +389,16 @@ export default {
       if (this.currentProjectSection) {
         section = this.currentProjectSection
       }
+      // Plugin pages accept the all / main pseudo-episodes (forwarded to
+      // the plugin iframe as episode_id): without these options the
+      // combobox silently displays the first episode while the route
+      // says "all".
+      if (this.$route.params.plugin_id !== undefined) {
+        const episodeList = this.getBaseEpisodeOptionGroups(
+          'episodes.all_episodes'
+        )
+        return [{ name: '', episodeList }].concat(this.episodeOptionGroups)
+      }
       if (this.assetSections.includes(section)) {
         const episodeList = this.getBaseEpisodeOptionGroups('main.all_assets')
         return [{ name: '', episodeList }].concat(this.episodeOptionGroups)
@@ -766,6 +776,11 @@ export default {
               routeEpisodeId === 'main'
             ) {
               this.currentEpisodeId = 'main'
+            } else if (
+              this.$route.params.plugin_id &&
+              ['all', 'main'].includes(routeEpisodeId)
+            ) {
+              this.currentEpisodeId = routeEpisodeId
             } else {
               let episode = episodes.find(({ id }) => id === routeEpisodeId)
               if (!episode) {
@@ -846,7 +861,11 @@ export default {
       const isAssetSection = this.assetSections.includes(section)
       const isEditSection = this.editSections.includes(section)
       const isBreakdownSection = this.breakdownSections.includes(section)
+      // Plugin pages keep the all / main pseudo-episodes: coercing to the
+      // first episode desyncs the combobox from the episode_id actually
+      // forwarded to the plugin iframe.
       if (
+        pluginId === undefined &&
         !isAssetSection &&
         !isEditSection &&
         !isBreakdownSection &&


### PR DESCRIPTION
## Problems

- On a TV Show, opening a project plugin from "All Assets" showed the first episode in the navbar while the plugin iframe received `episode_id=all`: the topbar coerced all/main to the first episode on plugin routes (with a broken route push) and its combobox had no all/main options to display. Fixes #2068

## Solutions

- Expose the all/main pseudo-episode options on plugin routes and stop coercing them to the first episode (both in `updateCombosFromRoute` and on production configuration), so the navbar reflects the episode_id actually forwarded to the plugin