### PR TITLE
[players] Fix video sub-elements never playing in playlists

### DIFF
--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -2176,6 +2176,12 @@ const playEntity = (entityIndex, updateFullPlaylist = true, frame = -1) => {
       }
     })
   } else {
+    // Keep the video decoder on the selected entity even when its main
+    // preview is not a movie: switching to a video sub-element of a
+    // multi-element revision reloads from the decoder's current index.
+    nextTick(() => {
+      rawPlayer.value?.loadEntity(entityIndex, 0, true)
+    })
     const ann = getAnnotation(0)
     if (!isPlaying.value) loadAnnotation(ann)
     if (wasDrawing) {

--- a/src/components/players/viewers/MultiVideoViewer.vue
+++ b/src/components/players/viewers/MultiVideoViewer.vue
@@ -304,27 +304,22 @@ const emitLoadedEvent = event => {
   emit('metadata-loaded', event)
 }
 
-const getMoviePath = entity => {
-  if (entity.preview_file_extension === 'mp4') {
-    let previewId
-    if (
-      props.currentPreviewIndex === 0 ||
-      !entity.preview_file_previews ||
-      props.currentPreviewIndex > entity.preview_file_previews.length
-    ) {
-      previewId = entity.preview_file_id
-    } else {
-      previewId = entity.preview_file_previews[props.currentPreviewIndex - 1].id
-    }
-    const base = props.urlPrefix || '/api'
-    // Originals for shared links or HD mode; the lighter low variant otherwise
-    if (props.urlPrefix || props.isHd) {
-      return `${base}/movies/originals/preview-files/${previewId}.mp4`
-    } else {
-      return `${base}/movies/low/preview-files/${previewId}.mp4`
-    }
+const getMoviePath = (entity, previewIndex = 0) => {
+  // Check the extension on the element actually selected (main preview or
+  // one of the additional previews): a revision whose main element is a
+  // picture can still carry video elements, and vice versa.
+  const subPreviews = entity.preview_file_previews || []
+  const preview =
+    previewIndex > 0 && previewIndex <= subPreviews.length
+      ? subPreviews[previewIndex - 1]
+      : { id: entity.preview_file_id, extension: entity.preview_file_extension }
+  if (preview.extension !== 'mp4') return ''
+  const base = props.urlPrefix || '/api'
+  // Originals for shared links or HD mode; the lighter low variant otherwise
+  if (props.urlPrefix || props.isHd) {
+    return `${base}/movies/originals/preview-files/${preview.id}.mp4`
   } else {
-    return ''
+    return `${base}/movies/low/preview-files/${preview.id}.mp4`
   }
 }
 
@@ -416,8 +411,7 @@ const loadEntity = (index = 0, currentTime = 0, silentLoad = false) => {
     // Reuse the decoder that already holds the target movie (usually the
     // one that preloaded the next entity): swapping keeps its buffer
     // instead of re-downloading on every manual navigation.
-    const moviePath =
-      entity.preview_file_extension === 'mp4' ? getMoviePath(entity) : ''
+    const moviePath = getMoviePath(entity, props.currentPreviewIndex)
     const preloadedPlayer = [player1Ref.value, player2Ref.value].find(
       player => moviePath && player?.src.endsWith(moviePath)
     )
@@ -436,10 +430,8 @@ const loadEntity = (index = 0, currentTime = 0, silentLoad = false) => {
     } else if (currentPlayer.value) {
       currentPlayer.value.src = ''
     }
-    const nextMoviePath =
-      nextEntity?.preview_file_extension === 'mp4'
-        ? getMoviePath(nextEntity)
-        : ''
+    // The next entity always starts on its main preview: preload index 0.
+    const nextMoviePath = nextEntity ? getMoviePath(nextEntity) : ''
     if (nextMoviePath) {
       if (!nextPlayer.value.src.endsWith(nextMoviePath)) {
         nextPlayer.value.src = nextMoviePath

--- a/tests/unit/players/multivideoviewer.spec.js
+++ b/tests/unit/players/multivideoviewer.spec.js
@@ -146,6 +146,45 @@ describe('players/MultiVideoViewer (canvas pipeline)', () => {
     wrapper.unmount()
   })
 
+  it('loads the video sub-element of a picture-main revision (#2095)', async () => {
+    const store = createStore({
+      getters: { currentProduction: () => ({ fps: '25' }) }
+    })
+    const wrapper = mount(MultiVideoViewer, {
+      props: {
+        currentPreviewIndex: 0,
+        entities: [
+          {
+            id: 'e1',
+            preview_file_id: 'p1',
+            preview_file_extension: 'png',
+            preview_file_previews: [{ id: 'p1b', extension: 'mp4' }],
+            fps: 25
+          }
+        ],
+        name: 'main'
+      },
+      global: {
+        mocks: { $t: key => key },
+        plugins: [store]
+      }
+    })
+
+    // Main preview is a picture: no movie source (jsdom resolves an empty
+    // src to the document base URL, hence the negative assertion)
+    wrapper.vm.loadEntity(0)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.vm.currentPlayer.src).not.toContain('.mp4')
+
+    // Switching to the video sub-element must load its movie path
+    await wrapper.setProps({ currentPreviewIndex: 1 })
+    expect(wrapper.vm.currentPlayer.src).toContain(
+      '/movies/low/preview-files/p1b.mp4'
+    )
+
+    wrapper.unmount()
+  })
+
   it('does not emit frame-update from ticks while paused', async () => {
     const wrapper = mountViewer()
     wrapper.vm.loadEntity(0)


### PR DESCRIPTION
## Problems

- In the playlist player, a revision whose main element is a picture never plays its video elements: the movie path is gated on the main preview's extension, so the decoder gets an empty src and play() does nothing (fixes #2095).
- The decoder also stays on the previously loaded entity when the selected entity's main preview is not a movie, so a later sub-element switch reloads the wrong entity.

## Solutions

- MultiVideoViewer resolves the selected element (main or additional preview) before building the movie path and gates on that element's extension; the next-entity preload explicitly targets the main preview.
- PlaylistPlayer silently loads the selected entity into the decoder even when its main preview is not a movie.
- Regression test covering the picture-main + video sub-element case.