### PR TITLE
[players] Keep timeline tick marks visible on long clips

### DIFF
--- a/src/components/players/progress/VideoProgress.vue
+++ b/src/components/players/progress/VideoProgress.vue
@@ -222,24 +222,28 @@ const backgroundSize = computed(() => {
 
 // Alternating frame stripes generated at the exact frame size, using the
 // two colors sampled from the legacy player-timeslider.png — the
-// stretched texture blurred as soon as the clip had few frames. Stripes
-// are dropped when frames get too dense to read.
-// Below this per-frame width the alternating stripes are too dense to read
-// and just shimmer, so we drop them. The clip is then painted a solid dark
-// grey rather than exposing the light base background, which on long clips
-// looked like a rendering bug.
+// stretched texture blurred as soon as the clip had few frames.
+// Below this stripe width the alternating pattern is too dense to read and
+// just shimmers. Instead of dropping the stripes entirely on long clips
+// (which removed every landmark from the timeline — issue #2061), group
+// several frames per stripe so it never gets thinner than this.
+const MIN_STRIPE_WIDTH = 4
+
 const DENSE_FRAME_FALLBACK = 'linear-gradient(rgb(54, 57, 63), rgb(54, 57, 63))'
 
 const frameTicksGradient = computed(() => {
   const size = effectiveFrameSize.value
-  if (!size || size < 3) return DENSE_FRAME_FALLBACK
+  if (!size) return DENSE_FRAME_FALLBACK
+  const framesPerStripe = Math.max(1, Math.ceil(MIN_STRIPE_WIDTH / size))
+  const stripe = size * framesPerStripe
   // Anchor the stripe phase on the view window so frames keep their
   // shade while panning/zooming.
-  const phase = -(viewStartFrame.value % 2) * size
+  const phase = -(viewStartFrame.value % (2 * framesPerStripe)) * size
   return (
     `repeating-linear-gradient(to right, ` +
-    `rgb(54, 57, 63) ${phase}px, rgb(54, 57, 63) ${phase + size}px, ` +
-    `rgb(84, 89, 98) ${phase + size}px, rgb(84, 89, 98) ${phase + 2 * size}px)`
+    `rgb(54, 57, 63) ${phase}px, rgb(54, 57, 63) ${phase + stripe}px, ` +
+    `rgb(84, 89, 98) ${phase + stripe}px, ` +
+    `rgb(84, 89, 98) ${phase + 2 * stripe}px)`
   )
 })
 


### PR DESCRIPTION
## Problems

- Frame tick stripes were dropped entirely below 3px per frame, so long clips showed a flat timeline with no landmarks unless the user zoomed with ctrl+wheel. Fixes #2061

## Solutions

- Group several frames per stripe so it never gets thinner than 4px: dense clips keep a readable visual rhythm, and zooming naturally returns to per-frame stripes (phase anchoring generalized to the group size)