### PR TITLE
[schedule] Let supervisors and managers reload the team schedule page

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -159,9 +159,16 @@ export const routes = [
             peopleStore.state.organisation,
             userStore.state.user
           )
+          const isSupervisorOrManager =
+            userStore.getters.isCurrentUserManager(userStore.state) ||
+            userStore.getters.isCurrentUserSupervisor(userStore.state)
           const isProhibited =
-            !userStore.getters.isCurrentUserAdmin(userStore.state) &&
-            to?.matched.some(record => record.meta.requiresAdmin)
+            (!userStore.getters.isCurrentUserAdmin(userStore.state) &&
+              to?.matched.some(record => record.meta.requiresAdmin)) ||
+            (!isSupervisorOrManager &&
+              to?.matched.some(
+                record => record.meta.requiresSupervisorOrManager
+              ))
           if (taskTypeStore.state.taskTypes.length === 0) {
             init()
               .then(ready => {
@@ -337,7 +344,7 @@ export const routes = [
         path: '/team-schedule',
         component: TeamSchedule,
         name: 'team-schedule',
-        meta: { requiresAdmin: true }
+        meta: { requiresSupervisorOrManager: true }
       },
 
       {

--- a/tests/unit/router/routes.spec.js
+++ b/tests/unit/router/routes.spec.js
@@ -1,7 +1,9 @@
 import { vi } from 'vitest'
 
 const h = vi.hoisted(() => ({
-  isAdmin: false
+  isAdmin: false,
+  isManager: false,
+  isSupervisor: false
 }))
 
 // Stub everything the route guards touch so importing the route table does
@@ -30,7 +32,9 @@ vi.mock('@/store/modules/user', () => ({
     state: { user: { locale: 'en' } },
     getters: {
       isCurrentUserAdmin: () => h.isAdmin,
-      isCurrentUserArtist: () => false
+      isCurrentUserArtist: () => false,
+      isCurrentUserManager: () => h.isAdmin || h.isManager,
+      isCurrentUserSupervisor: () => h.isSupervisor
     }
   }
 }))
@@ -63,13 +67,19 @@ const ADMIN_ONLY_ROUTES = [
   'status-automations',
   'studios',
   'task-status',
-  'task-types',
-  'team-schedule'
+  'task-types'
 ]
+
+// Pages linked from the sidebar for supervisors and production managers:
+// their route meta must match that visibility, otherwise a page reload
+// sends those roles to not-found (#1933).
+const SUPERVISOR_OR_MANAGER_ROUTES = ['team-schedule']
 
 describe('router/routes', () => {
   beforeEach(() => {
     h.isAdmin = false
+    h.isManager = false
+    h.isSupervisor = false
     taskTypeStore.state.taskTypes = [{ id: 'task-type-1' }]
     vi.clearAllMocks()
   })
@@ -80,6 +90,18 @@ describe('router/routes', () => {
       expect(route).toBeDefined()
       expect(route.meta?.requiresAdmin).toBe(true)
     })
+  })
+
+  describe('supervisor or manager route table', () => {
+    test.each(SUPERVISOR_OR_MANAGER_ROUTES)(
+      '%s requires supervisor or manager',
+      name => {
+        const route = mainRoute.children.find(child => child.name === name)
+        expect(route).toBeDefined()
+        expect(route.meta?.requiresSupervisorOrManager).toBe(true)
+        expect(route.meta?.requiresAdmin).toBeUndefined()
+      }
+    )
   })
 
   describe('main guard', () => {
@@ -103,6 +125,25 @@ describe('router/routes', () => {
     test('lets a non-admin through on a regular route', () => {
       const next = runGuard({ matched: [{ meta: {} }] })
       expect(next).toHaveBeenCalledWith()
+    })
+
+    test.each([
+      ['production manager', 'isManager'],
+      ['supervisor', 'isSupervisor'],
+      ['admin', 'isAdmin']
+    ])('lets a %s through on a supervisor-or-manager route', (role, flag) => {
+      h[flag] = true
+      const next = runGuard({
+        matched: [{ meta: { requiresSupervisorOrManager: true } }]
+      })
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    test('redirects an artist to not-found on a supervisor-or-manager route', () => {
+      const next = runGuard({
+        matched: [{ meta: { requiresSupervisorOrManager: true } }]
+      })
+      expect(next).toHaveBeenCalledWith({ name: 'not-found' })
     })
 
     test('still blocks admin routes when data loads first', async () => {


### PR DESCRIPTION
## Problems
- Reloading /team-schedule as a production manager or supervisor redirected to the not-found page, while the sidebar shows them the Team Schedule link (fixes #1933)
- The route was flagged admin-only since v0.17.41 and stayed so when the sidebar visibility was widened to supervisors and managers in Feb 2024; the / guard only runs on a hard load, so the mismatch surfaced only on reload

## Solutions
- Gate the team-schedule route with a requiresSupervisorOrManager meta that mirrors the sidebar visibility, enforced by the same route guard
- Cover the new meta and guard branch in tests/unit/router/routes.spec.js (manager, supervisor and admin pass; artists are redirected to not-found)