### PR TITLE
Revive dead tests, cover critical paths and enforce coverage floors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "@vitejs/plugin-vue": "6.0.7",
-        "@vitest/coverage-v8": "^4.1.9",
+        "@vitest/coverage-v8": "4.1.10",
         "@vue/compiler-sfc": "3.5.13",
         "@vue/test-utils": "2.4.11",
         "autoprefixer": "10.5.2",
@@ -2964,14 +2964,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
-      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.9",
+        "@vitest/utils": "4.1.10",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -2985,8 +2985,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.9",
-        "vitest": "4.1.9"
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
       "devDependencies": {
         "@eslint/js": "10.0.1",
         "@vitejs/plugin-vue": "6.0.7",
+        "@vitest/coverage-v8": "^4.1.9",
         "@vue/compiler-sfc": "3.5.13",
         "@vue/test-utils": "2.4.11",
         "autoprefixer": "10.5.2",
@@ -346,6 +347,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -2952,6 +2963,37 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.9",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -3608,6 +3650,35 @@
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ast-walker-scope": {
       "version": "0.9.0",
@@ -6563,6 +6634,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
@@ -6825,6 +6903,45 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -7826,6 +7943,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/marked": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@vitejs/plugin-vue": "6.0.7",
-    "@vitest/coverage-v8": "^4.1.9",
+    "@vitest/coverage-v8": "4.1.10",
     "@vue/compiler-sfc": "3.5.13",
     "@vue/test-utils": "2.4.11",
     "autoprefixer": "10.5.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "preview": "vite preview",
     "test": "npm run test:unit",
     "test:unit": "vitest tests/unit",
+    "test:coverage": "vitest run tests/unit --coverage",
     "prepare": "husky"
   },
   "dependencies": {
@@ -76,6 +77,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@vitejs/plugin-vue": "6.0.7",
+    "@vitest/coverage-v8": "^4.1.9",
     "@vue/compiler-sfc": "3.5.13",
     "@vue/test-utils": "2.4.11",
     "autoprefixer": "10.5.2",

--- a/tests/unit/lib/sorting.spec.js
+++ b/tests/unit/lib/sorting.spec.js
@@ -551,31 +551,32 @@ describe('lib/sorting', () => {
       }
     ]
     const sortingMetadata = [
-      { type: 'metadata', column: 'valid' }
+      { type: 'metadata', column: 'metadata1', data_type: 'string' }
     ]
     const sortingTaskType = [
-      { type: 'task_type', column: 'metadata1' }
+      { type: 'task_type', column: 'valid' }
     ]
+    // task2 sorts before task1 so the task-type order differs from the
+    // metadata one: a comparator mix-up cannot pass both assertions.
     const taskMap = new Map()
-    taskMap.set('task1', { task_status_short_name: 'status A' })
-    taskMap.set('task2', { task_status_short_name: 'status B' })
-    sortAssetResult(entries, sortingMetadata, taskTypeMap, taskMap)
-    sortAssetResult(entries, sortingTaskType, taskTypeMap, taskMap)
-    /*
-    expect(resultsMetadata).toHaveLength(5)
-    expect(resultsMetadata[0].id).toEqual(5)
-    expect(resultsMetadata[1].id).toEqual(4)
-    expect(resultsMetadata[2].id).toEqual(3)
-    expect(resultsMetadata[3].id).toEqual(2)
-    expect(resultsMetadata[4].id).toEqual(1)
+    taskMap.set('task1', { task_status_short_name: 'status Z' })
+    taskMap.set('task2', { task_status_short_name: 'status A' })
 
-    expect(resultsTaskTypes).toHaveLength(5)
-    expect(resultsTaskTypes[0].id).toEqual(5)
-    expect(resultsTaskTypes[1].id).toEqual(4)
-    expect(resultsTaskTypes[2].id).toEqual(3)
-    expect(resultsTaskTypes[3].id).toEqual(2)
-    expect(resultsTaskTypes[4].id).toEqual(1)
-    */
+    const resultsMetadata = sortAssetResult(
+      entries,
+      sortingMetadata,
+      taskTypeMap,
+      taskMap
+    )
+    expect(resultsMetadata.map(entry => entry.id)).toEqual([5, 4, 3, 2, 1])
+
+    const resultsTaskTypes = sortAssetResult(
+      entries,
+      sortingTaskType,
+      taskTypeMap,
+      taskMap
+    )
+    expect(resultsTaskTypes.map(entry => entry.id)).toEqual([5, 3, 2, 1, 4])
   })
 
   it('sortShotResult', () => {
@@ -645,19 +646,20 @@ describe('lib/sorting', () => {
       ['task1', { task_status_short_name: 'status A' }],
       ['task2', { task_status_short_name: 'status B' }]
     ])
-    sortShotResult(entries, sortingMetadata, taskTypeMap, taskMap)
-    const resultsTaskTypes =
-      sortShotResult(entries, sortingTaskType, taskTypeMap, taskMap)
-    /*
-    expect(resultsMetadata).toHaveLength(6)
-    expect(resultsMetadata[0].id).toEqual(5)
-    expect(resultsMetadata[1].id).toEqual(4)
-    expect(resultsMetadata[2].id).toEqual(6)
-    expect(resultsMetadata[3].id).toEqual(3)
-    expect(resultsMetadata[4].id).toEqual(1)
-    expect(resultsMetadata[5].id).toEqual(3)
-    */
+    const resultsMetadata = sortShotResult(
+      entries,
+      sortingMetadata,
+      taskTypeMap,
+      taskMap
+    )
+    expect(resultsMetadata.map(entry => entry.id)).toEqual([5, 4, 6, 1, 3, 2])
 
+    const resultsTaskTypes = sortShotResult(
+      entries,
+      sortingTaskType,
+      taskTypeMap,
+      taskMap
+    )
     expect(resultsTaskTypes).toHaveLength(6)
     expect(resultsTaskTypes[0].id).toEqual(5)
     expect(resultsTaskTypes[1].id).toEqual(4)

--- a/tests/unit/lib/time.spec.js
+++ b/tests/unit/lib/time.spec.js
@@ -3,12 +3,14 @@ import {
   addBusinessDays,
   daysToMinutes,
   formatDate,
+  formatDuration,
   formatFullDate,
   formatFullDateWithTimezone,
   formatFullDateWithRevertedTimezone,
   formatSimpleDate,
   hoursToDays,
   getBusinessDays,
+  getDayOffRange,
   getDayRange,
   getDatesFromEndDate,
   getDatesFromStartDate,
@@ -27,6 +29,17 @@ import {
 } from '@/lib/time'
 
 describe('time', () => {
+  // Several helpers read the real clock (moment().week(), moment().date());
+  // freeze it so expectations are literals instead of clock-dependent.
+  beforeAll(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2019-09-10T12:00:00Z'))
+  })
+
+  afterAll(() => {
+    vi.useRealTimers()
+  })
+
   test('range', () => {
     expect(range(1, 10)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     expect(range(1, -1)).toEqual([])
@@ -41,12 +54,8 @@ describe('time', () => {
     expect(date.toString()).toEqual(
       moment.tz('2019-09-01', 'UTC').toString()
     )
-    /*
     date = parseSimpleDate(null)
-    expect(formatSimpleDate(date)).toEqual(
-      formatSimpleDate(new Date())
-    )
-    */
+    expect(formatSimpleDate(date)).toEqual('2019-09-10')
   })
 
   test('formatSimpleDate', () => {
@@ -103,13 +112,14 @@ describe('time', () => {
 
   test('getWeekRange', () => {
     expect(getWeekRange(2018, 2019)).toEqual(range(1, 52))
-    expect(getWeekRange(2019, 2019)).toEqual(range(1, moment().week()))
+    // 2019-09-10 (frozen clock) falls in week 37.
+    expect(getWeekRange(2019, 2019)).toEqual(range(1, 37))
   })
 
   test('getDayRange', () => {
     expect(getDayRange(2018, 8, 2019, 9)).toEqual(range(1, 31))
     expect(getDayRange(2019, 7, 2019, 9)).toEqual(range(1, 31))
-    expect(getDayRange(2019, 9, 2019, 9)).toEqual(range(1, moment().date()))
+    expect(getDayRange(2019, 9, 2019, 9)).toEqual(range(1, 10))
   })
 
   test('getFirstStartDate', () => {
@@ -277,5 +287,41 @@ describe('time', () => {
     expect(hoursToDays({ hours_by_day: 8 }, 16)).toEqual(2)
     expect(hoursToDays({ hours_by_day: 7 }, 21)).toEqual(3)
     expect(hoursToDays({ hours_by_day: 7 }, undefined)).toEqual(0)
+  })
+
+  test('formatDuration', () => {
+    const organisation = { hours_by_day: 8 }
+    const hoursOrganisation = { format_duration_in_hours: true, hours_by_day: 8 }
+
+    expect(formatDuration(organisation, 0)).toEqual(0)
+    expect(formatDuration(organisation, null)).toEqual(0)
+
+    // toLocale=false returns plain numbers, rounded to 2 decimals.
+    expect(formatDuration(organisation, 480, false)).toEqual(1)
+    expect(formatDuration(organisation, 100, false)).toEqual(0.21)
+    expect(formatDuration(hoursOrganisation, 90, false)).toEqual(1.5)
+
+    // toLocale=true formats through toLocaleString; the decimal separator
+    // depends on the environment locale, so only integers are asserted.
+    expect(formatDuration(organisation, 480)).toEqual('1')
+    expect(formatDuration(organisation, 960)).toEqual('2')
+    expect(formatDuration(hoursOrganisation, 120)).toEqual('2')
+  })
+
+  test('getDayOffRange', () => {
+    expect(getDayOffRange()).toEqual([])
+    expect(getDayOffRange([])).toEqual([])
+
+    const singleDay = { id: 'off-1', date: '2023-05-01' }
+    expect(getDayOffRange([singleDay])).toEqual([
+      { id: 'off-1', date: '2023-05-01' }
+    ])
+
+    const multiDay = { id: 'off-2', date: '2023-05-01', end_date: '2023-05-03' }
+    expect(getDayOffRange([multiDay])).toEqual([
+      { id: 'off-2', date: '2023-05-01', end_date: '2023-05-03' },
+      { id: 'off-2', date: '2023-05-02', end_date: '2023-05-03' },
+      { id: 'off-2', date: '2023-05-03', end_date: '2023-05-03' }
+    ])
   })
 })

--- a/tests/unit/router/routes.spec.js
+++ b/tests/unit/router/routes.spec.js
@@ -1,0 +1,126 @@
+import { vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  isAdmin: false
+}))
+
+// Stub everything the route guards touch so importing the route table does
+// not drag the real store, auth flow or page components into jsdom.
+vi.mock('@/lib/auth', () => ({
+  default: { requireAuth: (to, from, callback) => callback(null) }
+}))
+vi.mock('@/lib/init', () => ({ default: vi.fn() }))
+vi.mock('@/lib/lang', () => ({ default: { setLocale: vi.fn() } }))
+vi.mock('@/lib/sentry', () => ({ default: { setContext: vi.fn() } }))
+vi.mock('@/lib/timezone', () => ({ default: { setTimezone: vi.fn() } }))
+vi.mock('@/store', () => ({
+  default: {
+    commit: vi.fn(),
+    state: { productions: { openProductions: [] } }
+  }
+}))
+vi.mock('@/store/modules/people', () => ({
+  default: { state: { organisation: {} } }
+}))
+vi.mock('@/store/modules/tasktypes', () => ({
+  default: { state: { taskTypes: [] } }
+}))
+vi.mock('@/store/modules/user', () => ({
+  default: {
+    state: { user: { locale: 'en' } },
+    getters: {
+      isCurrentUserAdmin: () => h.isAdmin,
+      isCurrentUserArtist: () => false
+    }
+  }
+}))
+vi.mock('@/components/Main.vue', () => ({ default: {} }))
+vi.mock('@/components/pages/Login.vue', () => ({ default: {} }))
+
+import init from '@/lib/init'
+import taskTypeStore from '@/store/modules/tasktypes'
+import { routes } from '@/router/routes'
+
+const mainRoute = routes.find(route => route.path === '/')
+
+// The admin-only pages: removing the requiresAdmin flag from any of them
+// would silently expose the page to every logged-in user.
+const ADMIN_ONLY_ROUTES = [
+  'asset-types',
+  'backgrounds',
+  'bots',
+  'custom-actions',
+  'departments',
+  'logs',
+  'main-schedule',
+  'newsfeed',
+  'people',
+  'productions',
+  'project-templates',
+  'project-template-settings',
+  'salary-scale',
+  'settings',
+  'status-automations',
+  'studios',
+  'task-status',
+  'task-types',
+  'team-schedule'
+]
+
+describe('router/routes', () => {
+  beforeEach(() => {
+    h.isAdmin = false
+    taskTypeStore.state.taskTypes = [{ id: 'task-type-1' }]
+    vi.clearAllMocks()
+  })
+
+  describe('admin route table', () => {
+    test.each(ADMIN_ONLY_ROUTES)('%s requires admin', name => {
+      const route = mainRoute.children.find(child => child.name === name)
+      expect(route).toBeDefined()
+      expect(route.meta?.requiresAdmin).toBe(true)
+    })
+  })
+
+  describe('main guard', () => {
+    const runGuard = to => {
+      const next = vi.fn()
+      mainRoute.beforeEnter(to, {}, next)
+      return next
+    }
+
+    test('redirects a non-admin to not-found on an admin route', () => {
+      const next = runGuard({ matched: [{ meta: { requiresAdmin: true } }] })
+      expect(next).toHaveBeenCalledWith({ name: 'not-found' })
+    })
+
+    test('lets an admin through on an admin route', () => {
+      h.isAdmin = true
+      const next = runGuard({ matched: [{ meta: { requiresAdmin: true } }] })
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    test('lets a non-admin through on a regular route', () => {
+      const next = runGuard({ matched: [{ meta: {} }] })
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    test('still blocks admin routes when data loads first', async () => {
+      taskTypeStore.state.taskTypes = []
+      init.mockResolvedValue(true)
+      const next = runGuard({ matched: [{ meta: { requiresAdmin: true } }] })
+      await vi.waitFor(() =>
+        expect(next).toHaveBeenCalledWith({ name: 'not-found' })
+      )
+    })
+
+    test('redirects to server-down when the initial load fails', async () => {
+      taskTypeStore.state.taskTypes = []
+      init.mockRejectedValue(new Error('api down'))
+      const next = runGuard({ matched: [{ meta: {} }] })
+      await vi.waitFor(() =>
+        expect(next).toHaveBeenCalledWith({ name: 'server-down' })
+      )
+    })
+  })
+})

--- a/tests/unit/store/api/client.spec.js
+++ b/tests/unit/store/api/client.spec.js
@@ -1,0 +1,150 @@
+import { vi } from 'vitest'
+
+// Fake superagent: every call returns a thenable request that resolves with
+// h.response or rejects with h.error, while recording what was requested.
+const h = vi.hoisted(() => ({
+  response: null,
+  error: null,
+  calls: [],
+  sent: null,
+  responseType: null
+}))
+
+vi.mock('superagent', () => {
+  const makeRequest = () => {
+    const request = {}
+    request.timeout = vi.fn(() => request)
+    request.send = vi.fn(data => {
+      h.sent = data
+      return request
+    })
+    request.responseType = vi.fn(type => {
+      h.responseType = type
+      return request
+    })
+    request.on = vi.fn(() => request)
+    request.then = (onFulfilled, onRejected) => {
+      const settled = h.error
+        ? Promise.reject(h.error)
+        : Promise.resolve(h.response)
+      return settled.then(onFulfilled, onRejected)
+    }
+    request.catch = onRejected => request.then(undefined, onRejected)
+    return request
+  }
+  const superagent = vi.fn((method, path) => {
+    h.calls.push({ method, path })
+    return makeRequest()
+  })
+  superagent.post = vi.fn(path => {
+    h.calls.push({ method: 'POST', path })
+    return makeRequest()
+  })
+  return { default: superagent }
+})
+
+vi.mock('@/lib/errors', () => ({
+  default: { backToLogin: vi.fn() }
+}))
+
+import client from '@/store/api/client'
+import errors from '@/lib/errors'
+
+describe('store/api/client', () => {
+  beforeEach(() => {
+    h.response = null
+    h.error = null
+    h.calls = []
+    h.sent = null
+    h.responseType = null
+    vi.clearAllMocks()
+  })
+
+  test('pget resolves with the response body', async () => {
+    h.response = { body: { id: 'model-1' } }
+    await expect(client.pget('/api/data/foo')).resolves.toEqual({
+      id: 'model-1'
+    })
+    expect(h.calls).toEqual([{ method: 'GET', path: '/api/data/foo' }])
+  })
+
+  test('ppost sends the payload', async () => {
+    h.response = { body: { ok: true } }
+    await client.ppost('/api/data/foo', { name: 'foo' })
+    expect(h.calls).toEqual([{ method: 'POST', path: '/api/data/foo' }])
+    expect(h.sent).toEqual({ name: 'foo' })
+  })
+
+  test('a 401 redirects to login and never settles the promise', async () => {
+    h.error = { response: { status: 401 } }
+    const outcome = await Promise.race([
+      client.pget('/api/data/foo').then(
+        () => 'resolved',
+        () => 'rejected'
+      ),
+      new Promise(resolve => setTimeout(() => resolve('pending'), 20))
+    ])
+    expect(outcome).toBe('pending')
+    expect(errors.backToLogin).toHaveBeenCalled()
+  })
+
+  test('other HTTP errors reject with the response body attached', async () => {
+    h.error = { response: { status: 500, body: { message: 'boom' } } }
+    await expect(client.pget('/api/data/foo')).rejects.toMatchObject({
+      body: { message: 'boom' }
+    })
+    expect(errors.backToLogin).not.toHaveBeenCalled()
+  })
+
+  test('network errors without a response reject with an empty body', async () => {
+    h.error = new Error('socket hang up')
+    await expect(client.pget('/api/data/foo')).rejects.toMatchObject({
+      body: ''
+    })
+  })
+
+  test('getText resolves with the response text', async () => {
+    h.response = { text: 'plain content' }
+    await expect(client.getText('/api/foo.txt')).resolves.toEqual(
+      'plain content'
+    )
+  })
+
+  test('getBlob requests a blob response type', async () => {
+    const blob = new Blob(['binary'])
+    h.response = { body: blob }
+    await expect(client.getBlob('/api/foo.png')).resolves.toBe(blob)
+    expect(h.responseType).toBe('blob')
+  })
+
+  test('getModel builds the path, with and without relations', async () => {
+    h.response = { body: {} }
+    await client.getModel('persons', 'person-1')
+    await client.getModel('persons', 'person-1', true)
+    expect(h.calls.map(call => call.path)).toEqual([
+      '/api/data/persons/person-1',
+      '/api/data/persons/person-1?relations=true'
+    ])
+  })
+
+  test('getEvents appends the cursor only when provided', async () => {
+    h.response = { body: [] }
+    await client.getEvents('2023-01-01', '2023-01-02', 100)
+    await client.getEvents('2023-01-01', '2023-01-02', 100, 'event-1')
+    expect(h.calls[0].path).toEqual(
+      '/api/data/events/last?after=2023-01-01&before=2023-01-02&limit=100'
+    )
+    expect(h.calls[1].path).toEqual(
+      '/api/data/events/last?after=2023-01-01&before=2023-01-02&limit=100' +
+        '&cursor_event_id=event-1'
+    )
+  })
+
+  test('searchData omits the production filter for "all"', async () => {
+    h.response = { body: [] }
+    await client.searchData('rabbit', 10, 0, ['assets'], 'all')
+    expect(h.sent.project_id).toBeUndefined()
+    await client.searchData('rabbit', 10, 0, ['assets'], 'production-1')
+    expect(h.sent.project_id).toEqual('production-1')
+  })
+})

--- a/tests/unit/store/departments.spec.js
+++ b/tests/unit/store/departments.spec.js
@@ -1,6 +1,6 @@
 import store from '@/store/modules/departments'
 
-const departments = [
+const buildDepartments = () => [
   {
     name: 'NAME1',
     id: '1',
@@ -13,67 +13,83 @@ const departments = [
   }
 ]
 
-const departmentMap = new Map()
-departments.forEach(department => {
-  departmentMap.set(department.id, department)
-})
+describe('Departments store', () => {
+  let rootState
 
-describe('Productions store', () => {
+  beforeEach(() => {
+    const departments = buildDepartments()
+    rootState = { departments }
+    store.cache.departmentMap = new Map(
+      departments.map(department => [department.id, department])
+    )
+  })
+
   describe('Getters', () => {
-    let rootState
-    beforeEach(() => {
-      rootState = {
-        departments: [...departments],
-        departmentMap
-      }
+    test('departments', () => {
+      expect(store.getters.departments(rootState)).toEqual(buildDepartments())
     })
 
-    test('departments', () => {
-      expect(store.getters.departments(rootState)).toStrictEqual(departments)
-    }),
-    test('getDepartment', () => {
+    test('departments filters archived ones', () => {
+      rootState.departments[0].archived = true
       expect(
-        store.getters.getDepartment(rootState)(departments[0].id))
-        .toStrictEqual(departments[0])
+        store.getters.departments(rootState).map(department => department.id)
+      ).toEqual(['2'])
+      expect(
+        store.getters
+          .archivedDepartments(rootState)
+          .map(department => department.id)
+      ).toEqual(['1'])
+    })
+
+    test('getDepartment', () => {
+      expect(store.getters.getDepartment(rootState)('1')).toEqual(
+        buildDepartments()[0]
+      )
     })
   })
 
   describe('Mutations', () => {
-    let rootState
-    beforeEach(() => {
-      rootState = {
-        departments,
-        departmentMap
-      }
-    })
-
     test('RESET_ALL', () => {
       store.mutations.RESET_ALL(rootState)
       expect(rootState.departments).toEqual([])
-    }),
+      expect(store.cache.departmentMap.size).toBe(0)
+    })
 
-    test('EDIT_DEPARTMENTS_END', () => {
+    test('EDIT_DEPARTMENTS_END adds a new department and keeps the list sorted', () => {
       const newDepartment = {
-        name: 'NEW DEPARTMENT',
-        id: 'newId',
-        color: '#eeeeee'
+        name: 'AAA DEPARTMENT',
+        id: 'new-id',
+        color: '#dddddd'
       }
       store.mutations.EDIT_DEPARTMENTS_END(rootState, newDepartment)
-      const result = departments
-      result.push(newDepartment)
-      expect(rootState.departments).toEqual(result)
-    }),
+      expect(rootState.departments.map(department => department.name)).toEqual(
+        ['AAA DEPARTMENT', 'NAME1', 'NAME2']
+      )
+      expect(store.cache.departmentMap.get('new-id')).toEqual(newDepartment)
+    })
+
+    test('EDIT_DEPARTMENTS_END updates an existing department in place', () => {
+      store.mutations.EDIT_DEPARTMENTS_END(rootState, {
+        name: 'ZZZ DEPARTMENT',
+        id: '1',
+        color: '#000000'
+      })
+      expect(rootState.departments.map(department => department.name)).toEqual(
+        ['NAME2', 'ZZZ DEPARTMENT']
+      )
+    })
 
     test('DELETE_DEPARTMENTS_END', () => {
-      store.mutations.DELETE_DEPARTMENTS_END(
-        rootState, rootState.departments[0])
-      store.mutations.DELETE_DEPARTMENTS_END(
-        rootState, rootState.departments[0])
-      store.mutations.DELETE_DEPARTMENTS_END(
-        rootState, rootState.departments[0])
-      store.mutations.DELETE_DEPARTMENTS_END(
-        rootState, rootState.departments[0])
-      expect(rootState.departments).toEqual([])
+      store.mutations.DELETE_DEPARTMENTS_END(rootState, { id: '1' })
+      expect(rootState.departments.map(department => department.id)).toEqual([
+        '2'
+      ])
+      expect(store.cache.departmentMap.has('1')).toBe(false)
+    })
+
+    test('DELETE_DEPARTMENTS_END ignores an unknown department', () => {
+      store.mutations.DELETE_DEPARTMENTS_END(rootState, { id: 'ghost' })
+      expect(rootState.departments).toHaveLength(2)
     })
   })
 })

--- a/tests/unit/store/tasktypes.spec.js
+++ b/tests/unit/store/tasktypes.spec.js
@@ -1,4 +1,5 @@
 import store from '@/store/modules/tasktypes'
+import taskTypesApi from '@/store/api/tasktypes'
 
 const taskTypes = [
   {
@@ -107,17 +108,78 @@ describe('Task types store', () => {
   })
 
   describe('Actions', () => {
-    test('loadTaskType', () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
     })
-    test('loadTaskTypes', () => {
+
+    test('loadTaskType', async () => {
+      const taskType = { id: 'task-type-9', name: 'Rigging' }
+      vi.spyOn(taskTypesApi, 'getTaskType').mockResolvedValue(taskType)
+      const commit = vi.fn()
+      await store.actions.loadTaskType({ commit }, 'task-type-9')
+      expect(taskTypesApi.getTaskType).toHaveBeenCalledWith('task-type-9')
+      expect(commit).toHaveBeenCalledWith('EDIT_TASK_TYPE_END', taskType)
     })
-    test('newTaskType', () => {
+
+    test('loadTaskTypes', async () => {
+      vi.spyOn(taskTypesApi, 'getTaskTypes').mockResolvedValue([...taskTypes])
+      const commit = vi.fn()
+      await store.actions.loadTaskTypes({ commit })
+      expect(commit).toHaveBeenCalledWith('LOAD_TASK_TYPES_START')
+      expect(commit).toHaveBeenCalledWith('LOAD_TASK_TYPES_END', taskTypes)
     })
-    test('editTaskType', () => {
+
+    test('newTaskType', async () => {
+      const data = { name: 'Rigging' }
+      const taskType = { id: 'task-type-9', name: 'Rigging' }
+      vi.spyOn(taskTypesApi, 'newTaskType').mockResolvedValue(taskType)
+      const commit = vi.fn()
+      await store.actions.newTaskType({ commit }, data)
+      expect(commit).toHaveBeenCalledWith('EDIT_TASK_TYPE_START', data)
+      expect(commit).toHaveBeenCalledWith('EDIT_TASK_TYPE_END', taskType)
     })
-    test('deleteTaskType', () => {
+
+    test('editTaskType', async () => {
+      const taskType = { id: 'task-type-1', name: 'Modeling edited' }
+      vi.spyOn(taskTypesApi, 'updateTaskType').mockResolvedValue(taskType)
+      const commit = vi.fn()
+      await store.actions.editTaskType({ commit }, taskType)
+      expect(taskTypesApi.updateTaskType).toHaveBeenCalledWith(taskType)
+      expect(commit).toHaveBeenCalledWith('EDIT_TASK_TYPE_END', taskType)
     })
-    test('initTaskType', () => {
+
+    test('deleteTaskType', async () => {
+      const taskType = taskTypes[0]
+      vi.spyOn(taskTypesApi, 'deleteTaskType').mockResolvedValue()
+      const commit = vi.fn()
+      await store.actions.deleteTaskType({ commit }, taskType)
+      expect(commit).toHaveBeenCalledWith('DELETE_TASK_TYPE_START')
+      expect(commit).toHaveBeenCalledWith('DELETE_TASK_TYPE_END', taskType)
+    })
+
+    test('initTaskType resolves without loading when shots are cached', async () => {
+      const dispatch = vi.fn()
+      const rootGetters = {
+        currentTaskType: { for_entity: 'Shot' },
+        shotMap: new Map([
+          ['shot-1', {}],
+          ['shot-2', {}]
+        ])
+      }
+      await store.actions.initTaskType({ dispatch, rootGetters }, false)
+      expect(dispatch).not.toHaveBeenCalled()
+    })
+
+    test('initTaskType loads shots when the shot map is empty', async () => {
+      const dispatch = vi.fn().mockResolvedValue()
+      const rootGetters = {
+        currentTaskType: { for_entity: 'Shot' },
+        shotMap: new Map(),
+        episodes: [],
+        isTVShow: false
+      }
+      await store.actions.initTaskType({ dispatch, rootGetters }, false)
+      expect(dispatch).toHaveBeenCalledWith('loadShots')
     })
   })
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -97,11 +97,29 @@ export default defineConfig({
     setupFiles: ['vitest-localstorage-mock', 'tests/unit.setup.js'],
     mockReset: false,
     isolate: true,
+    // Agent worktrees under .claude/ carry their own copy of the suite;
+    // without this exclude `vitest tests/unit` picks them up too.
+    exclude: ['**/node_modules/**', '**/dist/**', '.claude/**'],
     deps: {
       optimizer: {
         client: {
           include: ['vue', 'vuex', 'vue-router', '@vue/test-utils']
         }
+      }
+    },
+    coverage: {
+      provider: 'v8',
+      reporter: ['text-summary', 'lcov'],
+      // Components are exercised through the dev app, not unit tests;
+      // thresholds only guard the layers the suite actually covers.
+      include: ['src/lib/**/*.js', 'src/store/**/*.js'],
+      // Floors set just under the measured baseline (2026-07): raise them
+      // as coverage grows, never lower them.
+      thresholds: {
+        lines: 28,
+        functions: 17,
+        branches: 25,
+        statements: 28
       }
     }
   }


### PR DESCRIPTION
### Problems

* Several specs were dead weight: the `sortAssetResult` assertions were entirely commented out (the sort descriptors had their columns swapped, so they could never match), the departments spec mutated a shared fixture across tests and froze the unsorted append order, and the tasktypes Actions block held six empty test bodies passing vacuously.
* Critical paths had zero tests: `client.js` (every HTTP call of the app), the admin routing guard (the only barrier between a regular user and the admin pages), and `time.js`'s `formatDuration`/`getDayOffRange`. Two time tests compared against the live clock, so their expected values changed every day.
* No coverage measurement existed, so coverage could silently erode.

### Solutions

* Fix the swapped sort descriptors and restore the assertions with derived orders; task statuses are inverted so the metadata and task-type sorts produce distinct orders and a comparator mix-up cannot pass both. Rebuild the departments spec with fresh state per test, asserting sorted insertion. Fill the six tasktypes action tests against mocked API calls, covering commit sequences and both `initTaskType` branches.
* New `client.spec.js` (superagent faked): body unwrapping, the 401 redirect that leaves the promise pending, error-body attachment, path building and the searchData production filter. New `routes.spec.js`: pins the 19 admin-only routes — removing a `requiresAdmin` flag now fails a test — and exercises the guard (non-admin → not-found, admin passes, failed init → server-down). `time.spec` now freezes the clock with `vi.setSystemTime` and gains `formatDuration`/`getDayOffRange` tests.
* Coverage wired with the v8 provider and a `test:coverage` script. Thresholds are floors set just under the measured baseline (~29% lines on `src/lib` + `src/store`, the layers the unit suite actually covers): they only catch regressions and should be raised as coverage grows. Also excludes `.claude/` worktrees from test discovery.

Full suite: 88 files, 1031 tests, 0 failures.