### PR TITLE
[players] Pre-seek next decoder to handle-in to avoid slate flash

### DIFF
--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -135,6 +135,7 @@
           :is-hd="isHd"
           :is-repeating="isRepeating"
           :muted="true"
+          :next-handle-in="nextEntityHandleIn"
           :panzoom="true"
           :handle-in="
             ['shot', 'edit', 'episode'].includes(playlist.for_entity)
@@ -258,6 +259,7 @@
           :is-repeating="isRepeating"
           :current-preview-index="currentPreviewIndex"
           :muted="isMuted"
+          :next-handle-in="nextEntityHandleIn"
           :panzoom="true"
           @entity-change="onPlayerPlayingEntityChange"
           @frame-update="onRawPlayerFrameUpdate"
@@ -1303,6 +1305,12 @@ const nextEntityIndex = computed(() => {
   if (index > entityList.value.length - 1) index = 0
   return index
 })
+
+// Next entity's handle-in, so the viewers can park their preloaded decoder
+// past the slate before the players switch (#1019).
+const nextEntityHandleIn = computed(
+  () => getEntityHandles(entityList.value[nextEntityIndex.value]).handleIn
+)
 
 const picturePreviews = computed(() =>
   entityList.value.flatMap(e => [

--- a/src/components/players/viewers/MultiVideoViewer.vue
+++ b/src/components/players/viewers/MultiVideoViewer.vue
@@ -106,6 +106,11 @@ const props = defineProps({
     type: String,
     default: 'main'
   },
+  nextHandleIn: {
+    // Handle-in frame of the next entity, used to pre-seek its decoder
+    type: Number,
+    default: 0
+  },
   panzoom: {
     type: Boolean,
     default: false
@@ -401,6 +406,19 @@ const reloadCurrentEntity = (silentReload = false) => {
   loadEntity(currentIndex.value, currentPlayer.value.currentTime, silentReload)
 }
 
+// Park the preloaded decoder on the next entity's handle-in frame so its
+// first frame (slate) is never the one painted when players switch.
+const preseekNextPlayer = () => {
+  const player = nextPlayer.value
+  if (!player || !player.getAttribute('src') || props.nextHandleIn <= 0) return
+  const nextEntity = props.entities[getNextIndex(currentIndex.value)]
+  const nextFps =
+    parseFloat(nextEntity?.fps) ||
+    parseFloat(currentProduction.value?.fps) ||
+    DEFAULT_FPS
+  player.currentTime = props.nextHandleIn / nextFps
+}
+
 const loadEntity = (index = 0, currentTime = 0, silentLoad = false) => {
   if (index < props.entities.length) {
     const nextIndex = getNextIndex(index)
@@ -436,6 +454,7 @@ const loadEntity = (index = 0, currentTime = 0, silentLoad = false) => {
       if (!nextPlayer.value.src.endsWith(nextMoviePath)) {
         nextPlayer.value.src = nextMoviePath
       }
+      preseekNextPlayer()
     } else if (nextPlayer.value) {
       nextPlayer.value.src = ''
     }
@@ -596,6 +615,7 @@ const switchPlayers = () => {
   nextPlayer.value = tmpPlayer
   if (nextEntity) {
     nextPlayer.value.src = getMoviePath(nextEntity)
+    preseekNextPlayer()
   }
   resetHeight()
   setSpeed(rate)
@@ -707,6 +727,15 @@ watch(
       setCurrentTimeRaw(0)
       reloadCurrentEntity(true)
     }
+  }
+)
+
+// At switch time the prop still holds the previous "next" value: re-apply
+// the pre-seek once the parent pushes the new next entity's handle-in.
+watch(
+  () => props.nextHandleIn,
+  () => {
+    preseekNextPlayer()
   }
 )
 

--- a/tests/unit/players/multivideoviewer.spec.js
+++ b/tests/unit/players/multivideoviewer.spec.js
@@ -27,7 +27,7 @@ const removeRvfcMock = () => {
   delete HTMLVideoElement.prototype.cancelVideoFrameCallback
 }
 
-const mountViewer = () => {
+const mountViewer = (props = {}) => {
   const store = createStore({
     getters: { currentProduction: () => ({ fps: '25' }) }
   })
@@ -37,7 +37,8 @@ const mountViewer = () => {
         { id: 'e1', preview_file_id: 'p1', preview_file_extension: 'mp4', fps: 25 },
         { id: 'e2', preview_file_id: 'p2', preview_file_extension: 'mp4', fps: 25 }
       ],
-      name: 'main'
+      name: 'main',
+      ...props
     },
     global: {
       mocks: { $t: key => key },
@@ -181,6 +182,30 @@ describe('players/MultiVideoViewer (canvas pipeline)', () => {
     expect(wrapper.vm.currentPlayer.src).toContain(
       '/movies/low/preview-files/p1b.mp4'
     )
+
+    wrapper.unmount()
+  })
+
+  it('pre-seeks the preloaded decoder to the next entity handle-in (#1019)', async () => {
+    const wrapper = mountViewer({ nextHandleIn: 100 })
+
+    wrapper.vm.loadEntity(0)
+    await wrapper.vm.$nextTick()
+
+    const current = wrapper.vm.currentPlayer
+    const next = wrapper
+      .findAll('video.playlist-movie-decoder')
+      .map(w => w.element)
+      .find(el => el !== current)
+
+    // The decoder preloading e2 must already be parked on its handle-in
+    // frame so the slate at frame 0 never flashes when players switch
+    expect(next.src).toContain('/movies/low/preview-files/p2.mp4')
+    expect(next.currentTime).toBeCloseTo(100 / 25)
+
+    // A handle change on the next entity re-parks the decoder
+    await wrapper.setProps({ nextHandleIn: 50 })
+    expect(next.currentTime).toBeCloseTo(50 / 25)
 
     wrapper.unmount()
   })


### PR DESCRIPTION
## Problems

- With handles set on a playlist, continuous playback flashed the next shot's first frame (the slate) at every shot boundary before jumping to the handle-in frame (fixes #1019)
- The hidden decoder preloading the next entity stayed parked at t=0; the seek to handle-in only happened inside `playNext` at switch time, so the newly-current decoder painted frame 0 until that async seek completed

## Solutions

- Pre-seek the preloading decoder to the next entity's handle-in time as soon as its source is set (in `loadEntity` and `switchPlayers`), so frame 0 is never the frame presented when the players swap
- Feed `MultiVideoViewer` with a new `nextHandleIn` prop, computed in `PlaylistPlayer` from the next entity's own handle data (handles can differ per entity), and re-apply the pre-seek when the prop updates after a switch
- Add a jsdom regression test checking the preloaded decoder is already at the handle-in time after `loadEntity` and re-parks on handle changes