### PR TITLE
[schedule] Fix "Invalid date" sent by the schedule Assign Tasks panel

### DIFF
--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -180,7 +180,10 @@ export const getDatesFromStartDate = (
   estimation,
   daysOff = []
 ) => {
-  if (estimation > 0 && !organisation.format_duration_in_hours) {
+  // The estimation is always expressed in days here, whatever the display
+  // preference: skipping the computation for hours-displaying studios left
+  // a null due date that ended up serialized as "Invalid date".
+  if (estimation > 0) {
     dueDate = addBusinessDays(startDate, Math.ceil(estimation) - 1, daysOff)
   }
 
@@ -211,7 +214,8 @@ export const getDatesFromEndDate = (
   estimation,
   daysOff = []
 ) => {
-  if (estimation > 0 && !organisation.format_duration_in_hours) {
+  // Same day-based contract as getDatesFromStartDate.
+  if (estimation > 0) {
     startDate = removeBusinessDays(dueDate, Math.ceil(estimation) - 1, daysOff)
   }
 

--- a/tests/unit/lib/time.spec.js
+++ b/tests/unit/lib/time.spec.js
@@ -185,6 +185,20 @@ describe('time', () => {
       start_date: '2019-10-01', // tuesday
       due_date: '2019-10-10' // a week later + 2 days (weekend) + 1 day off
     })
+    // The estimation is in days regardless of the display preference: an
+    // hours-displaying organisation must not end up with a null due date
+    // (it was serialized as "Invalid date" by callers — issue #1977).
+    expect(
+      getDatesFromStartDate(
+        { format_duration_in_hours: true },
+        startDate,
+        null,
+        7
+      )
+    ).toEqual({
+      start_date: '2019-10-01',
+      due_date: '2019-10-09'
+    })
   })
   test('getDatesFromEndDate', () => {
     const startDate = parseSimpleDate('2019-10-01')


### PR DESCRIPTION
## Problems

- With "display durations in hours" enabled, `getDatesFromStartDate`/`getDatesFromEndDate` skipped the business-days computation, leaving a null due date that the schedule Assign Tasks panel serialized as the literal string "Invalid date" (400 from the API). Fixes #1977

## Solutions

- Drop the display-preference guard: every caller passes the estimation in days (`minutesToDays` converts regardless of the flag), so the computation is valid for hours-displaying studios too — covered by a unit test