### PR TITLE
[players] Sync preview version and image position in the review room

### DIFF
--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -1729,8 +1729,11 @@ const previewRoom = usePreviewRoom({
   onWindowResize: () => onWindowResize(),
   findEntity: info => findEntity(info),
   findEntityIndex: info => findEntityIndex(info),
+  // Remote version change: the entity still holds the previous preview
+  // file id locally. Silent so the receiver does not re-persist the
+  // change already saved by the sender.
   changePreviewFile: (entity, previewFile) =>
-    changePreviewFile(entity, previewFile),
+    changePreviewFile(entity, previewFile, entity.preview_file_id, true),
   setRawPlayerFrame: f => rawPlayer.value?.setCurrentFrame(f),
   setCurrentTimeRaw: t => setCurrentTimeRaw(t),
   exists: v => v !== null && v !== undefined,
@@ -3465,7 +3468,12 @@ const onPreviewChanged = ({ entity, previewFile, previousPreviewFileId }) => {
   updateRoomStatus(previousPreviewFileId)
 }
 
-const changePreviewFile = (entity, previewFile, previousPreviewFileId) => {
+const changePreviewFile = (
+  entity,
+  previewFile,
+  previousPreviewFileId,
+  silent = false
+) => {
   pause()
   const localEntity = entityList.value.find(
     s => s.id === entity.id && s.preview_file_id === previousPreviewFileId
@@ -3487,11 +3495,13 @@ const changePreviewFile = (entity, previewFile, previousPreviewFileId) => {
       rawPlayer.value.reloadCurrentEntity()
     }
   }
-  emit('preview-changed', {
-    entity,
-    previewFileId: previewFile.id,
-    previousPreviewFileId
-  })
+  if (!silent) {
+    emit('preview-changed', {
+      entity,
+      previewFileId: previewFile.id,
+      previousPreviewFileId
+    })
+  }
   clearCanvas()
   resetPanZoom()
   panzoomTransform.value = { x: 0, y: 0, scale: 1 }

--- a/src/composables/previewRoom.js
+++ b/src/composables/previewRoom.js
@@ -368,17 +368,25 @@ export const usePreviewRoom = options => {
       eventData.current_preview_file_id !== currentPreviewFileId &&
       eventData.current_preview_file_index === 0
     ) {
+      // The server relays room updates without previous_preview_file_id,
+      // so fall back to the local playing entity: on this side it still
+      // holds the preview file the sender switched away from.
       const previewFileId = eventData.current_preview_file_id
-      const entity = findEntity({
+      let entity = findEntity({
         entity_id: eventData.current_entity_id,
         preview_file_id: eventData.previous_preview_file_id
       })
-      const previewFile = getPreviewFileFromEntity(entity, previewFileId)
-      if (!previewFile) return
-      const tasks = unref(taskMap)
-      const task = tasks?.get?.(previewFile.task_id)
-      if (!task) return
-      changePreviewFile(entity, previewFile, task.task_type_id)
+      const localEntity = unref(currentEntity)
+      if (!entity && localEntity?.id === eventData.current_entity_id) {
+        entity = localEntity
+      }
+      if (entity && entity.preview_file_id !== previewFileId) {
+        const previewFile = getPreviewFileFromEntity(entity, previewFileId)
+        const task = previewFile
+          ? unref(taskMap)?.get?.(previewFile.task_id)
+          : null
+        if (task) changePreviewFile(entity, previewFile, task.task_type_id)
+      }
     }
 
     if (

--- a/tests/unit/composables/previewRoom.spec.js
+++ b/tests/unit/composables/previewRoom.spec.js
@@ -385,6 +385,110 @@ describe('composables/previewRoom', () => {
     })
   })
 
+  describe('loadRoomCurrentState', () => {
+    const makeEntity = () => ({
+      id: 'entity-7',
+      preview_file_id: 'preview-old',
+      preview_files: {
+        'task-type-1': [
+          { id: 'preview-old', task_id: 'task-1' },
+          { id: 'preview-new', task_id: 'task-1' }
+        ]
+      }
+    })
+
+    const mountPlayerState = (overrides = {}) => {
+      const socket = makeSocket()
+      const entity = makeEntity()
+      const changePreviewFile = vi.fn()
+      const currentPreviewIndex = ref(0)
+      const { wrapper, api } = mountWithRoom({
+        room: makeRoom({ people: ['user-1'] }),
+        userId: 'user-1',
+        socket,
+        playingEntityIndex: ref(0),
+        currentEntity: ref(entity),
+        currentPreview: ref({ id: 'preview-old' }),
+        currentPreviewIndex,
+        taskMap: ref(
+          new Map([['task-1', { id: 'task-1', task_type_id: 'task-type-1' }]])
+        ),
+        findEntity: () => null,
+        findEntityIndex: () => 0,
+        changePreviewFile,
+        ...overrides
+      })
+      return { wrapper, api, entity, changePreviewFile, currentPreviewIndex }
+    }
+
+    it('applies a remote version change without previous_preview_file_id', () => {
+      const { wrapper, api, entity, changePreviewFile } = mountPlayerState()
+      api.loadRoomCurrentState({
+        is_playing: false,
+        current_entity_id: 'entity-7',
+        current_entity_index: 0,
+        current_preview_file_id: 'preview-new',
+        current_preview_file_index: 0
+      })
+      expect(changePreviewFile).toHaveBeenCalledWith(
+        entity,
+        { id: 'preview-new', task_id: 'task-1' },
+        'task-type-1'
+      )
+      wrapper.unmount()
+    })
+
+    it('applies a remote position change within a multi-image preview', () => {
+      const { wrapper, api, changePreviewFile, currentPreviewIndex } =
+        mountPlayerState()
+      api.loadRoomCurrentState({
+        is_playing: false,
+        current_entity_id: 'entity-7',
+        current_entity_index: 0,
+        current_preview_file_id: 'sub-preview-2',
+        current_preview_file_index: 2
+      })
+      expect(changePreviewFile).not.toHaveBeenCalled()
+      expect(currentPreviewIndex.value).toBe(2)
+      wrapper.unmount()
+    })
+
+    it('goes back to the first image without treating it as a version change', () => {
+      const { wrapper, api, changePreviewFile, currentPreviewIndex } =
+        mountPlayerState({
+          currentPreview: ref({ id: 'sub-preview-2' }),
+          currentEntity: ref({
+            ...makeEntity(),
+            preview_file_id: 'preview-main'
+          })
+        })
+      currentPreviewIndex.value = 2
+      api.loadRoomCurrentState({
+        is_playing: false,
+        current_entity_id: 'entity-7',
+        current_entity_index: 0,
+        current_preview_file_id: 'preview-main',
+        current_preview_file_index: 0
+      })
+      expect(changePreviewFile).not.toHaveBeenCalled()
+      expect(currentPreviewIndex.value).toBe(0)
+      wrapper.unmount()
+    })
+
+    it('ignores a version change for an unknown entity', () => {
+      const { wrapper, api, changePreviewFile } = mountPlayerState()
+      api.loadRoomCurrentState({
+        is_playing: false,
+        current_entity_id: 'entity-unknown',
+        current_entity_index: 0,
+        current_preview_file_id: 'preview-new',
+        current_preview_file_index: 0
+      })
+      expect(changePreviewFile).not.toHaveBeenCalled()
+      wrapper.unmount()
+    })
+  })
+
   describe('incoming event echo guard', () => {
     /**
      * Helper: mount, grab the registered handler for `event`, return it.


### PR DESCRIPTION
## Problems

- In a review room, changing the preview version or the displayed image of a multi-image revision was not synchronized to the other participants, only shot changes were (fixes #1573)
- The receiving side resolved the changed entity through `previous_preview_file_id`, a field the server strips from the relayed room payload, then aborted the whole room-state application, which also blocked going back to the first image
- The `changePreviewFile` bridge between the room composable and the player dropped the previous preview file id, so the local entity lookup never matched even when an entity was resolved

## Solutions

- Fall back to the local playing entity when `previous_preview_file_id` is missing: from the receiver's point of view it still holds the preview file the sender switched away from
- Only treat a differing preview file id as a version change when it differs from the entity's own preview file, and keep applying the rest of the room state (image position, frame, speed...) instead of returning early
- Pass the entity's current preview file id to `changePreviewFile` and apply the remote change silently so the receiver does not re-persist a change already saved by the sender
- Cover the remote version-change and image-position paths with unit tests on `loadRoomCurrentState`