### PR TITLE
Add a user preference for the displayed date format

### DIFF
--- a/src/components/lists/AllTaskList.vue
+++ b/src/components/lists/AllTaskList.vue
@@ -123,13 +123,13 @@
               {{ formatDuration(task.duration) }}
             </td>
             <td class="start-date">
-              {{ formatDate(task.start_date) }}
+              {{ formatDisplayDate(task.start_date) }}
             </td>
             <td class="due-date">
-              {{ formatDate(task.due_date) }}
+              {{ formatDisplayDate(task.due_date) }}
             </td>
             <td class="done-date">
-              {{ formatDate(task.done_date) }}
+              {{ formatDisplayDate(task.done_date) }}
             </td>
             <td class="empty"></td>
           </tr>
@@ -307,11 +307,6 @@ export default {
 
     getDate(date) {
       return date ? moment(date, 'YYYY-MM-DD').toDate() : null
-    },
-
-    formatDate(date) {
-      if (date) return moment(date).format('YYYY-MM-DD')
-      return ''
     },
 
     isEstimationBurned(task) {

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -228,7 +228,7 @@
                 v-if="isInDepartment(task) && selectionGrid[task.id]"
               />
               <template v-else>
-                {{ formatDate(task.start_date) }}
+                {{ formatDisplayDate(task.start_date) }}
               </template>
             </td>
             <td class="due-date" v-if="!withSchedule">
@@ -241,20 +241,20 @@
                 v-if="isInDepartment(task) && selectionGrid[task.id]"
               />
               <template v-else>
-                {{ formatDate(task.due_date) }}
+                {{ formatDisplayDate(task.due_date) }}
               </template>
             </td>
             <td class="real-start-date" v-if="!withSchedule">
-              {{ formatDate(task.real_start_date) }}
+              {{ formatDisplayDate(task.real_start_date) }}
             </td>
             <td class="real-end-date" v-if="!withSchedule">
-              {{ formatDate(task.end_date) }}
+              {{ formatDisplayDate(task.end_date) }}
             </td>
             <td class="done-date" v-if="!withSchedule">
-              {{ formatDate(task.done_date) }}
+              {{ formatDisplayDate(task.done_date) }}
             </td>
             <td class="last-comment-date" v-if="!withSchedule">
-              {{ formatDate(task.last_comment_date) }}
+              {{ formatDisplayDate(task.last_comment_date) }}
             </td>
             <td v-if="!withSchedule"></td>
           </tr>

--- a/src/components/lists/TimesheetList.vue
+++ b/src/components/lists/TimesheetList.vue
@@ -224,6 +224,7 @@ import { mapGetters } from 'vuex'
 
 import { PAGE_SIZE } from '@/lib/pagination'
 import { getTaskEntityPath } from '@/lib/path'
+import { formatVerboseDate } from '@/lib/time'
 
 import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import DateField from '@/components/widgets/DateField.vue'
@@ -330,6 +331,7 @@ export default {
 
   computed: {
     ...mapGetters([
+      'dateFormat',
       'isCurrentUserArtist',
       'organisation',
       'productionMap',
@@ -382,7 +384,7 @@ export default {
     },
 
     currentDate() {
-      return moment().format('LL')
+      return formatVerboseDate(moment(), this.dateFormat)
     },
 
     onSliderChange(valueInfo) {

--- a/src/components/lists/TodosList.vue
+++ b/src/components/lists/TodosList.vue
@@ -176,7 +176,7 @@
                 v-if="isEditable && selectionGrid[entry.id]"
               />
               <template v-else>
-                {{ formatDate(entry.start_date) }}
+                {{ formatDisplayDate(entry.start_date) }}
               </template>
             </td>
             <td class="due-date">
@@ -189,7 +189,7 @@
                 v-if="isEditable && selectionGrid[entry.id]"
               />
               <template v-else>
-                {{ formatDate(entry.due_date) }}
+                {{ formatDisplayDate(entry.due_date) }}
               </template>
             </td>
             <td
@@ -269,7 +269,7 @@
                 v-if="!done"
               />
               <td class="end-date" v-else>
-                {{ formatDate(entry.end_date) }}
+                {{ formatDisplayDate(entry.end_date) }}
               </td>
             </template>
             <th class="actions" v-else></th>
@@ -548,10 +548,6 @@ export default {
 
     getDate(date) {
       return date ? moment(date, 'YYYY-MM-DD').toDate() : null
-    },
-
-    formatDate(date) {
-      return date ? formatSimpleDate(date) : ''
     },
 
     onBodyScroll(event) {

--- a/src/components/mixins/format.js
+++ b/src/components/mixins/format.js
@@ -5,6 +5,7 @@ import { mapGetters } from 'vuex'
 
 import {
   formatDate,
+  formatDisplayDate,
   formatDuration,
   formatFullDate,
   formatSimpleDate
@@ -12,7 +13,7 @@ import {
 
 export const formatListMixin = {
   computed: {
-    ...mapGetters(['organisation']),
+    ...mapGetters(['dateFormat', 'organisation']),
 
     isDurationInHours() {
       return this.organisation.format_duration_in_hours
@@ -33,6 +34,10 @@ export const formatListMixin = {
     formatDate,
     formatFullDate,
     formatSimpleDate,
+
+    formatDisplayDate(date) {
+      return formatDisplayDate(date, this.dateFormat)
+    },
 
     formatDuration(minutes, toLocale = true) {
       return formatDuration(this.organisation, minutes, toLocale)

--- a/src/components/pages/ProductionNewsFeed.vue
+++ b/src/components/pages/ProductionNewsFeed.vue
@@ -93,7 +93,6 @@
  */
 import { useHead } from '@unhead/vue'
 import { NewspaperIcon, XIcon } from 'lucide-vue-next'
-import moment from 'moment-timezone'
 import {
   computed,
   getCurrentInstance,
@@ -119,7 +118,7 @@ const { t } = useI18n()
 const route = useRoute()
 const router = useRouter()
 const store = useStore()
-const { timezone } = useTime()
+const { formatDay, timezone } = useTime()
 
 const instance = getCurrentInstance()
 const socket = instance.appContext.config.globalProperties.$socket
@@ -185,8 +184,6 @@ const params = computed(() => ({
 }))
 
 // Functions
-
-const formatDay = date => moment.tz(date, 'UTC').tz(timezone.value).format('LL')
 
 const setScrollPosition = scrollPosition => {
   if (body.value) {

--- a/src/components/pages/Profile.vue
+++ b/src/components/pages/Profile.vue
@@ -66,6 +66,11 @@
             v-model="form.country"
             v-if="user.role !== 'client' && !user.is_guest"
           />
+          <combobox
+            :label="$t('profile.date_format')"
+            :options="dateFormatOptions"
+            v-model="form.display_date_format"
+          />
         </div>
         <div class="toggle-row">
           <checkbox
@@ -198,6 +203,7 @@ import { useStore } from 'vuex'
 
 import { getCountryOptions } from '@/lib/countries'
 import lang, { localeCode } from '@/lib/lang'
+import { DATE_DISPLAY_FORMATS } from '@/lib/time'
 
 import ChangeAvatarModal from '@/components/modals/ChangeAvatarModal.vue'
 import Card from '@/components/widgets/Card.vue'
@@ -227,7 +233,8 @@ const form = ref({
   country: null,
   timezone: 'Europe/Paris',
   locale: 'en_US',
-  use_12_hour_clock: false
+  use_12_hour_clock: false,
+  display_date_format: 'YYYY-MM-DD'
 })
 
 const passwordForm = ref({
@@ -282,11 +289,18 @@ const timezoneOptions = computed(() =>
 
 const countryOptions = computed(() => getCountryOptions(localeCode.value))
 
+const dateFormatOptions = DATE_DISPLAY_FORMATS.map(format => ({
+  label: `${format} (${moment().format(format)})`,
+  value: format
+}))
+
 // Functions
 
 const syncFormFromUser = () => {
   Object.assign(form.value, user.value)
   form.value.use_12_hour_clock = Boolean(user.value.use_12_hour_clock)
+  form.value.display_date_format =
+    user.value.display_date_format || 'YYYY-MM-DD'
   form.value.notifications_enabled = Boolean(user.value.notifications_enabled)
   form.value.notifications_slack_enabled = Boolean(
     user.value.notifications_slack_enabled

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -233,25 +233,25 @@
                     <td class="field-label">
                       {{ $t('tasks.fields.start_date') }}
                     </td>
-                    <td>{{ formatSimpleDate(task.start_date) }}</td>
+                    <td>{{ formatDisplayDate(task.start_date) }}</td>
                   </tr>
                   <tr class="datatable-row">
                     <td class="field-label">
                       {{ $t('tasks.fields.due_date') }}
                     </td>
-                    <td>{{ formatSimpleDate(task.due_date) }}</td>
+                    <td>{{ formatDisplayDate(task.due_date) }}</td>
                   </tr>
                   <tr class="datatable-row">
                     <td class="field-label">
                       {{ $t('tasks.fields.end_date') }}
                     </td>
-                    <td>{{ formatSimpleDate(task.end_date) }}</td>
+                    <td>{{ formatDisplayDate(task.end_date) }}</td>
                   </tr>
                   <tr class="datatable-row">
                     <td class="field-label">
                       {{ $t('tasks.fields.done_date') }}
                     </td>
-                    <td>{{ formatSimpleDate(task.done_date) }}</td>
+                    <td>{{ formatDisplayDate(task.done_date) }}</td>
                   </tr>
                 </tbody>
               </table>

--- a/src/components/pages/entities/EntityChatDays.vue
+++ b/src/components/pages/entities/EntityChatDays.vue
@@ -107,7 +107,7 @@ import {
   getAttachmentThumbnailPath,
   getDownloadAttachmentPath
 } from '@/lib/path'
-import { formatTimeOfDay, parseDate } from '@/lib/time'
+import { formatTimeOfDay, formatVerboseDate, parseDate } from '@/lib/time'
 import { renderComment } from '@/lib/render'
 import files from '@/lib/files'
 
@@ -141,7 +141,13 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['departmentMap', 'personMap', 'use12HourClock', 'user']),
+    ...mapGetters([
+      'dateFormat',
+      'departmentMap',
+      'personMap',
+      'use12HourClock',
+      'user'
+    ]),
 
     messageList() {
       const messages = [...this.messages].sort((a, b) =>
@@ -176,7 +182,7 @@ export default {
             texts: [message ? message : '']
           }
           lastDay = {
-            title: messageDate.format('LL'),
+            title: formatVerboseDate(messageDate, this.dateFormat),
             date: messageDate.format('YYYY-MM-DD'),
             messages: [element]
           }

--- a/src/components/pages/entities/EntityTimeLogs.vue
+++ b/src/components/pages/entities/EntityTimeLogs.vue
@@ -27,7 +27,7 @@
         <tbody class="datatable-body">
           <tr :key="log.id" class="datatable-row" v-for="log in logs">
             <td class="date">
-              {{ formatSimpleDate(log.date) }}
+              {{ formatDisplayDate(log.date) }}
             </td>
             <people-name-cell
               class="person"

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -574,7 +574,7 @@ import { remove } from '@/lib/models'
 import { getDownloadAttachmentPath, pluralizeEntityType } from '@/lib/path'
 import { renderComment, replaceTimeWithTimecode, safeUrl } from '@/lib/render'
 import { sortByName } from '@/lib/sorting'
-import { formatTimeOfDay, parseDate } from '@/lib/time'
+import { formatShortDate, formatTimeOfDay, parseDate } from '@/lib/time'
 import stringHelpers from '@/lib/string'
 
 import { useAtMentionsMembers } from '@/composables/atMentions'
@@ -686,6 +686,7 @@ const uniqueClassName = (Math.random() + 1).toString(36).substring(2)
 let silent = false
 let lastCall = 0
 
+const dateFormat = computed(() => store.getters.dateFormat)
 const departmentMap = computed(() => store.getters.departmentMap)
 const isCurrentUserAdmin = computed(() => store.getters.isCurrentUserAdmin)
 const isCurrentUserArtist = computed(() => store.getters.isCurrentUserArtist)
@@ -872,7 +873,7 @@ const renderDate = date => {
   if (moment().isSame(date, 'd')) {
     return formatTimeOfDay(date.tz(user.value.timezone), use12HourClock.value)
   } else {
-    return date.tz(user.value.timezone).format('MM/DD')
+    return formatShortDate(date.tz(user.value.timezone), dateFormat.value)
   }
 }
 

--- a/src/composables/format.js
+++ b/src/composables/format.js
@@ -11,6 +11,7 @@ import { useStore } from 'vuex'
 
 import {
   formatDate,
+  formatDisplayDate as libFormatDisplayDate,
   formatDuration as libFormatDuration,
   formatFullDate,
   formatSimpleDate
@@ -48,7 +49,11 @@ export const useFormat = () => {
     () => organisation.value.format_duration_in_hours
   )
 
+  const dateFormat = computed(() => store.getters.dateFormat)
+
   const formatBoolean = value => (value ? t('main.yes') : t('main.no'))
+
+  const formatDisplayDate = date => libFormatDisplayDate(date, dateFormat.value)
 
   const formatDuration = (minutes, toLocale = true) =>
     libFormatDuration(organisation.value, minutes, toLocale)
@@ -64,8 +69,10 @@ export const useFormat = () => {
   return {
     organisation,
     isDurationInHours,
+    dateFormat,
     formatBoolean,
     formatDate,
+    formatDisplayDate,
     formatFullDate,
     formatSimpleDate,
     formatDuration,

--- a/src/composables/time.js
+++ b/src/composables/time.js
@@ -5,7 +5,11 @@ import { computed } from 'vue'
 import { useStore } from 'vuex'
 import moment from 'moment-timezone'
 
-import { formatFullDateWithTimezone, formatTimeOfDay } from '@/lib/time'
+import {
+  formatFullDateWithTimezone,
+  formatTimeOfDay,
+  formatVerboseDate
+} from '@/lib/time'
 
 export function useTime() {
   const store = useStore()
@@ -15,6 +19,8 @@ export function useTime() {
   )
 
   const use12HourClock = computed(() => store.getters.use12HourClock)
+
+  const dateFormat = computed(() => store.getters.dateFormat)
 
   const today = computed(() => moment().toDate())
 
@@ -31,5 +37,21 @@ export function useTime() {
     )
   }
 
-  return { timezone, use12HourClock, today, tomorrow, formatDate, formatTime }
+  function formatDay(eventDate) {
+    return formatVerboseDate(
+      moment.tz(eventDate, 'UTC').tz(timezone.value),
+      dateFormat.value
+    )
+  }
+
+  return {
+    timezone,
+    use12HourClock,
+    dateFormat,
+    today,
+    tomorrow,
+    formatDate,
+    formatTime,
+    formatDay
+  }
 }

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -94,6 +94,26 @@ export const formatDate = date => {
   }
 }
 
+export const DATE_DISPLAY_FORMATS = ['YYYY-MM-DD', 'DD/MM/YYYY', 'MM/DD/YYYY']
+
+export const formatDisplayDate = (date, dateFormat = 'YYYY-MM-DD') => {
+  if (!date) return ''
+  const format = DATE_DISPLAY_FORMATS.includes(dateFormat)
+    ? dateFormat
+    : 'YYYY-MM-DD'
+  return moment(date).format(format)
+}
+
+export const formatShortDate = (date, dateFormat = 'YYYY-MM-DD') => {
+  if (!date) return ''
+  return moment(date).format(dateFormat === 'DD/MM/YYYY' ? 'DD/MM' : 'MM/DD')
+}
+
+export const formatVerboseDate = (date, dateFormat = 'YYYY-MM-DD') => {
+  if (!date) return ''
+  return moment(date).format(dateFormat === 'DD/MM/YYYY' ? 'D MMMM YYYY' : 'LL')
+}
+
 export const monthToString = month => {
   return moment(`${month}`, 'M').format('MMM')
 }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1538,6 +1538,7 @@ export default {
   profile: {
     change_avatar: 'Change avatar',
     clear_avatar: 'Remove avatar',
+    date_format: 'Date format',
     info_title: 'Information',
     language: 'Language',
     notifications_title: 'Notifications',

--- a/src/store/api/people.js
+++ b/src/store/api/people.js
@@ -118,7 +118,8 @@ export default {
       departments: person.departments,
       studio_id: person.studio_id,
       country: person.country,
-      use_12_hour_clock: toBool(person.use_12_hour_clock)
+      use_12_hour_clock: toBool(person.use_12_hour_clock),
+      display_date_format: person.display_date_format
     }
     return client.pput(`/api/data/persons/${person.id}`, data)
   },

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -147,6 +147,7 @@ const getters = {
   isSaveProfileLoading: state => state.isSaveProfileLoading,
   isSaveProfileLoadingError: state => state.isSaveProfileLoadingError,
   changePassword: state => state.changePassword,
+  dateFormat: state => state.user?.display_date_format || 'YYYY-MM-DD',
 
   todoMap: state => state.todoMap,
   displayedTodos: state => state.displayedTodos,

--- a/tests/unit/lib/time.spec.js
+++ b/tests/unit/lib/time.spec.js
@@ -3,12 +3,15 @@ import {
   addBusinessDays,
   daysToMinutes,
   formatDate,
+  formatDisplayDate,
   formatDuration,
   formatFullDate,
   formatFullDateWithTimezone,
   formatFullDateWithRevertedTimezone,
+  formatShortDate,
   formatSimpleDate,
   formatTimeOfDay,
+  formatVerboseDate,
   hoursToDays,
   getBusinessDays,
   getDayOffRange,
@@ -26,7 +29,7 @@ import {
   parseDate,
   parseSimpleDate,
   range,
-  removeBusinessDays,
+  removeBusinessDays
 } from '@/lib/time'
 
 describe('time', () => {
@@ -56,9 +59,7 @@ describe('time', () => {
       moment.tz('2019-09-01T08:23:12Z', 'UTC').toString()
     )
     date = parseSimpleDate('2019-09-01')
-    expect(date.toString()).toEqual(
-      moment.tz('2019-09-01', 'UTC').toString()
-    )
+    expect(date.toString()).toEqual(moment.tz('2019-09-01', 'UTC').toString())
     date = parseSimpleDate(null)
     expect(formatSimpleDate(date)).toEqual('2019-09-10')
   })
@@ -71,6 +72,36 @@ describe('time', () => {
   test('formatDate', () => {
     const dateString = formatDate(new Date('2019-09-01T08:23:12Z'))
     expect(dateString).toEqual('2019-09-01 08:23')
+  })
+
+  test('formatDisplayDate', () => {
+    expect(formatDisplayDate('2019-09-01')).toEqual('2019-09-01')
+    expect(formatDisplayDate('2019-09-01', 'YYYY-MM-DD')).toEqual('2019-09-01')
+    expect(formatDisplayDate('2019-09-01', 'DD/MM/YYYY')).toEqual('01/09/2019')
+    expect(formatDisplayDate('2019-09-01', 'MM/DD/YYYY')).toEqual('09/01/2019')
+    // Unknown preference values fall back to the ISO default.
+    expect(formatDisplayDate('2019-09-01', 'bogus')).toEqual('2019-09-01')
+    expect(formatDisplayDate(null)).toEqual('')
+    expect(formatDisplayDate('')).toEqual('')
+  })
+
+  test('formatShortDate', () => {
+    expect(formatShortDate('2019-09-01')).toEqual('09/01')
+    expect(formatShortDate('2019-09-01', 'YYYY-MM-DD')).toEqual('09/01')
+    expect(formatShortDate('2019-09-01', 'MM/DD/YYYY')).toEqual('09/01')
+    expect(formatShortDate('2019-09-01', 'DD/MM/YYYY')).toEqual('01/09')
+    expect(formatShortDate(null)).toEqual('')
+  })
+
+  test('formatVerboseDate', () => {
+    expect(formatVerboseDate('2019-09-01')).toEqual('September 1, 2019')
+    expect(formatVerboseDate('2019-09-01', 'MM/DD/YYYY')).toEqual(
+      'September 1, 2019'
+    )
+    expect(formatVerboseDate('2019-09-01', 'DD/MM/YYYY')).toEqual(
+      '1 September 2019'
+    )
+    expect(formatVerboseDate(null)).toEqual('')
   })
 
   test('formatFullDate', () => {
@@ -131,8 +162,9 @@ describe('time', () => {
 
   test('getMonthRange', () => {
     expect(getMonthRange(2019, 2019, 8)).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
-    expect(getMonthRange(2018, 2019))
-      .toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+    expect(getMonthRange(2018, 2019)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
+    ])
   })
 
   test('getWeekRange', () => {
@@ -192,9 +224,9 @@ describe('time', () => {
     expect(
       formatSimpleDate(getEndDateFromString(startDate, '2019-01-01'))
     ).toEqual('2019-10-01')
-    expect(
-      formatSimpleDate(getEndDateFromString(startDate))
-    ).toEqual('2019-10-01')
+    expect(formatSimpleDate(getEndDateFromString(startDate))).toEqual(
+      '2019-10-01'
+    )
   })
 
   test('getDatesFromStartDate', () => {
@@ -282,45 +314,89 @@ describe('time', () => {
   test('getBusinessDays', () => {
     let startDate = parseSimpleDate('2024-06-03') // monday
     expect(getBusinessDays(startDate, startDate)).toEqual(1) // monday
-    expect(getBusinessDays(startDate, startDate.clone().add(1, 'days'))).toEqual(2) // tuesday
+    expect(
+      getBusinessDays(startDate, startDate.clone().add(1, 'days'))
+    ).toEqual(2) // tuesday
     let daysOff = [{ date: '2024-06-04' }] // monday
-    expect(getBusinessDays(startDate, startDate.clone().add(2, 'days'), daysOff)).toEqual(2) // wednesday + day off
+    expect(
+      getBusinessDays(startDate, startDate.clone().add(2, 'days'), daysOff)
+    ).toEqual(2) // wednesday + day off
     startDate = parseSimpleDate('2024-06-01') // saturday
     expect(getBusinessDays(startDate, startDate)).toEqual(0) // saturday
-    expect(getBusinessDays(startDate, startDate.clone().add(1, 'days'))).toEqual(0)// saturday
-    expect(getBusinessDays(startDate, startDate.clone().add(2, 'days'))).toEqual(1) // monday
-    expect(getBusinessDays(startDate, startDate.clone().add(7, 'days'))).toEqual(5) // next saturday + week-end
+    expect(
+      getBusinessDays(startDate, startDate.clone().add(1, 'days'))
+    ).toEqual(0) // saturday
+    expect(
+      getBusinessDays(startDate, startDate.clone().add(2, 'days'))
+    ).toEqual(1) // monday
+    expect(
+      getBusinessDays(startDate, startDate.clone().add(7, 'days'))
+    ).toEqual(5) // next saturday + week-end
     daysOff = [{ date: '2024-06-03' }] // monday
-    expect(getBusinessDays(startDate, startDate.clone().add(7, 'days'), daysOff)).toEqual(4) // next saturday + week-end + day off
+    expect(
+      getBusinessDays(startDate, startDate.clone().add(7, 'days'), daysOff)
+    ).toEqual(4) // next saturday + week-end + day off
   })
   test('addBusinessDays', () => {
     let startDate
     expect(addBusinessDays(startDate, 0)).toBeUndefined() // no start date
     startDate = parseSimpleDate('2019-10-01') // tuesday
-    expect(formatSimpleDate(addBusinessDays(startDate, 0))).toEqual('2019-10-01') // tuesday
-    expect(formatSimpleDate(addBusinessDays(startDate, 1))).toEqual('2019-10-02') // wednesday
-    expect(formatSimpleDate(addBusinessDays(startDate, 2))).toEqual('2019-10-03') // thursday
-    expect(formatSimpleDate(addBusinessDays(startDate, 3))).toEqual('2019-10-04') // friday
-    expect(formatSimpleDate(addBusinessDays(startDate, 4))).toEqual('2019-10-07') // next monday
+    expect(formatSimpleDate(addBusinessDays(startDate, 0))).toEqual(
+      '2019-10-01'
+    ) // tuesday
+    expect(formatSimpleDate(addBusinessDays(startDate, 1))).toEqual(
+      '2019-10-02'
+    ) // wednesday
+    expect(formatSimpleDate(addBusinessDays(startDate, 2))).toEqual(
+      '2019-10-03'
+    ) // thursday
+    expect(formatSimpleDate(addBusinessDays(startDate, 3))).toEqual(
+      '2019-10-04'
+    ) // friday
+    expect(formatSimpleDate(addBusinessDays(startDate, 4))).toEqual(
+      '2019-10-07'
+    ) // next monday
     let daysOff = [{ date: '2019-10-07' }]
-    expect(formatSimpleDate(addBusinessDays(startDate, 4, daysOff))).toEqual('2019-10-08') // next thuesday
+    expect(formatSimpleDate(addBusinessDays(startDate, 4, daysOff))).toEqual(
+      '2019-10-08'
+    ) // next thuesday
     daysOff = [{ date: '2019-10-07', end_date: '2019-10-08' }]
-    expect(formatSimpleDate(addBusinessDays(startDate, 4, daysOff))).toEqual('2019-10-09') // next friday
+    expect(formatSimpleDate(addBusinessDays(startDate, 4, daysOff))).toEqual(
+      '2019-10-09'
+    ) // next friday
     startDate = parseSimpleDate('2019-09-29') // sunday
-    expect(formatSimpleDate(addBusinessDays(startDate, 0))).toEqual('2019-09-30') // monday
-    expect(formatSimpleDate(addBusinessDays(startDate, 1))).toEqual('2019-10-01') // tuesday
+    expect(formatSimpleDate(addBusinessDays(startDate, 0))).toEqual(
+      '2019-09-30'
+    ) // monday
+    expect(formatSimpleDate(addBusinessDays(startDate, 1))).toEqual(
+      '2019-10-01'
+    ) // tuesday
     startDate = parseSimpleDate('2019-10-04') // friday
-    expect(formatSimpleDate(addBusinessDays(startDate, 1))).toEqual('2019-10-07') // monday
+    expect(formatSimpleDate(addBusinessDays(startDate, 1))).toEqual(
+      '2019-10-07'
+    ) // monday
   })
   test('removeBusinessDays', () => {
     const startDate = parseSimpleDate('2019-10-07')
-    expect(formatSimpleDate(removeBusinessDays(startDate, 0))).toEqual('2019-10-07')
-    expect(formatSimpleDate(removeBusinessDays(startDate, 1))).toEqual('2019-10-04')
-    expect(formatSimpleDate(removeBusinessDays(startDate, 2))).toEqual('2019-10-03')
-    expect(formatSimpleDate(removeBusinessDays(startDate, 3))).toEqual('2019-10-02')
-    expect(formatSimpleDate(removeBusinessDays(startDate, 4))).toEqual('2019-10-01')
+    expect(formatSimpleDate(removeBusinessDays(startDate, 0))).toEqual(
+      '2019-10-07'
+    )
+    expect(formatSimpleDate(removeBusinessDays(startDate, 1))).toEqual(
+      '2019-10-04'
+    )
+    expect(formatSimpleDate(removeBusinessDays(startDate, 2))).toEqual(
+      '2019-10-03'
+    )
+    expect(formatSimpleDate(removeBusinessDays(startDate, 3))).toEqual(
+      '2019-10-02'
+    )
+    expect(formatSimpleDate(removeBusinessDays(startDate, 4))).toEqual(
+      '2019-10-01'
+    )
     const daysOff = [{ date: '2019-10-01' }]
-    expect(formatSimpleDate(removeBusinessDays(startDate, 4, daysOff))).toEqual('2019-09-30')
+    expect(formatSimpleDate(removeBusinessDays(startDate, 4, daysOff))).toEqual(
+      '2019-09-30'
+    )
   })
   test('daysToMinutes', () => {
     expect(daysToMinutes({ hours_by_day: 8 }, 8)).toEqual(8 * 8 * 60)
@@ -340,7 +416,10 @@ describe('time', () => {
 
   test('formatDuration', () => {
     const organisation = { hours_by_day: 8 }
-    const hoursOrganisation = { format_duration_in_hours: true, hours_by_day: 8 }
+    const hoursOrganisation = {
+      format_duration_in_hours: true,
+      hours_by_day: 8
+    }
 
     expect(formatDuration(organisation, 0)).toEqual(0)
     expect(formatDuration(organisation, null)).toEqual(0)


### PR DESCRIPTION
**Problem**
- Dates are always displayed in the fixed ISO / US-centric formats (`YYYY-MM-DD` tables, `MM/DD` comment dates, "August 26" day headers) with no way to get `DD/MM/YYYY` or "26 August" (fixes #936)

**Solution**
- Add a **Date format** combobox to the profile Information card (`YYYY-MM-DD` default, `DD/MM/YYYY`, `MM/DD/YYYY`), persisted in the new `display_date_format` person field through the existing profile save path (falls back to ISO against a Zou without the field)
- New `formatDisplayDate`, `formatShortDate` and `formatVerboseDate` helpers in `src/lib/time.js`, exposed through `formatListMixin` / `useFormat()` and `useTime()`, applied to task tables (task page, task lists, todos), time logs, comment short dates, entity chat and news feed day headers, and the timesheet header — storage, API and CSV export formats stay ISO