### PR TITLE
[timesheets] Fix week list truncation at the ISO year boundary

### DIFF
--- a/src/components/lists/PeopleTimesheetList.vue
+++ b/src/components/lists/PeopleTimesheetList.vue
@@ -369,7 +369,7 @@ export default {
     },
 
     getWeekTitle(week) {
-      const beginning = moment(this.currentYear + '-' + week, 'YYYY-W')
+      const beginning = moment(this.year + '-' + week, 'YYYY-W')
       const end = beginning.clone().add(6, 'days')
       return beginning.format('YYYY-MM-DD') + ' - ' + end.format('YYYY-MM-DD')
     },

--- a/src/components/pages/Timesheets.vue
+++ b/src/components/pages/Timesheets.vue
@@ -168,7 +168,7 @@ export default {
 
       currentYear: moment().year(),
       currentMonth: moment().month() + 1,
-      currentWeek: moment().week(),
+      currentWeek: moment().isoWeek(),
       currentDay: moment().date(),
       currentPerson: this.getCurrentPerson(),
 
@@ -441,7 +441,7 @@ export default {
         todayMonth: this.currentMonth,
         year: moment().year(),
         month: moment().month() + 1,
-        week: moment().week()
+        week: moment().isoWeek()
       })
     },
 

--- a/src/components/sides/PeopleTimesheetInfo.vue
+++ b/src/components/sides/PeopleTimesheetInfo.vue
@@ -107,25 +107,21 @@ export default {
   emits: ['close'],
 
   computed: {
+    // Monday of the displayed ISO week, as aggregated by the backend.
+    weekStartDate() {
+      return moment(this.year + '-' + this.week, 'YYYY-W')
+    },
+
     startDay() {
-      return moment().day('Monday').year(this.year).week(this.week).date()
+      return this.weekStartDate.date()
     },
 
     endDay() {
-      return moment()
-        .day('Monday')
-        .year(this.year)
-        .week(this.week)
-        .add(6, 'days')
-        .date()
+      return this.weekStartDate.clone().add(6, 'days').date()
     },
 
     weekMonth() {
-      return moment()
-        .day('Monday')
-        .year(this.year)
-        .week(this.week)
-        .format('MMM')
+      return this.weekStartDate.format('MMM')
     },
 
     monthString() {

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -112,8 +112,12 @@ export const getDayRange = (year, month, currentYear, currentMonth) => {
 }
 
 export const getWeekRange = (year, currentYear) => {
-  if (currentYear === year) {
-    return range(1, moment().week())
+  const now = moment()
+  // Late December days can belong to ISO week 1 of the next year: only
+  // truncate the range at the current week when today's ISO week still
+  // belongs to the displayed year.
+  if (currentYear === year && now.isoWeekYear() <= year) {
+    return range(1, now.isoWeek())
   } else {
     return range(1, moment(String(year), 'YYYY').isoWeeksInYear())
   }

--- a/tests/unit/lib/time.spec.js
+++ b/tests/unit/lib/time.spec.js
@@ -36,6 +36,10 @@ describe('time', () => {
     vi.setSystemTime(new Date('2019-09-10T12:00:00Z'))
   })
 
+  afterEach(() => {
+    vi.setSystemTime(new Date('2019-09-10T12:00:00Z'))
+  })
+
   afterAll(() => {
     vi.useRealTimers()
   })
@@ -114,6 +118,16 @@ describe('time', () => {
     expect(getWeekRange(2018, 2019)).toEqual(range(1, 52))
     // 2019-09-10 (frozen clock) falls in week 37.
     expect(getWeekRange(2019, 2019)).toEqual(range(1, 37))
+    // 2020 has 53 ISO weeks.
+    expect(getWeekRange(2020, 2026)).toEqual(range(1, 53))
+    // Regression #1928: 2025-12-30 belongs to ISO week 1 of 2026, all the
+    // weeks of 2025 must stay visible.
+    vi.setSystemTime(new Date('2025-12-30T12:00:00Z'))
+    expect(getWeekRange(2025, 2025)).toEqual(range(1, 52))
+    // 2027-01-01 belongs to ISO week 53 of 2026, where the backend files
+    // its hours in the 2027 table.
+    vi.setSystemTime(new Date('2027-01-01T12:00:00Z'))
+    expect(getWeekRange(2027, 2027)).toEqual(range(1, 53))
   })
 
   test('getDayRange', () => {


### PR DESCRIPTION
## Problems

- In the last week of December, the weekly timesheet showed a single column labelled week 1 with next-year hours, hiding every other week of the year (fixes #1928): `getWeekRange` used `moment().week()`, which already returns 1 for late-December days.
- The week header tooltip computed its date span from today's year instead of the displayed one, and the side panel derived the week interval from locale weeks, so the displayed range could be shifted a full week from what the backend (which uses `isocalendar`/`isoweek`) actually aggregates.

## Solutions

- `getWeekRange` now uses `isoWeek()`/`isoWeekYear()` and only truncates the range at the current week when today's ISO week belongs to the displayed year, otherwise it lists the full 52/53-week range.
- The tooltip uses the displayed year, and the side panel derives start/end days from the Monday of the ISO week, matching the backend aggregation; regression tests cover 2025-12-30, 2027-01-01 and a 53-week year.