### PR TITLE
Add a 12-hour clock option for displayed times

### DIFF
--- a/src/components/pages/Profile.vue
+++ b/src/components/pages/Profile.vue
@@ -67,6 +67,13 @@
             v-if="user.role !== 'client' && !user.is_guest"
           />
         </div>
+        <div class="toggle-row">
+          <checkbox
+            :toggle="true"
+            :label="$t('profile.use_12_hour_clock')"
+            v-model="form.use_12_hour_clock"
+          />
+        </div>
       </card>
 
       <card
@@ -219,7 +226,8 @@ const form = ref({
   phone: '',
   country: null,
   timezone: 'Europe/Paris',
-  locale: 'en_US'
+  locale: 'en_US',
+  use_12_hour_clock: false
 })
 
 const passwordForm = ref({
@@ -278,6 +286,7 @@ const countryOptions = computed(() => getCountryOptions(localeCode.value))
 
 const syncFormFromUser = () => {
   Object.assign(form.value, user.value)
+  form.value.use_12_hour_clock = Boolean(user.value.use_12_hour_clock)
   form.value.notifications_enabled = Boolean(user.value.notifications_enabled)
   form.value.notifications_slack_enabled = Boolean(
     user.value.notifications_slack_enabled

--- a/src/components/pages/entities/EntityChatDays.vue
+++ b/src/components/pages/entities/EntityChatDays.vue
@@ -95,7 +95,7 @@ import {
   getAttachmentThumbnailPath,
   getDownloadAttachmentPath
 } from '@/lib/path'
-import { parseDate } from '@/lib/time'
+import { formatTimeOfDay, parseDate } from '@/lib/time'
 import { renderComment } from '@/lib/render'
 import files from '@/lib/files'
 
@@ -129,7 +129,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['departmentMap', 'personMap', 'user']),
+    ...mapGetters(['departmentMap', 'personMap', 'use12HourClock', 'user']),
 
     messageList() {
       const messages = [...this.messages].sort((a, b) =>
@@ -182,7 +182,7 @@ export default {
 
     renderDate(date) {
       date = moment(parseDate(date)).tz(this.user.timezone)
-      return date.tz(this.user.timezone).format('HH:mm')
+      return formatTimeOfDay(date, this.use12HourClock)
     },
 
     getAttachmentThumbnailPath,

--- a/src/components/pages/news/NewsRow.vue
+++ b/src/components/pages/news/NewsRow.vue
@@ -152,7 +152,6 @@
 </template>
 
 <script setup>
-import moment from 'moment-timezone'
 import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
 
@@ -166,7 +165,7 @@ import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
 import ValidationTag from '@/components/widgets/ValidationTag.vue'
 
 const store = useStore()
-const { timezone } = useTime()
+const { formatTime } = useTime()
 
 const props = defineProps({
   canvasId: { type: String, required: true },
@@ -219,11 +218,6 @@ const hasDoneValue = computed(() => {
   const status = taskStatusMap.value.get(props.news.task_status_id)
   return status ? props.news.change && status.is_done : false
 })
-
-// Functions
-
-const formatTime = date =>
-  moment.tz(date, 'UTC').tz(timezone.value).format('HH:mm')
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -530,7 +530,7 @@ import { remove } from '@/lib/models'
 import { getDownloadAttachmentPath, pluralizeEntityType } from '@/lib/path'
 import { renderComment, replaceTimeWithTimecode, safeUrl } from '@/lib/render'
 import { sortByName } from '@/lib/sorting'
-import { parseDate } from '@/lib/time'
+import { formatTimeOfDay, parseDate } from '@/lib/time'
 import stringHelpers from '@/lib/string'
 
 import { useAtMentionsMembers } from '@/composables/atMentions'
@@ -649,6 +649,7 @@ const isCurrentUserClient = computed(() => store.getters.isCurrentUserClient)
 const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
 const personMap = computed(() => store.getters.personMap)
 const taskTypeMap = computed(() => store.getters.taskTypeMap)
+const use12HourClock = computed(() => store.getters.use12HourClock)
 const user = computed(() => store.getters.user)
 
 const attachmentNamePrefix = computed(() =>
@@ -825,7 +826,7 @@ const replyShortDate = date => {
 const renderDate = date => {
   date = moment(date)
   if (moment().isSame(date, 'd')) {
-    return date.tz(user.value.timezone).format('HH:mm')
+    return formatTimeOfDay(date.tz(user.value.timezone), use12HourClock.value)
   } else {
     return date.tz(user.value.timezone).format('MM/DD')
   }

--- a/src/composables/time.js
+++ b/src/composables/time.js
@@ -5,7 +5,7 @@ import { computed } from 'vue'
 import { useStore } from 'vuex'
 import moment from 'moment-timezone'
 
-import { formatFullDateWithTimezone } from '@/lib/time'
+import { formatFullDateWithTimezone, formatTimeOfDay } from '@/lib/time'
 
 export function useTime() {
   const store = useStore()
@@ -13,6 +13,8 @@ export function useTime() {
   const timezone = computed(
     () => store.getters.user?.timezone || moment.tz.guess()
   )
+
+  const use12HourClock = computed(() => store.getters.use12HourClock)
 
   const today = computed(() => moment().toDate())
 
@@ -22,5 +24,12 @@ export function useTime() {
     return formatFullDateWithTimezone(eventDate, timezone.value)
   }
 
-  return { timezone, today, tomorrow, formatDate }
+  function formatTime(eventDate) {
+    return formatTimeOfDay(
+      moment.tz(eventDate, 'UTC').tz(timezone.value),
+      use12HourClock.value
+    )
+  }
+
+  return { timezone, use12HourClock, today, tomorrow, formatDate, formatTime }
 }

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -56,6 +56,10 @@ export const formatSimpleDate = date => {
   else return ''
 }
 
+export const formatTimeOfDay = (date, use12HourClock = false) => {
+  return moment(date).format(use12HourClock ? 'h:mm A' : 'HH:mm')
+}
+
 export const formatFullDate = date => {
   if (date) {
     const utcDate = moment.tz(date, 'UTC')

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1548,6 +1548,7 @@ export default {
     password_title: 'Change password',
     timezone: 'Timezone',
     title: 'Your Profile',
+    use_12_hour_clock: '12-hour clock (AM/PM)',
     webhook_error: 'the webhook mattermost does not correspond to a hook',
     avatar: {
       title: 'Change avatar',

--- a/src/store/api/people.js
+++ b/src/store/api/people.js
@@ -117,7 +117,8 @@ export default {
       notifications_discord_userid: person.notifications_discord_userid,
       departments: person.departments,
       studio_id: person.studio_id,
-      country: person.country
+      country: person.country,
+      use_12_hour_clock: toBool(person.use_12_hour_clock)
     }
     return client.pput(`/api/data/persons/${person.id}`, data)
   },

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -143,6 +143,7 @@ const getters = {
     state.user && state.user.role === 'supervisor',
   isCurrentUserClient: state => state.user && state.user.role === 'client',
   isCurrentUserVendor: state => state.user && state.user.role === 'vendor',
+  use12HourClock: state => Boolean(state.user?.use_12_hour_clock),
   isSaveProfileLoading: state => state.isSaveProfileLoading,
   isSaveProfileLoadingError: state => state.isSaveProfileLoadingError,
   changePassword: state => state.changePassword,

--- a/tests/unit/lib/time.spec.js
+++ b/tests/unit/lib/time.spec.js
@@ -8,6 +8,7 @@ import {
   formatFullDateWithTimezone,
   formatFullDateWithRevertedTimezone,
   formatSimpleDate,
+  formatTimeOfDay,
   hoursToDays,
   getBusinessDays,
   getDayOffRange,
@@ -71,6 +72,26 @@ describe('time', () => {
   test('formatFullDate', () => {
     const dateString = formatFullDate(new Date('2019-09-01T08:23:12Z'))
     expect(dateString).toEqual('2019-09-01 08:23:12')
+  })
+
+  test('formatTimeOfDay', () => {
+    const afternoon = moment.tz('2019-09-01T14:05:00', 'UTC')
+    expect(formatTimeOfDay(afternoon)).toEqual('14:05')
+    expect(formatTimeOfDay(afternoon, false)).toEqual('14:05')
+    expect(formatTimeOfDay(afternoon, true)).toEqual('2:05 PM')
+
+    const midnight = moment.tz('2019-09-01T00:30:00', 'UTC')
+    expect(formatTimeOfDay(midnight)).toEqual('00:30')
+    expect(formatTimeOfDay(midnight, true)).toEqual('12:30 AM')
+
+    const noon = moment.tz('2019-09-01T12:00:00', 'UTC')
+    expect(formatTimeOfDay(noon)).toEqual('12:00')
+    expect(formatTimeOfDay(noon, true)).toEqual('12:00 PM')
+
+    // Keeps the timezone of an already tz-converted moment.
+    const paris = moment.tz('2019-09-01T14:05:00Z', 'UTC').tz('Europe/Paris')
+    expect(formatTimeOfDay(paris)).toEqual('16:05')
+    expect(formatTimeOfDay(paris, true)).toEqual('4:05 PM')
   })
 
   test('formatFullDateWithTimezone', () => {


### PR DESCRIPTION
**Problem**
- Clock times (comment timestamps, news feed, entity chat) are always rendered in 24-hour format, forcing users from 12-hour regions to convert in their head (fixes #1929)

**Solution**
- Add an opt-in "12-hour clock (AM/PM)" toggle to the profile page, next to the timezone and language settings
- Persist the preference in the new `use_12_hour_clock` person field through the existing profile save path, so it follows the user across browsers (falls back to 24h against a Zou without the field)
- Centralize time-of-day rendering in a new `formatTimeOfDay` helper in `src/lib/time.js` (plus a `formatTime` wrapper in the `useTime` composable) and use it in Comment, NewsRow and EntityChatDays, with unit tests covering 24h/12h, midnight and noon