### PR TITLE
[players] Fix comparison picture picker gating and stale index

### DIFF
--- a/src/components/players/bars/PlayerComparisonBar.vue
+++ b/src/components/players/bars/PlayerComparisonBar.vue
@@ -38,21 +38,26 @@
         showPanel &&
         isComparing &&
         (!light || isComparisonEnabled) &&
-        comparisonPreviewLength > 0
+        comparisonPreviewLength > 1
       "
     >
       <button-simple
         class="button playlist-button flexrow-item"
         icon="left"
+        :title="$t('playlists.actions.files_previous')"
         @click="$emit('previous-comparison-clicked')"
       />
-      <span class="flexrow-item comparison-index">
+      <span
+        class="flexrow-item comparison-index"
+        :title="$t('playlists.actions.files_position')"
+      >
         {{ comparisonPreviewIndex + 1 }} /
         {{ comparisonPreviewLength }}
       </span>
       <button-simple
         class="button playlist-button flexrow-item"
         icon="right"
+        :title="$t('playlists.actions.files_next')"
         @click="$emit('next-comparison-clicked')"
       />
     </div>

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -1561,6 +1561,7 @@ const {
   currentComparisonPreviewLength,
   comparisonAnnotations,
   toggleComparison,
+  clampComparisonPreviewIndex,
   goToPreviousComparisonPicture,
   goToNextComparisonPicture
 } = usePlaylistComparison({
@@ -4377,6 +4378,7 @@ watch(isComparing, () => {
 })
 
 watch(currentRevisionToCompare, () => {
+  clampComparisonPreviewIndex()
   if (isComparing.value && !isComparisonOverlay.value) {
     loadComparisonAnnotation(currentTimeRaw.value)
   }

--- a/src/composables/players/playlistComparison.js
+++ b/src/composables/players/playlistComparison.js
@@ -126,6 +126,18 @@ export const usePlaylistComparison = ({
       : []
   )
 
+  // When the compared revision changes, a picture index picked on the
+  // previous revision can point past the new one's sub-previews, which
+  // blanks the comparison pane. Reset to the main picture in that case.
+  const clampComparisonPreviewIndex = () => {
+    if (
+      currentComparisonPreviewIndex.value >=
+      currentComparisonPreviewLength.value
+    ) {
+      currentComparisonPreviewIndex.value = 0
+    }
+  }
+
   const goToPreviousComparisonPicture = () => {
     const index = currentComparisonPreviewIndex.value - 1
     currentComparisonPreviewIndex.value =
@@ -188,6 +200,7 @@ export const usePlaylistComparison = ({
 
     // Playlist-specific actions
     toggleComparison,
+    clampComparisonPreviewIndex,
     goToPreviousComparisonPicture,
     goToNextComparisonPicture,
 

--- a/tests/unit/composables/playlistComparison.spec.js
+++ b/tests/unit/composables/playlistComparison.spec.js
@@ -379,6 +379,56 @@ describe('composables/playlistComparison', () => {
     })
   })
 
+  describe('clampComparisonPreviewIndex', () => {
+    const setup = () => {
+      const entity = {
+        preview_files: {
+          'tt-anim': [
+            {
+              id: 'p2',
+              revision: 2,
+              extension: 'png',
+              previews: [{ id: 'sub-1' }, { id: 'sub-2' }]
+            },
+            { id: 'p1', revision: 1, extension: 'png', previews: [] }
+          ]
+        }
+      }
+      const c = usePlaylistComparison(
+        makeInputs({
+          entityList: [entity],
+          taskTypeMap: new Map([['tt-anim', { id: 'tt-anim', name: 'Anim' }]])
+        })
+      )
+      c.taskTypeId.value = 'tt-anim'
+      return c
+    }
+
+    it('resets the index when it points past the compared revision previews', () => {
+      const c = setup()
+      c.revisionToCompare.value = '2'
+      c.currentComparisonPreviewIndex.value = 2
+      c.revisionToCompare.value = '1'
+      c.clampComparisonPreviewIndex()
+      expect(c.currentComparisonPreviewIndex.value).toBe(0)
+      expect(c.currentPreviewToCompare.value.id).toBe('p1')
+    })
+
+    it('keeps an index that is still valid for the compared revision', () => {
+      const c = setup()
+      c.revisionToCompare.value = '2'
+      c.currentComparisonPreviewIndex.value = 2
+      c.clampComparisonPreviewIndex()
+      expect(c.currentComparisonPreviewIndex.value).toBe(2)
+    })
+
+    it('is a no-op when there is no revision to compare', () => {
+      const c = usePlaylistComparison(makeInputs())
+      c.clampComparisonPreviewIndex()
+      expect(c.currentComparisonPreviewIndex.value).toBe(0)
+    })
+  })
+
   describe('overlayOpacity', () => {
     const setup = () => {
       const entity = {

--- a/tests/unit/players/playercomparisonbar.spec.js
+++ b/tests/unit/players/playercomparisonbar.spec.js
@@ -1,0 +1,59 @@
+import { mount } from '@vue/test-utils'
+
+import PlayerComparisonBar from '@/components/players/bars/PlayerComparisonBar.vue'
+
+const mountBar = (props = {}) =>
+  mount(PlayerComparisonBar, {
+    props: {
+      isComparing: true,
+      isComparisonEnabled: true,
+      taskTypeOptions: [{ label: 'Animation', value: 'tt-anim' }],
+      ...props
+    },
+    global: {
+      mocks: { $t: key => key },
+      stubs: { Combobox: true }
+    }
+  })
+
+describe('players/PlayerComparisonBar', () => {
+  describe('comparison picture picker', () => {
+    it('is hidden when the compared revision has a single picture', () => {
+      const wrapper = mountBar({ comparisonPreviewLength: 1 })
+      expect(wrapper.find('.comparison-list').exists()).toBe(false)
+    })
+
+    it('is hidden when the compared revision picture count is unknown', () => {
+      const wrapper = mountBar({ comparisonPreviewLength: 0 })
+      expect(wrapper.find('.comparison-list').exists()).toBe(false)
+    })
+
+    it('is hidden when not comparing', () => {
+      const wrapper = mountBar({
+        isComparing: false,
+        comparisonPreviewLength: 3
+      })
+      expect(wrapper.find('.comparison-list').exists()).toBe(false)
+    })
+
+    it('shows the position when the compared revision has several pictures', () => {
+      const wrapper = mountBar({
+        comparisonPreviewIndex: 1,
+        comparisonPreviewLength: 3
+      })
+      const index = wrapper.find('.comparison-index')
+      expect(index.exists()).toBe(true)
+      expect(index.text().replace(/\s+/g, ' ')).toBe('2 / 3')
+    })
+
+    it('emits previous/next comparison events on arrow clicks', async () => {
+      const wrapper = mountBar({ comparisonPreviewLength: 3 })
+      const buttons = wrapper.findAll('.comparison-list button')
+      expect(buttons).toHaveLength(2)
+      await buttons[0].trigger('click')
+      await buttons[1].trigger('click')
+      expect(wrapper.emitted('previous-comparison-clicked')).toHaveLength(1)
+      expect(wrapper.emitted('next-comparison-clicked')).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
## Problems

- Selecting the compared picture was unreliable when comparing revisions that contain several pictures (fixes #1503)
- The comparison-side picker rendered a pointless "1 / 1" control for single-picture revisions, because zou always includes a `previews` array on revision heads
- In the PlaylistPlayer, the compared picture index went stale when switching the compared revision or task type: an index pointing past the new revision's pictures blanked the comparison pane, with the picker hidden so there was no way to navigate back

## Solutions

- Gate the picture picker (prev/next arrows + "i / n" counter) in the shared PlayerComparisonBar on more than one picture, matching the main-side picker; the bar serves both the task-page PreviewPlayer and the PlaylistPlayer, so both players get the corrected picker
- Add a `clampComparisonPreviewIndex` action to `usePlaylistComparison` and call it from the PlaylistPlayer's compared-revision watcher, so an out-of-range index falls back to the main picture while a still-valid index is preserved (keeps review-room sync intact)
- Add tooltips on the picker arrows and counter, reusing the existing `playlists.actions.files_*` locale keys
- Cover the picker gating/counter/events with a new PlayerComparisonBar spec and the clamp behavior in the playlistComparison composable spec