### PR TITLE
[events] Fix automatic entity thumbnail not refreshing in the UI

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -354,6 +354,16 @@ export default {
         }
       },
 
+      // Emitted by Zou when a production has "set preview automatically"
+      // enabled: reflect the new entity thumbnail without a manual refresh.
+      'preview-file:set-main'(eventData) {
+        this.$store.commit('SET_PREVIEW', {
+          entityId: eventData.entity_id,
+          previewId: eventData.preview_file_id,
+          taskMap: this.taskMap
+        })
+      },
+
       'task:delete'(eventData) {
         const task = this.taskMap.get(eventData.task_id)
         if (task) {


### PR DESCRIPTION
## Problems

- With "Set Preview As Entity Thumbnail Automatically" enabled, Zou updates the entity and emits `preview-file:set-main`, but Kitsu never listened to that event — the thumbnail only appeared after a manual refresh, which read as the feature being temperamental. Fixes #1617

## Solutions

- Handle `preview-file:set-main` in the global socket handlers (App.vue) and commit the existing `SET_PREVIEW` mutation, mirroring what the manual set-preview action already does