### PR TITLE
[assets] Keep cells with existing tasks actionable after workflow change

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -683,7 +683,6 @@ export default {
       type: 'asset',
       columnSelectorDisplayed: false,
       hiddenColumns: {},
-      isSelectableMap: {},
       lastSelection: null,
       lastHeaderMenuDisplayed: null,
       lastMetadataHeaderMenuDisplayed: null,
@@ -923,23 +922,23 @@ export default {
         : mainEpisodeName
     },
 
-    // Selectable if the task type is included in the workflow.
+    // Selectable if the cell already holds a task or if the task type is
+    // included in the workflow. Cells with existing tasks stay actionable
+    // even when a workflow change removed their task type, so they can
+    // still be selected and managed instead of freezing.
     isSelectable(asset, columnId) {
       if (asset.shared) {
         return false
       }
-      const key = asset.asset_type_id + columnId
-      if (this.isSelectableMap === undefined) this.isSelectableMap = {}
-      if (this.isSelectableMap[key] === undefined) {
-        const taskType = this.taskTypeMap.get(columnId)
-        const assetType = this.assetTypeMap.get(asset.asset_type_id)
-        let taskTypes = assetType?.task_types || []
-        if (taskTypes.length === 0) {
-          taskTypes = this.productionAssetTaskTypes.map(t => t.id)
-        }
-        this.isSelectable[key] = taskTypes.includes(taskType.id)
+      if (this.taskMap.get(asset.validations?.get(columnId))) {
+        return true
       }
-      return this.isSelectable[key]
+      const assetType = this.assetTypeMap.get(asset.asset_type_id)
+      let taskTypes = assetType?.task_types || []
+      if (taskTypes.length === 0) {
+        taskTypes = this.productionAssetTaskTypes.map(t => t.id)
+      }
+      return taskTypes.includes(columnId)
     },
 
     isSelected(indexInGroup, groupIndex, columnIndex) {
@@ -1114,11 +1113,6 @@ export default {
 
     'displaySettings.bigThumbnails'() {
       this.updateOffsets()
-    },
-
-    currentProduction() {
-      // Map used for performance reasons, to avoid array traversals
-      this.isSelectableMap = {}
     }
   }
 }

--- a/tests/unit/components/lists/AssetList.spec.js
+++ b/tests/unit/components/lists/AssetList.spec.js
@@ -1,0 +1,66 @@
+vi.mock('@/store', () => ({ default: {} }))
+
+import AssetList from '@/components/lists/AssetList.vue'
+
+const isSelectable = AssetList.methods.isSelectable
+
+const modelingId = 'task-type-modeling'
+const riggingId = 'task-type-rigging'
+const assetTypeId = 'asset-type-props'
+
+const buildContext = () => ({
+  assetTypeMap: new Map([
+    [assetTypeId, { id: assetTypeId, task_types: [riggingId] }]
+  ]),
+  taskTypeMap: new Map([
+    [modelingId, { id: modelingId }],
+    [riggingId, { id: riggingId }]
+  ]),
+  taskMap: new Map([['task-1', { id: 'task-1' }]]),
+  productionAssetTaskTypes: [{ id: modelingId }, { id: riggingId }]
+})
+
+const buildAsset = validations => ({
+  id: 'asset-1',
+  asset_type_id: assetTypeId,
+  validations
+})
+
+describe('lists/AssetList', () => {
+  describe('isSelectable', () => {
+    test('cell with an existing task stays selectable when its task type left the workflow', () => {
+      const asset = buildAsset(new Map([[modelingId, 'task-1']]))
+      expect(isSelectable.call(buildContext(), asset, modelingId)).toBe(true)
+    })
+
+    test('empty cell outside the workflow is not selectable', () => {
+      const asset = buildAsset(new Map())
+      expect(isSelectable.call(buildContext(), asset, modelingId)).toBe(false)
+    })
+
+    test('empty cell inside the workflow is selectable', () => {
+      const asset = buildAsset(new Map())
+      expect(isSelectable.call(buildContext(), asset, riggingId)).toBe(true)
+    })
+
+    test('empty workflow allows every production task type', () => {
+      const context = buildContext()
+      context.assetTypeMap.get(assetTypeId).task_types = []
+      const asset = buildAsset(new Map())
+      expect(isSelectable.call(context, asset, modelingId)).toBe(true)
+    })
+
+    test('shared asset cells are never selectable', () => {
+      const asset = {
+        ...buildAsset(new Map([[modelingId, 'task-1']])),
+        shared: true
+      }
+      expect(isSelectable.call(buildContext(), asset, modelingId)).toBe(false)
+    })
+
+    test('stale validation entry pointing to a deleted task does not force selectability', () => {
+      const asset = buildAsset(new Map([[modelingId, 'task-gone']]))
+      expect(isSelectable.call(buildContext(), asset, modelingId)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Problems
- After changing an asset type workflow, validation cells whose task type left the workflow were rendered frozen even when they already held a task: dark background, status tag hidden (`.disabled .tag { opacity: 0 }`) and clicks ignored, so the tasks became unmanageable from the assets page (fixes #1685)
- `AssetList.isSelectable` carried a broken cache: the write targeted the method object (`this.isSelectable[key]`) instead of `isSelectableMap`, which was therefore never populated and only reset on production change

## Solutions
- `isSelectable` now returns true whenever the cell holds an existing task, so those cells keep their status tag, assignees and selection behavior after a workflow change; the workflow check only gates empty cells, keeping out-of-workflow task creation blocked
- Drop the never-populated `isSelectableMap` cache and its `currentProduction` watcher; the method recomputes from `assetTypeMap`/`productionAssetTaskTypes` as it effectively always did
- Regression spec `tests/unit/components/lists/AssetList.spec.js` covering existing-task cells, empty in/out-of-workflow cells, empty-workflow fallback, shared assets and stale validation entries (fails on the previous code)