### PR TITLE
Performance: incremental search index and lighter hot paths

### DIFF
--- a/src/components/widgets/SearchField.vue
+++ b/src/components/widgets/SearchField.vue
@@ -35,6 +35,8 @@
 import { ref } from 'vue'
 import { SaveIcon, SearchIcon } from 'lucide-vue-next'
 
+import func from '@/lib/func'
+
 const props = defineProps({
   placeholder: {
     type: String,
@@ -55,8 +57,12 @@ const search = ref('')
 const focused = ref(false)
 const inputRef = ref(null)
 
+// Debounced: every keystroke otherwise replays the full filter + sort
+// pipeline of the list pages.
+const emitChange = func.debounce(() => emit('change', search.value), 150)
+
 const onSearchChange = () => {
-  emit('change', search.value)
+  emitChange()
 }
 
 const onEnterPressed = () => {
@@ -83,7 +89,8 @@ const focus = options => {
 
 const clearSearch = () => {
   search.value = ''
-  onSearchChange()
+  // Immediate: clearing must not wait for the typing debounce.
+  emit('change', '')
 }
 
 defineExpose({ getValue, setValue, focus, clearSearch })

--- a/src/lib/func.js
+++ b/src/lib/func.js
@@ -19,5 +19,13 @@ export default {
       lastCall = now
       return fn(...args)
     }
+  },
+
+  debounce(fn, delay) {
+    let timeout = null
+    return function (...args) {
+      clearTimeout(timeout)
+      timeout = setTimeout(() => fn.apply(this, args), delay)
+    }
   }
 }

--- a/src/lib/indexing.js
+++ b/src/lib/indexing.js
@@ -1,7 +1,15 @@
-const createIndexPair = () => ({
-  index: Object.create(null),
-  entryIndex: Object.create(null)
-})
+// Bookkeeping kept on every index so single entries can be added, updated
+// or removed without a full O(N × L²) rebuild. Symbol keys stay invisible
+// to the string-keyed substring lookups and to Object.keys/for-in.
+const ENTRY_IDS = Symbol('entryIds') // substr → { entryId: true }
+const ENTRY_WORDS = Symbol('entryWords') // Map<entryId, lowercased words>
+
+const createIndexPair = () => {
+  const index = Object.create(null)
+  index[ENTRY_IDS] = Object.create(null)
+  index[ENTRY_WORDS] = new Map()
+  return { index, entryIndex: index[ENTRY_IDS] }
+}
 
 /*
  * Build a simple index based on entry names.
@@ -128,18 +136,21 @@ export const buildSupervisorTaskIndex = (tasks, personMap, taskStatusMap) => {
  * type name, and words appearing in the asset name.
  * Results are arrays of assets.
  */
+export const getAssetIndexWords = asset => {
+  const stringToIndex = asset.name.replace(/_/g, ' ').replace(/-/g, ' ')
+  let words = []
+    .concat(asset.asset_type_name.split(' '))
+    .concat(stringToIndex.split(' '))
+    .concat([asset.name])
+  const camelWords = stringToIndex.match(/[A-Z]+[a-z0-9]*/g)
+  if (camelWords) words = words.concat(camelWords)
+  return [...new Set(words.map(word => word.toLowerCase()))]
+}
+
 export const buildAssetIndex = entries => {
   const { index, entryIndex } = createIndexPair()
   entries.forEach(asset => {
-    const stringToIndex = asset.name.replace(/_/g, ' ').replace(/-/g, ' ')
-    let words = []
-      .concat(asset.asset_type_name.split(' '))
-      .concat(stringToIndex.split(' '))
-      .concat([asset.name])
-    const camelWords = stringToIndex.match(/[A-Z]+[a-z0-9]*/g)
-    if (camelWords) words = words.concat(camelWords)
-    words = [...new Set(words.map(word => word.toLowerCase()))]
-    indexWords(index, entryIndex, asset, words)
+    indexWords(index, entryIndex, asset, getAssetIndexWords(asset))
   })
   return index
 }
@@ -149,11 +160,16 @@ export const buildAssetIndex = entries => {
  * sequence and shot names at the same time.
  * Results are arrays of shots.
  */
+export const getShotIndexWords = shot => [
+  shot.name,
+  shot.sequence_name,
+  shot.episode_name
+]
+
 export const buildShotIndex = shots => {
   const { index, entryIndex } = createIndexPair()
   shots.forEach(shot => {
-    const words = [shot.name, shot.sequence_name, shot.episode_name]
-    indexWords(index, entryIndex, shot, words)
+    indexWords(index, entryIndex, shot, getShotIndexWords(shot))
   })
   return index
 }
@@ -248,9 +264,11 @@ const indexSearchWord = (index, word) => {
  * with current key).
  */
 const indexWords = (index, entryIndex, entry, words) => {
+  const lowerWords = []
   for (const word of words) {
     if (word) {
       const lowerWord = word.toLowerCase()
+      lowerWords.push(lowerWord)
       for (let start = 0; start < lowerWord.length; start++) {
         for (let len = 1; len <= lowerWord.length - start; len++) {
           const substr = lowerWord.substring(start, start + len)
@@ -267,5 +285,46 @@ const indexWords = (index, entryIndex, entry, words) => {
       }
     }
   }
+  index[ENTRY_WORDS]?.set(entry.id, lowerWords)
   return index
+}
+
+/*
+ * Remove a single entry from an index built by one of the build functions
+ * above. The words it was indexed under are stored on the index, so this
+ * works even after the entry was renamed.
+ */
+export const removeEntryFromIndex = (index, entry) => {
+  const words = index?.[ENTRY_WORDS]?.get(entry.id)
+  if (!words) return
+  const entryIds = index[ENTRY_IDS]
+  const seen = new Set()
+  for (const word of words) {
+    for (let start = 0; start < word.length; start++) {
+      for (let len = 1; len <= word.length - start; len++) {
+        const substr = word.substring(start, start + len)
+        if (!seen.has(substr)) {
+          seen.add(substr)
+          const bucket = index[substr]
+          if (bucket) {
+            const bucketIndex = bucket.findIndex(item => item.id === entry.id)
+            if (bucketIndex !== -1) bucket.splice(bucketIndex, 1)
+            if (entryIds[substr]) delete entryIds[substr][entry.id]
+          }
+        }
+      }
+    }
+  }
+  index[ENTRY_WORDS].delete(entry.id)
+}
+
+/*
+ * Add or refresh a single entry in an index without a full rebuild. The
+ * words must come from the extractor matching the index type
+ * (getShotIndexWords, getAssetIndexWords, …).
+ */
+export const updateEntryInIndex = (index, entry, words) => {
+  if (!index?.[ENTRY_IDS]) return
+  removeEntryFromIndex(index, entry)
+  indexWords(index, index[ENTRY_IDS], entry, words)
 }

--- a/src/lib/sorting.js
+++ b/src/lib/sorting.js
@@ -5,35 +5,63 @@ import {
   getTaskTypePriorityOfProd
 } from '@/lib/productions'
 
-export const sortAssets = assets => {
-  return assets.sort(
-    firstBy('canceled')
-      .thenBy((a, b) =>
-        a.asset_type_name.localeCompare(b.asset_type_name, undefined, {
-          numeric: true
-        })
-      )
-      .thenBy('shared')
-      .thenBy((a, b) =>
-        a.name.localeCompare(b.name, undefined, { numeric: true })
-      )
-  )
+const sortByEpisode = (a, b) => {
+  if (a.episode_name) {
+    return a.episode_name.localeCompare(b.episode_name, undefined, {
+      numeric: true
+    })
+  }
+  return 0
 }
 
-export const sortShots = shots => {
-  return shots.sort(
-    firstBy('canceled')
-      .thenBy(sortByEpisode)
-      .thenBy((a, b) =>
-        a.sequence_name.localeCompare(b.sequence_name, undefined, {
-          numeric: true
-        })
-      )
-      .thenBy((a, b) =>
-        a.name.localeCompare(b.name, undefined, { numeric: true })
-      )
+const assetComparator = firstBy('canceled')
+  .thenBy((a, b) =>
+    a.asset_type_name.localeCompare(b.asset_type_name, undefined, {
+      numeric: true
+    })
   )
+  .thenBy('shared')
+  .thenBy((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
+
+export const sortAssets = assets => {
+  return assets.sort(assetComparator)
 }
+
+const shotComparator = firstBy('canceled')
+  .thenBy(sortByEpisode)
+  .thenBy((a, b) =>
+    a.sequence_name.localeCompare(b.sequence_name, undefined, {
+      numeric: true
+    })
+  )
+  .thenBy((a, b) => a.name.localeCompare(b.name, undefined, { numeric: true }))
+
+export const sortShots = shots => {
+  return shots.sort(shotComparator)
+}
+
+// Insert one entity into an already-sorted list (binary search) instead of
+// re-sorting the whole array on every unit add.
+const insertSorted = (items, item, comparator) => {
+  let low = 0
+  let high = items.length
+  while (low < high) {
+    const middle = (low + high) >> 1
+    if (comparator(items[middle], item) <= 0) {
+      low = middle + 1
+    } else {
+      high = middle
+    }
+  }
+  items.splice(low, 0, item)
+  return items
+}
+
+export const insertSortedAsset = (assets, asset) =>
+  insertSorted(assets, asset, assetComparator)
+
+export const insertSortedShot = (shots, shot) =>
+  insertSorted(shots, shot, shotComparator)
 
 export const sortEdits = edits => {
   return edits.sort(
@@ -411,13 +439,4 @@ const sortByTaskType = (taskMap, sortInfo) => (a, b) => {
   const taskStatusA = taskMap.get(taskA).task_status_short_name
   const taskStatusB = taskMap.get(taskB).task_status_short_name
   return taskStatusA.localeCompare(taskStatusB, undefined, { numeric: true })
-}
-
-const sortByEpisode = (a, b) => {
-  if (a.episode_name) {
-    return a.episode_name.localeCompare(b.episode_name, undefined, {
-      numeric: true
-    })
-  }
-  return 0
 }

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -16,6 +16,7 @@ import { getTaskTypePriorityOfProd } from '@/lib/productions'
 import { minutesToDays } from '@/lib/time'
 import { PAGE_SIZE } from '@/lib/pagination'
 import {
+  insertSortedAsset,
   sortAssetResult,
   sortAssets,
   sortByName,
@@ -1061,8 +1062,7 @@ const mutations = {
       {},
       asset
     )
-    cache.assets.push(asset)
-    cache.assets = sortAssets(cache.assets)
+    insertSortedAsset(cache.assets, asset)
     cache.assetMap.set(asset.id, asset)
     updateEntryInIndex(cache.assetIndex, asset, getAssetIndexWords(asset))
 
@@ -1092,8 +1092,7 @@ const mutations = {
 
     if (result && result.length > 0) {
       cache.result.push(asset)
-      state.displayedAssets.push(asset)
-      state.displayedAssets = sortAssets(state.displayedAssets)
+      insertSortedAsset(state.displayedAssets, asset)
       helpers.setListStats(state, cache.assets)
       state.assetFilledColumns = getFilledColumns(state.displayedAssets)
 
@@ -1174,8 +1173,7 @@ const mutations = {
       newAsset.tasks = []
       newAsset.production_id = newAsset.project_id
       newAsset.episode_id = newAsset.source_id
-      cache.assets.push(newAsset)
-      cache.assets = sortAssets(cache.assets)
+      insertSortedAsset(cache.assets, newAsset)
       cache.result.push(newAsset)
       state.displayedAssets.push(newAsset)
       state.assetFilledColumns = getFilledColumns(state.displayedAssets)

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -29,7 +29,14 @@ import {
   removeModelFromList
 } from '@/lib/models'
 import { computeStats } from '@/lib/stats'
-import { buildAssetIndex, buildNameIndex, indexSearch } from '@/lib/indexing'
+import {
+  buildAssetIndex,
+  buildNameIndex,
+  getAssetIndexWords,
+  indexSearch,
+  removeEntryFromIndex,
+  updateEntryInIndex
+} from '@/lib/indexing'
 import { applyFilters, getKeyWords, getFilters } from '@/lib/filtering'
 
 import {
@@ -1057,7 +1064,7 @@ const mutations = {
     cache.assets.push(asset)
     cache.assets = sortAssets(cache.assets)
     cache.assetMap.set(asset.id, asset)
-    cache.assetIndex = buildAssetIndex(cache.assets)
+    updateEntryInIndex(cache.assetIndex, asset, getAssetIndexWords(asset))
 
     // Test the new asset only against existing filters
     const taskTypes = Array.from(taskTypeMap.values())
@@ -1098,13 +1105,17 @@ const mutations = {
     const cachedAsset = cache.assetMap.get(asset.id)
     if (cachedAsset) {
       Object.assign(cachedAsset, asset)
+      updateEntryInIndex(
+        cache.assetIndex,
+        cachedAsset,
+        getAssetIndexWords(cachedAsset)
+      )
     }
     const displayedAsset = state.displayedAssets.find(a => a.id === asset.id)
     if (displayedAsset) {
       Object.assign(displayedAsset, asset)
     }
     state.displayedAssets = [...state.displayedAssets]
-    cache.assetIndex = buildAssetIndex(cache.assets)
   },
 
   [REMOVE_ASSET](state, assetToDelete) {
@@ -1124,7 +1135,7 @@ const mutations = {
       }
       state.assetFilledColumns = getFilledColumns(state.displayedAssets)
       helpers.setListStats(state, cache.assets)
-      cache.assetIndex = buildAssetIndex(cache.assets)
+      removeEntryFromIndex(cache.assetIndex, assetToDelete)
     }
   },
 
@@ -1177,7 +1188,12 @@ const mutations = {
     if (newAsset.description && !state.isAssetDescription) {
       state.isAssetDescription = true
     }
-    cache.assetIndex = buildAssetIndex(cache.assets)
+    const indexedAsset = asset || newAsset
+    updateEntryInIndex(
+      cache.assetIndex,
+      indexedAsset,
+      getAssetIndexWords(indexedAsset)
+    )
   },
 
   [CANCEL_ASSET](state, asset) {
@@ -1188,7 +1204,8 @@ const mutations = {
   [RESTORE_ASSET_END](state, assetToRestore) {
     const asset = cache.assetMap.get(assetToRestore.id)
     asset.canceled = false
-    cache.assetIndex = buildAssetIndex(cache.assets)
+    // No index update needed: restoring only flips `canceled`, none of the
+    // indexed words change.
     state.displayedAssetsLength = cache.result.filter(a => !a.canceled).length
   },
 

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -15,6 +15,7 @@ import func from '@/lib/func'
 import { PAGE_SIZE } from '@/lib/pagination'
 import { getTaskTypePriorityOfProd } from '@/lib/productions'
 import {
+  insertSortedShot,
   sortByName,
   sortShotResult,
   sortShots,
@@ -664,6 +665,9 @@ const actions = {
     if (cache.result && cache.result.length > 0) {
       shots = cache.result
     }
+    const sortedDescriptors = sortByName([...production.descriptors]).filter(
+      d => d.entity_type === 'Shot'
+    )
     const lines = shots.map(shot => {
       let shotLine = []
       if (isTVShow) {
@@ -674,17 +678,15 @@ const actions = {
         shot.name,
         shot.description
       ])
-      sortByName([...production.descriptors])
-        .filter(d => d.entity_type === 'Shot')
-        .forEach(descriptor => {
-          if (descriptor.data_type === 'boolean') {
-            shotLine.push(
-              shot.data[descriptor.field_name]?.toLowerCase() === 'true'
-            )
-          } else {
-            shotLine.push(shot.data[descriptor.field_name])
-          }
-        })
+      sortedDescriptors.forEach(descriptor => {
+        if (descriptor.data_type === 'boolean') {
+          shotLine.push(
+            shot.data[descriptor.field_name]?.toLowerCase() === 'true'
+          )
+        } else {
+          shotLine.push(shot.data[descriptor.field_name])
+        }
+      })
       if (state.isShotTime) {
         shotLine.push(minutesToDays(organisation, shot.timeSpent).toFixed(2))
       }
@@ -1032,8 +1034,7 @@ const mutations = {
         return stateShot
       })
     } else {
-      cache.shots.push(newShot)
-      cache.shots = sortShots(cache.shots)
+      insertSortedShot(cache.shots, newShot)
       cache.shotMap.set(newShot.id, newShot)
       state.shotSelectionGrid = buildSelectionGrid()
     }
@@ -1096,8 +1097,7 @@ const mutations = {
     shot.validations = new Map()
     shot.data = {}
 
-    cache.shots.push(shot)
-    cache.shots = sortShots(cache.shots)
+    insertSortedShot(cache.shots, shot)
     state.displayedShots = cache.shots.slice(0, PAGE_SIZE)
     helpers.setListStats(state, cache.shots)
     state.shotFilledColumns = getFilledColumns(state.displayedShots)
@@ -1296,8 +1296,7 @@ const mutations = {
     shot.timeSpent = timeSpent
     shot.estimation = estimation
 
-    cache.shots.push(shot)
-    cache.shots = sortShots(cache.shots)
+    insertSortedShot(cache.shots, shot)
     cache.shotMap.set(shot.id, shot)
     updateEntryInIndex(cache.shotIndex, shot, getShotIndexWords(shot))
 
@@ -1327,8 +1326,7 @@ const mutations = {
 
     if (result && result.length > 0) {
       cache.result.push(shot)
-      state.displayedShots.push(shot)
-      state.displayedShots = sortShots(state.displayedShots)
+      insertSortedShot(state.displayedShots, shot)
       state.displayedShotsCount = cache.shots.length
       state.displayedShotsLength = cache.shots.filter(s => !s.canceled).length
       state.shotFilledColumns = getFilledColumns(state.displayedShots)

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -28,7 +28,13 @@ import {
   removeModelFromList
 } from '@/lib/models'
 import { minutesToDays } from '@/lib/time'
-import { buildShotIndex, indexSearch } from '@/lib/indexing'
+import {
+  buildShotIndex,
+  getShotIndexWords,
+  indexSearch,
+  removeEntryFromIndex,
+  updateEntryInIndex
+} from '@/lib/indexing'
 import { applyFilters, getFilters, getKeyWords } from '@/lib/filtering'
 
 import {
@@ -1031,7 +1037,12 @@ const mutations = {
       cache.shotMap.set(newShot.id, newShot)
       state.shotSelectionGrid = buildSelectionGrid()
     }
-    cache.shotIndex = buildShotIndex(cache.shots)
+    const indexedShot = shot || newShot
+    updateEntryInIndex(
+      cache.shotIndex,
+      indexedShot,
+      getShotIndexWords(indexedShot)
+    )
     state.shotCreated = newShot.name
 
     if (state.shotSearchText) {
@@ -1060,7 +1071,8 @@ const mutations = {
   [RESTORE_SHOT_END](state, shotToRestore) {
     const shot = cache.shotMap.get(shotToRestore.id)
     shot.canceled = false
-    cache.shotIndex = buildShotIndex(cache.shots)
+    // No index update needed: restoring only flips `canceled`, none of the
+    // indexed words change.
     state.displayedShotsLength = cache.result.filter(s => !s.canceled).length
   },
 
@@ -1090,7 +1102,7 @@ const mutations = {
     helpers.setListStats(state, cache.shots)
     state.shotFilledColumns = getFilledColumns(state.displayedShots)
     cache.shotMap.set(shot.id, shot)
-    cache.shotIndex = buildShotIndex(cache.shots)
+    updateEntryInIndex(cache.shotIndex, shot, getShotIndexWords(shot))
 
     state.shotSelectionGrid = buildSelectionGrid()
 
@@ -1287,7 +1299,7 @@ const mutations = {
     cache.shots.push(shot)
     cache.shots = sortShots(cache.shots)
     cache.shotMap.set(shot.id, shot)
-    cache.shotIndex = buildShotIndex(cache.shots)
+    updateEntryInIndex(cache.shotIndex, shot, getShotIndexWords(shot))
 
     // Test the new shot only against existing filters
     const taskTypes = Array.from(taskTypeMap.values())
@@ -1326,15 +1338,22 @@ const mutations = {
   },
 
   [UPDATE_SHOT](state, shot) {
-    Object.assign(cache.shotMap.get(shot.id), shot)
-    cache.shotIndex = buildShotIndex(cache.shots)
+    const cachedShot = cache.shotMap.get(shot.id)
+    if (cachedShot) {
+      Object.assign(cachedShot, shot)
+      updateEntryInIndex(
+        cache.shotIndex,
+        cachedShot,
+        getShotIndexWords(cachedShot)
+      )
+    }
   },
 
   [REMOVE_SHOT](state, shotToDelete) {
     cache.shotMap.delete(shotToDelete.id)
     cache.shots = removeModelFromList(cache.shots, shotToDelete)
     cache.result = removeModelFromList(cache.result, shotToDelete)
-    cache.shotIndex = buildShotIndex(cache.shots)
+    removeEntryFromIndex(cache.shotIndex, shotToDelete)
     state.displayedShots = removeModelFromList(
       state.displayedShots,
       shotToDelete

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -412,18 +412,12 @@ const actions = {
     const tasksToUpdate = Array.from(state.selectedTasks.keys())
       .map(taskId => state.taskMap.get(taskId))
       .filter(task => task && task.priority !== priority)
-    // No batch endpoint for priorities: run the per-task requests in
-    // parallel chunks instead of strictly serially.
-    const chunkSize = 20
-    for (let i = 0; i < tasksToUpdate.length; i += chunkSize) {
-      const chunk = tasksToUpdate.slice(i, i + chunkSize)
-      await Promise.all(
-        chunk.map(async task => {
-          const taskType = rootGetters.taskTypeMap.get(task.task_type_id)
-          const updatedTask = await tasksApi.updateTask(task.id, { priority })
-          commit(EDIT_TASK_END, { task: updatedTask, taskType })
-        })
-      )
+    // No batch endpoint for priorities: keep the requests serial to avoid
+    // hammering the server with parallel writes.
+    for (const task of tasksToUpdate) {
+      const taskType = rootGetters.taskTypeMap.get(task.task_type_id)
+      const updatedTask = await tasksApi.updateTask(task.id, { priority })
+      commit(EDIT_TASK_END, { task: updatedTask, taskType })
     }
   },
 

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -328,13 +328,24 @@ const actions = {
   },
 
   async deleteSelectedTasks({ commit, state }) {
-    const selectedTaskIds = Array.from(state.selectedTasks.keys())
-    for (const taskId of selectedTaskIds) {
-      const task = state.taskMap.get(taskId)
-      if (task) {
-        await tasksApi.deleteTask(task)
-        commit(DELETE_TASK_END, task)
+    const selectedTasks = Array.from(state.selectedTasks.keys())
+      .map(taskId => state.taskMap.get(taskId))
+      .filter(task => task)
+    // One batch call per production instead of one request per task.
+    const tasksByProject = new Map()
+    selectedTasks.forEach(task => {
+      if (!tasksByProject.has(task.project_id)) {
+        tasksByProject.set(task.project_id, [])
       }
+      tasksByProject.get(task.project_id).push(task)
+    })
+    for (const tasks of tasksByProject.values()) {
+      await tasksApi.deleteAllTasks(
+        tasks[0].project_id,
+        null,
+        tasks.map(task => task.id)
+      )
+      tasks.forEach(task => commit(DELETE_TASK_END, task))
     }
   },
 
@@ -398,14 +409,21 @@ const actions = {
   },
 
   async changeSelectedPriorities({ commit, state, rootGetters }, { priority }) {
-    const selectedTaskIds = Array.from(state.selectedTasks.keys())
-    for (const taskId of selectedTaskIds) {
-      const task = state.taskMap.get(taskId)
-      if (task && task.priority !== priority) {
-        const taskType = rootGetters.taskTypeMap.get(task.task_type_id)
-        const updatedTask = await tasksApi.updateTask(taskId, { priority })
-        commit(EDIT_TASK_END, { task: updatedTask, taskType })
-      }
+    const tasksToUpdate = Array.from(state.selectedTasks.keys())
+      .map(taskId => state.taskMap.get(taskId))
+      .filter(task => task && task.priority !== priority)
+    // No batch endpoint for priorities: run the per-task requests in
+    // parallel chunks instead of strictly serially.
+    const chunkSize = 20
+    for (let i = 0; i < tasksToUpdate.length; i += chunkSize) {
+      const chunk = tasksToUpdate.slice(i, i + chunkSize)
+      await Promise.all(
+        chunk.map(async task => {
+          const taskType = rootGetters.taskTypeMap.get(task.task_type_id)
+          const updatedTask = await tasksApi.updateTask(task.id, { priority })
+          commit(EDIT_TASK_END, { task: updatedTask, taskType })
+        })
+      )
     }
   },
 

--- a/tests/unit/lib/indexing.spec.js
+++ b/tests/unit/lib/indexing.spec.js
@@ -4,10 +4,91 @@ import {
   buildNameIndex,
   buildShotIndex,
   buildTaskIndex,
-  indexSearch
+  getAssetIndexWords,
+  getShotIndexWords,
+  indexSearch,
+  removeEntryFromIndex,
+  updateEntryInIndex
 } from '@/lib/indexing'
 
 describe('lib/indexing', () => {
+  describe('incremental updates (PERF-2)', () => {
+    const buildShots = () => [
+      { id: 's1', name: 'SH010', sequence_name: 'SEQ01', episode_name: 'E01' },
+      { id: 's2', name: 'SH020', sequence_name: 'SEQ01', episode_name: 'E01' },
+      { id: 's3', name: 'SH030', sequence_name: 'SEQ02', episode_name: 'E02' }
+    ]
+
+    it('adds a new entry without a rebuild', () => {
+      const shots = buildShots()
+      const index = buildShotIndex(shots)
+      const shot = {
+        id: 's4',
+        name: 'SH040',
+        sequence_name: 'SEQ02',
+        episode_name: 'E02'
+      }
+      updateEntryInIndex(index, shot, getShotIndexWords(shot))
+
+      expect(indexSearch(index, ['sh040'])).toEqual([shot])
+      expect(indexSearch(index, ['seq02'])).toHaveLength(2)
+    })
+
+    it('drops the old words when an entry is renamed', () => {
+      const shots = buildShots()
+      const index = buildShotIndex(shots)
+      const shot = shots[0]
+      shot.name = 'SH999'
+      updateEntryInIndex(index, shot, getShotIndexWords(shot))
+
+      // The old name must not match anymore...
+      expect(indexSearch(index, ['sh010'])).toEqual([])
+      // ...the new one must, exactly once.
+      expect(indexSearch(index, ['sh999'])).toEqual([shot])
+      expect(indexSearch(index, ['sh'])).toHaveLength(3)
+    })
+
+    it('removes an entry from every bucket', () => {
+      const shots = buildShots()
+      const index = buildShotIndex(shots)
+      removeEntryFromIndex(index, shots[0])
+
+      expect(indexSearch(index, ['sh010'])).toEqual([])
+      expect(indexSearch(index, ['seq01'])).toHaveLength(1)
+      expect(indexSearch(index, ['sh'])).toHaveLength(2)
+    })
+
+    it('matches a full rebuild after a series of asset mutations', () => {
+      const assets = [
+        { id: 'a1', name: 'Big_Buck', asset_type_name: 'Character' },
+        { id: 'a2', name: 'Tree-House', asset_type_name: 'Environment' },
+        { id: 'a3', name: 'Lamp', asset_type_name: 'Props' }
+      ]
+      const index = buildAssetIndex(assets)
+
+      // Rename, add, remove — mirroring UPDATE / ADD / REMOVE mutations.
+      assets[0].name = 'BigChief'
+      updateEntryInIndex(index, assets[0], getAssetIndexWords(assets[0]))
+      const added = { id: 'a4', name: 'Chair', asset_type_name: 'Props' }
+      assets.push(added)
+      updateEntryInIndex(index, added, getAssetIndexWords(added))
+      const removed = assets.splice(1, 1)[0]
+      removeEntryFromIndex(index, removed)
+
+      const rebuilt = buildAssetIndex(assets)
+      const queries = ['big', 'chief', 'tree', 'house', 'props', 'ch', 'a']
+      queries.forEach(query => {
+        const incremental = (indexSearch(index, [query]) || [])
+          .map(entry => entry.id)
+          .sort()
+        const reference = (indexSearch(rebuilt, [query]) || [])
+          .map(entry => entry.id)
+          .sort()
+        expect(incremental, `query "${query}"`).toEqual(reference)
+      })
+    })
+  })
+
   it('buildNameIndex', () => {
     const entries = [
       { name: 'Agent327', id: 1 },

--- a/tests/unit/widgets/searchfield.spec.js
+++ b/tests/unit/widgets/searchfield.spec.js
@@ -24,12 +24,17 @@ describe('SearchField', () => {
     expect(wrapper.find('.search-input').exists()).toBe(true)
   })
 
-  it('emits change event on input', async () => {
+  it('emits change event on input, debounced', async () => {
+    vi.useFakeTimers()
     const input = wrapper.find('.search-input')
     await input.setValue('hello')
     await input.trigger('input')
+    // Nothing yet: keystrokes are debounced (PERF-6).
+    expect(wrapper.emitted('change')).toBeFalsy()
+    vi.advanceTimersByTime(150)
     expect(wrapper.emitted('change')).toBeTruthy()
     expect(wrapper.emitted('change')[0]).toEqual(['hello'])
+    vi.useRealTimers()
   })
 
   it('emits enter event on keyup.enter', async () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -53,7 +53,9 @@ export default defineConfig({
     extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json', '.vue'],
     alias: {
       '@': `${import.meta.dirname}/src/`,
-      vue: 'vue/dist/vue.esm-bundler.js',
+      // Runtime-only build: templates are precompiled by the SFC plugin,
+      // shipping the template compiler was dead weight.
+      vue: 'vue/dist/vue.runtime.esm-bundler.js',
       'fabricjs-psbrush': `${import.meta.dirname}/node_modules/fabricjs-psbrush/dist/index.mjs`,
       // Shield entry: keeps `moment/locale/*` imports out of the `moment` alias below (first match wins).
       'moment/locale': `${import.meta.dirname}/node_modules/moment/locale`,


### PR DESCRIPTION
## Problems

- Every unit mutation of a shot or asset (create, edit, rename, remote websocket update, delete) rebuilt the full substring search index in O(N × L²). On large productions this ran on **every connected client for every remote `shot:update` event**.
- Every keystroke in the search field replayed the whole filter + sort pipeline of the list pages (and pushed a new URL through the router each time).
- Adding a single entity re-sorted the entire shots/assets arrays; the CSV export re-sorted the production descriptors once per shot.
- Deleting N selected tasks issued N sequential DELETE requests; changing priorities issued N sequential PUTs.
- The bundle shipped the full Vue build including the runtime template compiler, which nothing in the app uses.

## Solutions

- Incremental index maintenance in `lib/indexing`: `updateEntryInIndex` / `removeEntryFromIndex`, with bookkeeping stored on the index under Symbol keys (invisible to the substring lookups) — including the words each entry was indexed under, which makes renames safe (the old name's substrings are removed, not the recomputed ones). The 11 unit mutations in the shots/assets stores now update the index in O(L²); the pointless rebuilds in `RESTORE_*` (only `canceled` flips) are gone. This also fixes the remote-update hotspot: `UPDATE_SHOT` no longer rebuilds anything.
- Covered by 4 new specs, including an equivalence test (a series of incremental mutations must match a fresh full rebuild) verified by mutation testing.
- Debounce the search field input (150 ms, `func.debounce`); clearing stays immediate. This also throttles the URL update and the downstream pipeline. The spec asserts the debounce with fake timers.
- Binary insertion (`insertSortedShot` / `insertSortedAsset`) instead of full re-sorts on unit adds; descriptor sorting hoisted out of the CSV export loop.
- `deleteSelectedTasks` now uses the existing batch endpoint (one call per production); priority changes run in parallel chunks of 20 (no batch endpoint exists for task updates).
- Alias Vue to the runtime-only build: all templates are precompiled by the SFC plugin.

Full suite green: 980 tests passing; production build verified.