### PR TITLE
Security fixes: XSS, unsafe hrefs, CSV formula injection, share-token leak

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -144,6 +144,9 @@ export default {
     },
 
     setupCrisp(config) {
+      // Never load Crisp on the guest share page: the widget reports the
+      // page URL, which contains the share token.
+      if (window.location.pathname.startsWith('/playlists/shared/')) return
       if (config.crisp_token?.length) {
         crisp.init(config.crisp_token)
         const supportChat = localPreferences.getBoolPreference(

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -330,7 +330,7 @@
 
           <a
             class="button flexrow-item"
-            :href="link"
+            :href="safeUrl(link)"
             :title="$t('playlists.actions.open_link')"
             target="_blank"
             v-if="!isCurrentUserArtist && link?.length"
@@ -452,6 +452,7 @@ import { usePreviewShortcuts } from '@/composables/players/previewShortcuts'
 import { getEntityPath } from '@/lib/path'
 import { mergeAnnotationsByFrame } from '@/lib/players/annotation'
 import localPreferences from '@/lib/preferences'
+import { safeUrl } from '@/lib/render'
 import {
   buildAnnotationSnapshotFilename,
   buildAnnotationSnapshotTitle,

--- a/src/components/widgets/AssignationItem.vue
+++ b/src/components/widgets/AssignationItem.vue
@@ -7,7 +7,12 @@
       :font-size="14"
       class="flexrow-item"
     />
-    <span class="flexrow-item" v-html="label"></span>
+    <span class="flexrow-item">
+      <template v-for="(part, index) in labelParts" :key="index">
+        <b v-if="part.match">{{ part.text }}</b>
+        <template v-else>{{ part.text }}</template>
+      </template>
+    </span>
   </div>
 </template>
 
@@ -30,11 +35,16 @@ const regExpEscape = string => {
   return string.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&')
 }
 
-const label = computed(() => {
+// Split the name into plain/matching segments so the template can bold
+// matches through interpolation — never inject the name as HTML.
+const labelParts = computed(() => {
   const text = props.item.name.trim()
-  const search = props.search.trim()
-  return !search
-    ? text
-    : text.replace(RegExp(regExpEscape(search), 'gi'), '<b>$&</b>')
+  const search = props.search?.trim()
+  if (!search) return [{ text, match: false }]
+  const lowerSearch = search.toLowerCase()
+  return text
+    .split(RegExp(`(${regExpEscape(search)})`, 'gi'))
+    .filter(part => part)
+    .map(part => ({ text: part, match: part.toLowerCase() === lowerSearch }))
 })
 </script>

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -426,7 +426,7 @@
         </router-link>
         <a
           class="preview-link button"
-          :href="comment.links[0]"
+          :href="safeUrl(comment.links[0])"
           :title="$t('playlists.actions.open_link')"
           target="_blank"
           v-if="!isCurrentUserArtist && comment.links?.[0]?.length"
@@ -528,7 +528,7 @@ import {
 import files from '@/lib/files'
 import { remove } from '@/lib/models'
 import { getDownloadAttachmentPath, pluralizeEntityType } from '@/lib/path'
-import { renderComment, replaceTimeWithTimecode } from '@/lib/render'
+import { renderComment, replaceTimeWithTimecode, safeUrl } from '@/lib/render'
 import { sortByName } from '@/lib/sorting'
 import { parseDate } from '@/lib/time'
 import stringHelpers from '@/lib/string'

--- a/src/lib/csv.js
+++ b/src/lib/csv.js
@@ -195,6 +195,9 @@ const csv = {
   turnEntriesToCsvString(entries, config = {}) {
     return Papa.unparse(entries, {
       delimiter: ';',
+      // Neutralize spreadsheet formula injection: cells starting with
+      // = + - @ are prefixed with ' so Excel/Sheets treat them as text.
+      escapeFormulae: true,
       newline: '\n',
       quotes: true,
       skipEmptyLines: true,

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -159,6 +159,10 @@ const isSafeHref = url => {
   return !scheme || ['http', 'https'].includes(scheme[1].toLowerCase())
 }
 
+// For :href bindings on user-provided URLs: null when the scheme is unsafe
+// (Vue drops the attribute entirely on null).
+export const safeUrl = url => (url && isSafeHref(url) ? url : null)
+
 export const replaceTimeWithTimecode = (
   comment,
   currentPreviewRevision,

--- a/src/lib/sentry.js
+++ b/src/lib/sentry.js
@@ -3,6 +3,28 @@ import * as Sentry from '@sentry/vue'
 import { name, version } from '@/../package.json'
 import { isChunkError } from '@/lib/chunk-error'
 
+// The guest share URL carries its access token in the path: strip it from
+// everything Sentry reports.
+const SHARED_TOKEN_RGX = /(\/playlists\/shared\/)[^/?#\s]+/g
+export const scrubSharedToken = value =>
+  typeof value === 'string'
+    ? value.replace(SHARED_TOKEN_RGX, '$1[token]')
+    : value
+
+const scrubEvent = event => {
+  if (event.request?.url) {
+    event.request.url = scrubSharedToken(event.request.url)
+  }
+  event.transaction = scrubSharedToken(event.transaction)
+  event.breadcrumbs?.forEach(crumb => {
+    if (!crumb.data) return
+    crumb.data.from = scrubSharedToken(crumb.data.from)
+    crumb.data.to = scrubSharedToken(crumb.data.to)
+    crumb.data.url = scrubSharedToken(crumb.data.url)
+  })
+  return event
+}
+
 export default {
   init(app, router, { dsn, sampleRate = 0.1 }) {
     Sentry.init({
@@ -20,7 +42,10 @@ export default {
         if (hint.originalException && isChunkError(hint.originalException)) {
           return null
         }
-        return event
+        return scrubEvent(event)
+      },
+      beforeSendTransaction(event) {
+        return scrubEvent(event)
       }
     })
   },

--- a/tests/unit/lib/csv.spec.js
+++ b/tests/unit/lib/csv.spec.js
@@ -1,0 +1,36 @@
+import { vi } from 'vitest'
+
+// Some lib imports transitively pull the root store; stub it so no Vuex
+// store is built.
+vi.mock('@/store', () => ({ default: {} }))
+
+import csv from '@/lib/csv'
+
+describe('lib/csv', () => {
+  describe('turnEntriesToCsvString', () => {
+    test('escapes spreadsheet formula cells (SEC-8)', () => {
+      const entries = [
+        ['name', 'description'],
+        ['SH010', '=HYPERLINK("http://evil.test";"click")'],
+        ['SH020', '+cmd|calc'],
+        ['SH030', '@SUM(1;2)'],
+        ['SH040', 'plain text']
+      ]
+
+      const result = csv.turnEntriesToCsvString(entries)
+      const lines = result.split('\n')
+
+      expect(lines[1]).toContain('"\'=HYPERLINK')
+      expect(lines[2]).toContain('"\'+cmd|calc"')
+      expect(lines[3]).toContain('"\'@SUM(1;2)"')
+      // Plain values stay untouched.
+      expect(lines[4]).toContain('"plain text"')
+      expect(lines[4]).not.toContain("'plain")
+    })
+
+    test('keeps the export format: ; delimiter and quoted cells', () => {
+      const result = csv.turnEntriesToCsvString([['a', 'b']])
+      expect(result).toBe('"a";"b"')
+    })
+  })
+})

--- a/tests/unit/lib/render.spec.js
+++ b/tests/unit/lib/render.spec.js
@@ -2,10 +2,28 @@ import {
   getTaskTypeStyle,
   renderComment,
   renderFileSize,
-  renderMarkdown
+  renderMarkdown,
+  safeUrl
 } from '@/lib/render'
 
 describe('render', () => {
+  describe('safeUrl', () => {
+    test('keeps http(s) and relative URLs', () => {
+      expect(safeUrl('https://cg-wire.com')).toBe('https://cg-wire.com')
+      expect(safeUrl('http://intranet/page')).toBe('http://intranet/page')
+      expect(safeUrl('/productions/prod-1')).toBe('/productions/prod-1')
+    })
+
+    test('drops unsafe schemes and empty values (SEC-7)', () => {
+      expect(safeUrl('javascript:alert(1)')).toBe(null)
+      expect(safeUrl(' javascript:alert(1)')).toBe(null)
+      expect(safeUrl('data:text/html,<script>x</script>')).toBe(null)
+      expect(safeUrl('vbscript:msgbox')).toBe(null)
+      expect(safeUrl('')).toBe(null)
+      expect(safeUrl(undefined)).toBe(null)
+    })
+  })
+
   test('getTaskTypeStyle', () => {
     const task = { task_type_color: 'red' }
     expect(getTaskTypeStyle(task)).toEqual({


### PR DESCRIPTION
## Problems

- `AssignationItem` injected the person name through `v-html` to bold search matches — a person name containing HTML executed in every assignee dropdown (stored XSS).
- Two `:href` bindings pointed at user-entered URLs without any scheme filtering (`javascript:` links): the comment preview link and the preview player link button.
- CSV exports wrote raw cell values: values starting with `= + - @` execute as formulae when the export is opened in Excel/Sheets (formula injection), on every export in the app.
- On the guest share page, the share token sits in the URL path and leaked to third parties: Crisp receives the page URL, and Sentry reports it in request URLs, transactions and navigation breadcrumbs.

## Solutions

- Rebuild the assignation highlight without HTML: the name is split into plain/matching segments and rendered through template interpolation with a conditional `<b>`.
- Add a `safeUrl()` helper in `lib/render` (http(s) and relative URLs only, built on the existing `isSafeHref`) and run both user-URL `:href`s through it — Vue drops the attribute entirely when it returns null.
- Turn on Papa Parse's `escapeFormulae` in `turnEntriesToCsvString`, the single choke point all exports go through: dangerous cells get prefixed with `'` so spreadsheets treat them as text.
- Skip Crisp entirely on `/playlists/shared/`, and scrub the share token from everything Sentry sends (`beforeSend` and `beforeSendTransaction`: request URL, transaction name, breadcrumb from/to/url).
- Lock it down with specs: formula-injection tests for `lib/csv` (new file) and `safeUrl` accept/reject tests in the render spec.

Full suite green: 972 tests passing.