### PR TITLE
[productions] Hide archived status automations from production settings

### DIFF
--- a/src/store/modules/productions.js
+++ b/src/store/modules/productions.js
@@ -298,8 +298,11 @@ const getters = {
   },
 
   remainingStatusAutomations: (state, getters, rootState, rootGetters) => {
+    // Archived automations are hidden from the main settings list: they
+    // must not stay addable from the production settings either.
     return rootState.statusAutomations.statusAutomations.filter(
       s =>
+        !s.archived &&
         !state.currentProduction.status_automations.includes(s.id) &&
         !rootGetters.isStatusAutomationDisabled(s)
     )


### PR DESCRIPTION
## Problems

- An automation removed from the main settings (archived — deletion is refused by the API when it is linked to a project) still appeared in the production settings dropdown, even after a hard refresh: `remainingStatusAutomations` read the raw store state instead of applying the archived filter used by the main list. Fixes #1577

## Solutions

- Exclude archived automations from `remainingStatusAutomations`, aligning the production settings dropdown with the main settings list