### PR TITLE
[audit] Players write-path cleanup and keyboard accessibility lot

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -862,6 +862,7 @@ h2 {
 .avatar {
   border-radius: 50%;
   color: $white;
+  overflow: hidden;
 
   a,
   a:hover {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1295,7 +1295,7 @@ textarea.input:focus {
     border-radius: 0.5em;
     padding: 2.8em 3em 3em 3em;
 
-    h1.title {
+    h2.title {
       font-family: Lato;
       font-weight: 400;
       font-size: 3em;
@@ -1324,7 +1324,7 @@ textarea.input:focus {
     .box {
       padding: 1.5em;
 
-      h1.title {
+      h2.title {
         font-size: 1.8em;
         margin-bottom: 0.5em;
       }

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -1,9 +1,14 @@
 <template>
   <XyzTransition appear xyz="fade">
     <div class="main">
+      <a class="skip-link" href="#main-content">{{
+        $t('main.skip_to_content')
+      }}</a>
       <topbar />
       <sidebar />
-      <router-view />
+      <main id="main-content">
+        <router-view />
+      </main>
     </div>
   </XyzTransition>
 </template>
@@ -31,5 +36,19 @@ export default {
   height: 100%;
   display: flex;
   flex-direction: column;
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  z-index: 100;
+  padding: 0.5em 1em;
+  background: var(--background);
+  color: var(--text);
+}
+
+.skip-link:focus {
+  top: 0;
 }
 </style>

--- a/src/components/cells/DescriptionCell.vue
+++ b/src/components/cells/DescriptionCell.vue
@@ -1,5 +1,12 @@
 <template>
-  <td class="description-cell" @keyup.esc="onClick" @click="onClick">
+  <td
+    class="description-cell"
+    role="button"
+    tabindex="0"
+    @keyup.esc="onClick"
+    @click="onClick"
+    @keydown.enter.prevent="onClick"
+  >
     <template v-if="full">
       <div
         class="description-shorten-text"

--- a/src/components/cells/LastCommentCell.vue
+++ b/src/components/cells/LastCommentCell.vue
@@ -1,5 +1,10 @@
 <template>
-  <td @click="$emit('click')">
+  <td
+    role="button"
+    tabindex="0"
+    @click="$emit('click')"
+    @keydown.enter.prevent="$emit('click')"
+  >
     <div class="flexrow">
       <people-avatar
         class="flexrow-item avatar-wrapper"

--- a/src/components/cells/MetadataHeader.vue
+++ b/src/components/cells/MetadataHeader.vue
@@ -22,7 +22,11 @@
 
       <span
         class="metadata-menu-button header-icon pointer"
+        role="button"
+        tabindex="0"
         @click="$emit('show-metadata-header-menu', $event)"
+        @keydown.enter.prevent="$emit('show-metadata-header-menu', $event)"
+        @keydown.space.prevent="$emit('show-metadata-header-menu', $event)"
         v-if="!noMenu"
       >
         <chevron-down-icon :size="14" />

--- a/src/components/cells/PeopleUserCell.vue
+++ b/src/components/cells/PeopleUserCell.vue
@@ -9,7 +9,15 @@
           class="email nowrap"
         >
           {{ person.email }}
-          <span class="copy-icon" :title="$t('main.copy')" @click="copyEmail">
+          <span
+            class="copy-icon"
+            :title="$t('main.copy')"
+            role="button"
+            tabindex="0"
+            @click="copyEmail"
+            @keydown.enter.prevent="copyEmail"
+            @keydown.space.prevent="copyEmail"
+          >
             <copy-icon :size="12" />
           </span>
         </div>

--- a/src/components/cells/ProductionNameCell.vue
+++ b/src/components/cells/ProductionNameCell.vue
@@ -13,7 +13,7 @@
         <template v-if="!entry.has_avatar">
           {{ generatedAvatar }}
         </template>
-        <img :src="thumbnailPath" v-else />
+        <img :src="thumbnailPath" :alt="entry.name" v-else />
       </div>
       <span class="flexrow-item" v-if="!onlyAvatar">
         {{ entry.name }}
@@ -28,7 +28,7 @@
         <template v-if="!entry.has_avatar">
           {{ generatedAvatar }}
         </template>
-        <img :src="thumbnailPath" v-else />
+        <img :src="thumbnailPath" :alt="entry.name" v-else />
       </div>
       <span class="flexrow-item" v-if="!onlyAvatar">
         {{ entry.name }}

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -42,8 +42,16 @@
             :title="castingTitle"
             v-if="!isCurrentUserClient && castingTitle"
           >
-            <img src="@/assets/icons/casting-ready.png" v-if="isCastingReady" />
-            <img src="@/assets/icons/casting-not-ready.png" v-else />
+            <img
+              src="@/assets/icons/casting-ready.png"
+              :alt="castingTitle"
+              v-if="isCastingReady"
+            />
+            <img
+              src="@/assets/icons/casting-not-ready.png"
+              :alt="castingTitle"
+              v-else
+            />
           </span>
         </template>
         <template v-if="isAssignees && !isCurrentUserClient && !disabled">
@@ -60,7 +68,7 @@
           >
             <img
               loading="lazy"
-              alt=""
+              :alt="person.full_name"
               :src="person.avatarPath"
               v-if="person.has_avatar"
             />

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -7,7 +7,10 @@
       validation: selectable
     }"
     :style="cellStyle"
+    role="button"
+    tabindex="0"
     @click="onClick"
+    @keydown.enter.prevent="onClick"
   >
     <div class="wrapper full-wrapper" :style="wrapperStyle" v-if="!minimized">
       <div class="filler" v-if="contactSheet"></div>

--- a/src/components/cells/ValidationHeader.vue
+++ b/src/components/cells/ValidationHeader.vue
@@ -33,7 +33,11 @@
       </span>
       <span
         class="metadata-menu-button header-icon pointer"
+        role="button"
+        tabindex="0"
         @click="$emit('show-header-menu', $event)"
+        @keydown.enter.prevent="$emit('show-header-menu', $event)"
+        @keydown.space.prevent="$emit('show-header-menu', $event)"
       >
         <chevron-down-icon :size="14" />
       </span>

--- a/src/components/lists/AllTaskList.vue
+++ b/src/components/lists/AllTaskList.vue
@@ -55,7 +55,10 @@
               'datatable-row': true,
               selected: selectionGrid[task.id]
             }"
+            role="button"
+            tabindex="0"
             @click="selectTask($event, index, task)"
+            @keydown.enter.prevent="selectTask($event, index, task)"
             v-for="(task, index) in tasks"
           >
             <td class="project">

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -252,7 +252,12 @@
               <th scope="rowgroup">
                 <span
                   class="datatable-row-header pointer"
+                  role="button"
+                  tabindex="0"
                   @click="$emit('asset-type-clicked', group[0].asset_type_name)"
+                  @keydown.enter.prevent="
+                    $emit('asset-type-clicked', group[0].asset_type_name)
+                  "
                 >
                   {{ group[0] ? group[0].asset_type_name : '' }}
                 </span>

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -550,7 +550,7 @@
         v-if="isEmptyList && !isCurrentUserClient && !isLoading"
       >
         <p class="info">
-          <img src="../../assets/illustrations/empty_asset.png" />
+          <img src="../../assets/illustrations/empty_asset.png" alt="" />
         </p>
         <p class="info">{{ $t('assets.empty_list') }}</p>
         <button-simple
@@ -564,7 +564,7 @@
         v-if="isEmptyList && isCurrentUserClient && !isLoading"
       >
         <p class="info">
-          <img src="../../assets/illustrations/empty_asset.png" />
+          <img src="../../assets/illustrations/empty_asset.png" alt="" />
         </p>
         <p class="info">{{ $t('assets.empty_list_client') }}</p>
       </div>

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -460,7 +460,7 @@
       v-if="isEmptyList && !isCurrentUserClient && !isLoading"
     >
       <p class="info">
-        <img src="../../assets/illustrations/empty_edit.png" />
+        <img src="../../assets/illustrations/empty_edit.png" alt="" />
       </p>
       <p class="info">{{ $t('edits.empty_list') }}</p>
       <button-simple
@@ -474,7 +474,7 @@
       v-if="isEmptyList && isCurrentUserClient && !isLoading"
     >
       <p class="info">
-        <img src="../../assets/illustrations/empty_edit.png" />
+        <img src="../../assets/illustrations/empty_edit.png" alt="" />
       </p>
       <p class="info">{{ $t('edits.empty_list_client') }}</p>
     </div>

--- a/src/components/lists/EntityTaskList.vue
+++ b/src/components/lists/EntityTaskList.vue
@@ -52,7 +52,10 @@
               'datatable-row': true,
               'datatable-row--selectable': true
             }"
+            role="button"
+            tabindex="0"
             @click="selectTask(task)"
+            @keydown.enter.prevent="selectTask(task)"
             v-for="task in sortedEntries"
           >
             <task-type-cell

--- a/src/components/lists/EpisodeList.vue
+++ b/src/components/lists/EpisodeList.vue
@@ -491,7 +491,7 @@
       v-if="isEmptyList && isCurrentUserClient && !isLoading"
     >
       <p class="info">
-        <img src="../../assets/illustrations/empty_shot.png" />
+        <img src="../../assets/illustrations/empty_shot.png" alt="" />
       </p>
       <p class="info">{{ $t('episodes.empty_list_client') }}</p>
     </div>

--- a/src/components/lists/EpisodeStatsList.vue
+++ b/src/components/lists/EpisodeStatsList.vue
@@ -199,7 +199,7 @@
       v-if="!isLoading && isEmptyList && !isCurrentUserClient"
     >
       <p class="info">
-        <img src="../../assets/illustrations/empty_shot.png" />
+        <img src="../../assets/illustrations/empty_shot.png" alt="" />
       </p>
       <p class="info">{{ $t('episodes.empty_list') }}</p>
     </div>
@@ -208,7 +208,7 @@
       v-if="!isLoading && isEmptyList && isCurrentUserClient"
     >
       <p class="info">
-        <img src="../../assets/illustrations/empty_shot.png" />
+        <img src="../../assets/illustrations/empty_shot.png" alt="" />
       </p>
       <p class="info">{{ $t('episodes.empty_list_client') }}</p>
     </div>

--- a/src/components/lists/EpisodeStatsList.vue
+++ b/src/components/lists/EpisodeStatsList.vue
@@ -73,7 +73,13 @@
 
           <template v-for="entry in entries" :key="entry.id">
             <tr class="datatable-row">
-              <td class="expander" @click="toggleExpanded(entry.id)">
+              <td
+                class="expander"
+                role="button"
+                tabindex="0"
+                @click="toggleExpanded(entry.id)"
+                @keydown.enter.prevent="toggleExpanded(entry.id)"
+              >
                 <chevron-right-icon
                   v-if="isRetakes && expanded[entry.id] !== true"
                 />

--- a/src/components/lists/KanbanBoard.vue
+++ b/src/components/lists/KanbanBoard.vue
@@ -47,7 +47,11 @@
             }"
             draggable="true"
             :key="task.id"
+            role="button"
             @click="onSelectTask(task, $event.ctrlKey || $event.metaKey)"
+            @keydown.enter.prevent="
+              onSelectTask(task, $event.ctrlKey || $event.metaKey)
+            "
             @dragstart="onCardDragStart($event, task, column.status)"
             @drag="onCardDrag"
             @dragend="onCardDragEnd"

--- a/src/components/lists/PreviewFileList.vue
+++ b/src/components/lists/PreviewFileList.vue
@@ -41,7 +41,10 @@
           <tr
             :key="previewFile.id"
             class="datatable-row"
+            role="button"
+            tabindex="0"
             @click="redirectToTask(previewFile)"
+            @keydown.enter.prevent="redirectToTask(previewFile)"
             v-for="previewFile in previewFiles"
           >
             <td class="date">

--- a/src/components/lists/ProductionAssetTypeList.vue
+++ b/src/components/lists/ProductionAssetTypeList.vue
@@ -111,7 +111,7 @@
       v-if="isEmptyList && !isCurrentUserClient && !isLoading"
     >
       <p class="info">
-        <img src="../../assets/illustrations/empty_asset.png" />
+        <img src="../../assets/illustrations/empty_asset.png" alt="" />
       </p>
       <p class="info">{{ $t('assets.empty_list') }}</p>
     </div>
@@ -120,7 +120,7 @@
       v-if="isEmptyList && isCurrentUserClient && !isLoading"
     >
       <p class="info">
-        <img src="../../assets/illustrations/empty_asset.png" />
+        <img src="../../assets/illustrations/empty_asset.png" alt="" />
       </p>
       <p class="info">{{ $t('assets.empty_list_client') }}</p>
     </div>

--- a/src/components/lists/SequenceList.vue
+++ b/src/components/lists/SequenceList.vue
@@ -456,7 +456,7 @@
       v-if="isEmptyList && !isCurrentUserClient && !isLoading"
     >
       <p class="info">
-        <img src="../../assets/illustrations/empty_shot.png" />
+        <img src="../../assets/illustrations/empty_shot.png" alt="" />
       </p>
       <p class="info">{{ $t('sequences.empty_list_client') }}</p>
     </div>

--- a/src/components/lists/SequenceStatsList.vue
+++ b/src/components/lists/SequenceStatsList.vue
@@ -124,7 +124,7 @@
       v-if="isEmptyList && !isCurrentUserClient && !isLoading"
     >
       <p class="info">
-        <img src="../../assets/illustrations/empty_shot.png" />
+        <img src="../../assets/illustrations/empty_shot.png" alt="" />
       </p>
       <p class="info">{{ $t('sequences.empty_list') }}</p>
     </div>
@@ -133,7 +133,7 @@
       v-if="isEmptyList && isCurrentUserClient && !isLoading"
     >
       <p class="info">
-        <img src="../../assets/illustrations/empty_shot.png" />
+        <img src="../../assets/illustrations/empty_shot.png" alt="" />
       </p>
       <p class="info">{{ $t('sequences.empty_list_client') }}</p>
     </div>

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -764,7 +764,7 @@
       v-if="isEmptyList && !isCurrentUserClient && !isLoading"
     >
       <p class="info">
-        <img src="../../assets/illustrations/empty_shot.png" />
+        <img src="../../assets/illustrations/empty_shot.png" alt="" />
       </p>
       <p class="info">{{ $t('shots.empty_list') }}</p>
       <button-simple
@@ -778,7 +778,7 @@
       v-if="isEmptyList && isCurrentUserClient && !isLoading"
     >
       <p class="info">
-        <img src="../../assets/illustrations/empty_shot.png" />
+        <img src="../../assets/illustrations/empty_shot.png" alt="" />
       </p>
       <p class="info">{{ $t('shots.empty_list_client') }}</p>
     </div>

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -293,7 +293,12 @@
               <th scope="rowgroup">
                 <div
                   class="datatable-row-header pointer"
+                  role="button"
+                  tabindex="0"
                   @click="$emit('sequence-clicked', group[0].sequence_name)"
+                  @keydown.enter.prevent="
+                    $emit('sequence-clicked', group[0].sequence_name)
+                  "
                 >
                   {{ group[0] ? group[0].sequence_name : '' }}
                 </div>

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -93,7 +93,10 @@
               'datatable-row': true,
               selected: selectionGrid[task.id]
             }"
+            role="button"
+            tabindex="0"
             @click="selectTask($event, index, task)"
+            @keydown.enter.prevent="selectTask($event, index, task)"
             v-for="(task, index) in tasks"
           >
             <td class="thumbnail flexrow">
@@ -279,7 +282,10 @@
               selected: selectionGrid[task.id]
             }"
             :key="task.id"
+            role="button"
+            tabindex="0"
             @click="selectTask($event, index, task)"
+            @keydown.enter.prevent="selectTask($event, index, task)"
             v-for="(task, index) in taskGroup.tasks"
           >
             <entity-preview
@@ -320,7 +326,10 @@
           selected: selectionGrid[task.id]
         }"
         :key="task.id"
+        role="button"
+        tabindex="0"
         @click="selectTask($event, index, task)"
+        @keydown.enter.prevent="selectTask($event, index, task)"
         v-for="(task, index) in displayedTasks"
       >
         <entity-preview

--- a/src/components/lists/TodosList.vue
+++ b/src/components/lists/TodosList.vue
@@ -82,7 +82,10 @@
             :class="{
               selected: selectionGrid[entry.id]
             }"
+            role="button"
+            tabindex="0"
             @click="selectTask($event, i, entry)"
+            @keydown.enter.prevent="selectTask($event, i, entry)"
             v-for="(entry, i) in displayedTasks"
           >
             <td

--- a/src/components/lists/TodosList.vue
+++ b/src/components/lists/TodosList.vue
@@ -290,7 +290,7 @@
       v-if="tasks.length === 0 && !isLoading"
     >
       <p>
-        <img src="../../assets/illustrations/empty_todo.png" />
+        <img src="../../assets/illustrations/empty_todo.png" alt="" />
       </p>
       <p>
         {{ emptyText }}

--- a/src/components/modals/AddAttachmentModal.vue
+++ b/src/components/modals/AddAttachmentModal.vue
@@ -85,7 +85,14 @@
           <template v-for="(form, index) in forms" :key="`attachment-${index}`">
             <p class="attachment-name">
               {{ form.get('file').name }}
-              <span @click="removeAttachment(form)">x</span>
+              <span
+                role="button"
+                tabindex="0"
+                @click="removeAttachment(form)"
+                @keydown.enter.prevent="removeAttachment(form)"
+                @keydown.space.prevent="removeAttachment(form)"
+                >x</span
+              >
             </p>
             <img alt="uploaded file" :src="getURL(form)" v-if="isImage(form)" />
             <attachment-video-player
@@ -119,7 +126,11 @@
               'is-loading': isLoading,
               'is-disabled': forms.length === 0
             }"
+            role="button"
+            tabindex="0"
             @click="confirm()"
+            @keydown.enter.prevent="confirm()"
+            @keydown.space.prevent="confirm()"
           >
             {{ $t('tasks.confirm_attachments') }}
           </a>

--- a/src/components/modals/AddAttachmentModal.vue
+++ b/src/components/modals/AddAttachmentModal.vue
@@ -23,9 +23,9 @@
           {{ $t('main.drop_files_here') }}
         </div>
         <h2 class="subtitle">{{ title }}</h2>
-        <h1 class="title">
+        <h2 class="title">
           {{ $t('tasks.comment_image') }}
-        </h1>
+        </h2>
 
         <file-upload-zone
           ref="fileField"
@@ -314,7 +314,7 @@ defineExpose({
   text-transform: uppercase;
 }
 
-.content h1.title {
+.content h2.title {
   margin-bottom: 0.5em;
   margin-top: 0.5em;
 }

--- a/src/components/modals/AddMetadataModal.vue
+++ b/src/components/modals/AddMetadataModal.vue
@@ -52,7 +52,11 @@
               <span>{{ value }}</span>
               <span
                 class="remove-button pull-right"
+                role="button"
+                tabindex="0"
                 @click="removeValue(value)"
+                @keydown.enter.prevent="removeValue(value)"
+                @keydown.space.prevent="removeValue(value)"
               >
                 x
               </span>
@@ -102,7 +106,11 @@
           <div
             class="department-element mb1"
             :key="departmentId"
+            role="button"
+            tabindex="0"
             @click="removeDepartment(departmentId)"
+            @keydown.enter.prevent="removeDepartment(departmentId)"
+            @keydown.space.prevent="removeDepartment(departmentId)"
             v-for="departmentId in form.departments"
           >
             <department-name :department="departmentMap.get(departmentId)" />

--- a/src/components/modals/AddMetadataModal.vue
+++ b/src/components/modals/AddMetadataModal.vue
@@ -9,13 +9,13 @@
 
     <div class="modal-content">
       <div class="box content">
-        <h1 class="title">
+        <h2 class="title">
           {{
             isEditing
               ? $t('productions.metadata.edit_title')
               : $t('productions.metadata.title')
           }}
-        </h1>
+        </h2>
 
         <p
           class="explanation mb1"

--- a/src/components/modals/AddPreviewModal.vue
+++ b/src/components/modals/AddPreviewModal.vue
@@ -23,12 +23,12 @@
           {{ $t('main.drop_files_here') }}
         </div>
         <h2 class="subtitle">{{ title }}</h2>
-        <h1 class="title" v-if="isEditing">
+        <h2 class="title" v-if="isEditing">
           {{ $t('tasks.change_preview') }}
-        </h1>
-        <h1 class="title" v-else>
+        </h2>
+        <h2 class="title" v-else>
           {{ isConcept ? $t('concepts.add_concept') : $t('tasks.add_preview') }}
-        </h1>
+        </h2>
 
         <p>
           {{ $t('tasks.select_preview_file') }}
@@ -281,7 +281,7 @@ defineExpose({
   text-transform: uppercase;
 }
 
-.modal-content .box h1.title {
+.modal-content .box h2.title {
   font-weight: 350;
   font-size: 2.2em;
   line-height: 1.2em;

--- a/src/components/modals/AddPreviewModal.vue
+++ b/src/components/modals/AddPreviewModal.vue
@@ -57,7 +57,14 @@
           <template v-for="(form, index) in forms" :key="`preview-${index}`">
             <p class="preview-name">
               {{ form.get('file').name }}
-              <span @click="removePreview(form)">x</span>
+              <span
+                role="button"
+                tabindex="0"
+                @click="removePreview(form)"
+                @keydown.enter.prevent="removePreview(form)"
+                @keydown.space.prevent="removePreview(form)"
+                >x</span
+              >
             </p>
             <img alt="uploaded file" :src="getURL(form)" v-if="isImage(form)" />
             <video
@@ -100,7 +107,11 @@
               'is-loading': isLoading,
               'is-disabled': forms.length === 0
             }"
+            role="button"
+            tabindex="0"
             @click="$emit('confirm', forms)"
+            @keydown.enter.prevent="$emit('confirm', forms)"
+            @keydown.space.prevent="$emit('confirm', forms)"
           >
             {{
               confirmLabel?.length

--- a/src/components/modals/AddThumbnailsModal.vue
+++ b/src/components/modals/AddThumbnailsModal.vue
@@ -55,6 +55,7 @@
         src="@/assets/icons/movie-thumbnail.png"
         width="150"
         height="100"
+        alt=""
         v-if="!thumbnailInfo.src"
       />
       <img
@@ -62,6 +63,7 @@
         :src="thumbnailInfo.src"
         width="150"
         height="100"
+        :alt="thumbnailInfo.name"
         v-if="thumbnailInfo.src"
       />
       <span class="flexrow-item">

--- a/src/components/modals/BaseModal.vue
+++ b/src/components/modals/BaseModal.vue
@@ -15,9 +15,9 @@
       :aria-label="title"
     >
       <div class="box">
-        <h1 class="title">
+        <h2 class="title">
           {{ title }}
-        </h1>
+        </h2>
         <slot />
       </div>
     </div>

--- a/src/components/modals/BuildFilterModal.vue
+++ b/src/components/modals/BuildFilterModal.vue
@@ -9,9 +9,9 @@
 
     <div class="modal-content">
       <div class="box content">
-        <h1 class="title">
+        <h2 class="title">
           {{ $t('entities.build_filter.title') }}
-        </h1>
+        </h2>
 
         <combobox
           locale-key-prefix="entities.build_filter."

--- a/src/components/modals/ConfirmModal.vue
+++ b/src/components/modals/ConfirmModal.vue
@@ -16,7 +16,11 @@
               button: true,
               'is-loading': isLoading
             }"
+            role="button"
+            tabindex="0"
             @click="$emit('confirm')"
+            @keydown.enter.prevent="$emit('confirm')"
+            @keydown.space.prevent="$emit('confirm')"
           >
             {{ confirmButtonText || $t('main.confirmation') }}
           </a>

--- a/src/components/modals/CreateTasksModal.vue
+++ b/src/components/modals/CreateTasksModal.vue
@@ -49,7 +49,11 @@
               'is-loading': isLoadingAll,
               'is-disabled': missingTaskTypes.length === 0
             }"
+            role="button"
+            tabindex="0"
             @click="confirmAllMissingClicked"
+            @keydown.enter.prevent="confirmAllMissingClicked"
+            @keydown.space.prevent="confirmAllMissingClicked"
           >
             {{
               missingTaskTypes.length > 0
@@ -66,7 +70,11 @@
               'is-primary': true,
               'is-loading': isLoadingStay
             }"
+            role="button"
+            tabindex="0"
             @click="confirmAndStayClicked"
+            @keydown.enter.prevent="confirmAndStayClicked"
+            @keydown.space.prevent="confirmAndStayClicked"
           >
             {{ $t('main.confirmation_and_stay') }}
           </a>
@@ -77,7 +85,11 @@
               'is-primary': true,
               'is-loading': isLoading
             }"
+            role="button"
+            tabindex="0"
             @click="confirmClicked"
+            @keydown.enter.prevent="confirmClicked"
+            @keydown.space.prevent="confirmClicked"
           >
             {{ $t('main.confirmation') }}
           </a>

--- a/src/components/modals/DeleteModal.vue
+++ b/src/components/modals/DeleteModal.vue
@@ -18,7 +18,11 @@
               'is-danger': true,
               'is-loading': isLoading
             }"
+            role="button"
+            tabindex="0"
             @click="$emit('confirm')"
+            @keydown.enter.prevent="$emit('confirm')"
+            @keydown.space.prevent="$emit('confirm')"
           >
             {{ deleteButtonText || $t('main.confirmation') }}
           </a>

--- a/src/components/modals/EditAssetModal.vue
+++ b/src/components/modals/EditAssetModal.vue
@@ -58,7 +58,11 @@
           'is-primary': true,
           'is-loading': isLoadingStay
         }"
+        role="button"
+        tabindex="0"
         @click="confirmAndStayClicked"
+        @keydown.enter.prevent="confirmAndStayClicked"
+        @keydown.space.prevent="confirmAndStayClicked"
         v-if="!assetToEdit?.id"
       >
         {{ $t('main.confirmation_and_stay') }}
@@ -69,7 +73,11 @@
           'is-primary': true,
           'is-loading': isLoading
         }"
+        role="button"
+        tabindex="0"
         @click="confirmClicked"
+        @keydown.enter.prevent="confirmClicked"
+        @keydown.space.prevent="confirmClicked"
       >
         {{ $t('main.confirmation') }}
       </a>

--- a/src/components/modals/EditAssetTypeModal.vue
+++ b/src/components/modals/EditAssetTypeModal.vue
@@ -34,7 +34,11 @@
         <div
           class="flexrow-item mb1"
           :key="taskTypeId"
+          role="button"
+          tabindex="0"
           @click="removeTaskType(taskTypeId)"
+          @keydown.enter.prevent="removeTaskType(taskTypeId)"
+          @keydown.space.prevent="removeTaskType(taskTypeId)"
           v-for="taskTypeId in form.task_types"
         >
           <task-type-name

--- a/src/components/modals/EditCommentModal.vue
+++ b/src/components/modals/EditCommentModal.vue
@@ -119,7 +119,13 @@
               v-for="(attachment, index) in form.attachment_files"
             >
               {{ attachment.name }}
-              <span @click="removeAttachment(attachment)">
+              <span
+                role="button"
+                tabindex="0"
+                @click="removeAttachment(attachment)"
+                @keydown.enter.prevent="removeAttachment(attachment)"
+                @keydown.space.prevent="removeAttachment(attachment)"
+              >
                 <x-icon :size="12" />
               </span>
             </div>
@@ -138,7 +144,14 @@
             v-for="(attachment, index) in attachmentFiles"
           >
             {{ attachment.get('file').name }}
-            <span @click="removeNewAttachment(attachment)">x</span>
+            <span
+              role="button"
+              tabindex="0"
+              @click="removeNewAttachment(attachment)"
+              @keydown.enter.prevent="removeNewAttachment(attachment)"
+              @keydown.space.prevent="removeNewAttachment(attachment)"
+              >x</span
+            >
           </div>
         </div>
 

--- a/src/components/modals/EditCommentModal.vue
+++ b/src/components/modals/EditCommentModal.vue
@@ -9,9 +9,9 @@
 
     <div class="modal-content">
       <div class="box">
-        <h1 class="title" v-if="commentToEdit && commentToEdit.id">
+        <h2 class="title" v-if="commentToEdit && commentToEdit.id">
           {{ $t('comments.edit_title') }}
-        </h1>
+        </h2>
 
         <form @submit.prevent>
           <combobox-status

--- a/src/components/modals/EditCustomActionModal.vue
+++ b/src/components/modals/EditCustomActionModal.vue
@@ -9,12 +9,12 @@
 
     <div class="modal-content">
       <div class="box">
-        <h1 class="title" v-if="isEditing">
+        <h2 class="title" v-if="isEditing">
           {{ $t('custom_actions.edit_title') }} {{ customActionToEdit.name }}
-        </h1>
-        <h1 class="title" v-else>
+        </h2>
+        <h2 class="title" v-else>
           {{ $t('custom_actions.new_custom_action') }}
-        </h1>
+        </h2>
 
         <form @submit.prevent>
           <text-field

--- a/src/components/modals/EditPersonModal.vue
+++ b/src/components/modals/EditPersonModal.vue
@@ -84,7 +84,11 @@
         <div
           class="department-element mb1 mt05"
           :key="departmentId"
+          role="button"
+          tabindex="0"
           @click="removeDepartment(departmentId)"
+          @keydown.enter.prevent="removeDepartment(departmentId)"
+          @keydown.space.prevent="removeDepartment(departmentId)"
           v-for="departmentId in form.departments"
         >
           <department-name

--- a/src/components/modals/EditPlaylistModal.vue
+++ b/src/components/modals/EditPlaylistModal.vue
@@ -44,7 +44,14 @@
         {{ successText || $t('playlists.created') }}
       </span>
       <div class="filler"></div>
-      <a class="button is-primary flexrow-item" @click="$emit('view')">
+      <a
+        class="button is-primary flexrow-item"
+        role="button"
+        tabindex="0"
+        @click="$emit('view')"
+        @keydown.enter.prevent="$emit('view')"
+        @keydown.space.prevent="$emit('view')"
+      >
         {{ $t('playlists.view_created') }}
       </a>
       <button class="button is-link flexrow-item" @click="$emit('cancel')">

--- a/src/components/modals/EditProductionModal.vue
+++ b/src/components/modals/EditProductionModal.vue
@@ -9,9 +9,9 @@
 
     <div class="modal-content">
       <div class="box">
-        <h1 class="title">
+        <h2 class="title">
           {{ $t('productions.edit_title') }} {{ productionToEdit.name }}
-        </h1>
+        </h2>
 
         <form @submit.prevent>
           <text-field

--- a/src/components/modals/EditStatusAutomationModal.vue
+++ b/src/components/modals/EditStatusAutomationModal.vue
@@ -9,12 +9,12 @@
 
     <div class="modal-content">
       <div class="box">
-        <h1 class="title" v-if="isEditing">
+        <h2 class="title" v-if="isEditing">
           {{ $t('status_automations.edit_title') }}
-        </h1>
-        <h1 class="title" v-else>
+        </h2>
+        <h2 class="title" v-else>
           {{ $t('status_automations.new_status_automation') }}
-        </h1>
+        </h2>
 
         <form @submit.prevent>
           <h3 class="subtitle">

--- a/src/components/modals/HardDeleteModal.vue
+++ b/src/components/modals/HardDeleteModal.vue
@@ -35,7 +35,11 @@
               'is-loading': isLoading
             }"
             :disabled="isLocked || null"
+            role="button"
+            tabindex="0"
             @click="$emit('confirm', selectionOnly === 'true')"
+            @keydown.enter.prevent="$emit('confirm', selectionOnly === 'true')"
+            @keydown.space.prevent="$emit('confirm', selectionOnly === 'true')"
           >
             {{ $t('main.confirmation') }}
           </a>

--- a/src/components/modals/ImportModal.vue
+++ b/src/components/modals/ImportModal.vue
@@ -36,7 +36,14 @@
           :key="`tab-${tab.id}`"
           v-for="tab in tabs"
         >
-          <a @click="activeTab = tab.id">{{ tab.name }}</a>
+          <a
+            role="button"
+            tabindex="0"
+            @click="activeTab = tab.id"
+            @keydown.enter.prevent="activeTab = tab.id"
+            @keydown.space.prevent="activeTab = tab.id"
+            >{{ tab.name }}</a
+          >
         </li>
       </ul>
     </div>

--- a/src/components/modals/ImportRenderModal.vue
+++ b/src/components/modals/ImportRenderModal.vue
@@ -366,7 +366,7 @@ const existingData = index => {
   margin-top: 2rem;
 }
 
-.modal-content .box h1.title {
+.modal-content .box h2.title {
   margin-bottom: 0;
 }
 

--- a/src/components/modals/ManageShotsModal.vue
+++ b/src/components/modals/ManageShotsModal.vue
@@ -33,7 +33,11 @@
                   selected: episode.id === selectedEpisodeId
                 }"
                 :key="episode.id"
+                role="button"
+                tabindex="0"
                 @click="selectEpisode(episode.id)"
+                @keydown.enter.prevent="selectEpisode(episode.id)"
+                @keydown.space.prevent="selectEpisode(episode.id)"
                 v-for="episode in displayedEpisodes"
               >
                 {{ episode.name }}
@@ -73,8 +77,12 @@
                   selected: sequence.id === selectedSequenceId
                 }"
                 :key="sequence.id"
+                role="button"
+                tabindex="0"
                 @keyup.tab="focusAddShot"
                 @click="selectSequence(sequence.id)"
+                @keydown.enter.prevent="selectSequence(sequence.id)"
+                @keydown.space.prevent="selectSequence(sequence.id)"
                 v-for="sequence in displayedSequences"
               >
                 {{ sequence.name }}

--- a/src/components/modals/ModalFooter.vue
+++ b/src/components/modals/ModalFooter.vue
@@ -8,7 +8,11 @@
           'is-loading': isLoading,
           'is-disabled': isDisabled
         }"
+        role="button"
+        tabindex="0"
         @click="$emit('confirm')"
+        @keydown.enter.prevent="$emit('confirm')"
+        @keydown.space.prevent="$emit('confirm')"
       >
         {{ confirmLabel || $t('main.confirmation') }}
       </a>

--- a/src/components/modals/NewTokenModal.vue
+++ b/src/components/modals/NewTokenModal.vue
@@ -56,9 +56,21 @@
             <eye-off-icon
               v-if="visible"
               class="icon"
+              role="button"
+              tabindex="0"
               @click="visible = false"
+              @keydown.enter.prevent="visible = false"
+              @keydown.space.prevent="visible = false"
             />
-            <eye-icon v-else class="icon" @click="visible = true" />
+            <eye-icon
+              v-else
+              class="icon"
+              role="button"
+              tabindex="0"
+              @click="visible = true"
+              @keydown.enter.prevent="visible = true"
+              @keydown.space.prevent="visible = true"
+            />
           </div>
           <div class="flexrow right">
             <Transition name="fade">

--- a/src/components/modals/NewTokenModal.vue
+++ b/src/components/modals/NewTokenModal.vue
@@ -8,9 +8,9 @@
     <div class="modal-background"></div>
     <div class="modal-content">
       <div class="box">
-        <h1 class="title">
+        <h2 class="title">
           {{ $t('bots.new_token_title', { name: person.full_name }) }}
-        </h1>
+        </h2>
 
         <form class="form" @submit.prevent v-if="!person.access_token">
           <p class="mb2 warning-text">

--- a/src/components/modals/NewTokenModal.vue
+++ b/src/components/modals/NewTokenModal.vue
@@ -53,24 +53,15 @@
               :type="visible ? 'text' : 'password'"
               :model-value="person.access_token"
             />
-            <eye-off-icon
-              v-if="visible"
-              class="icon"
-              role="button"
-              tabindex="0"
-              @click="visible = false"
-              @keydown.enter.prevent="visible = false"
-              @keydown.space.prevent="visible = false"
-            />
-            <eye-icon
-              v-else
-              class="icon"
-              role="button"
-              tabindex="0"
-              @click="visible = true"
-              @keydown.enter.prevent="visible = true"
-              @keydown.space.prevent="visible = true"
-            />
+            <button
+              type="button"
+              class="visibility-toggle"
+              :aria-label="visible ? 'Hide token' : 'Show token'"
+              @click="visible = !visible"
+            >
+              <eye-off-icon v-if="visible" class="icon" />
+              <eye-icon v-else class="icon" />
+            </button>
           </div>
           <div class="flexrow right">
             <Transition name="fade">
@@ -174,7 +165,10 @@ watch(
     }
   }
 
-  .icon {
+  .visibility-toggle {
+    background: none;
+    border: none;
+    padding: 0;
     cursor: pointer;
     opacity: 0.5;
     position: absolute;

--- a/src/components/modals/PreviewModal.vue
+++ b/src/components/modals/PreviewModal.vue
@@ -21,7 +21,15 @@
       >
         <arrow-up-right-icon />
       </a>
-      <span class="pointer" :title="$t('main.close')" @click="$emit('cancel')">
+      <span
+        class="pointer"
+        :title="$t('main.close')"
+        role="button"
+        tabindex="0"
+        @click="$emit('cancel')"
+        @keydown.enter.prevent="$emit('cancel')"
+        @keydown.space.prevent="$emit('cancel')"
+      >
         <x-icon />
       </span>
     </div>

--- a/src/components/modals/PreviewModal.vue
+++ b/src/components/modals/PreviewModal.vue
@@ -34,7 +34,7 @@
       </span>
     </div>
     <div class="modal-content" @click="$emit('cancel')">
-      <img :src="previewPath" />
+      <img :src="previewPath" :alt="attachment.name" />
     </div>
   </div>
 </template>

--- a/src/components/modals/SelectTaskTypeModal.vue
+++ b/src/components/modals/SelectTaskTypeModal.vue
@@ -25,7 +25,11 @@
               'is-primary': true,
               'is-loading': isLoading
             }"
+            role="button"
+            tabindex="0"
             @click="runConfirmation"
+            @keydown.enter.prevent="runConfirmation"
+            @keydown.space.prevent="runConfirmation"
           >
             {{ $t('main.apply') }}
           </a>
@@ -46,7 +50,11 @@
               'is-primary': true,
               'is-loading': isLoading
             }"
+            role="button"
+            tabindex="0"
             @click="runUpdateLatest"
+            @keydown.enter.prevent="runUpdateLatest"
+            @keydown.space.prevent="runUpdateLatest"
           >
             {{ $t('main.apply') }}
           </a>

--- a/src/components/modals/SharePlaylistModal.vue
+++ b/src/components/modals/SharePlaylistModal.vue
@@ -431,7 +431,7 @@ onMounted(() => {
 </script>
 
 <style lang="scss" scoped>
-:deep(h1.title) {
+:deep(h2.title) {
   margin-bottom: 0em !important;
 }
 

--- a/src/components/pages/AssetLibrary.vue
+++ b/src/components/pages/AssetLibrary.vue
@@ -59,7 +59,12 @@
                     'selected-item': isSelected(entity)
                   }"
                   :key="entity.id"
+                  role="button"
+                  tabindex="0"
                   @click="isCurrentUserManager && toggleEntity(entity)"
+                  @keydown.enter.prevent="
+                    isCurrentUserManager && toggleEntity(entity)
+                  "
                   v-for="entity in group"
                 >
                   <div class="card" :title="entity.full_name">

--- a/src/components/pages/Concepts.vue
+++ b/src/components/pages/Concepts.vue
@@ -70,7 +70,12 @@
                 'selected-item': isSelected(concept)
               }"
               :key="concept.id"
+              role="button"
+              tabindex="0"
               @click="
+                onSelectConcept(concept, $event.ctrlKey || $event.metaKey)
+              "
+              @keydown.enter.prevent="
                 onSelectConcept(concept, $event.ctrlKey || $event.metaKey)
               "
               v-for="concept in filteredConcepts"

--- a/src/components/pages/EntityChats.vue
+++ b/src/components/pages/EntityChats.vue
@@ -7,7 +7,10 @@
           <div
             :key="chat.id"
             :class="chatClass(chat)"
+            role="button"
+            tabindex="0"
             @click="selectChat(chat)"
+            @keydown.enter.prevent="selectChat(chat)"
             v-for="chat in chatList"
           >
             <div class="flexrow">

--- a/src/components/pages/FirstConnection.vue
+++ b/src/components/pages/FirstConnection.vue
@@ -41,7 +41,11 @@
             :class="{
               'is-loading': isLoading
             }"
+            role="button"
+            tabindex="0"
             @click="confirmResetPassword"
+            @keydown.enter.prevent="confirmResetPassword"
+            @keydown.space.prevent="confirmResetPassword"
             v-if="!isSuccess"
           >
             {{ $t('login.reset_password') }}

--- a/src/components/pages/FirstConnection.vue
+++ b/src/components/pages/FirstConnection.vue
@@ -3,8 +3,12 @@
     <div class="container has-text-centered">
       <div class="box has-text-left">
         <div class="has-text-centered login-header">
-          <img src="../../assets/kitsu-text-dark.svg" v-if="isDarkTheme" />
-          <img src="../../assets/kitsu-text.svg" v-else />
+          <img
+            src="../../assets/kitsu-text-dark.svg"
+            alt="Kitsu"
+            v-if="isDarkTheme"
+          />
+          <img src="../../assets/kitsu-text.svg" alt="Kitsu" v-else />
         </div>
 
         <div class="has-text-centered">

--- a/src/components/pages/Login.vue
+++ b/src/components/pages/Login.vue
@@ -77,7 +77,11 @@
             :class="{
               'is-loading': isLoginLoading
             }"
+            role="button"
+            tabindex="0"
             @click="confirmLogIn()"
+            @keydown.enter.prevent="confirmLogIn()"
+            @keydown.space.prevent="confirmLogIn()"
           >
             {{ $t('login.login') }}
           </a>

--- a/src/components/pages/Login.vue
+++ b/src/components/pages/Login.vue
@@ -9,8 +9,12 @@
         xyz="fade"
       >
         <div class="has-text-centered login-header">
-          <img src="../../assets/kitsu-text-dark.svg" v-if="isDarkTheme" />
-          <img src="../../assets/kitsu-text.svg" v-else />
+          <img
+            src="../../assets/kitsu-text-dark.svg"
+            alt="Kitsu"
+            v-if="isDarkTheme"
+          />
+          <img src="../../assets/kitsu-text.svg" alt="Kitsu" v-else />
         </div>
         <form v-if="!(isMissingOTP || isWrongOTP)">
           <div class="field" v-if="mainConfig?.saml_enabled">

--- a/src/components/pages/Login2FA.vue
+++ b/src/components/pages/Login2FA.vue
@@ -3,8 +3,12 @@
     <div class="container">
       <div class="box">
         <div class="has-text-centered login-header">
-          <img src="@/assets/kitsu-text-dark.svg" v-if="isDarkTheme" />
-          <img src="@/assets/kitsu-text.svg" v-else />
+          <img
+            src="@/assets/kitsu-text-dark.svg"
+            alt="Kitsu"
+            v-if="isDarkTheme"
+          />
+          <img src="@/assets/kitsu-text.svg" alt="Kitsu" v-else />
         </div>
         <p class="has-text-centered mandatory-message">
           {{ $t('profile.two_factor_authentication.mandatory') }}

--- a/src/components/pages/NotFound.vue
+++ b/src/components/pages/NotFound.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="not-found page has-text-centered">
-    <img class="illustration" src="@/assets/illustrations/404.png" />
+    <img class="illustration" src="@/assets/illustrations/404.png" alt="" />
     <h1 class="title">{{ $t('not_found.title') }}</h1>
     <p>
       {{ $t('not_found.text') }}

--- a/src/components/pages/Notifications.vue
+++ b/src/components/pages/Notifications.vue
@@ -128,7 +128,10 @@
             selected: isSelected(notification)
           }"
           :key="notification.id"
+          role="button"
+          tabindex="0"
           @click="onNotificationSelected($event, notification)"
+          @keydown.enter.prevent="onNotificationSelected($event, notification)"
           v-for="notification in notifications"
           v-show="!loading.notifications"
         >

--- a/src/components/pages/OpenProductions.vue
+++ b/src/components/pages/OpenProductions.vue
@@ -8,6 +8,7 @@
         <img
           class="flexrow-item kitsu-with-body"
           src="../../assets/illustrations/kitsu-band.png"
+          alt=""
         />
         <div class="filler">
           <span
@@ -67,7 +68,7 @@
       class="flexrow open-productions-header"
       v-if="!isOpenProductionsLoading && openProductions.length > 0"
     >
-      <img class="logo" src="../../assets/kitsu.png" width="23" />
+      <img class="logo" src="../../assets/kitsu.png" width="23" alt="Kitsu" />
       <h1 class="title filler">
         {{ $t('productions.home.title') }}
       </h1>
@@ -119,7 +120,11 @@
               <template v-if="!production.has_avatar">
                 {{ generateAvatar(production) }}
               </template>
-              <img :src="getThumbnailPath(production)" v-else />
+              <img
+                :src="getThumbnailPath(production)"
+                :alt="production.name"
+                v-else
+              />
             </div>
             <div class="production-name">
               {{ production.name }}
@@ -131,7 +136,7 @@
 
     <div class="has-text-centered welcome" v-else>
       <p class="kitsu-logo info">
-        <img src="../../assets/illustrations/empty_production.png" />
+        <img src="../../assets/illustrations/empty_production.png" alt="" />
       </p>
       <div v-if="isCurrentUserAdmin">
         <p class="has-text-centered info">

--- a/src/components/pages/OpenProductions.vue
+++ b/src/components/pages/OpenProductions.vue
@@ -10,7 +10,14 @@
           src="../../assets/illustrations/kitsu-band.png"
         />
         <div class="filler">
-          <span class="close-contributions" @click="hideContributions">
+          <span
+            class="close-contributions"
+            role="button"
+            tabindex="0"
+            @click="hideContributions"
+            @keydown.enter.prevent="hideContributions"
+            @keydown.space.prevent="hideContributions"
+          >
             <x-icon :size="14" />
           </span>
           <p>

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -237,7 +237,14 @@
             <div class="flexrow">
               <page-subtitle class="flexrow-item" :text="addEntitiesText" />
               <span class="filler"></span>
-              <a class="close-button" @click="toggleAddEntities">
+              <a
+                class="close-button"
+                role="button"
+                tabindex="0"
+                @click="toggleAddEntities"
+                @keydown.enter.prevent="toggleAddEntities"
+                @keydown.space.prevent="toggleAddEntities"
+              >
                 <x-icon />
               </a>
             </div>
@@ -362,8 +369,12 @@
                       playlisted: currentEntitiesMap[asset.id] !== undefined
                     }"
                     draggable="true"
+                    role="button"
+                    tabindex="0"
                     @dragstart="onEntityDragStart($event, asset)"
                     @click.prevent="addEntityToPlaylist(asset)"
+                    @keydown.enter.prevent="addEntityToPlaylist(asset)"
+                    @keydown.space.prevent="addEntityToPlaylist(asset)"
                     v-for="asset in typeAssets.filter(a => !a.canceled)"
                   >
                     <div
@@ -391,8 +402,12 @@
                     playlisted: currentEntitiesMap[sequence.id] !== undefined
                   }"
                   draggable="true"
+                  role="button"
+                  tabindex="0"
                   @dragstart="onEntityDragStart($event, sequence)"
                   @click.prevent="addEntityToPlaylist(sequence)"
+                  @keydown.enter.prevent="addEntityToPlaylist(sequence)"
+                  @keydown.space.prevent="addEntityToPlaylist(sequence)"
                   v-for="sequence in displayedSequences.filter(
                     s => !s.canceled
                   )"
@@ -434,8 +449,12 @@
                     playlisted: currentEntitiesMap[edit.id] !== undefined
                   }"
                   draggable="true"
+                  role="button"
+                  tabindex="0"
                   @dragstart="onEntityDragStart($event, edit)"
                   @click.prevent="addEntityToPlaylist(edit)"
+                  @keydown.enter.prevent="addEntityToPlaylist(edit)"
+                  @keydown.space.prevent="addEntityToPlaylist(edit)"
                   v-for="edit in displayedEdits.filter(e => !e.canceled)"
                 >
                   <div
@@ -473,8 +492,12 @@
                     playlisted: currentEntitiesMap[episode.id] !== undefined
                   }"
                   draggable="true"
+                  role="button"
+                  tabindex="0"
                   @dragstart="onEntityDragStart($event, episode)"
                   @click.prevent="addEntityToPlaylist(episode)"
+                  @keydown.enter.prevent="addEntityToPlaylist(episode)"
+                  @keydown.space.prevent="addEntityToPlaylist(episode)"
                   v-for="episode in displayedEpisodes.filter(e => !e.canceled)"
                 >
                   <div
@@ -530,8 +553,12 @@
                         playlisted: currentEntitiesMap[shot.id] !== undefined
                       }"
                       draggable="true"
+                      role="button"
+                      tabindex="0"
                       @dragstart="onEntityDragStart($event, shot)"
                       @click.prevent="addEntityToPlaylist(shot)"
+                      @keydown.enter.prevent="addEntityToPlaylist(shot)"
+                      @keydown.space.prevent="addEntityToPlaylist(shot)"
                     >
                       <div
                         class="entity-loading-spinner"

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -142,7 +142,14 @@
       v-if="isSidePanelOpen && !isLockedSchedule && !isTVShow"
     >
       <div class="side">
-        <a class="close-button" @click="toggleSidePanel">
+        <a
+          class="close-button"
+          role="button"
+          tabindex="0"
+          @click="toggleSidePanel"
+          @keydown.enter.prevent="toggleSidePanel"
+          @keydown.space.prevent="toggleSidePanel"
+        >
           <x-icon class="align-middle" :size="16" />
         </a>
         <h2 class="mt1">
@@ -186,10 +193,13 @@
             <div
               class="assignment-item"
               draggable="true"
+              role="button"
+              tabindex="0"
               @dragstart="
                 onAssignmentItemDragStart($event, entityType, selectedTaskType)
               "
               @click="onAssignmentItemSelected(entityType)"
+              @keydown.enter.prevent="onAssignmentItemSelected(entityType)"
             >
               <grip-vertical-icon class="icon" />
               <span class="name">
@@ -198,7 +208,15 @@
               </span>
               <span
                 class="expand"
+                role="button"
+                tabindex="0"
                 @click.stop="entityType.expanded = !entityType.expanded"
+                @keydown.enter.stop.prevent="
+                  entityType.expanded = !entityType.expanded
+                "
+                @keydown.space.stop.prevent="
+                  entityType.expanded = !entityType.expanded
+                "
               >
                 <chevron-right-icon v-if="!entityType.expanded" />
                 <chevron-down-icon v-else />
@@ -212,6 +230,8 @@
                 <div
                   class="assignment-item"
                   draggable="true"
+                  role="button"
+                  tabindex="0"
                   @dragstart="
                     onAssignmentItemDragStart(
                       $event,
@@ -220,6 +240,12 @@
                     )
                   "
                   @click="
+                    onAssignmentItemSelected({
+                      ...entityType,
+                      children: [child]
+                    })
+                  "
+                  @keydown.enter.prevent="
                     onAssignmentItemSelected({
                       ...entityType,
                       children: [child]
@@ -290,7 +316,11 @@
                     <a
                       class="reset-assignees"
                       :title="$t('schedule.reset_list')"
+                      role="button"
+                      tabindex="0"
                       @click="assignments.excludes = []"
+                      @keydown.enter.prevent="assignments.excludes = []"
+                      @keydown.space.prevent="assignments.excludes = []"
                       v-if="assignments.excludes.length"
                     >
                       <list-restart-icon
@@ -357,7 +387,11 @@
               />
               <a
                 class="reset-quotas ml05"
+                role="button"
+                tabindex="0"
                 @click="assignments.forcedDailyQuota = null"
+                @keydown.enter.prevent="assignments.forcedDailyQuota = null"
+                @keydown.space.prevent="assignments.forcedDailyQuota = null"
                 v-if="assignments.forcedDailyQuota"
               >
                 <trash-icon class="align-middle" :size="14" />

--- a/src/components/pages/ProductionSettings.vue
+++ b/src/components/pages/ProductionSettings.vue
@@ -4,42 +4,90 @@
       <div class="tabs">
         <ul>
           <li :class="{ 'is-active': isActiveTab('parameters') }">
-            <a @click="activeTab = 'parameters'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'parameters'"
+              @keydown.enter.prevent="activeTab = 'parameters'"
+              @keydown.space.prevent="activeTab = 'parameters'"
+            >
               {{ $t('productions.parameters.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('brief') }">
-            <a @click="activeTab = 'brief'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'brief'"
+              @keydown.enter.prevent="activeTab = 'brief'"
+              @keydown.space.prevent="activeTab = 'brief'"
+            >
               {{ $t('productions.brief.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('assetTypes') }">
-            <a @click="activeTab = 'assetTypes'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'assetTypes'"
+              @keydown.enter.prevent="activeTab = 'assetTypes'"
+              @keydown.space.prevent="activeTab = 'assetTypes'"
+            >
               {{ $t('asset_types.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('taskTypes') }">
-            <a @click="activeTab = 'taskTypes'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'taskTypes'"
+              @keydown.enter.prevent="activeTab = 'taskTypes'"
+              @keydown.space.prevent="activeTab = 'taskTypes'"
+            >
               {{ $t('task_types.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('taskStatus') }">
-            <a @click="activeTab = 'taskStatus'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'taskStatus'"
+              @keydown.enter.prevent="activeTab = 'taskStatus'"
+              @keydown.space.prevent="activeTab = 'taskStatus'"
+            >
               {{ $t('task_status.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('board') }">
-            <a @click="activeTab = 'board'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'board'"
+              @keydown.enter.prevent="activeTab = 'board'"
+              @keydown.space.prevent="activeTab = 'board'"
+            >
               {{ $t('board.settings.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('statusAutomations') }">
-            <a @click="activeTab = 'statusAutomations'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'statusAutomations'"
+              @keydown.enter.prevent="activeTab = 'statusAutomations'"
+              @keydown.space.prevent="activeTab = 'statusAutomations'"
+            >
               {{ $t('status_automations.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('backgrounds') }">
-            <a @click="activeTab = 'backgrounds'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'backgrounds'"
+              @keydown.enter.prevent="activeTab = 'backgrounds'"
+              @keydown.space.prevent="activeTab = 'backgrounds'"
+            >
               {{ $t('backgrounds.title') }}
             </a>
           </li>

--- a/src/components/pages/ProjectTemplateSettings.vue
+++ b/src/components/pages/ProjectTemplateSettings.vue
@@ -15,42 +15,90 @@
       <div class="tabs">
         <ul>
           <li :class="{ 'is-active': isActiveTab('parameters') }">
-            <a @click="activeTab = 'parameters'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'parameters'"
+              @keydown.enter.prevent="activeTab = 'parameters'"
+              @keydown.space.prevent="activeTab = 'parameters'"
+            >
               {{ $t('productions.parameters.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('metadataDescriptors') }">
-            <a @click="activeTab = 'metadataDescriptors'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'metadataDescriptors'"
+              @keydown.enter.prevent="activeTab = 'metadataDescriptors'"
+              @keydown.space.prevent="activeTab = 'metadataDescriptors'"
+            >
               {{ $t('project_templates.tabs.metadata_descriptors') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('assetTypes') }">
-            <a @click="activeTab = 'assetTypes'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'assetTypes'"
+              @keydown.enter.prevent="activeTab = 'assetTypes'"
+              @keydown.space.prevent="activeTab = 'assetTypes'"
+            >
               {{ $t('asset_types.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('taskTypes') }">
-            <a @click="activeTab = 'taskTypes'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'taskTypes'"
+              @keydown.enter.prevent="activeTab = 'taskTypes'"
+              @keydown.space.prevent="activeTab = 'taskTypes'"
+            >
               {{ $t('task_types.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('taskStatuses') }">
-            <a @click="activeTab = 'taskStatuses'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'taskStatuses'"
+              @keydown.enter.prevent="activeTab = 'taskStatuses'"
+              @keydown.space.prevent="activeTab = 'taskStatuses'"
+            >
               {{ $t('task_status.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('board') }">
-            <a @click="activeTab = 'board'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'board'"
+              @keydown.enter.prevent="activeTab = 'board'"
+              @keydown.space.prevent="activeTab = 'board'"
+            >
               {{ $t('board.settings.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('statusAutomations') }">
-            <a @click="activeTab = 'statusAutomations'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'statusAutomations'"
+              @keydown.enter.prevent="activeTab = 'statusAutomations'"
+              @keydown.space.prevent="activeTab = 'statusAutomations'"
+            >
               {{ $t('status_automations.title') }}
             </a>
           </li>
           <li :class="{ 'is-active': isActiveTab('backgrounds') }">
-            <a @click="activeTab = 'backgrounds'">
+            <a
+              role="button"
+              tabindex="0"
+              @click="activeTab = 'backgrounds'"
+              @keydown.enter.prevent="activeTab = 'backgrounds'"
+              @keydown.space.prevent="activeTab = 'backgrounds'"
+            >
               {{ $t('backgrounds.title') }}
             </a>
           </li>
@@ -202,7 +250,14 @@
               :key="tab.name"
               :class="{ 'is-active': metadataEntityTab === tab.name }"
             >
-              <a @click="metadataEntityTab = tab.name">{{ tab.label }}</a>
+              <a
+                role="button"
+                tabindex="0"
+                @click="metadataEntityTab = tab.name"
+                @keydown.enter.prevent="metadataEntityTab = tab.name"
+                @keydown.space.prevent="metadataEntityTab = tab.name"
+                >{{ tab.label }}</a
+              >
             </li>
           </ul>
         </div>

--- a/src/components/pages/ResetChangePassword.vue
+++ b/src/components/pages/ResetChangePassword.vue
@@ -49,7 +49,11 @@
               'is-fullwidth': true,
               'is-loading': isLoading
             }"
+            role="button"
+            tabindex="0"
             @click="confirmResetChangePassword"
+            @keydown.enter.prevent="confirmResetChangePassword"
+            @keydown.space.prevent="confirmResetChangePassword"
             v-if="!isSuccess"
           >
             {{

--- a/src/components/pages/ResetPassword.vue
+++ b/src/components/pages/ResetPassword.vue
@@ -30,7 +30,11 @@
             :class="{
               'is-loading': isLoading
             }"
+            role="button"
+            tabindex="0"
             @click="confirmResetPassword"
+            @keydown.enter.prevent="confirmResetPassword"
+            @keydown.space.prevent="confirmResetPassword"
           >
             {{ $t('login.reset_password') }}
           </a>

--- a/src/components/pages/ServerDown.vue
+++ b/src/components/pages/ServerDown.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="server-down page has-text-centered">
     <div class="illustration">
-      <img src="@/assets/illustrations/500.png" />
+      <img src="@/assets/illustrations/500.png" alt="" />
     </div>
     <h1 class="title">{{ $t('server_down.title') }}</h1>
     <p>

--- a/src/components/pages/Team.vue
+++ b/src/components/pages/Team.vue
@@ -68,7 +68,10 @@
           <div
             :key="`unlisted-person-${person.id}`"
             class="flexrow person-to-add mb05"
+            role="button"
+            tabindex="0"
             @click="addPersonToTeam(person)"
+            @keydown.enter.prevent="addPersonToTeam(person)"
             v-for="person in unlistedPeople"
           >
             <people-avatar

--- a/src/components/pages/TeamSchedule.vue
+++ b/src/components/pages/TeamSchedule.vue
@@ -102,7 +102,14 @@
 
     <div class="column side-column" v-if="isTaskSidePanelOpen">
       <task-info>
-        <a class="close-button" @click="toggleTaskSidePanel">
+        <a
+          class="close-button"
+          role="button"
+          tabindex="0"
+          @click="toggleTaskSidePanel"
+          @keydown.enter.prevent="toggleTaskSidePanel"
+          @keydown.space.prevent="toggleTaskSidePanel"
+        >
           <x-icon class="align-middle" :size="16" />
         </a>
         <h2 class="mt1">

--- a/src/components/pages/breakdown/AssetBlock.vue
+++ b/src/components/pages/breakdown/AssetBlock.vue
@@ -35,7 +35,7 @@
       <div class="asset-picture" v-if="asset.preview_file_id">
         <img
           loading="lazy"
-          alt=""
+          :alt="asset.name"
           :src="`/api/pictures/thumbnails-square/preview-files/${asset.preview_file_id}.png`"
         />
         <span class="nb-occurences" v-if="nbOccurences > 1">

--- a/src/components/pages/breakdown/AssetBlock.vue
+++ b/src/components/pages/breakdown/AssetBlock.vue
@@ -11,8 +11,26 @@
   >
     <div class="asset-wrapper">
       <template v-if="!readOnly && active">
-        <div class="asset-add-1" @click.stop="addOneAsset">+ 1</div>
-        <div class="asset-add" @click.stop="removeOneAsset">- 1</div>
+        <div
+          class="asset-add-1"
+          role="button"
+          tabindex="0"
+          @click.stop="addOneAsset"
+          @keydown.enter.prevent.stop="addOneAsset"
+          @keydown.space.prevent.stop="addOneAsset"
+        >
+          + 1
+        </div>
+        <div
+          class="asset-add"
+          role="button"
+          tabindex="0"
+          @click.stop="removeOneAsset"
+          @keydown.enter.prevent.stop="removeOneAsset"
+          @keydown.space.prevent.stop="removeOneAsset"
+        >
+          - 1
+        </div>
       </template>
       <div class="asset-picture" v-if="asset.preview_file_id">
         <img
@@ -30,7 +48,15 @@
         </span>
       </div>
     </div>
-    <div class="asset-label" :label="asset.label" @click="onEditLabelClicked">
+    <div
+      class="asset-label"
+      :label="asset.label"
+      role="button"
+      tabindex="0"
+      @click="onEditLabelClicked"
+      @keydown.enter.prevent="onEditLabelClicked"
+      @keydown.space.prevent="onEditLabelClicked"
+    >
       {{ asset.label || $t('breakdown.options.animate') }}
     </div>
   </div>
@@ -46,7 +72,11 @@
     </span>
     <span
       class="modify-asset flexrow-item"
+      role="button"
+      tabindex="0"
       @click.stop="removeOneAsset"
+      @keydown.enter.prevent.stop="removeOneAsset"
+      @keydown.space.prevent.stop="removeOneAsset"
       v-if="!readOnly && active"
     >
       - 1

--- a/src/components/pages/breakdown/AvailableAssetBlock.vue
+++ b/src/components/pages/breakdown/AvailableAssetBlock.vue
@@ -33,7 +33,7 @@
     <div class="asset-picture" v-if="asset.preview_file_id">
       <img
         loading="lazy"
-        alt=""
+        :alt="asset.name"
         :src="`/api/pictures/thumbnails-square/preview-files/${asset.preview_file_id}.png`"
       />
     </div>

--- a/src/components/pages/breakdown/AvailableAssetBlock.vue
+++ b/src/components/pages/breakdown/AvailableAssetBlock.vue
@@ -10,8 +10,26 @@
     :title="asset.name"
     v-if="!textMode"
   >
-    <div class="asset-add" @click="addOneAsset">+ 1</div>
-    <div class="asset-add-10" @click="addTenAssets">+ 10</div>
+    <div
+      class="asset-add"
+      role="button"
+      tabindex="0"
+      @click="addOneAsset"
+      @keydown.enter.prevent="addOneAsset"
+      @keydown.space.prevent="addOneAsset"
+    >
+      + 1
+    </div>
+    <div
+      class="asset-add-10"
+      role="button"
+      tabindex="0"
+      @click="addTenAssets"
+      @keydown.enter.prevent="addTenAssets"
+      @keydown.space.prevent="addTenAssets"
+    >
+      + 10
+    </div>
     <div class="asset-picture" v-if="asset.preview_file_id">
       <img
         loading="lazy"
@@ -35,7 +53,16 @@
     <span class="asset-text-name flexrow-item">
       {{ asset.name }}
     </span>
-    <span class="modify-asset flexrow-item" @click="addOneAsset"> + 1 </span>
+    <span
+      class="modify-asset flexrow-item"
+      role="button"
+      tabindex="0"
+      @click="addOneAsset"
+      @keydown.enter.prevent="addOneAsset"
+      @keydown.space.prevent="addOneAsset"
+    >
+      + 1
+    </span>
   </div>
 </template>
 

--- a/src/components/pages/breakdown/ShotLine.vue
+++ b/src/components/pages/breakdown/ShotLine.vue
@@ -7,7 +7,10 @@
       stdby: entity ? entity.is_casting_standby : false,
       'text-mode': textMode
     }"
+    role="button"
+    tabindex="0"
     @click="onClicked($event)"
+    @keydown.enter.prevent="onClicked($event)"
   >
     <div
       class="flexrow-item sticky"

--- a/src/components/pages/budget/BudgetDepartmentRow.vue
+++ b/src/components/pages/budget/BudgetDepartmentRow.vue
@@ -1,7 +1,11 @@
 <template>
   <tr
     class="datatable-row department-row pointer"
+    role="button"
+    tabindex="0"
     @click="toggleDepartment(departmentEntry.id)"
+    @keydown.enter.prevent="toggleDepartment(departmentEntry.id)"
+    @keydown.space.prevent="toggleDepartment(departmentEntry.id)"
   >
     <td class="datatable-row-header strong department-header" colspan="3">
       <div

--- a/src/components/pages/departments/DepartmentLinks.vue
+++ b/src/components/pages/departments/DepartmentLinks.vue
@@ -9,7 +9,10 @@
           }"
           v-for="dept in departments"
           :key="dept.id"
+          role="button"
+          tabindex="0"
           @click="selectDepartment(dept)"
+          @keydown.enter.prevent="selectDepartment(dept)"
         >
           <department-name :department="dept" />
         </li>
@@ -30,7 +33,10 @@
           <li
             :key="item.id"
             v-for="item in departmentLinkedItems"
+            role="button"
+            tabindex="0"
             @click="removeItem(item)"
+            @keydown.enter.prevent="removeItem(item)"
           >
             <div class="item-info">
               {{ item.name }}
@@ -47,7 +53,10 @@
         <li
           :key="item.id"
           v-for="item in availableItems"
+          role="button"
+          tabindex="0"
           @click="selectItem(item)"
+          @keydown.enter.prevent="selectItem(item)"
         >
           {{ item.name }}
         </li>

--- a/src/components/pages/entities/EntityChat.vue
+++ b/src/components/pages/entities/EntityChat.vue
@@ -78,7 +78,13 @@
             v-for="attachment in attachments"
           >
             {{ attachment.get('file').name }}
-            <span @click="removeAttachment(attachment)">
+            <span
+              role="button"
+              tabindex="0"
+              @click="removeAttachment(attachment)"
+              @keydown.enter.prevent="removeAttachment(attachment)"
+              @keydown.space.prevent="removeAttachment(attachment)"
+            >
               <x-icon :size="8" />
             </span>
           </div>

--- a/src/components/pages/entities/EntityChatDays.vue
+++ b/src/components/pages/entities/EntityChatDays.vue
@@ -50,6 +50,7 @@
                 :src="getAttachmentThumbnailPath(attachment)"
                 role="button"
                 tabindex="0"
+                :alt="attachment.name"
                 @click="currentAttachment = attachment"
                 @keydown.enter.prevent="currentAttachment = attachment"
                 v-for="attachment in pictureAttachments(

--- a/src/components/pages/entities/EntityChatDays.vue
+++ b/src/components/pages/entities/EntityChatDays.vue
@@ -48,7 +48,10 @@
                 class="attachment-thumbnail"
                 :key="attachment.id"
                 :src="getAttachmentThumbnailPath(attachment)"
+                role="button"
+                tabindex="0"
                 @click="currentAttachment = attachment"
+                @keydown.enter.prevent="currentAttachment = attachment"
                 v-for="attachment in pictureAttachments(
                   messageText.attachment_files
                 )"
@@ -67,7 +70,15 @@
             </div>
             <div
               class="delete-message-button"
+              role="button"
+              tabindex="0"
               @click="$emit('delete-message', chatMessage.data.id)"
+              @keydown.enter.prevent="
+                $emit('delete-message', chatMessage.data.id)
+              "
+              @keydown.space.prevent="
+                $emit('delete-message', chatMessage.data.id)
+              "
               v-if="chatMessage.data.person_id === user.id"
             >
               <x-icon :size="12" />

--- a/src/components/pages/logs/EventLogs.vue
+++ b/src/components/pages/logs/EventLogs.vue
@@ -35,7 +35,10 @@
       <div
         class="event-line"
         :key="event.id"
+        role="button"
+        tabindex="0"
         @click="selectLine(event)"
+        @keydown.enter.prevent="selectLine(event)"
         v-for="event in filteredEvents"
       >
         <span class="date tag mr1">{{ event.date }}</span>

--- a/src/components/pages/news/NewsRow.vue
+++ b/src/components/pages/news/NewsRow.vue
@@ -9,7 +9,10 @@
           selected: isSelected,
           'is-new': isNew
         }"
+        role="button"
+        tabindex="0"
         @click.prevent="$emit('select', news)"
+        @keydown.enter.prevent="$emit('select', news)"
       >
         <span
           :class="{
@@ -88,7 +91,10 @@
           selected: isSelected,
           'is-new': isNew
         }"
+        role="button"
+        tabindex="0"
         @click.prevent="$emit('select', news)"
+        @keydown.enter.prevent="$emit('select', news)"
       >
         <span
           :class="{

--- a/src/components/pages/production/NewProduction.vue
+++ b/src/components/pages/production/NewProduction.vue
@@ -320,7 +320,11 @@
               <span
                 :key="assetType.id"
                 class="asset-type-name flexrow-item"
+                role="button"
+                tabindex="0"
                 @click="deleteFromList(assetType, 'assetTypes')"
+                @keydown.enter.prevent="deleteFromList(assetType, 'assetTypes')"
+                @keydown.space.prevent="deleteFromList(assetType, 'assetTypes')"
                 v-for="assetType in productionToCreate.assetTypes"
               >
                 {{ assetType.name }}

--- a/src/components/pages/production/ProductionStats.vue
+++ b/src/components/pages/production/ProductionStats.vue
@@ -1,5 +1,13 @@
 <template>
-  <div class="project-stats" :class="{ expandable }" @click="expandStats">
+  <div
+    class="project-stats"
+    :class="{ expandable }"
+    :role="expandable ? 'button' : undefined"
+    :tabindex="expandable ? 0 : undefined"
+    @click="expandStats"
+    @keydown.enter.prevent="expandStats"
+    @keydown.space.prevent="expandStats"
+  >
     <div class="nb-tasks">
       <span class="tag">
         {{ stats.amount_done || 0 }} {{ $t('tasks.done') }}

--- a/src/components/pages/production/TaskTypeSettings.vue
+++ b/src/components/pages/production/TaskTypeSettings.vue
@@ -7,7 +7,14 @@
           :key="tab.name"
           :class="{ 'is-active': entityTab === tab.name }"
         >
-          <a @click="entityTab = tab.name">{{ tab.label }}</a>
+          <a
+            role="button"
+            tabindex="0"
+            @click="entityTab = tab.name"
+            @keydown.enter.prevent="entityTab = tab.name"
+            @keydown.space.prevent="entityTab = tab.name"
+            >{{ tab.label }}</a
+          >
         </li>
       </ul>
     </div>

--- a/src/components/pages/tasktype/EstimationHelper.vue
+++ b/src/components/pages/tasktype/EstimationHelper.vue
@@ -87,7 +87,10 @@
                 {{ getSeconds(task) }}
               </td>
               <td
+                role="button"
+                tabindex="0"
                 @click="selectTask($event, task, index)"
+                @keydown.enter.prevent="selectTask($event, task, index)"
                 class="estimation numeric-cell"
               >
                 <input

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -905,7 +905,6 @@
  * This modules manages all the options available while playing a playlist.
  * It is made to work with a single playlist.
  */
-import { PSBrush } from 'fabricjs-psbrush'
 import { ArrowUpRightIcon, DownloadIcon, PlayIcon } from 'lucide-vue-next'
 import moment from 'moment-timezone'
 import { v4 as uuidv4 } from 'uuid'
@@ -4019,20 +4018,13 @@ const resetPlaylist = () => {
 const onAnnotateClicked = () => {
   showCanvas()
   if (isDrawing.value) {
-    if (fabricCanvas.value) fabricCanvas.value.isDrawingMode = false
     isDrawing.value = false
   } else {
+    _resetColor()
+    _resetPencil()
     isShapeMode.value = false
     isTyping.value = false
     isEraserModeOn.value = false
-    if (fabricCanvas.value) {
-      fabricCanvas.value.isDrawingMode = true
-      const brush = new PSBrush(fabricCanvas.value)
-      fabricCanvas.value.freeDrawingBrush = brush
-      brush.pressureManager.fallback = 0.5
-    }
-    _resetColor()
-    _resetPencil()
     isDrawing.value = true
   }
 }
@@ -4252,6 +4244,7 @@ watch(isAnnotationsDisplayed, () => {
 })
 
 watch(isDrawing, () => {
+  setAnnotationDrawingMode(isDrawing.value)
   if (!isDrawing.value && isLaserModeOn.value) isLaserModeOn.value = false
   if (isDrawing.value && !isAnnotationsDisplayed.value) {
     isAnnotationsDisplayed.value = true

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -985,9 +985,9 @@ const FRAME_DELAY = 100
 const RESIZE_DELAY = 300
 
 const store = useStore()
+const $socket = store.$socket
 const { t } = useI18n()
 const instance = getCurrentInstance()
-const $socket = instance.appContext.config.globalProperties.$socket
 
 // Props
 

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -662,7 +662,7 @@
         :pencil-palette="pencilPalette"
         :pencil-width="pencilWidth"
         :production-backgrounds="productionBackgrounds"
-        :read-only="isCurrentUserArtist"
+        :read-only="readOnly"
         :show-comments-button="true"
         :text-color="textColor"
         v-model:current-background="currentBackground"
@@ -1170,6 +1170,9 @@ const currentProduction = computed(() => store.getters.currentProduction)
 const editMap = computed(() => store.getters.editMap)
 const episodeMap = computed(() => store.getters.episodeMap)
 const isCurrentUserArtist = computed(() => store.getters.isCurrentUserArtist)
+// Same intent as PreviewPlayer's readOnly prop: artists may watch
+// playlists but must not annotate or save.
+const readOnly = computed(() => isCurrentUserArtist.value)
 const isCurrentUserClient = computed(() => store.getters.isCurrentUserClient)
 const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
 const isCurrentUserSupervisor = computed(
@@ -2949,7 +2952,7 @@ const saveAnnotations = () => {
     }
   }
 
-  if (!isCurrentUserArtist.value) {
+  if (!readOnly.value) {
     if (!notSaved.value) {
       startAnnotationSaving(preview, newAnnotations)
     }

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -927,6 +927,7 @@ import { useFullScreen } from '@/composables/fullScreen'
 import { useAnnotation } from '@/composables/players/annotation'
 import { useAnnotationBroadcast } from '@/composables/players/annotationBroadcast'
 import { useAnnotationCursor } from '@/composables/players/annotationCursor'
+import { useMediaKind } from '@/composables/players/mediaKind'
 import { useOnionSkin } from '@/composables/players/onionSkin'
 import { usePlaylistComparison } from '@/composables/players/playlistComparison'
 import { usePreviewShortcuts } from '@/composables/players/previewShortcuts'
@@ -937,13 +938,8 @@ import {
   buildAnnotationSnapshotFilename,
   buildAnnotationSnapshotTitle,
   drawSnapshotTitle,
-  isDiffPreview,
-  isMarkdownPreview,
-  isModelPreview,
   isMoviePreview,
-  isPdfPreview,
-  isPicturePreview,
-  isSoundPreview
+  isPicturePreview
 } from '@/lib/preview'
 import {
   ceilToFrame,
@@ -1210,27 +1206,16 @@ const userId = computed(() => store.getters.user?.id)
 // Computed — file type helpers
 
 const extension = computed(() => currentPreview.value?.extension || '')
-const isCurrentPreviewMovie = computed(() => isMoviePreview(extension.value))
-const isCurrentPreviewPicture = computed(() =>
-  isPicturePreview(extension.value)
-)
-const isCurrentPreviewModel = computed(() => isModelPreview(extension.value))
-const isCurrentPreviewSound = computed(() => isSoundPreview(extension.value))
-const isCurrentPreviewPdf = computed(() => isPdfPreview(extension.value))
-const isCurrentPreviewMarkdown = computed(() =>
-  isMarkdownPreview(extension.value)
-)
-const isCurrentPreviewDiff = computed(() => isDiffPreview(extension.value))
-const isCurrentPreviewFile = computed(
-  () =>
-    !isCurrentPreviewMovie.value &&
-    !isCurrentPreviewPicture.value &&
-    !isCurrentPreviewSound.value &&
-    !isCurrentPreviewModel.value &&
-    !isCurrentPreviewPdf.value &&
-    !isCurrentPreviewMarkdown.value &&
-    !isCurrentPreviewDiff.value
-)
+const {
+  isDiff: isCurrentPreviewDiff,
+  isFile: isCurrentPreviewFile,
+  isMarkdown: isCurrentPreviewMarkdown,
+  isModel: isCurrentPreviewModel,
+  isMovie: isCurrentPreviewMovie,
+  isPdf: isCurrentPreviewPdf,
+  isPicture: isCurrentPreviewPicture,
+  isSound: isCurrentPreviewSound
+} = useMediaKind(extension)
 
 // Computed — entity & preview state
 

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -931,6 +931,7 @@ import { useMediaKind } from '@/composables/players/mediaKind'
 import { useOnionSkin } from '@/composables/players/onionSkin'
 import { usePlaylistComparison } from '@/composables/players/playlistComparison'
 import { usePreviewShortcuts } from '@/composables/players/previewShortcuts'
+import { usePlayerTransport } from '@/composables/players/transport'
 import { usePreviewRoom } from '@/composables/previewRoom'
 import { scrubFrame } from '@/lib/players/scrub'
 import preferences from '@/lib/preferences'
@@ -1101,7 +1102,8 @@ const framesSeenOfPicture = ref(1)
 const currentBackground = ref(null)
 const currentPreviewIndex = ref(0)
 const currentTime = ref('00:00.000')
-const currentTimeRaw = ref(0)
+const { currentTimeRaw, isHd, isMuted, isPlaying, isRepeating, speed, volume } =
+  usePlayerTransport()
 const handleIn = ref(0)
 const handleOut = ref(0)
 const hasActiveShareLinks = ref(false)
@@ -1113,12 +1115,8 @@ const isDrawing = ref(false)
 const isEntitiesHidden = ref(false)
 const isEnvironmentSkybox = ref(false)
 const isFullMode = ref(false)
-const isHd = ref(false)
 const isLaserModeOn = ref(false)
-const isMuted = ref(false)
 const isObjectBackground = ref(false)
-const isPlaying = ref(false)
-const isRepeating = ref(false)
 const isShowAnnotationsWhilePlaying = ref(false)
 const isTyping = ref(false)
 const isWaveformDisplayed = ref(false)
@@ -1143,8 +1141,6 @@ const room = ref({
   people: [],
   newComer: true
 })
-const speed = ref(3)
-const volume = ref(50)
 
 const modals = ref({
   delete: false,

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -1586,7 +1586,8 @@ const annotation = useAnnotation({
   isLaserModeOn,
   postAnnotationAddition,
   postAnnotationDeletion,
-  postAnnotationUpdate
+  postAnnotationUpdate,
+  getAdditionalPreviews: () => getAdditionalPreviews()
 })
 
 annotation.setCurrentPreviewGetter(() => currentPreview.value)
@@ -2919,6 +2920,39 @@ const prefetchAnnotationsAround = index => {
   }
 }
 
+// Store copies of the current preview kept under entity.preview_files (one
+// group per task type in the playlist payload). The annotation composable
+// hands them to the updatePreviewAnnotations action so its store write also
+// refreshes the revision copies — saveAnnotations no longer commits itself.
+const getAdditionalPreviews = () => {
+  if (readOnly.value) return []
+  const entity = entityList.value[playingEntityIndex.value]
+  if (!entity) return []
+
+  let previewId = entity.preview_file_id
+  if (currentPreviewIndex.value > 0) {
+    const index = currentPreviewIndex.value - 1
+    const previewFile = currentEntity.value?.preview_file_previews?.[index]
+    if (previewFile) previewId = previewFile.id
+  }
+
+  const taskId = entity.preview_file_task_id
+  const pairs = []
+  Object.keys(entity.preview_files || {}).forEach(taskTypeId => {
+    let revPreview = null
+    entity.preview_files[taskTypeId].forEach(p => {
+      if (p.id === previewId) revPreview = p
+      if (!revPreview && p.previews) {
+        p.previews.forEach(sub => {
+          if (sub.id === previewId) revPreview = p
+        })
+      }
+    })
+    if (revPreview) pairs.push({ taskId, preview: revPreview })
+  })
+  return pairs
+}
+
 const saveAnnotations = () => {
   let time = roundToFrame(currentTimeRaw.value, fps.value) || 0
   if (time < 0) time = 0
@@ -2954,24 +2988,6 @@ const saveAnnotations = () => {
     }
 
     entity.preview_file_annotations = newAnnotations
-    Object.keys(entity.preview_files || {}).forEach(taskTypeId => {
-      let revPreview = null
-      entity.preview_files[taskTypeId].forEach(p => {
-        if (p.id === preview.id) revPreview = p
-        if (!revPreview && p.previews) {
-          p.previews.forEach(sub => {
-            if (sub.id === preview.id) revPreview = p
-          })
-        }
-      })
-      if (revPreview) {
-        store.commit('UPDATE_PREVIEW_ANNOTATION', {
-          taskId: preview.task_id,
-          preview: revPreview,
-          annotations: newAnnotations
-        })
-      }
-    })
   }
 }
 

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -972,11 +972,14 @@ const setVideoFrameContext = frame => {
   }
 }
 
-// Continuous player time → smooth progress bar during playback. The +1 mirrors
-// getFrameFromPlayer's convention so the bar doesn't jump when pausing.
+// Player time → progress bar during playback. `time` carries the
+// mediaTime + frameDuration/2 convention offset, so a raw division parks the
+// fill at half-frame positions; quantize with the same ceil(...)+1 convention
+// as getFrameFromPlayer so the bar fills whole frames and doesn't jump when
+// pausing.
 const onVideoTimeUpdate = time => {
   if (!isPlaying.value) return
-  progress.value?.updateProgressBar(time / frameDuration.value + 1)
+  progress.value?.updateProgressBar(Math.ceil(time / frameDuration.value) + 1)
 }
 
 const onSubPreviewsWheel = event => {

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -449,6 +449,7 @@ import { useAnnotationCursor } from '@/composables/players/annotationCursor'
 import { useComparison } from '@/composables/players/comparison'
 import { useOnionSkin } from '@/composables/players/onionSkin'
 import { usePreviewShortcuts } from '@/composables/players/previewShortcuts'
+import { usePlayerTransport } from '@/composables/players/transport'
 import { getEntityPath } from '@/lib/path'
 import { mergeAnnotationsByFrame } from '@/lib/players/annotation'
 import localPreferences from '@/lib/preferences'
@@ -609,27 +610,22 @@ const currentBackground = ref(null)
 const currentFrame = ref(0)
 const currentIndex = ref(1)
 const currentTime = ref('00:00:00:00')
-const currentTimeRaw = ref(0)
+const { currentTimeRaw, isHd, isMuted, isPlaying, isRepeating, speed, volume } =
+  usePlayerTransport()
 const is3DAnimation = ref(false)
 const isAnnotationsDisplayed = ref(true)
 const isCommentsHidden = ref(true)
 const isDrawing = ref(false)
 const isEnvironmentSkybox = ref(false)
-const isHd = ref(false)
-const isMuted = ref(false)
 const isObjectBackground = ref(false)
 const isOrdering = ref(true)
-const isPlaying = ref(false)
-const isRepeating = ref(false)
 const isTyping = ref(false)
 const isWireframe = ref(false)
 const maxDuration = ref('00:00:00:00')
 const movieDimensions = ref({ width: 1920, height: 1080 })
 const objectBackgroundUrl = ref(null)
 const pencilPalette = ref(['huge', 'big', 'medium', 'small', 'tiny'])
-const speed = ref(3)
 const videoDuration = ref(0)
-const volume = ref(50)
 const width = ref(0)
 
 // Vuex getters

--- a/src/components/players/players/SharedPlaylistPlayer.vue
+++ b/src/components/players/players/SharedPlaylistPlayer.vue
@@ -250,17 +250,9 @@ import { useStore } from 'vuex'
 
 import darkTimesliderUrl from '@/assets/background/video-timeslider-dark.png'
 import { usePanzoomSync } from '@/composables/panzoom'
+import { useMediaKind } from '@/composables/players/mediaKind'
 import { isAltLetter } from '@/composables/players/previewShortcuts'
 import { mergeAnnotationsByFrame } from '@/lib/players/annotation'
-import {
-  isDiffPreview,
-  isMarkdownPreview,
-  isModelPreview,
-  isMoviePreview,
-  isPdfPreview,
-  isPicturePreview,
-  isSoundPreview
-} from '@/lib/preview'
 import { DEFAULT_FPS, floorToFrame, formatTime } from '@/lib/video'
 
 import SharedAnnotationOverlay from '@/components/players/annotations/SharedAnnotationOverlay.vue'
@@ -416,24 +408,17 @@ const currentEntityPreviewLength = computed(() => {
 })
 
 const extension = computed(() => currentPreview.value?.extension || '')
-const isMovie = computed(() => isMoviePreview(extension.value))
-const isPicture = computed(() => isPicturePreview(extension.value))
-const isSound = computed(() => isSoundPreview(extension.value))
-const isModel = computed(() => isModelPreview(extension.value))
-const isPdf = computed(() => isPdfPreview(extension.value))
-const isMarkdown = computed(() => isMarkdownPreview(extension.value))
-const isDiff = computed(() => isDiffPreview(extension.value))
-const isOtherFile = computed(
-  () =>
-    !!currentPreview.value &&
-    !isMovie.value &&
-    !isPicture.value &&
-    !isSound.value &&
-    !isModel.value &&
-    !isPdf.value &&
-    !isMarkdown.value &&
-    !isDiff.value
-)
+const {
+  isDiff,
+  isFile,
+  isMarkdown,
+  isModel,
+  isMovie,
+  isPdf,
+  isPicture,
+  isSound
+} = useMediaKind(extension)
+const isOtherFile = computed(() => !!currentPreview.value && isFile.value)
 
 const downloadUrl = computed(() => {
   if (!currentPreview.value) return ''

--- a/src/components/players/players/SharedPlaylistPlayer.vue
+++ b/src/components/players/players/SharedPlaylistPlayer.vue
@@ -252,6 +252,7 @@ import darkTimesliderUrl from '@/assets/background/video-timeslider-dark.png'
 import { usePanzoomSync } from '@/composables/panzoom'
 import { useMediaKind } from '@/composables/players/mediaKind'
 import { isAltLetter } from '@/composables/players/previewShortcuts'
+import { usePlayerTransport } from '@/composables/players/transport'
 import { mergeAnnotationsByFrame } from '@/lib/players/annotation'
 import { DEFAULT_FPS, floorToFrame, formatTime } from '@/lib/video'
 
@@ -308,9 +309,7 @@ const isCommentsHidden = ref(
 const isEntitiesHidden = ref(false)
 const isFullScreen = ref(false)
 const isHd = ref(true)
-const isMuted = ref(false)
-const isPlaying = ref(false)
-const isRepeating = ref(false)
+const { isMuted, isPlaying, isRepeating } = usePlayerTransport()
 const maxDuration = ref(0)
 const movieDimensions = ref({ width: 0, height: 0 })
 const picturePlayer = ref(null)

--- a/src/components/players/viewers/PreviewViewer.vue
+++ b/src/components/players/viewers/PreviewViewer.vue
@@ -127,15 +127,7 @@
 import { ref, computed, watch } from 'vue'
 import { DownloadIcon } from 'lucide-vue-next'
 
-import {
-  isDiffPreview,
-  isMarkdownPreview,
-  isModelPreview,
-  isMoviePreview,
-  isPdfPreview,
-  isPicturePreview,
-  isSoundPreview
-} from '@/lib/preview'
+import { useMediaKind } from '@/composables/players/mediaKind'
 
 /* eslint-disable no-unused-vars */
 import DiffViewer from '@/components/players/viewers/DiffViewer.vue'
@@ -268,31 +260,17 @@ const status = computed(() =>
 const isBroken = computed(() => ['broken', 'missing'].includes(status.value))
 const isProcessing = computed(() => status.value === 'processing')
 const isReady = computed(() => status.value === 'ready')
-const isDiff = computed(() => isReady.value && isDiffPreview(extension.value))
-const isMarkdown = computed(
-  () => isReady.value && isMarkdownPreview(extension.value)
-)
-const isMovie = computed(() => isReady.value && isMoviePreview(extension.value))
-const isPdf = computed(() => isReady.value && isPdfPreview(extension.value))
-const isPicture = computed(
-  () => isReady.value && isPicturePreview(extension.value)
-)
-const is3DModel = computed(
-  () => isReady.value && isModelPreview(extension.value)
-)
-const isSound = computed(() => isReady.value && isSoundPreview(extension.value))
 
-const isFile = computed(
-  () =>
-    isReady.value &&
-    !isPicture.value &&
-    !isMovie.value &&
-    !is3DModel.value &&
-    !isSound.value &&
-    !isPdf.value &&
-    !isMarkdown.value &&
-    !isDiff.value
-)
+const {
+  isDiff,
+  isFile,
+  isMarkdown,
+  isModel: is3DModel,
+  isMovie,
+  isPdf,
+  isPicture,
+  isSound
+} = useMediaKind(extension, isReady)
 
 const originalPath = computed(() => {
   if (props.preview) {

--- a/src/components/sides/ManageLibrary.vue
+++ b/src/components/sides/ManageLibrary.vue
@@ -15,7 +15,14 @@
           @confirm="removeSharedEntities(selectedEntities)"
         />
         <div class="has-text-centered pa1">
-          <a @click="clearSelectedAssets()">{{ $t('main.clear_selection') }}</a>
+          <a
+            role="button"
+            tabindex="0"
+            @click="clearSelectedAssets()"
+            @keydown.enter.prevent="clearSelectedAssets()"
+            @keydown.space.prevent="clearSelectedAssets()"
+            >{{ $t('main.clear_selection') }}</a
+          >
         </div>
         <!--h1 class="title mt05">{{ $t('tasks.selected_entities') }}</h1>
         <div class="pa2 mt1">
@@ -93,7 +100,11 @@
               >
                 <td
                   class="datatable-row-header pointer"
+                  role="button"
+                  tabindex="0"
                   @click="toggleEntity(entity)"
+                  @keydown.enter.prevent="toggleEntity(entity)"
+                  @keydown.space.prevent="toggleEntity(entity)"
                 >
                   <div class="flexrow">
                     <input

--- a/src/components/sides/Sidebar.vue
+++ b/src/components/sides/Sidebar.vue
@@ -6,14 +6,21 @@
           <div class="company-logo has-text-centered" :title="title">
             <img
               :src="logoPath"
+              :alt="organisation.name"
               v-if="organisation && organisation.has_avatar"
             />
             <img
               src="../../assets/kitsu-text-dark.svg"
               width="180"
+              alt="Kitsu"
               v-else-if="isDarkTheme"
             />
-            <img src="../../assets/kitsu-text.svg" width="180" v-else />
+            <img
+              src="../../assets/kitsu-text.svg"
+              width="180"
+              alt="Kitsu"
+              v-else
+            />
           </div>
         </router-link>
 

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -30,10 +30,10 @@
           ((nbSelectedTasks || 0) > 1 || nbSelectedValidations > 0)
         "
       >
-        <h1 class="title">
+        <h2 class="title">
           {{ $t('tasks.selected_tasks') }}
           ({{ nbSelectedTasks }})
-        </h1>
+        </h2>
         <div class="task-list mt1">
           <div
             class="selected-task-line flexrow"
@@ -339,7 +339,7 @@
         />
       </div>
       <div class="side task-info pa1" v-else-if="nbSelectedEntities > 0">
-        <h1 class="title mt2">{{ $t('tasks.selected_entities') }}</h1>
+        <h2 class="title mt2">{{ $t('tasks.selected_entities') }}</h2>
         <div class="pa2 mt1">
           <div
             class="entity-line"

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -48,7 +48,11 @@
             <span class="flexrow-item">{{ task.entity_name }}</span>
             <span
               class="flexrow-item pointer"
+              role="button"
+              tabindex="0"
               @click="removeTaskFromSelection(task)"
+              @keydown.enter.prevent="removeTaskFromSelection(task)"
+              @keydown.space.prevent="removeTaskFromSelection(task)"
             >
               <x-icon :size="12" />
             </span>

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -8,7 +8,11 @@
             active: selectedBar === 'change-status'
           }"
           :title="$t('menu.change_status')"
+          role="button"
+          tabindex="0"
           @click="selectBar('change-status')"
+          @keydown.enter.prevent="selectBar('change-status')"
+          @keydown.space.prevent="selectBar('change-status')"
           v-if="
             (isCurrentUserManager ||
               isSupervisorInDepartment ||
@@ -28,7 +32,11 @@
             active: selectedBar === 'assignation'
           }"
           :title="$t('menu.assign_tasks')"
+          role="button"
+          tabindex="0"
           @click="selectBar('assignation')"
+          @keydown.enter.prevent="selectBar('assignation')"
+          @keydown.space.prevent="selectBar('assignation')"
           v-if="
             (isCurrentViewSingleEntity || isCurrentViewEntity) &&
             (isCurrentUserManager ||
@@ -62,7 +70,11 @@
             !isEntitySelection &&
             isTaskSelection
           "
+          role="button"
+          tabindex="0"
           @click="selectBar('priorities')"
+          @keydown.enter.prevent="selectBar('priorities')"
+          @keydown.space.prevent="selectBar('priorities')"
         >
           <kitsu-icon
             name="priority"
@@ -80,7 +92,11 @@
           v-if="
             isTaskSelection && !isCurrentUserArtist && !isCurrentViewConcept
           "
+          role="button"
+          tabindex="0"
           @click="selectBar('thumbnails')"
+          @keydown.enter.prevent="selectBar('thumbnails')"
+          @keydown.space.prevent="selectBar('thumbnails')"
         >
           <kitsu-icon
             name="add-thumbnail"
@@ -101,7 +117,11 @@
             !isCurrentViewTodos &&
             !isCurrentViewConcept
           "
+          role="button"
+          tabindex="0"
           @click="selectBar('subscribe')"
+          @keydown.enter.prevent="selectBar('subscribe')"
+          @keydown.space.prevent="selectBar('subscribe')"
         >
           <kitsu-icon
             name="watch"
@@ -116,7 +136,11 @@
             active: selectedBar === 'edit-concepts'
           }"
           :title="$t('menu.edit_concepts')"
+          role="button"
+          tabindex="0"
           @click="selectBar('edit-concepts')"
+          @keydown.enter.prevent="selectBar('edit-concepts')"
+          @keydown.space.prevent="selectBar('edit-concepts')"
           v-if="
             isCurrentViewConcept &&
             (isCurrentUserManager || isConceptPublisher) &&
@@ -148,7 +172,11 @@
             isTaskSelection &&
             nbSelectedTasks > 0
           "
+          role="button"
+          tabindex="0"
           @click="selectBar('playlists')"
+          @keydown.enter.prevent="selectBar('playlists')"
+          @keydown.space.prevent="selectBar('playlists')"
         >
           <kitsu-icon
             name="playlists"
@@ -176,7 +204,11 @@
             active: selectedBar === 'create-tasks'
           }"
           :title="$t('menu.create_tasks')"
+          role="button"
+          tabindex="0"
           @click="selectBar('create-tasks')"
+          @keydown.enter.prevent="selectBar('create-tasks')"
+          @keydown.space.prevent="selectBar('create-tasks')"
           v-if="
             isCurrentViewEntity &&
             !isCurrentViewTaskType &&
@@ -194,7 +226,11 @@
             active: selectedBar === 'delete-tasks'
           }"
           :title="$t('menu.delete_tasks')"
+          role="button"
+          tabindex="0"
           @click="selectBar('delete-tasks')"
+          @keydown.enter.prevent="selectBar('delete-tasks')"
+          @keydown.space.prevent="selectBar('delete-tasks')"
           v-if="
             isCurrentViewEntity &&
             isCurrentUserManager &&
@@ -226,7 +262,11 @@
             active: selectedBar === 'custom-actions'
           }"
           :title="$t('menu.run_custom_action')"
+          role="button"
+          tabindex="0"
           @click="selectBar('custom-actions')"
+          @keydown.enter.prevent="selectBar('custom-actions')"
+          @keydown.space.prevent="selectBar('custom-actions')"
           v-if="
             !isEntitySelection &&
             isTaskSelection &&
@@ -243,7 +283,11 @@
             active: selectedBar === 'delete-assets'
           }"
           :title="$t('menu.delete_assets')"
+          role="button"
+          tabindex="0"
           @click="selectBar('delete-assets')"
+          @keydown.enter.prevent="selectBar('delete-assets')"
+          @keydown.space.prevent="selectBar('delete-assets')"
           v-if="isCurrentViewAsset && isCurrentUserManager && !isTaskSelection"
         >
           <kitsu-icon name="trash" :title="$t('menu.delete_assets')" />
@@ -255,7 +299,11 @@
             active: selectedBar === 'delete-shots'
           }"
           :title="$t('menu.delete_shots')"
+          role="button"
+          tabindex="0"
           @click="selectBar('delete-shots')"
+          @keydown.enter.prevent="selectBar('delete-shots')"
+          @keydown.space.prevent="selectBar('delete-shots')"
           v-if="isCurrentViewShot && isCurrentUserManager && !isTaskSelection"
         >
           <kitsu-icon name="trash" :title="$t('menu.delete_shots')" />
@@ -267,7 +315,11 @@
             active: selectedBar === 'delete-edits'
           }"
           :title="$t('menu.delete_edits')"
+          role="button"
+          tabindex="0"
           @click="selectBar('delete-edits')"
+          @keydown.enter.prevent="selectBar('delete-edits')"
+          @keydown.space.prevent="selectBar('delete-edits')"
           v-if="isCurrentViewEdit && isCurrentUserManager && !isTaskSelection"
         >
           <kitsu-icon name="trash" :title="$t('menu.delete_edits')" />
@@ -279,7 +331,11 @@
             active: selectedBar === 'delete-concepts'
           }"
           :title="$t('menu.delete_concepts')"
+          role="button"
+          tabindex="0"
           @click="selectBar('delete-concepts')"
+          @keydown.enter.prevent="selectBar('delete-concepts')"
+          @keydown.space.prevent="selectBar('delete-concepts')"
           v-if="
             isCurrentViewConcept && (isCurrentUserManager || isConceptPublisher)
           "
@@ -292,7 +348,11 @@
         <div
           class="menu-item"
           :title="$t('main.csv.export_file')"
+          role="button"
+          tabindex="0"
           @click="$emit('export-task')"
+          @keydown.enter.prevent="$emit('export-task')"
+          @keydown.space.prevent="$emit('export-task')"
           v-if="
             isTaskSelection &&
             !isEntitySelection &&
@@ -306,7 +366,11 @@
         <div
           class="menu-item mr05"
           :title="$t('main.clear_selection')"
+          role="button"
+          tabindex="0"
           @click="clearSelection"
+          @keydown.enter.prevent="clearSelection"
+          @keydown.space.prevent="clearSelection"
         >
           <x-icon :size="16" />
         </div>
@@ -570,7 +634,11 @@
               <li
                 :key="entity.id"
                 class="tag"
+                role="button"
+                tabindex="0"
                 @click="onRemoveLink(entity)"
+                @keydown.enter.prevent="onRemoveLink(entity)"
+                @keydown.space.prevent="onRemoveLink(entity)"
                 v-for="entity in conceptLinkedEntities"
               >
                 {{ entity.name }}
@@ -811,7 +879,11 @@
                 <li
                   class="tag"
                   :key="link.id"
+                  role="button"
+                  tabindex="0"
                   @click="onSelectLink(link)"
+                  @keydown.enter.prevent="onSelectLink(link)"
+                  @keydown.space.prevent="onSelectLink(link)"
                   v-for="link in linkGroup.links"
                 >
                   {{ link.name }}

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -4,7 +4,11 @@
       <div class="nav-left">
         <a
           class="studio-logo-wrapper nav-item"
+          role="button"
+          tabindex="0"
           @click="toggleSidebar()"
+          @keydown.enter.prevent="toggleSidebar()"
+          @keydown.space.prevent="toggleSidebar()"
           v-if="!isCurrentUserClient"
         >
           <img
@@ -126,7 +130,14 @@
             <help-circle-icon />
           </a>
         </div>
-        <div class="nav-item pointer" @click="toggleUserMenu">
+        <div
+          class="nav-item pointer"
+          role="button"
+          tabindex="0"
+          @click="toggleUserMenu"
+          @keydown.enter.prevent="toggleUserMenu"
+          @keydown.space.prevent="toggleUserMenu"
+        >
           <people-avatar
             class="avatar"
             :is-lazy="false"
@@ -151,11 +162,21 @@
             {{ $t('main.profile') }}
           </router-link>
         </li>
-        <li @click="toggleDarkTheme">
+        <li
+          role="button"
+          tabindex="0"
+          @click="toggleDarkTheme"
+          @keydown.enter.prevent="toggleDarkTheme"
+          @keydown.space.prevent="toggleDarkTheme"
+        >
           {{ !isDarkTheme ? $t('main.dark_theme') : $t('main.white_theme') }}
         </li>
         <li
+          role="button"
+          tabindex="0"
           @click="toggleDesktopNotifications"
+          @keydown.enter.prevent="toggleDesktopNotifications"
+          @keydown.space.prevent="toggleDesktopNotifications"
           :class="{ disabled: desktopNotificationsPermission === 'denied' }"
           :title="
             desktopNotificationsPermission === 'denied'
@@ -181,7 +202,13 @@
             </span>
           </span>
         </li>
-        <li @click="setSupportChat(!isSupportChat)">
+        <li
+          role="button"
+          tabindex="0"
+          @click="setSupportChat(!isSupportChat)"
+          @keydown.enter.prevent="setSupportChat(!isSupportChat)"
+          @keydown.space.prevent="setSupportChat(!isSupportChat)"
+        >
           {{
             isSupportChat
               ? $t('main.hide_support_chat')
@@ -198,7 +225,13 @@
           </a>
         </li>
         <li>
-          <a @click="display.shortcutModal = true">
+          <a
+            role="button"
+            tabindex="0"
+            @click="display.shortcutModal = true"
+            @keydown.enter.prevent="display.shortcutModal = true"
+            @keydown.space.prevent="display.shortcutModal = true"
+          >
             {{ $t('keyboard.shortcuts') }}
           </a>
         </li>
@@ -233,7 +266,14 @@
         <li class="version">Kitsu {{ kitsuVersion }}</li>
         <hr />
         <li>
-          <a @click="onLogout" class="flexrow">
+          <a
+            class="flexrow"
+            role="button"
+            tabindex="0"
+            @click="onLogout"
+            @keydown.enter.prevent="onLogout"
+            @keydown.space.prevent="onLogout"
+          >
             <log-out-icon class="flexrow-item icon-1x" />
             <span class="flexrow-item">{{ $t('main.logout') }}</span>
           </a>

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -14,9 +14,15 @@
           <img
             class="studio-logo"
             :src="logoPath"
+            :alt="organisation.name"
             v-if="organisation?.has_avatar"
           />
-          <img class="studio-logo" src="@/assets/kitsu.png" v-else />
+          <img
+            class="studio-logo"
+            src="@/assets/kitsu.png"
+            alt="Kitsu"
+            v-else
+          />
         </a>
 
         <router-link
@@ -27,9 +33,15 @@
           <img
             class="studio-logo"
             :src="logoPath"
+            :alt="organisation.name"
             v-if="organisation?.has_avatar"
           />
-          <img class="studio-logo" src="@/assets/kitsu.png" v-else />
+          <img
+            class="studio-logo"
+            src="@/assets/kitsu.png"
+            alt="Kitsu"
+            v-else
+          />
         </router-link>
 
         <div class="flexrow topbar-menu" v-if="isProductionContext">

--- a/src/components/tops/TopbarEpisodeList.vue
+++ b/src/components/tops/TopbarEpisodeList.vue
@@ -6,7 +6,14 @@
     }"
   >
     <div class="episode-menu">
-      <div class="flexrow unselectable" @click="toggleEpisodeList">
+      <div
+        class="flexrow unselectable"
+        role="button"
+        tabindex="0"
+        @click="toggleEpisodeList"
+        @keydown.enter.prevent="toggleEpisodeList"
+        @keydown.space.prevent="toggleEpisodeList"
+      >
         <div class="selected-production-line flexrow-item">
           {{ episodeLabel }}
         </div>
@@ -36,14 +43,22 @@
         </div>
         <div
           class="group-name episode-line has-text-centered more-button"
+          role="button"
+          tabindex="0"
           @click="showAllMode = true"
+          @keydown.enter.prevent="showAllMode = true"
+          @keydown.space.prevent="showAllMode = true"
           v-if="!showAllMode"
         >
           +
         </div>
         <div
           class="group-name episode-line has-text-centered more-button"
+          role="button"
+          tabindex="0"
           @click="showAllMode = false"
+          @keydown.enter.prevent="showAllMode = false"
+          @keydown.space.prevent="showAllMode = false"
           v-else
         >
           -

--- a/src/components/tops/TopbarProductionList.vue
+++ b/src/components/tops/TopbarProductionList.vue
@@ -6,7 +6,14 @@
     }"
   >
     <div class="production-menu">
-      <div class="flexrow" @click="toggleProductionList">
+      <div
+        class="flexrow"
+        role="button"
+        tabindex="0"
+        @click="toggleProductionList"
+        @keydown.enter.prevent="toggleProductionList"
+        @keydown.space.prevent="toggleProductionList"
+      >
         <div class="selected-production-line flexrow-item unselectable">
           <production-name
             :production="currentProduction"

--- a/src/components/tops/TopbarSectionList.vue
+++ b/src/components/tops/TopbarSectionList.vue
@@ -6,7 +6,14 @@
     }"
   >
     <div class="section-menu">
-      <div class="flexrow unselectable" @click="toggleSectionList">
+      <div
+        class="flexrow unselectable"
+        role="button"
+        tabindex="0"
+        @click="toggleSectionList"
+        @keydown.enter.prevent="toggleSectionList"
+        @keydown.space.prevent="toggleSectionList"
+      >
         <div
           class="selected-section-line flexrow-item flexrow"
           v-if="currentSection"

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -16,7 +16,11 @@
           :class="{
             active: mode === 'status'
           }"
+          role="button"
+          tabindex="0"
           @click="mode = 'status'"
+          @keydown.enter.prevent="mode = 'status'"
+          @keydown.space.prevent="mode = 'status'"
         >
           {{ $t('tasks.change_status') }}
         </span>
@@ -25,7 +29,11 @@
           :class="{
             active: mode === 'publish'
           }"
+          role="button"
+          tabindex="0"
           @click="mode = 'publish'"
+          @keydown.enter.prevent="mode = 'publish'"
+          @keydown.space.prevent="mode = 'publish'"
           v-if="!isConcept"
         >
           {{ $t('tasks.publish_revision') }}
@@ -131,7 +139,11 @@
         />
         <span
           class="flexrow-item column preview-delete-link"
+          role="button"
+          tabindex="0"
           @click.prevent="toggleLinkField(true)"
+          @keydown.enter.prevent="toggleLinkField(true)"
+          @keydown.space.prevent="toggleLinkField(true)"
         >
           x
         </span>
@@ -159,7 +171,15 @@
           >
             <div class="m0">
               {{ shortenText(preview.get('file').name, 40) }}
-              <span @click="$emit('remove-preview', preview)">x</span>
+              <span
+                role="button"
+                tabindex="0"
+                @click="$emit('remove-preview', preview)"
+                @keydown.enter.prevent="$emit('remove-preview', preview)"
+                @keydown.space.prevent="$emit('remove-preview', preview)"
+              >
+                x
+              </span>
             </div>
             <div class="progress-wrapper">
               <div
@@ -199,7 +219,11 @@
             <span
               class="flexrow-item column preview-delete-revision"
               :title="$t('tasks.auto_revision')"
+              role="button"
+              tabindex="0"
               @click.prevent="nextRevision = undefined"
+              @keydown.enter.prevent="nextRevision = undefined"
+              @keydown.space.prevent="nextRevision = undefined"
             >
               x
             </span>
@@ -219,13 +243,28 @@
             v-if="isImageAttachment(attach)"
           >
             <img :src="attachmentURL(attach)" :alt="attach.get('file').name" />
-            <span class="attachment-remove" @click="removeAttachment(attach)">
+            <span
+              class="attachment-remove"
+              role="button"
+              tabindex="0"
+              @click="removeAttachment(attach)"
+              @keydown.enter.prevent="removeAttachment(attach)"
+              @keydown.space.prevent="removeAttachment(attach)"
+            >
               x
             </span>
           </div>
           <div class="attachment-file" :title="attach.get('file').name" v-else>
             {{ shortenText(attach.get('file').name, 70) }}
-            <span @click="removeAttachment(attach)">x</span>
+            <span
+              role="button"
+              tabindex="0"
+              @click="removeAttachment(attach)"
+              @keydown.enter.prevent="removeAttachment(attach)"
+              @keydown.space.prevent="removeAttachment(attach)"
+            >
+              x
+            </span>
           </div>
         </template>
 

--- a/src/components/widgets/BooleanField.vue
+++ b/src/components/widgets/BooleanField.vue
@@ -7,7 +7,11 @@
       small: isSmall
     }"
     :disabled="disabled || null"
+    role="button"
+    :tabindex="disabled ? -1 : 0"
     @click="onClick"
+    @keydown.enter.prevent="onClick"
+    @keydown.space.prevent="onClick"
   >
     <span class="icon-wrapper flexrow-item">
       <check-icon

--- a/src/components/widgets/Checklist.vue
+++ b/src/components/widgets/Checklist.vue
@@ -9,13 +9,34 @@
       :key="`comment-checklist-${index}`"
       v-for="(entry, index) in filteredChecklist"
     >
-      <span class="checklist-checkbox" @click="toggleEntryChecked(entry)">
+      <span
+        class="checklist-checkbox"
+        role="button"
+        tabindex="0"
+        @click="toggleEntryChecked(entry)"
+        @keydown.enter.prevent="toggleEntryChecked(entry)"
+        @keydown.space.prevent="toggleEntryChecked(entry)"
+      >
         <check-square-icon class="icon" v-if="entry.checked" />
         <square-icon class="icon" v-else />
       </span>
       <span
         class="frame"
+        role="button"
+        tabindex="0"
         @click="
+          $emit('time-code-clicked', {
+            frame: entry.frame,
+            revision: entry.revision
+          })
+        "
+        @keydown.enter.prevent="
+          $emit('time-code-clicked', {
+            frame: entry.frame,
+            revision: entry.revision
+          })
+        "
+        @keydown.space.prevent="
           $emit('time-code-clicked', {
             frame: entry.frame,
             revision: entry.revision
@@ -25,7 +46,14 @@
       >
         v{{ entry.revision }} - {{ formatFrame(entry.frame) }}
       </span>
-      <span @click="setFrame(entry)" v-if="isMoviePreview">
+      <span
+        role="button"
+        tabindex="0"
+        @click="setFrame(entry)"
+        @keydown.enter.prevent="setFrame(entry)"
+        @keydown.space.prevent="setFrame(entry)"
+        v-if="isMoviePreview"
+      >
         <clock-icon class="icon clock" />
       </span>
       <span class="checklist-label" v-if="disabled">{{ entry.text }}</span>

--- a/src/components/widgets/ColorField.vue
+++ b/src/components/widgets/ColorField.vue
@@ -9,7 +9,11 @@
         }"
         :key="`color-${index}`"
         :style="{ 'border-color': color + hexaOpacity }"
+        role="button"
+        tabindex="0"
         @click="colorChanged(color)"
+        @keydown.enter.prevent="colorChanged(color)"
+        @keydown.space.prevent="colorChanged(color)"
         v-for="(color, index) in colors"
       >
         <span :style="{ background: color + hexaOpacity }"> </span>

--- a/src/components/widgets/ComboboxActions.vue
+++ b/src/components/widgets/ComboboxActions.vue
@@ -10,21 +10,35 @@
       }"
       ref="select"
     >
-      <div class="flexrow" :title="title" @click="toggleList">
+      <div
+        class="flexrow"
+        :title="title"
+        role="combobox"
+        tabindex="0"
+        aria-haspopup="listbox"
+        :aria-expanded="showList"
+        :aria-activedescendant="
+          activeIndex > -1 ? optionId(activeIndex) : undefined
+        "
+        @click="toggleList"
+        @keydown="onKeydown"
+      >
         <div class="selected-line mr05 ellipsis nowrap">
           {{ title }}
         </div>
         <chevron-down-icon class="down-icon flexrow-item" />
       </div>
-      <div class="select-input" v-if="showList">
+      <div class="select-input" ref="listRef" role="listbox" v-if="showList">
         <a
+          :id="optionId(index)"
           :key="action.label"
           class="option-line flexrow"
+          role="option"
           :href="action.href || null"
           :target="action.href ? '_blank' : null"
           :rel="action.href ? 'noopener noreferrer' : null"
           @click="onActionClick(action)"
-          v-for="action in actions"
+          v-for="(action, index) in actions"
         >
           <component
             :is="action.icon"
@@ -48,7 +62,9 @@
 import { ChevronDownIcon } from 'lucide-vue-next'
 import { ref } from 'vue'
 
-defineProps({
+import { useComboboxKeyboard } from '@/composables/comboboxKeyboard'
+
+const props = defineProps({
   actions: {
     type: Array,
     default: () => []
@@ -82,6 +98,27 @@ const onActionClick = action => {
   if (action.handler) action.handler()
   showList.value = false
 }
+
+// Mouse clicks navigate through the anchor's own href natively; a
+// keyboard-selected action (focus stays on the trigger, see
+// useComboboxKeyboard) has to replicate that navigation itself.
+const selectActionByIndex = index => {
+  const action = props.actions[index]
+  if (!action) return
+  onActionClick(action)
+  if (action.href) {
+    window.open(action.href, '_blank', 'noopener,noreferrer')
+  }
+}
+
+const listRef = ref(null)
+const { activeIndex, onKeydown, optionId } = useComboboxKeyboard({
+  isOpen: showList,
+  toggle: toggleList,
+  optionsLength: () => props.actions.length,
+  onSelect: selectActionByIndex,
+  listRef
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/widgets/ComboboxDepartment.vue
+++ b/src/components/widgets/ComboboxDepartment.vue
@@ -15,7 +15,18 @@
         width: `${width}px`
       }"
     >
-      <div class="flexrow" @click="toggleDepartmentList">
+      <div
+        class="flexrow"
+        role="combobox"
+        tabindex="0"
+        aria-haspopup="listbox"
+        :aria-expanded="showDepartmentList"
+        :aria-activedescendant="
+          activeIndex > -1 ? optionId(activeIndex) : undefined
+        "
+        @click="toggleDepartmentList"
+        @keydown="onKeydown"
+      >
         <div
           class="selected-department-line flexrow-item"
           v-if="currentDepartment"
@@ -26,17 +37,19 @@
       </div>
       <div
         class="select-input"
-        ref="select"
+        ref="listRef"
+        role="listbox"
         :style="listStyle"
         v-if="showDepartmentList"
       >
         <div
-          class="department-line"
+          :id="optionId(index)"
           :key="department.id"
+          class="department-line"
+          role="option"
+          :aria-selected="department.id === currentDepartment?.id"
           @click="selectDepartment(department)"
-          v-for="department in departmentList.filter(
-            ({ id }) => id !== modelValue
-          )"
+          v-for="(department, index) in selectableDepartmentList"
         >
           <department-name :department="department" />
         </div>
@@ -54,6 +67,8 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 import { ChevronDownIcon } from 'lucide-vue-next'
+
+import { useComboboxKeyboard } from '@/composables/comboboxKeyboard'
 
 import ComboboxMask from '@/components/widgets/ComboboxMask.vue'
 import DepartmentName from '@/components/widgets/DepartmentName.vue'
@@ -166,6 +181,10 @@ const departmentList = computed(() => {
   }
 })
 
+const selectableDepartmentList = computed(() =>
+  departmentList.value.filter(({ id }) => id !== props.modelValue)
+)
+
 const currentDepartment = computed(() => {
   if (props.modelValue) {
     const departmentMapped = departmentMap.value.get(props.modelValue)
@@ -208,6 +227,15 @@ const selectDepartment = department => {
 const toggleDepartmentList = () => {
   showDepartmentList.value = !showDepartmentList.value
 }
+
+const listRef = ref(null)
+const { activeIndex, onKeydown, optionId } = useComboboxKeyboard({
+  isOpen: showDepartmentList,
+  toggle: toggleDepartmentList,
+  optionsLength: () => selectableDepartmentList.value.length,
+  onSelect: index => selectDepartment(selectableDepartmentList.value[index]),
+  listRef
+})
 
 const focus = () => {
   combobox.value.focus()

--- a/src/components/widgets/ComboboxOptions.vue
+++ b/src/components/widgets/ComboboxOptions.vue
@@ -9,18 +9,39 @@
       }"
       ref="select"
     >
-      <div class="flexrow" :title="title" @click="toggleList()">
+      <div
+        class="flexrow"
+        :title="title"
+        role="combobox"
+        tabindex="0"
+        aria-haspopup="listbox"
+        :aria-expanded="showList"
+        :aria-activedescendant="
+          activeIndex > -1 ? optionId(activeIndex) : undefined
+        "
+        @click="toggleList()"
+        @keydown="onKeydown"
+      >
         <div class="selected-line mr05 ellipsis nowrap">
           {{ title }}
         </div>
         <chevron-down-icon class="down-icon flexrow-item" />
       </div>
-      <div ref="list" class="select-input" v-if="showList">
+      <div
+        ref="list"
+        class="select-input"
+        role="listbox"
+        aria-multiselectable="true"
+        v-if="showList"
+      >
         <div
+          :id="optionId(index)"
           :key="option.value"
           class="option-line flexrow"
+          role="option"
+          :aria-selected="!!modelValue[option.value]"
           @click="onUpdateValue(option.value)"
-          v-for="option in optionList"
+          v-for="(option, index) in optionList"
         >
           <toggle-button
             :label="option.label"
@@ -42,6 +63,8 @@
 <script setup>
 import { ref, computed, nextTick } from 'vue'
 import { ChevronDownIcon } from 'lucide-vue-next'
+
+import { useComboboxKeyboard } from '@/composables/comboboxKeyboard'
 
 import ToggleButton from '@/components/widgets/ToggleButton.vue'
 
@@ -103,6 +126,14 @@ const onUpdateValue = key => {
   })
   emit('change', { key, value })
 }
+
+const { activeIndex, onKeydown, optionId } = useComboboxKeyboard({
+  isOpen: showList,
+  toggle: toggleList,
+  optionsLength: () => optionList.value.length,
+  onSelect: index => onUpdateValue(optionList.value[index].value),
+  listRef: list
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/widgets/ComboboxProduction.vue
+++ b/src/components/widgets/ComboboxProduction.vue
@@ -8,7 +8,18 @@
       {{ label }}
     </label>
     <div class="production-combo">
-      <div class="flexrow" @click="toggleProductionList">
+      <div
+        class="flexrow"
+        role="combobox"
+        tabindex="0"
+        aria-haspopup="listbox"
+        :aria-expanded="showProductionList"
+        :aria-activedescendant="
+          activeIndex > -1 ? optionId(activeIndex) : undefined
+        "
+        @click="toggleProductionList"
+        @keydown="onKeydown"
+      >
         <div class="selected-production-line flexrow-item">
           <production-name
             :production="currentProduction"
@@ -19,12 +30,20 @@
         </div>
         <chevron-down-icon class="down-icon flexrow-item" />
       </div>
-      <div class="select-input" v-if="showProductionList">
+      <div
+        class="select-input"
+        ref="listRef"
+        role="listbox"
+        v-if="showProductionList"
+      >
         <div
-          class="production-line"
+          :id="optionId(index)"
           :key="production.id"
+          class="production-line"
+          role="option"
+          :aria-selected="production.id === currentProduction?.id"
           @click="selectProduction(production)"
-          v-for="production in productionList"
+          v-for="(production, index) in productionList"
         >
           <production-name
             :size="25"
@@ -42,10 +61,11 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { ChevronDownIcon } from 'lucide-vue-next'
 
 import { useCombobox } from '@/composables/combobox'
+import { useComboboxKeyboard } from '@/composables/comboboxKeyboard'
 
 import ComboboxMask from '@/components/widgets/ComboboxMask.vue'
 import ProductionName from '@/components/widgets/ProductionName.vue'
@@ -76,6 +96,15 @@ const {
   toggle: toggleProductionList,
   select: selectProduction
 } = useCombobox(emit)
+
+const listRef = ref(null)
+const { activeIndex, onKeydown, optionId } = useComboboxKeyboard({
+  isOpen: showProductionList,
+  toggle: toggleProductionList,
+  optionsLength: () => props.productionList.length,
+  onSelect: index => selectProduction(props.productionList[index]),
+  listRef
+})
 
 const currentProduction = computed(() => {
   return (

--- a/src/components/widgets/ComboboxSimple.vue
+++ b/src/components/widgets/ComboboxSimple.vue
@@ -3,16 +3,21 @@
     <label class="label" v-if="label.length > 0">
       {{ label }}
     </label>
-    <div class="flexrow">
+    <div class="flexrow" role="radiogroup" :aria-label="label || undefined">
       <span
+        :ref="el => (choiceRefs[index] = el)"
         :key="option.label"
         :class="{
           choice: true,
           'flexrow-item': true,
           selected: selectedOption.value === option.value
         }"
+        role="radio"
+        :aria-checked="selectedOption.value === option.value"
+        :tabindex="selectedOption.value === option.value ? 0 : -1"
         @click="selectOption(option)"
-        v-for="option in options"
+        @keydown="onChoiceKeydown($event, index)"
+        v-for="(option, index) in options"
       >
         {{ getOptionLabel(option) }}
       </span>
@@ -21,7 +26,7 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted } from 'vue'
+import { nextTick, ref, watch, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
@@ -55,6 +60,39 @@ const selectedOption = ref({
 const selectOption = option => {
   emit('update:model-value', option.value)
   selectedOption.value = option
+}
+
+// ComboboxSimple has no open/close popup (all choices are always visible),
+// so it uses a plain roving-tabindex radiogroup instead of
+// useComboboxKeyboard: arrow keys both move and select, like a native
+// <input type="radio"> group.
+const choiceRefs = ref([])
+
+const onChoiceKeydown = (event, index) => {
+  switch (event.key) {
+    case 'Enter':
+    case ' ':
+      event.preventDefault()
+      selectOption(props.options[index])
+      break
+    case 'ArrowRight':
+    case 'ArrowDown':
+      event.preventDefault()
+      focusChoiceAt(Math.min(index + 1, props.options.length - 1))
+      break
+    case 'ArrowLeft':
+    case 'ArrowUp':
+      event.preventDefault()
+      focusChoiceAt(Math.max(index - 1, 0))
+      break
+  }
+}
+
+const focusChoiceAt = index => {
+  const option = props.options[index]
+  if (!option) return
+  selectOption(option)
+  nextTick(() => choiceRefs.value[index]?.focus())
 }
 
 const getOptionLabel = option => {

--- a/src/components/widgets/ComboboxStatus.vue
+++ b/src/components/widgets/ComboboxStatus.vue
@@ -9,7 +9,18 @@
       {{ label }}
     </label>
     <div class="status-combo" :style="comboStyles">
-      <div class="flexrow" @click="toggleStatusList">
+      <div
+        class="flexrow"
+        role="combobox"
+        tabindex="0"
+        aria-haspopup="listbox"
+        :aria-expanded="showStatusList"
+        :aria-activedescendant="
+          activeIndex > -1 ? optionId(activeIndex) : undefined
+        "
+        @click="toggleStatusList"
+        @keydown="onKeydown"
+      >
         <div class="selected-status-line flexrow-item">
           <span
             class="tag"
@@ -32,16 +43,21 @@
       </div>
       <div
         class="select-input"
+        ref="listRef"
+        role="listbox"
         :class="{
           'open-top': openTop
         }"
         v-if="showStatusList"
       >
         <div
+          :id="optionId(index)"
           :key="status.id"
           class="status-line"
+          role="option"
+          :aria-selected="status.id === currentStatus?.id"
           @click="selectStatus(status)"
-          v-for="status in sortedTaskStatusList"
+          v-for="(status, index) in sortedTaskStatusList"
         >
           <span
             class="tag"
@@ -61,13 +77,14 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 import { ChevronDownIcon } from 'lucide-vue-next'
 
 import { sortTaskStatuses } from '@/lib/sorting'
 import { useCombobox } from '@/composables/combobox'
+import { useComboboxKeyboard } from '@/composables/comboboxKeyboard'
 import { useTaskStatusStyle } from '@/composables/taskStatus'
 
 import ComboboxMask from '@/components/widgets/ComboboxMask.vue'
@@ -122,6 +139,15 @@ const {
   toggle: toggleStatusList,
   select: selectStatus
 } = useCombobox(emit)
+
+const listRef = ref(null)
+const { activeIndex, onKeydown, optionId } = useComboboxKeyboard({
+  isOpen: showStatusList,
+  toggle: toggleStatusList,
+  optionsLength: () => sortedTaskStatusList.value.length,
+  onSelect: index => selectStatus(sortedTaskStatusList.value[index]),
+  listRef
+})
 
 const productionMap = computed(() => store.getters.productionMap)
 const taskStatusMap = computed(() => store.getters.taskStatusMap)

--- a/src/components/widgets/ComboboxStatusAutomation.vue
+++ b/src/components/widgets/ComboboxStatusAutomation.vue
@@ -9,7 +9,18 @@
       {{ label }}
     </label>
     <div class="status-automation-combo">
-      <div class="flexrow" @click="toggleStatusAutomationsList">
+      <div
+        class="flexrow"
+        role="combobox"
+        tabindex="0"
+        aria-haspopup="listbox"
+        :aria-expanded="showStatusAutomationsList"
+        :aria-activedescendant="
+          activeIndex > -1 ? optionId(activeIndex) : undefined
+        "
+        @click="toggleStatusAutomationsList"
+        @keydown="onKeydown"
+      >
         <div class="selected-status-automation-line flexrow-item">
           <status-automation-item
             :status-automation="currentStatusAutomation"
@@ -21,12 +32,20 @@
         </div>
         <chevron-down-icon class="down-icon flexrow-item" />
       </div>
-      <div class="select-input" ref="select" v-if="showStatusAutomationsList">
+      <div
+        class="select-input"
+        ref="listRef"
+        role="listbox"
+        v-if="showStatusAutomationsList"
+      >
         <div
-          class="status-automation-line"
+          :id="optionId(index)"
           :key="statusAutomation.id"
+          class="status-automation-line"
+          role="option"
+          :aria-selected="statusAutomation.id === currentStatusAutomation?.id"
           @click="selectStatusAutomation(statusAutomation)"
-          v-for="statusAutomation in statusAutomationsList"
+          v-for="(statusAutomation, index) in statusAutomationsList"
         >
           <status-automation-item
             :status-automation="statusAutomation"
@@ -43,11 +62,12 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useStore } from 'vuex'
 import { ChevronDownIcon } from 'lucide-vue-next'
 
 import { useCombobox } from '@/composables/combobox'
+import { useComboboxKeyboard } from '@/composables/comboboxKeyboard'
 
 import ComboboxMask from '@/components/widgets/ComboboxMask.vue'
 import StatusAutomationItem from '@/components/widgets/StatusAutomationItem.vue'
@@ -88,6 +108,15 @@ const {
   toggle: toggleStatusAutomationsList,
   select: selectStatusAutomation
 } = useCombobox(emit)
+
+const listRef = ref(null)
+const { activeIndex, onKeydown, optionId } = useComboboxKeyboard({
+  isOpen: showStatusAutomationsList,
+  toggle: toggleStatusAutomationsList,
+  optionsLength: () => props.statusAutomationsList.length,
+  onSelect: index => selectStatusAutomation(props.statusAutomationsList[index]),
+  listRef
+})
 
 const statusAutomationMap = computed(() => store.getters.statusAutomationMap)
 

--- a/src/components/widgets/ComboboxStudio.vue
+++ b/src/components/widgets/ComboboxStudio.vue
@@ -11,7 +11,18 @@
       }"
       :style="{ width: `${width}px` }"
     >
-      <div class="flexrow" @click="toggleStudioList">
+      <div
+        class="flexrow"
+        role="combobox"
+        tabindex="0"
+        aria-haspopup="listbox"
+        :aria-expanded="showStudioList"
+        :aria-activedescendant="
+          activeIndex > -1 ? optionId(activeIndex) : undefined
+        "
+        @click="toggleStudioList"
+        @keydown="onKeydown"
+      >
         <div class="selected-studio-line flexrow-item">
           <studio-name :studio="currentStudio" v-if="currentStudio" />
         </div>
@@ -19,6 +30,8 @@
       </div>
       <div
         class="select-input"
+        ref="listRef"
+        role="listbox"
         :style="{
           'max-height': `${maxHeightSelectInput}px`,
           width: `${width}px`,
@@ -27,10 +40,13 @@
         v-if="showStudioList"
       >
         <div
-          class="studio-line"
+          :id="optionId(index)"
           :key="studio.id"
+          class="studio-line"
+          role="option"
+          :aria-selected="studio.id === currentStudio?.id"
           @click="selectStudio(studio)"
-          v-for="studio in studioList"
+          v-for="(studio, index) in studioList"
         >
           <studio-name :studio="studio" />
         </div>
@@ -41,12 +57,13 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 import { ChevronDownIcon } from 'lucide-vue-next'
 
 import { useCombobox } from '@/composables/combobox'
+import { useComboboxKeyboard } from '@/composables/comboboxKeyboard'
 
 import ComboboxMask from '@/components/widgets/ComboboxMask.vue'
 import StudioName from '@/components/widgets/StudioName.vue'
@@ -92,6 +109,15 @@ const {
   toggle: toggleStudioList,
   select: selectStudio
 } = useCombobox(emit)
+
+const listRef = ref(null)
+const { activeIndex, onKeydown, optionId } = useComboboxKeyboard({
+  isOpen: showStudioList,
+  toggle: toggleStudioList,
+  optionsLength: () => studioList.value.length,
+  onSelect: index => selectStudio(studioList.value[index]),
+  listRef
+})
 
 const studios = computed(() => store.getters.studios)
 const studioMap = computed(() => store.getters.studioMap)

--- a/src/components/widgets/ComboboxStyled.vue
+++ b/src/components/widgets/ComboboxStyled.vue
@@ -12,7 +12,15 @@
         open: showList
       }"
       ref="select"
+      role="combobox"
+      :tabindex="disabled ? -1 : 0"
+      aria-haspopup="listbox"
+      :aria-expanded="showList"
+      :aria-activedescendant="
+        activeIndex > -1 ? optionId(activeIndex) : undefined
+      "
       @click="toggleList"
+      @keydown="onKeydown"
     >
       <div class="flexrow" :title="selectedOptionLabel">
         <slot name="icon"></slot>
@@ -30,14 +38,17 @@
         ></span>
         <chevron-down-icon class="down-icon flexrow-item" />
       </div>
-      <div class="select-input" v-if="showList">
+      <div class="select-input" ref="listRef" role="listbox" v-if="showList">
         <div
+          :id="optionId(index)"
           :key="option.id"
           class="option-line flexrow"
+          role="option"
+          :aria-selected="option.value === selectedOption?.value"
           :class="{ placeholder: option.placeholder }"
           @click="selectOption(option)"
           @click.middle="openRoute(option)"
-          v-for="option in optionList"
+          v-for="(option, index) in optionList"
         >
           <entity-thumbnail
             class="revision-thumbnail"
@@ -75,6 +86,8 @@ import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { ChevronDownIcon } from 'lucide-vue-next'
+
+import { useComboboxKeyboard } from '@/composables/comboboxKeyboard'
 
 import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
 
@@ -169,6 +182,7 @@ const selectOption = option => {
 }
 
 const toggleList = () => {
+  if (props.disabled) return
   if (showList.value) {
     lastScrollPosition = select.value.scrollTop
   }
@@ -179,6 +193,15 @@ const toggleList = () => {
     })
   }
 }
+
+const listRef = ref(null)
+const { activeIndex, onKeydown, optionId } = useComboboxKeyboard({
+  isOpen: showList,
+  toggle: toggleList,
+  optionsLength: () => optionList.value.length,
+  onSelect: index => selectOption(optionList.value[index]),
+  listRef
+})
 
 watch(
   () => props.options,

--- a/src/components/widgets/ComboboxTag.vue
+++ b/src/components/widgets/ComboboxTag.vue
@@ -13,18 +13,39 @@
       }"
       ref="selectRef"
     >
-      <div class="flexrow" @click="toggleList" :title="renderedValue">
+      <div
+        class="flexrow"
+        :title="renderedValue"
+        role="combobox"
+        tabindex="0"
+        aria-haspopup="listbox"
+        :aria-expanded="showList"
+        :aria-activedescendant="
+          activeIndex > -1 ? optionId(activeIndex) : undefined
+        "
+        @click="toggleList"
+        @keydown="onKeydown"
+      >
         <div class="selected-line filler nowrap ellipsis">
           {{ renderedValue }}
         </div>
         <chevron-down-icon class="down-icon" />
       </div>
-      <div class="select-input" v-if="showList">
+      <div
+        class="select-input"
+        ref="listRef"
+        role="listbox"
+        aria-multiselectable="true"
+        v-if="showList"
+      >
         <div
+          :id="optionId(index)"
           :key="option.id"
           class="option-line flexrow"
+          role="option"
+          :aria-selected="isChecked(option)"
           @click="!disabled && selectOption(option)"
-          v-for="option in optionList"
+          v-for="(option, index) in optionList"
         >
           <input
             type="checkbox"
@@ -52,6 +73,7 @@ import { useI18n } from 'vue-i18n'
 import { ChevronDownIcon } from 'lucide-vue-next'
 
 import { sortByValue } from '@/lib/sorting'
+import { useComboboxKeyboard } from '@/composables/comboboxKeyboard'
 
 const { t } = useI18n()
 
@@ -157,6 +179,17 @@ const getOptionLabel = option => {
 const isChecked = option => {
   return selectedValues.value.includes(option.value)
 }
+
+const listRef = ref(null)
+const { activeIndex, onKeydown, optionId } = useComboboxKeyboard({
+  isOpen: showList,
+  toggle: toggleList,
+  optionsLength: () => optionList.value.length,
+  onSelect: index => {
+    if (!props.disabled) selectOption(optionList.value[index])
+  },
+  listRef
+})
 
 watch(showList, () => {
   if (showList.value) {

--- a/src/components/widgets/ComboboxTaskType.vue
+++ b/src/components/widgets/ComboboxTaskType.vue
@@ -4,7 +4,19 @@
       {{ label }}
     </label>
     <div class="task-type-combo" :class="{ disabled, shy }">
-      <div class="flexrow selector" @click="toggleTaskTypeList">
+      <div
+        class="flexrow selector"
+        ref="triggerRef"
+        role="combobox"
+        :tabindex="disabled ? -1 : 0"
+        aria-haspopup="listbox"
+        :aria-expanded="showTaskTypeList"
+        :aria-activedescendant="
+          activeIndex > -1 ? optionId(activeIndex) : undefined
+        "
+        @click="toggleTaskTypeList"
+        @keydown="onKeydown"
+      >
         <div class="selected-task-type-line flexrow-item">
           <task-type-name :task-type="currentTaskType" v-if="currentTaskType" />
         </div>
@@ -13,15 +25,20 @@
       <teleport to="body">
         <div
           class="select-input"
+          ref="listRef"
+          role="listbox"
           :class="[{ 'open-top': openTop }, { dark: isDarkTheme }]"
           :style="tooltipStyle"
           v-if="showTaskTypeList"
         >
           <div
-            class="task-type-line"
+            :id="optionId(index)"
             :key="taskType.id"
+            class="task-type-line"
+            role="option"
+            :aria-selected="taskType.id === currentTaskType?.id"
             @click="!disabled && selectTaskType(taskType)"
-            v-for="taskType in taskTypeList"
+            v-for="(taskType, index) in taskTypeList"
           >
             <task-type-name :task-type="taskType" />
           </div>
@@ -37,6 +54,8 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 import { ChevronDownIcon } from 'lucide-vue-next'
+
+import { useComboboxKeyboard } from '@/composables/comboboxKeyboard'
 
 import ComboboxMask from '@/components/widgets/ComboboxMask.vue'
 import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
@@ -121,6 +140,8 @@ const selectTaskType = taskType => {
   showTaskTypeList.value = false
 }
 
+const triggerRef = ref(null)
+
 const toggleTaskTypeList = event => {
   if (props.disabled) {
     return
@@ -132,7 +153,9 @@ const toggleTaskTypeList = event => {
     return
   }
 
-  const curDiv = event.currentTarget
+  // Keyboard-triggered opens (via useComboboxKeyboard) call toggle() with no
+  // event, so fall back to the trigger element for positioning.
+  const curDiv = event?.currentTarget ?? triggerRef.value
   const rect = curDiv.getBoundingClientRect()
   const scrollTop = window.pageYOffset || document.documentElement.scrollTop
   const scrollLeft = window.pageXOffset || document.documentElement.scrollLeft
@@ -141,6 +164,17 @@ const toggleTaskTypeList = event => {
     left: rect.left + scrollLeft
   }
 }
+
+const listRef = ref(null)
+const { activeIndex, onKeydown, optionId } = useComboboxKeyboard({
+  isOpen: showTaskTypeList,
+  toggle: toggleTaskTypeList,
+  optionsLength: () => props.taskTypeList.length,
+  onSelect: index => {
+    if (!props.disabled) selectTaskType(props.taskTypeList[index])
+  },
+  listRef
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -41,14 +41,14 @@
               isPinnable || isEditable || canToggleForClient || canMoveComment
             "
           >
-            <chevron-down-icon
-              class="menu-icon"
-              role="button"
-              tabindex="0"
+            <button
+              type="button"
+              class="menu-icon-button"
+              aria-label="Comment options"
               @click="toggleCommentMenu"
-              @keydown.enter.prevent="toggleCommentMenu"
-              @keydown.space.prevent="toggleCommentMenu"
-            />
+            >
+              <chevron-down-icon class="menu-icon" />
+            </button>
             <comment-menu
               :is-pinnable="isPinnable"
               :is-pinned="comment.pinned"
@@ -500,7 +500,14 @@
           {{ shortDate }}
         </span>
         <div class="flexrow-item menu-wrapper" v-if="isPinnable || isEditable">
-          <chevron-down-icon class="menu-icon" @click="toggleCommentMenu" />
+          <button
+            type="button"
+            class="menu-icon-button"
+            aria-label="Comment options"
+            @click="toggleCommentMenu"
+          >
+            <chevron-down-icon class="menu-icon" />
+          </button>
           <comment-menu
             :is-pinnable="isPinnable"
             :is-editable="isEditable"
@@ -1125,9 +1132,15 @@ article.comment {
   margin-top: 0.5em;
 }
 
+.menu-icon-button {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
 .menu-icon {
   width: 20px;
-  cursor: pointer;
   color: $light-grey;
 }
 

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -41,7 +41,14 @@
               isPinnable || isEditable || canToggleForClient || canMoveComment
             "
           >
-            <chevron-down-icon class="menu-icon" @click="toggleCommentMenu" />
+            <chevron-down-icon
+              class="menu-icon"
+              role="button"
+              tabindex="0"
+              @click="toggleCommentMenu"
+              @keydown.enter.prevent="toggleCommentMenu"
+              @keydown.space.prevent="toggleCommentMenu"
+            />
             <comment-menu
               :is-pinnable="isPinnable"
               :is-pinned="comment.pinned"
@@ -93,7 +100,11 @@
               <copy-icon
                 class="copy-icon"
                 :size="12"
+                role="button"
+                tabindex="0"
                 @click="emit('duplicate-comment', comment)"
+                @keydown.enter.prevent="emit('duplicate-comment', comment)"
+                @keydown.space.prevent="emit('duplicate-comment', comment)"
               />
             </p>
             <p
@@ -198,7 +209,11 @@
                   <span
                     class="flexrow-item reply-delete"
                     :title="$t('main.delete')"
+                    role="button"
+                    tabindex="0"
                     @click="onDeleteReplyClicked(replyComment)"
+                    @keydown.enter.prevent="onDeleteReplyClicked(replyComment)"
+                    @keydown.space.prevent="onDeleteReplyClicked(replyComment)"
                     v-if="
                       isCurrentUserAdmin || replyComment.person_id === user.id
                     "
@@ -341,7 +356,15 @@
                       v-for="(attach, index) in replyAttachments"
                     >
                       {{ shortenText(attach.get('file').name, 40) }}
-                      <span @click="removeReplyAttachment(attach)">x</span>
+                      <span
+                        role="button"
+                        tabindex="0"
+                        @click="removeReplyAttachment(attach)"
+                        @keydown.enter.prevent="removeReplyAttachment(attach)"
+                        @keydown.space.prevent="removeReplyAttachment(attach)"
+                      >
+                        x
+                      </span>
                     </div>
                   </div>
                   <div class="flexrow ml05">
@@ -388,7 +411,11 @@
               <span class="filler"></span>
               <span
                 class="flexrow-item reply-button"
+                role="button"
+                tabindex="0"
                 @click="showReplyWidget"
+                @keydown.enter.prevent="showReplyWidget"
+                @keydown.space.prevent="showReplyWidget"
                 v-if="!showReply && isReplyable"
               >
                 {{ $t('main.reply') }}
@@ -438,7 +465,15 @@
           :class="{ pointer: isCurrentUserManager }"
           :title="comment.previews[0].validation_status"
           :data-status="comment.previews[0].validation_status"
+          role="button"
+          tabindex="0"
           @click="changePreviewValidationStatus(comment.previews)"
+          @keydown.enter.prevent="
+            changePreviewValidationStatus(comment.previews)
+          "
+          @keydown.space.prevent="
+            changePreviewValidationStatus(comment.previews)
+          "
         ></span>
       </div>
     </article>

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -149,6 +149,7 @@
                 <img
                   class="attachment"
                   :src="getDownloadAttachmentPath(attachment)"
+                  :alt="attachment.name"
                 />
               </a>
               <attachment-audio-player
@@ -248,6 +249,7 @@
                     <img
                       class="attachment"
                       :src="getDownloadAttachmentPath(attachment)"
+                      :alt="attachment.name"
                     />
                   </a>
                   <attachment-audio-player

--- a/src/components/widgets/CommentMenu.vue
+++ b/src/components/widgets/CommentMenu.vue
@@ -1,18 +1,54 @@
 <template>
   <div class="comment-menu">
-    <div @click="$emit('pin-clicked')" v-if="isPinnable && !isEmpty">
+    <div
+      role="button"
+      tabindex="0"
+      @click="$emit('pin-clicked')"
+      @keydown.enter.prevent="$emit('pin-clicked')"
+      @keydown.space.prevent="$emit('pin-clicked')"
+      v-if="isPinnable && !isEmpty"
+    >
       {{ isPinned ? $t('comments.unpin') : $t('comments.pin') }}
     </div>
-    <div @click="$emit('toggle-for-client-clicked')" v-if="canToggleForClient">
+    <div
+      role="button"
+      tabindex="0"
+      @click="$emit('toggle-for-client-clicked')"
+      @keydown.enter.prevent="$emit('toggle-for-client-clicked')"
+      @keydown.space.prevent="$emit('toggle-for-client-clicked')"
+      v-if="canToggleForClient"
+    >
       {{ $t('comments.toggle_for_client') }}
     </div>
-    <div @click="$emit('edit-clicked')" v-if="isEditable">
+    <div
+      role="button"
+      tabindex="0"
+      @click="$emit('edit-clicked')"
+      @keydown.enter.prevent="$emit('edit-clicked')"
+      @keydown.space.prevent="$emit('edit-clicked')"
+      v-if="isEditable"
+    >
       {{ $t('main.edit') }}
     </div>
-    <div @click="$emit('move-clicked')" v-if="canMove">
+    <div
+      role="button"
+      tabindex="0"
+      @click="$emit('move-clicked')"
+      @keydown.enter.prevent="$emit('move-clicked')"
+      @keydown.space.prevent="$emit('move-clicked')"
+      v-if="canMove"
+    >
       {{ $t('comments.move_to_task') }}
     </div>
-    <div class="error" @click="$emit('delete-clicked')" v-if="isEditable">
+    <div
+      class="error"
+      role="button"
+      tabindex="0"
+      @click="$emit('delete-clicked')"
+      @keydown.enter.prevent="$emit('delete-clicked')"
+      @keydown.space.prevent="$emit('delete-clicked')"
+      v-if="isEditable"
+    >
       {{ $t('main.delete') }}
     </div>
   </div>

--- a/src/components/widgets/ConceptCard.vue
+++ b/src/components/widgets/ConceptCard.vue
@@ -1,5 +1,11 @@
 <template>
-  <div class="concept-item" @click="$emit('click')">
+  <div
+    class="concept-item"
+    role="button"
+    tabindex="0"
+    @click="$emit('click')"
+    @keydown.enter.prevent="$emit('click')"
+  >
     <entity-preview
       :entity="concept"
       :empty-height="200"

--- a/src/components/widgets/EntityPreview.vue
+++ b/src/components/widgets/EntityPreview.vue
@@ -9,7 +9,11 @@
         extension: entity.preview_file_extension
       }"
       :is-rounded-top-border="isRoundedTopBorder"
+      role="button"
+      tabindex="0"
       @click="onVideoClicked()"
+      @keydown.enter.prevent="onVideoClicked()"
+      @keydown.space.prevent="onVideoClicked()"
     />
     <button-simple
       class="button-play"
@@ -45,7 +49,14 @@
         :width="width || ''"
         alt=""
       />
-      <a class="view-icon" @click.stop="onPictureClicked()">
+      <a
+        class="view-icon"
+        role="button"
+        tabindex="0"
+        @click.stop="onPictureClicked()"
+        @keydown.enter.stop.prevent="onPictureClicked()"
+        @keydown.space.stop.prevent="onPictureClicked()"
+      >
         <eye-icon :size="18" />
       </a>
     </template>

--- a/src/components/widgets/EntityPreview.vue
+++ b/src/components/widgets/EntityPreview.vue
@@ -47,7 +47,7 @@
           'max-height': `${emptyHeight}px`
         }"
         :width="width || ''"
-        alt=""
+        :alt="entity?.name"
       />
       <a
         class="view-icon"

--- a/src/components/widgets/EntityThumbnail.vue
+++ b/src/components/widgets/EntityThumbnail.vue
@@ -8,7 +8,11 @@
       height: emptyHeight + 'px',
       cursor: noPreview ? 'default' : 'zoom-in'
     }"
+    role="button"
+    tabindex="0"
     @click="onClicked"
+    @keydown.enter.prevent="onClicked"
+    @keydown.space.prevent="onClicked"
     v-if="isPreview && withLink"
   >
     <img

--- a/src/components/widgets/EntityThumbnail.vue
+++ b/src/components/widgets/EntityThumbnail.vue
@@ -22,7 +22,7 @@
       :src="thumbnailPath"
       :style="imgStyle"
       :width="width || ''"
-      alt=""
+      :alt="entity?.name"
     />
   </a>
 
@@ -33,7 +33,7 @@
     :key="thumbnailKey"
     :src="thumbnailPath"
     :style="imgStyle"
-    alt=""
+    :alt="entity?.name"
   />
 
   <span

--- a/src/components/widgets/PeopleAvatar.vue
+++ b/src/components/widgets/PeopleAvatar.vue
@@ -14,7 +14,7 @@
   >
     <img
       :loading="isLazy ? 'lazy' : undefined"
-      alt=""
+      :alt="person.full_name"
       :src="person.avatarPath"
       v-if="person.has_avatar"
     />
@@ -30,7 +30,7 @@
   >
     <img
       :loading="isLazy ? 'lazy' : undefined"
-      alt=""
+      :alt="person.full_name"
       :src="person.avatarPath"
       v-if="person.has_avatar"
     />

--- a/src/components/widgets/PeopleAvatarWithMenu.vue
+++ b/src/components/widgets/PeopleAvatarWithMenu.vue
@@ -8,7 +8,7 @@
     >
       <img
         :loading="isLazy ? 'lazy' : undefined"
-        alt=""
+        :alt="person.full_name"
         :src="person.avatarPath"
         v-if="person.has_avatar"
       />

--- a/src/components/widgets/PeopleAvatarWithMenu.vue
+++ b/src/components/widgets/PeopleAvatarWithMenu.vue
@@ -26,7 +26,14 @@
           {{ $t('main.avatar.open_page', { personName: person.name }) }}
         </span>
       </router-link>
-      <div class="menu-button flexrow" @click.stop="$emit('unassign', person)">
+      <div
+        class="menu-button flexrow"
+        role="button"
+        tabindex="0"
+        @click.stop="$emit('unassign', person)"
+        @keydown.enter.stop.prevent="$emit('unassign', person)"
+        @keydown.space.stop.prevent="$emit('unassign', person)"
+      >
         <user-minus-icon class="flexrow-item" :size="16" />
         <span class="flexrow-item">
           {{ $t('main.avatar.unassign', { personName: person.name }) }}

--- a/src/components/widgets/PeopleField.vue
+++ b/src/components/widgets/PeopleField.vue
@@ -29,7 +29,11 @@
       </multiselect>
       <span
         class="clear-button"
+        role="button"
+        tabindex="0"
         @click="clear"
+        @keydown.enter.prevent="clear"
+        @keydown.space.prevent="clear"
         v-if="item && clearable && !disabled"
       >
         <x-icon :size="12" />

--- a/src/components/widgets/ProductionName.vue
+++ b/src/components/widgets/ProductionName.vue
@@ -15,6 +15,7 @@
       <template v-if="!production.has_avatar">{{ avatar }}</template>
       <img
         :src="thumbnailPath"
+        :alt="production.name"
         :style="{
           width: `${size}px`,
           height: `${size}px`

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -58,7 +58,11 @@
                   color: isDarkTheme ? '#EEE' : '#999',
                   'margin-top': '4px'
                 }"
+                role="button"
+                tabindex="0"
                 @click="expandRootElement(rootElement)"
+                @keydown.enter.prevent="expandRootElement(rootElement)"
+                @keydown.space.prevent="expandRootElement(rootElement)"
               >
                 <chevron-right-icon v-if="!rootElement.expanded" />
                 <chevron-down-icon v-else />
@@ -265,7 +269,15 @@
           >
             <div
               class="milestone pointer"
+              role="button"
+              tabindex="0"
               @click="showEditMilestoneModal(day, currentMilestones[day.text])"
+              @keydown.enter.prevent="
+                showEditMilestoneModal(day, currentMilestones[day.text])
+              "
+              @keydown.space.prevent="
+                showEditMilestoneModal(day, currentMilestones[day.text])
+              "
               v-if="currentMilestones[day.text] && withMilestones"
             >
               <div class="milestone-tooltip">
@@ -305,7 +317,15 @@
               <div
                 class="add-milestone"
                 :title="addMilestoneTitle(day)"
+                role="button"
+                tabindex="0"
                 @click="
+                  showEditMilestoneModal(day, currentMilestones[day.text])
+                "
+                @keydown.enter.prevent="
+                  showEditMilestoneModal(day, currentMilestones[day.text])
+                "
+                @keydown.space.prevent="
                   showEditMilestoneModal(day, currentMilestones[day.text])
                 "
                 v-if="withMilestones && isCurrentUserManager"
@@ -439,7 +459,12 @@
                   <div
                     class="timebar"
                     v-show="isVisible(rootElement)"
+                    role="button"
+                    tabindex="0"
                     @click="$emit('root-element-selected', rootElement)"
+                    @keydown.enter.prevent="
+                      $emit('root-element-selected', rootElement)
+                    "
                     v-if="rootElement.editable"
                   >
                     <div
@@ -616,7 +641,12 @@
                       )
                     "
                     v-show="subchildren || isVisible(childElement)"
+                    role="button"
+                    tabindex="0"
                     @click="$emit('item-selected', rootElement, childElement)"
+                    @keydown.enter.prevent="
+                      $emit('item-selected', rootElement, childElement)
+                    "
                     v-if="withEstimations"
                   >
                     <div
@@ -710,9 +740,20 @@
                         ></div>
                         <div
                           class="timebar-center ellipsis"
+                          role="button"
+                          tabindex="0"
                           @mousedown="moveTimebar(task, $event)"
                           @touchstart="moveTimebar(task, $event)"
                           @click="
+                            $emit(
+                              'task-selected',
+                              rootElement,
+                              childElement,
+                              task,
+                              selection
+                            )
+                          "
+                          @keydown.enter.prevent="
                             $emit(
                               'task-selected',
                               rootElement,

--- a/src/components/widgets/SearchField.vue
+++ b/src/components/widgets/SearchField.vue
@@ -5,7 +5,9 @@
     </div>
 
     <div class="flexrow-item search-field">
+      <label class="sr-only" :for="fieldId">{{ t('main.search_query') }}</label>
       <input
+        :id="fieldId"
         ref="inputRef"
         class="search-input"
         type="text"
@@ -41,10 +43,13 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, useId } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { SaveIcon, SearchIcon } from 'lucide-vue-next'
 
 import func from '@/lib/func'
+
+const { t } = useI18n()
 
 const props = defineProps({
   placeholder: {
@@ -65,6 +70,7 @@ const emit = defineEmits(['change', 'enter', 'save'])
 const search = ref('')
 const focused = ref(false)
 const inputRef = ref(null)
+const fieldId = useId()
 
 // Debounced: every keystroke otherwise replays the full filter + sort
 // pipeline of the list pages.
@@ -106,6 +112,18 @@ defineExpose({ getValue, setValue, focus, clearSearch })
 </script>
 
 <style lang="scss" scoped>
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .dark {
   .button.save-button:hover {
     color: $white-grey;

--- a/src/components/widgets/SearchField.vue
+++ b/src/components/widgets/SearchField.vue
@@ -5,7 +5,9 @@
     </div>
 
     <div class="flexrow-item search-field">
-      <label class="sr-only" :for="fieldId">{{ t('main.search_query') }}</label>
+      <label class="visuallyhidden" :for="fieldId">
+        {{ t('main.search_query') }}
+      </label>
       <input
         :id="fieldId"
         ref="inputRef"
@@ -112,18 +114,6 @@ defineExpose({ getValue, setValue, focus, clearSearch })
 </script>
 
 <style lang="scss" scoped>
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .dark {
   .button.save-button:hover {
     color: $white-grey;

--- a/src/components/widgets/SearchField.vue
+++ b/src/components/widgets/SearchField.vue
@@ -20,7 +20,16 @@
     </div>
 
     <div class="flexrow-item erase-search">
-      <span class="tag" @click="clearSearch"> x </span>
+      <span
+        class="tag"
+        role="button"
+        tabindex="0"
+        @click="clearSearch"
+        @keydown.enter.prevent="clearSearch"
+        @keydown.space.prevent="clearSearch"
+      >
+        x
+      </span>
     </div>
 
     <div class="flexrow-item save-search" v-if="canSave">

--- a/src/components/widgets/SearchQueryList.vue
+++ b/src/components/widgets/SearchQueryList.vue
@@ -2,7 +2,11 @@
   <div class="search-queries">
     <span
       class="tag folder mr1"
+      role="button"
+      tabindex="0"
       @click="editGroup()"
+      @keydown.enter.prevent="editGroup()"
+      @keydown.space.prevent="editGroup()"
       :title="$t('main.filter_group_add')"
       v-if="isGroupEnabled"
     >
@@ -13,7 +17,11 @@
       :class="{
         active: isEditing
       }"
+      role="button"
+      tabindex="0"
       @click="isEditing = !isEditing"
+      @keydown.enter.prevent="isEditing = !isEditing"
+      @keydown.space.prevent="isEditing = !isEditing"
       :title="$t('main.edit_mode_on')"
       v-if="
         userFilters.length > 0 ||
@@ -34,7 +42,11 @@
         :style="{
           backgroundColor: `${group.color}23`
         }"
+        role="button"
+        tabindex="0"
         @click="toggleFilterGroup(group)"
+        @keydown.enter.prevent="toggleFilterGroup(group)"
+        @keydown.space.prevent="toggleFilterGroup(group)"
         v-for="group in userFilterGroups"
       >
         <div class="group-header">

--- a/src/components/widgets/SettingImporter.vue
+++ b/src/components/widgets/SettingImporter.vue
@@ -32,7 +32,10 @@
         <div
           :key="`unlisted-item-${item.id}`"
           class="flexrow item-to-add mb05"
+          role="button"
+          tabindex="0"
           @click="$emit('import-item', item)"
+          @keydown.enter.prevent="$emit('import-item', item)"
           v-for="item in items"
         >
           <slot name="item-line" :item="item" />

--- a/src/components/widgets/Spinner.vue
+++ b/src/components/widgets/Spinner.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="has-text-centered" :style="sizeStyle">
-    <img src="../../assets/spinner-white.svg" v-if="isWhite" />
+    <img src="../../assets/spinner-white.svg" alt="" v-if="isWhite" />
     <square-grid :style="{ margin: 'auto' }" v-else-if="isProcessing" />
     <origami :style="{ margin: 'auto' }" v-else-if="isStylish" />
-    <img src="../../assets/spinner.svg" v-else />
+    <img src="../../assets/spinner.svg" alt="" v-else />
   </div>
 </template>
 

--- a/src/components/widgets/TableHeaderMenu.vue
+++ b/src/components/widgets/TableHeaderMenu.vue
@@ -1,18 +1,42 @@
 <template>
   <div class="header-menu hidden">
-    <div @click="$emit('minimize-clicked')">
+    <div
+      role="button"
+      tabindex="0"
+      @click="$emit('minimize-clicked')"
+      @keydown.enter.prevent="$emit('minimize-clicked')"
+      @keydown.space.prevent="$emit('minimize-clicked')"
+    >
       <span v-if="isMinimized">
         {{ $t('main.maximize') }}
       </span>
       <span v-else>{{ $t('main.minimize') }}</span>
     </div>
-    <div @click="$emit('sort-by-clicked')">
+    <div
+      role="button"
+      tabindex="0"
+      @click="$emit('sort-by-clicked')"
+      @keydown.enter.prevent="$emit('sort-by-clicked')"
+      @keydown.space.prevent="$emit('sort-by-clicked')"
+    >
       {{ $t('main.sort_by') }}
     </div>
-    <div @click="$emit('select-column')">
+    <div
+      role="button"
+      tabindex="0"
+      @click="$emit('select-column')"
+      @keydown.enter.prevent="$emit('select-column')"
+      @keydown.space.prevent="$emit('select-column')"
+    >
       {{ $t('main.select_column') }}
     </div>
-    <div @click="$emit('toggle-stick')">
+    <div
+      role="button"
+      tabindex="0"
+      @click="$emit('toggle-stick')"
+      @keydown.enter.prevent="$emit('toggle-stick')"
+      @keydown.space.prevent="$emit('toggle-stick')"
+    >
       <template v-if="isSticked">
         {{ $t('main.unstick') }}
       </template>
@@ -22,7 +46,11 @@
     </div>
     <div
       class="error"
+      role="button"
+      tabindex="0"
       @click="$emit('delete-all-clicked')"
+      @keydown.enter.prevent="$emit('delete-all-clicked')"
+      @keydown.space.prevent="$emit('delete-all-clicked')"
       v-if="isEditAllowed"
     >
       {{ $t('main.delete_all') }}

--- a/src/components/widgets/TableMetadataHeaderMenu.vue
+++ b/src/components/widgets/TableMetadataHeaderMenu.vue
@@ -1,12 +1,33 @@
 <template>
   <div class="header-menu hidden">
-    <div @click="$emit('edit-clicked')" v-if="isEditAllowed">
+    <div
+      role="button"
+      tabindex="0"
+      @click="$emit('edit-clicked')"
+      @keydown.enter.prevent="$emit('edit-clicked')"
+      @keydown.space.prevent="$emit('edit-clicked')"
+      v-if="isEditAllowed"
+    >
       {{ $t('main.edit') }}
     </div>
-    <div @click="$emit('sort-by-clicked')" v-if="showSort">
+    <div
+      role="button"
+      tabindex="0"
+      @click="$emit('sort-by-clicked')"
+      @keydown.enter.prevent="$emit('sort-by-clicked')"
+      @keydown.space.prevent="$emit('sort-by-clicked')"
+      v-if="showSort"
+    >
       {{ $t('main.sort_by') }}
     </div>
-    <div @click="$emit('toggle-stick')" v-if="showStick">
+    <div
+      role="button"
+      tabindex="0"
+      @click="$emit('toggle-stick')"
+      @keydown.enter.prevent="$emit('toggle-stick')"
+      @keydown.space.prevent="$emit('toggle-stick')"
+      v-if="showStick"
+    >
       <template v-if="isSticked">
         {{ $t('main.unstick') }}
       </template>
@@ -14,7 +35,15 @@
         {{ $t('main.stick') }}
       </template>
     </div>
-    <div class="error" @click="$emit('delete-clicked')" v-if="isEditAllowed">
+    <div
+      class="error"
+      role="button"
+      tabindex="0"
+      @click="$emit('delete-clicked')"
+      @keydown.enter.prevent="$emit('delete-clicked')"
+      @keydown.space.prevent="$emit('delete-clicked')"
+      v-if="isEditAllowed"
+    >
       {{ $t('main.delete') }}
     </div>
   </div>

--- a/src/components/widgets/TaskTypeName.vue
+++ b/src/components/widgets/TaskTypeName.vue
@@ -31,7 +31,15 @@
     <span :title="title">
       {{ taskType.name }}
     </span>
-    <span class="delete-times" v-if="deletable" @click="$emit('delete')">
+    <span
+      class="delete-times"
+      role="button"
+      tabindex="0"
+      v-if="deletable"
+      @click="$emit('delete')"
+      @keydown.enter.prevent="$emit('delete')"
+      @keydown.space.prevent="$emit('delete')"
+    >
       ×
     </span>
   </div>

--- a/src/components/widgets/TextField.vue
+++ b/src/components/widgets/TextField.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="field" :class="{ 'is-inline': isInline }">
     <label class="label" :for="fieldId" v-if="label">{{ label }}</label>
-    <label class="sr-only" :for="fieldId" v-else-if="placeholder">
+    <label class="visuallyhidden" :for="fieldId" v-else-if="placeholder">
       {{ placeholder }}
     </label>
     <label class="label empty-label" v-if="emptyLabel">&nbsp;</label>
@@ -165,18 +165,6 @@ const checkValidity = () => {
 defineExpose({ focus, checkValidity })
 </script>
 <style lang="scss" scoped>
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .input.is-size-2 {
   width: 3rem;
 }

--- a/src/components/widgets/TextField.vue
+++ b/src/components/widgets/TextField.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="field" :class="{ 'is-inline': isInline }">
     <label class="label" :for="fieldId" v-if="label">{{ label }}</label>
+    <label class="sr-only" :for="fieldId" v-else-if="placeholder">
+      {{ placeholder }}
+    </label>
     <label class="label empty-label" v-if="emptyLabel">&nbsp;</label>
     <p
       class="control"
@@ -18,6 +21,8 @@
             : 'input flexrow-item' + inputClass
         "
         :autocomplete="autocomplete"
+        :aria-describedby="errored ? errorId : undefined"
+        :aria-invalid="errored"
         :disabled="disabled"
         :maxlength="maxlength"
         :min="type === 'number' ? min || 0 : undefined"
@@ -42,7 +47,7 @@
         {{ unitLabel }}
       </span>
     </p>
-    <p class="error" v-if="errored">
+    <p class="error" :id="errorId" v-if="errored">
       {{ errorText }}
     </p>
   </div>
@@ -126,6 +131,7 @@ const props = defineProps({
 const emit = defineEmits(['enter', 'update:model-value'])
 
 const fieldId = useId()
+const errorId = `${fieldId}-error`
 const inputRef = ref(null)
 
 const getInputValue = () => {
@@ -159,6 +165,18 @@ const checkValidity = () => {
 defineExpose({ focus, checkValidity })
 </script>
 <style lang="scss" scoped>
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .input.is-size-2 {
   width: 3rem;
 }

--- a/src/components/widgets/TwoFactorAuthentication.vue
+++ b/src/components/widgets/TwoFactorAuthentication.vue
@@ -45,13 +45,25 @@
         {{ $t('login.error_sending_email') }}
       </p>
       <p v-if="chosenTwoFA === 'email_otp'">
-        <a @click="requestSendEmailOTP">
+        <a
+          role="button"
+          tabindex="0"
+          @click="requestSendEmailOTP"
+          @keydown.enter.prevent="requestSendEmailOTP"
+          @keydown.space.prevent="requestSendEmailOTP"
+        >
           {{ $t('login.send_email_otp') }}
         </a>
       </p>
 
       <p v-if="chosenTwoFA === 'fido'">
-        <a @click="requestGetFIDOChallenge">
+        <a
+          role="button"
+          tabindex="0"
+          @click="requestGetFIDOChallenge"
+          @keydown.enter.prevent="requestGetFIDOChallenge"
+          @keydown.space.prevent="requestGetFIDOChallenge"
+        >
           {{ $t('login.retry_fido_challenge') }}
         </a>
       </p>
@@ -65,7 +77,13 @@
         </p>
         <ul>
           <li :key="twoFA" v-for="twoFA in othersTwoFA">
-            <a @click="changeTwoFA(twoFA)">
+            <a
+              role="button"
+              tabindex="0"
+              @click="changeTwoFA(twoFA)"
+              @keydown.enter.prevent="changeTwoFA(twoFA)"
+              @keydown.space.prevent="changeTwoFA(twoFA)"
+            >
               {{ changeTwoFAText(twoFA) }}
             </a>
           </li>

--- a/src/components/widgets/TwoFactorAuthenticationSetup.vue
+++ b/src/components/widgets/TwoFactorAuthenticationSetup.vue
@@ -12,17 +12,29 @@
       <x-circle-icon
         class="action-icon"
         :size="20"
+        role="button"
+        tabindex="0"
         @click="cancelCurrentTwoFactorAuthAction"
+        @keydown.enter.prevent="cancelCurrentTwoFactorAuthAction"
+        @keydown.space.prevent="cancelCurrentTwoFactorAuthAction"
       />
       <save-icon
         class="action-icon"
         :size="20"
+        role="button"
+        tabindex="0"
         @click="saveRecoveryCodesToFile"
+        @keydown.enter.prevent="saveRecoveryCodesToFile"
+        @keydown.space.prevent="saveRecoveryCodesToFile"
       />
       <copy-icon
         class="action-icon"
         :size="20"
+        role="button"
+        tabindex="0"
         @click="copyRecoveryCodesToClipboard"
+        @keydown.enter.prevent="copyRecoveryCodesToClipboard"
+        @keydown.space.prevent="copyRecoveryCodesToClipboard"
       />
       <textarea
         class="input recovery-codes"
@@ -388,7 +400,11 @@
         <trash-icon
           class="action-icon pull-right"
           :size="15"
+          role="button"
+          tabindex="0"
           @click="unregisterFIDORequested(device)"
+          @keydown.enter.prevent="unregisterFIDORequested(device)"
+          @keydown.space.prevent="unregisterFIDORequested(device)"
         />
       </li>
     </ul>

--- a/src/components/widgets/UserCalendar.vue
+++ b/src/components/widgets/UserCalendar.vue
@@ -25,7 +25,11 @@
             background: event.backgroundColor
           }"
           :title="event.title"
+          role="button"
+          tabindex="0"
           @click="onEventClicked(event)"
+          @keydown.enter.prevent="onEventClicked(event)"
+          @keydown.space.prevent="onEventClicked(event)"
           v-else
         >
           <production-name

--- a/src/components/widgets/ValidationTag.vue
+++ b/src/components/widgets/ValidationTag.vue
@@ -15,7 +15,11 @@
         class="tag"
         :style="tagStyle"
         :title="taskStatus.name"
+        role="button"
+        tabindex="0"
         @click="$event => $emit('click', $event)"
+        @keydown.enter.prevent="$event => $emit('click', $event)"
+        @keydown.space.prevent="$event => $emit('click', $event)"
         v-else
       >
         {{ taskStatus.short_name }}

--- a/src/composables/comboboxKeyboard.js
+++ b/src/composables/comboboxKeyboard.js
@@ -1,0 +1,100 @@
+import { nextTick, ref, useId, watch } from 'vue'
+
+// Shared keyboard behavior for the custom Combobox* dropdowns (the ones that
+// render their own trigger + option list instead of a native <select>).
+// Follows the collapsible-listbox ARIA pattern: focus stays on the trigger,
+// the active option is tracked by index and exposed via aria-activedescendant
+// (see optionId), the list itself only carries role="listbox"/"option".
+export const useComboboxKeyboard = ({
+  isOpen,
+  toggle,
+  optionsLength,
+  onSelect,
+  listRef
+}) => {
+  const uid = useId()
+  const activeIndex = ref(-1)
+
+  const length = () =>
+    typeof optionsLength === 'function' ? optionsLength() : optionsLength.value
+
+  const optionId = index => `combobox-${uid}-option-${index}`
+
+  const clampIndex = index => {
+    const max = length() - 1
+    return max < 0 ? -1 : Math.min(Math.max(index, 0), max)
+  }
+
+  const open = () => {
+    if (!isOpen.value) toggle()
+  }
+
+  const close = () => {
+    if (isOpen.value) toggle()
+  }
+
+  const move = delta => {
+    if (length() === 0) return
+    if (activeIndex.value === -1) {
+      activeIndex.value = delta > 0 ? 0 : length() - 1
+    } else {
+      activeIndex.value = clampIndex(activeIndex.value + delta)
+    }
+  }
+
+  const onKeydown = event => {
+    switch (event.key) {
+      case 'Enter':
+      case ' ':
+        event.preventDefault()
+        if (!isOpen.value) {
+          open()
+        } else if (activeIndex.value !== -1) {
+          onSelect(activeIndex.value)
+        } else {
+          close()
+        }
+        break
+      case 'ArrowDown':
+        event.preventDefault()
+        if (isOpen.value) {
+          move(1)
+        } else {
+          open()
+        }
+        break
+      case 'ArrowUp':
+        event.preventDefault()
+        if (isOpen.value) {
+          move(-1)
+        } else {
+          open()
+        }
+        break
+      case 'Escape':
+        if (isOpen.value) {
+          event.preventDefault()
+          close()
+        }
+        break
+      case 'Tab':
+        close()
+        break
+    }
+  }
+
+  watch(isOpen, value => {
+    if (!value) activeIndex.value = -1
+  })
+
+  if (listRef) {
+    watch(activeIndex, index => {
+      if (index === -1) return
+      nextTick(() => {
+        listRef.value?.children[index]?.scrollIntoView?.({ block: 'nearest' })
+      })
+    })
+  }
+
+  return { activeIndex, onKeydown, optionId }
+}

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -11,26 +11,22 @@ import {
   getFabricDocument,
   util
 } from 'fabric'
-import { PSStroke, PSBrush } from 'fabricjs-psbrush'
+import { PSStroke } from 'fabricjs-psbrush'
 import moment from 'moment'
 import { v4 as uuidv4 } from 'uuid'
 import { markRaw, ref, watch } from 'vue'
 
+import { useDrawingTools } from '@/composables/players/drawingTools'
 import {
   SHAPE_WIDTHS,
   addSerialization,
   attachShapeDrawing,
   buildReadOnlyShape,
   deserializePSStroke,
-  getAnnotationContainMapping,
-  lockBrushToFirstPointer
+  getAnnotationContainMapping
 } from '@/lib/players/annotation'
 import { normalizeType } from '@/lib/players/annotationTypes'
-import {
-  Eraser,
-  EraserBrush,
-  reviveObjectEraser
-} from '@/lib/players/eraserbrush'
+import { Eraser, reviveObjectEraser } from '@/lib/players/eraserbrush'
 import clipboard from '@/lib/clipboard'
 import { formatFullDate } from '@/lib/time'
 import localPreferences from '@/lib/preferences'
@@ -724,109 +720,6 @@ export const useAnnotation = ({
 
   // Events
 
-  const onChangePencilColor = color => {
-    pencilColor.value = color
-    _resetColor()
-    localPreferences.setPreference('player:pencil-color', pencilColor.value)
-  }
-
-  const onChangePencilWidth = pencil => {
-    pencilWidth.value = pencil
-    _resetPencil()
-    localPreferences.setPreference('player:pencil-width', pencilWidth.value)
-  }
-
-  const onChangeTextColor = newValue => {
-    textColor.value = newValue
-    localPreferences.setPreference('player:text-color', textColor.value)
-  }
-
-  const _resetColor = () => {
-    if (!fabricCanvas.value) return
-    fabricCanvas.value.freeDrawingBrush.color = pencilColor.value
-  }
-
-  const _resetPencil = () => {
-    if (!fabricCanvas.value) return
-    const converter = {
-      huge: 30,
-      big: 20,
-      medium: 10,
-      small: 4,
-      tiny: 2
-    }
-    const strokeWidth = converter[pencilWidth.value]
-    fabricCanvas.value.freeDrawingBrush.width = strokeWidth
-  }
-
-  const resetPencilConfiguration = () => {
-    pencilColor.value =
-      localPreferences.getPreference('player:pencil-color') || '#ff3860'
-    textColor.value =
-      localPreferences.getPreference('player:text-color') || '#ff3860'
-    pencilWidth.value =
-      localPreferences.getPreference('player:pencil-width') || 'big'
-
-    _resetColor()
-    _resetPencil()
-  }
-
-  // Drawing config
-
-  const onAnnotateClicked = () => {
-    showCanvas()
-    // Toggle off only when the pencil itself is the active brush. If the
-    // eraser is on, switch over to the pencil instead of turning drawing off.
-    if (fabricCanvas.value.isDrawingMode && !isEraserModeOn.value) {
-      fabricCanvas.value.isDrawingMode = false
-      return
-    }
-    isEraserModeOn.value = false
-    if (fabricCanvas.value) {
-      fabricCanvas.value.isDrawingMode = true
-    }
-    const brush = new PSBrush(fabricCanvas.value)
-    brush.pressureManager.fallback = 0.5
-    // PSBrush drops BaseBrush's round cap/join defaults (its initialize
-    // doesn't call super), so restore them or strokes get flat ends.
-    brush.strokeLineCap = 'round'
-    brush.strokeLineJoin = 'round'
-    lockBrushToFirstPointer(brush)
-    fabricCanvas.value.freeDrawingBrush = brush
-    _resetColor()
-    _resetPencil()
-  }
-
-  // Eraser tool — mirror of onAnnotateClicked. Installs the v2 EraserBrush
-  // (destination-out). Type-selectivity is handled per-object by the
-  // `erasable` flag (IText is non-erasable), not by z-order.
-  const onEraseClicked = () => {
-    showCanvas()
-    if (isEraserModeOn.value) {
-      isEraserModeOn.value = false
-      if (fabricCanvas.value) fabricCanvas.value.isDrawingMode = false
-      return
-    }
-    isEraserModeOn.value = true
-    isShapeMode.value = false
-    if (fabricCanvas.value) {
-      fabricCanvas.value.isDrawingMode = true
-      const brush = new EraserBrush(fabricCanvas.value)
-      brush.strokeLineCap = 'round'
-      brush.strokeLineJoin = 'round'
-      lockBrushToFirstPointer(brush)
-      fabricCanvas.value.freeDrawingBrush = brush
-      _resetEraserWidth()
-    }
-  }
-
-  const _resetEraserWidth = () => {
-    if (!fabricCanvas.value?.freeDrawingBrush) return
-    // Reuse the pencil-width preference (same mapping as _resetPencil).
-    const converter = { huge: 30, big: 20, medium: 10, small: 4, tiny: 2 }
-    fabricCanvas.value.freeDrawingBrush.width = converter[pencilWidth.value]
-  }
-
   const onObjectAdded = obj => {
     if (silentAnnotation) return
     let o = obj.target ? obj.target : obj.targets[0]
@@ -1019,52 +912,6 @@ export const useAnnotation = ({
 
   const setAnnotationCanvasDimensions = (width, height) => {
     fabricCanvas.value.setDimensions({ width, height })
-  }
-
-  const setAnnotationDrawingMode = isDrawingMode => {
-    if (isDrawingMode) {
-      isShapeMode.value = false
-      // Coming back to the pencil from the eraser: the eraser swapped
-      // freeDrawingBrush for an EraserBrush, so restore the pressure brush
-      // (consumers that toggle drawing through this entry point — e.g.
-      // PreviewPlayer — never re-create a PSBrush themselves).
-      if (fabricCanvas.value?.freeDrawingBrush instanceof EraserBrush) {
-        isEraserModeOn.value = false
-        const brush = new PSBrush(fabricCanvas.value)
-        brush.pressureManager.fallback = 0.5
-        brush.strokeLineCap = 'round'
-        brush.strokeLineJoin = 'round'
-        lockBrushToFirstPointer(brush)
-        fabricCanvas.value.freeDrawingBrush = brush
-        _resetColor()
-        _resetPencil()
-      }
-    } else if (isEraserModeOn.value) {
-      // The eraser runs in drawing mode. A stray "leave drawing" — typically
-      // the isDrawing watcher firing async as the user switches pencil→eraser
-      // (onEraseClicked set isDrawing=false) — must not tear it down, or the
-      // eraser stops working and its ring cursor reverts to the default.
-      return
-    }
-    fabricCanvas.value.isDrawingMode = isDrawingMode
-  }
-
-  const toggleShapeMode = () => {
-    if (isShapeMode.value) {
-      isShapeMode.value = false
-      return
-    }
-    isShapeMode.value = true
-    // Mutex with the freehand drawing mode owned by the composable.
-    // Consumers (PreviewPlayer / PlaylistPlayer) own `isDrawing` /
-    // `isTyping` refs and clear them via a watcher on `isShapeMode`.
-    if (fabricCanvas.value) {
-      fabricCanvas.value.isDrawingMode = false
-    }
-  }
-
-  const setShapeTool = shape => {
-    currentShape.value = shape
   }
 
   // Suppress object selection while shape mode is active so a mousedown
@@ -1546,6 +1393,32 @@ export const useAnnotation = ({
       canvasWrapper.value.style.display = 'block'
     }
   }
+
+  // Pencil / eraser / shape / text tool transitions and brush configuration
+  // live in their own module; the facade re-exposes them unchanged.
+  const {
+    onChangePencilColor,
+    onChangePencilWidth,
+    onChangeTextColor,
+    _resetColor,
+    _resetPencil,
+    resetPencilConfiguration,
+    onAnnotateClicked,
+    onEraseClicked,
+    setAnnotationDrawingMode,
+    toggleShapeMode,
+    setShapeTool
+  } = useDrawingTools({
+    fabricCanvas,
+    isEraserModeOn,
+    isShapeMode,
+    currentShape,
+    pencilColor,
+    pencilWidth,
+    textColor,
+    showCanvas,
+    localPreferences
+  })
 
   // Helper to get the current preview (needed by updateAnnotationsInStore)
   let currentPreview = () => null

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -121,6 +121,9 @@ if (PSStroke) {
  *   local deletion is recorded. Receives `(currentTime, serializedObject)`.
  * @param {Function} [options.postAnnotationUpdate] - hook fired after a
  *   local update is recorded. Receives `(currentTime, serializedObject)`.
+ * @param {Function} [options.getAdditionalPreviews] - extra store previews
+ *   that mirror the current one and must receive the same annotations
+ *   (playlist revision copies). Returns `[{ taskId, preview }]` pairs.
  */
 export const useAnnotation = ({
   mainCanvasComponent,
@@ -141,7 +144,8 @@ export const useAnnotation = ({
   isEraserModeOn = ref(false),
   postAnnotationAddition = () => {},
   postAnnotationDeletion = () => {},
-  postAnnotationUpdate = () => {}
+  postAnnotationUpdate = () => {},
+  getAdditionalPreviews = () => []
 }) => {
   // Canvas instances are owned by AnnotationCanvas components; we
   // mirror them into local refs through watchers so internal code
@@ -511,10 +515,10 @@ export const useAnnotation = ({
   const updateAnnotationsInStore = () => {
     const preview = currentPreview()
     if (preview) {
-      store.commit('UPDATE_PREVIEW_ANNOTATION', {
-        taskId: preview.task_id,
-        preview: preview,
-        annotations: annotations.value
+      store.dispatch('updatePreviewAnnotations', {
+        preview,
+        annotations: annotations.value,
+        extraPreviews: getAdditionalPreviews()
       })
     }
   }

--- a/src/composables/players/drawingTools.js
+++ b/src/composables/players/drawingTools.js
@@ -1,0 +1,184 @@
+/*
+ * Drawing-tools slice of the annotation composable: owns the pencil /
+ * eraser / shape / text tool state transitions and brush configuration.
+ * Canvas lifecycle, persistence and onion compositing stay in annotation.js,
+ * which builds the shared `ctx` and re-exposes these functions unchanged.
+ */
+import { PSBrush } from 'fabricjs-psbrush'
+
+import { lockBrushToFirstPointer } from '@/lib/players/annotation'
+import { EraserBrush } from '@/lib/players/eraserbrush'
+
+export const useDrawingTools = ({
+  fabricCanvas,
+  isEraserModeOn,
+  isShapeMode,
+  currentShape,
+  pencilColor,
+  pencilWidth,
+  textColor,
+  showCanvas,
+  localPreferences
+}) => {
+  const onChangePencilColor = color => {
+    pencilColor.value = color
+    _resetColor()
+    localPreferences.setPreference('player:pencil-color', pencilColor.value)
+  }
+
+  const onChangePencilWidth = pencil => {
+    pencilWidth.value = pencil
+    _resetPencil()
+    localPreferences.setPreference('player:pencil-width', pencilWidth.value)
+  }
+
+  const onChangeTextColor = newValue => {
+    textColor.value = newValue
+    localPreferences.setPreference('player:text-color', textColor.value)
+  }
+
+  const _resetColor = () => {
+    if (!fabricCanvas.value) return
+    fabricCanvas.value.freeDrawingBrush.color = pencilColor.value
+  }
+
+  const _resetPencil = () => {
+    if (!fabricCanvas.value) return
+    const converter = {
+      huge: 30,
+      big: 20,
+      medium: 10,
+      small: 4,
+      tiny: 2
+    }
+    const strokeWidth = converter[pencilWidth.value]
+    fabricCanvas.value.freeDrawingBrush.width = strokeWidth
+  }
+
+  const resetPencilConfiguration = () => {
+    pencilColor.value =
+      localPreferences.getPreference('player:pencil-color') || '#ff3860'
+    textColor.value =
+      localPreferences.getPreference('player:text-color') || '#ff3860'
+    pencilWidth.value =
+      localPreferences.getPreference('player:pencil-width') || 'big'
+
+    _resetColor()
+    _resetPencil()
+  }
+
+  const onAnnotateClicked = () => {
+    showCanvas()
+    // Toggle off only when the pencil itself is the active brush. If the
+    // eraser is on, switch over to the pencil instead of turning drawing off.
+    if (fabricCanvas.value.isDrawingMode && !isEraserModeOn.value) {
+      fabricCanvas.value.isDrawingMode = false
+      return
+    }
+    isEraserModeOn.value = false
+    if (fabricCanvas.value) {
+      fabricCanvas.value.isDrawingMode = true
+    }
+    const brush = new PSBrush(fabricCanvas.value)
+    brush.pressureManager.fallback = 0.5
+    // PSBrush drops BaseBrush's round cap/join defaults (its initialize
+    // doesn't call super), so restore them or strokes get flat ends.
+    brush.strokeLineCap = 'round'
+    brush.strokeLineJoin = 'round'
+    lockBrushToFirstPointer(brush)
+    fabricCanvas.value.freeDrawingBrush = brush
+    _resetColor()
+    _resetPencil()
+  }
+
+  // Eraser tool — mirror of onAnnotateClicked. Installs the v2 EraserBrush
+  // (destination-out). Type-selectivity is handled per-object by the
+  // `erasable` flag (IText is non-erasable), not by z-order.
+  const onEraseClicked = () => {
+    showCanvas()
+    if (isEraserModeOn.value) {
+      isEraserModeOn.value = false
+      if (fabricCanvas.value) fabricCanvas.value.isDrawingMode = false
+      return
+    }
+    isEraserModeOn.value = true
+    isShapeMode.value = false
+    if (fabricCanvas.value) {
+      fabricCanvas.value.isDrawingMode = true
+      const brush = new EraserBrush(fabricCanvas.value)
+      brush.strokeLineCap = 'round'
+      brush.strokeLineJoin = 'round'
+      lockBrushToFirstPointer(brush)
+      fabricCanvas.value.freeDrawingBrush = brush
+      _resetEraserWidth()
+    }
+  }
+
+  const _resetEraserWidth = () => {
+    if (!fabricCanvas.value?.freeDrawingBrush) return
+    // Reuse the pencil-width preference (same mapping as _resetPencil).
+    const converter = { huge: 30, big: 20, medium: 10, small: 4, tiny: 2 }
+    fabricCanvas.value.freeDrawingBrush.width = converter[pencilWidth.value]
+  }
+
+  const setAnnotationDrawingMode = isDrawingMode => {
+    if (isDrawingMode) {
+      isShapeMode.value = false
+      // Coming back to the pencil from the eraser: the eraser swapped
+      // freeDrawingBrush for an EraserBrush, so restore the pressure brush
+      // (consumers that toggle drawing through this entry point — e.g.
+      // PreviewPlayer — never re-create a PSBrush themselves).
+      if (fabricCanvas.value?.freeDrawingBrush instanceof EraserBrush) {
+        isEraserModeOn.value = false
+        const brush = new PSBrush(fabricCanvas.value)
+        brush.pressureManager.fallback = 0.5
+        brush.strokeLineCap = 'round'
+        brush.strokeLineJoin = 'round'
+        lockBrushToFirstPointer(brush)
+        fabricCanvas.value.freeDrawingBrush = brush
+        _resetColor()
+        _resetPencil()
+      }
+    } else if (isEraserModeOn.value) {
+      // The eraser runs in drawing mode. A stray "leave drawing" — typically
+      // the isDrawing watcher firing async as the user switches pencil→eraser
+      // (onEraseClicked set isDrawing=false) — must not tear it down, or the
+      // eraser stops working and its ring cursor reverts to the default.
+      return
+    }
+    fabricCanvas.value.isDrawingMode = isDrawingMode
+  }
+
+  const toggleShapeMode = () => {
+    if (isShapeMode.value) {
+      isShapeMode.value = false
+      return
+    }
+    isShapeMode.value = true
+    // Mutex with the freehand drawing mode owned by the composable.
+    // Consumers (PreviewPlayer / PlaylistPlayer) own `isDrawing` /
+    // `isTyping` refs and clear them via a watcher on `isShapeMode`.
+    if (fabricCanvas.value) {
+      fabricCanvas.value.isDrawingMode = false
+    }
+  }
+
+  const setShapeTool = shape => {
+    currentShape.value = shape
+  }
+
+  return {
+    onChangePencilColor,
+    onChangePencilWidth,
+    onChangeTextColor,
+    _resetColor,
+    _resetPencil,
+    _resetEraserWidth,
+    resetPencilConfiguration,
+    onAnnotateClicked,
+    onEraseClicked,
+    setAnnotationDrawingMode,
+    toggleShapeMode,
+    setShapeTool
+  }
+}

--- a/src/composables/players/mediaKind.js
+++ b/src/composables/players/mediaKind.js
@@ -1,0 +1,53 @@
+/*
+ * Single source of the "preview extension → media kind" dispatch, shared by
+ * PreviewViewer and the playlist players so a new preview type is wired in
+ * one place. `enabled` gates every kind (PreviewViewer holds everything off
+ * while a preview is processing or broken); `isFile` is the catch-all for
+ * previews no viewer handles.
+ */
+import { computed, unref } from 'vue'
+
+import {
+  isDiffPreview,
+  isMarkdownPreview,
+  isModelPreview,
+  isMoviePreview,
+  isPdfPreview,
+  isPicturePreview,
+  isSoundPreview
+} from '@/lib/preview'
+
+export const useMediaKind = (extension, enabled = null) => {
+  const isOn = () => (enabled ? unref(enabled) : true)
+  const isDiff = computed(() => isOn() && isDiffPreview(unref(extension)))
+  const isMarkdown = computed(
+    () => isOn() && isMarkdownPreview(unref(extension))
+  )
+  const isModel = computed(() => isOn() && isModelPreview(unref(extension)))
+  const isMovie = computed(() => isOn() && isMoviePreview(unref(extension)))
+  const isPdf = computed(() => isOn() && isPdfPreview(unref(extension)))
+  const isPicture = computed(() => isOn() && isPicturePreview(unref(extension)))
+  const isSound = computed(() => isOn() && isSoundPreview(unref(extension)))
+  const isFile = computed(
+    () =>
+      isOn() &&
+      !isDiff.value &&
+      !isMarkdown.value &&
+      !isModel.value &&
+      !isMovie.value &&
+      !isPdf.value &&
+      !isPicture.value &&
+      !isSound.value
+  )
+
+  return {
+    isDiff,
+    isFile,
+    isMarkdown,
+    isModel,
+    isMovie,
+    isPdf,
+    isPicture,
+    isSound
+  }
+}

--- a/src/composables/players/transport.js
+++ b/src/composables/players/transport.js
@@ -1,0 +1,27 @@
+/*
+ * Transport state shared by the players (PreviewPlayer, PlaylistPlayer,
+ * SharedPlaylistPlayer). Owns only the refs whose defaults are identical
+ * across players; side effects (preference persistence, decoder calls,
+ * room sync) stay in each player.
+ */
+import { ref } from 'vue'
+
+export const usePlayerTransport = () => {
+  const currentTimeRaw = ref(0)
+  const isHd = ref(false)
+  const isMuted = ref(false)
+  const isPlaying = ref(false)
+  const isRepeating = ref(false)
+  const speed = ref(3)
+  const volume = ref(50)
+
+  return {
+    currentTimeRaw,
+    isHd,
+    isMuted,
+    isPlaying,
+    isRepeating,
+    speed,
+    volume
+  }
+}

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -900,6 +900,7 @@ export default {
     select_file: 'Select files from your hard drive',
     show: 'Show',
     show_support_chat: 'Show support chat',
+    skip_to_content: 'Skip to content',
     sorted_by: 'Sorted by',
     sort_by: 'Sort by',
     start_date: 'Start date',

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -703,6 +703,27 @@ const actions = {
       })
   },
 
+  // Single entry point for pushing a preview's annotations into the store.
+  // `extraPreviews` carries store copies that mirror the main preview
+  // (playlist revision copies) and must receive the same annotations.
+  updatePreviewAnnotations(
+    { commit },
+    { preview, annotations, extraPreviews = [] }
+  ) {
+    commit(UPDATE_PREVIEW_ANNOTATION, {
+      taskId: preview.task_id,
+      preview,
+      annotations
+    })
+    extraPreviews.forEach(({ taskId, preview: extraPreview }) => {
+      commit(UPDATE_PREVIEW_ANNOTATION, {
+        taskId,
+        preview: extraPreview,
+        annotations
+      })
+    })
+  },
+
   refreshPreview({ commit }, { taskId, previewId }) {
     return tasksApi.getPreviewFile(previewId).then(preview => {
       commit(UPDATE_PREVIEW_ANNOTATION, {

--- a/tests/unit/composables/comboboxKeyboard.spec.js
+++ b/tests/unit/composables/comboboxKeyboard.spec.js
@@ -1,0 +1,152 @@
+import { mount } from '@vue/test-utils'
+import { computed, defineComponent, nextTick, ref } from 'vue'
+
+import { useComboboxKeyboard } from '@/composables/comboboxKeyboard'
+
+const createWrapper = (optionCount = 3) => {
+  const options = Array.from({ length: optionCount }, (_, i) => `option-${i}`)
+
+  const TestComponent = defineComponent({
+    setup() {
+      const isOpen = ref(false)
+      const selected = ref(null)
+      const listRef = ref(null)
+      const optionsLength = computed(() => options.length)
+
+      const toggle = () => {
+        isOpen.value = !isOpen.value
+      }
+
+      const onSelect = index => {
+        selected.value = options[index]
+        isOpen.value = false
+      }
+
+      const { activeIndex, onKeydown, optionId } = useComboboxKeyboard({
+        isOpen,
+        toggle,
+        optionsLength,
+        onSelect,
+        listRef
+      })
+
+      return {
+        isOpen,
+        selected,
+        options,
+        toggle,
+        activeIndex,
+        onKeydown,
+        optionId,
+        listRef
+      }
+    },
+    template: `
+      <div>
+        <div
+          class="trigger"
+          role="combobox"
+          tabindex="0"
+          :aria-expanded="isOpen"
+          @click="toggle"
+          @keydown="onKeydown"
+        ></div>
+        <ul class="list" ref="listRef" v-if="isOpen">
+          <li
+            v-for="(option, index) in options"
+            :id="optionId(index)"
+            :key="option"
+          >{{ option }}</li>
+        </ul>
+      </div>
+    `
+  })
+
+  return mount(TestComponent)
+}
+
+describe('composables/comboboxKeyboard', () => {
+  it('opens the list on ArrowDown when closed', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' })
+    expect(wrapper.vm.isOpen).toBe(true)
+  })
+
+  it('opens the list on Enter when closed', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.trigger').trigger('keydown', { key: 'Enter' })
+    expect(wrapper.vm.isOpen).toBe(true)
+  })
+
+  it('moves the active option down on ArrowDown while open', async () => {
+    const wrapper = createWrapper()
+    // First ArrowDown only opens the list; the following ones move the cursor.
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' })
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' })
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' })
+    expect(wrapper.vm.activeIndex).toBe(1)
+  })
+
+  it('clamps the active option at the last one on ArrowDown', async () => {
+    const wrapper = createWrapper(2)
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' })
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' })
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' })
+    expect(wrapper.vm.activeIndex).toBe(1)
+  })
+
+  it('clamps the active option at the first one on ArrowUp', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' }) // opens, lands on none
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowUp' }) // wraps to the last option
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowUp' })
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowUp' })
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowUp' }) // clamps at 0
+    expect(wrapper.vm.activeIndex).toBe(0)
+  })
+
+  it('selects the active option on Enter and closes the list', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' })
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' })
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' })
+    await wrapper.find('.trigger').trigger('keydown', { key: 'Enter' })
+    expect(wrapper.vm.selected).toBe('option-1')
+    expect(wrapper.vm.isOpen).toBe(false)
+  })
+
+  it('closes the list on Escape and resets the active option', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' })
+    await wrapper.find('.trigger').trigger('keydown', { key: 'Escape' })
+    expect(wrapper.vm.isOpen).toBe(false)
+    expect(wrapper.vm.activeIndex).toBe(-1)
+  })
+
+  it('closes the list on Tab', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.trigger').trigger('keydown', { key: 'ArrowDown' })
+    await wrapper.find('.trigger').trigger('keydown', { key: 'Tab' })
+    expect(wrapper.vm.isOpen).toBe(false)
+  })
+
+  it('prevents Space from scrolling the page', async () => {
+    const wrapper = createWrapper()
+    const event = new KeyboardEvent('keydown', { key: ' ', cancelable: true })
+    wrapper.find('.trigger').element.dispatchEvent(event)
+    await nextTick()
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('ignores unrelated keys', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.trigger').trigger('keydown', { key: 'a' })
+    expect(wrapper.vm.isOpen).toBe(false)
+  })
+
+  it('assigns each option a unique, stable id', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.vm.optionId(0)).toBe(wrapper.vm.optionId(0))
+    expect(wrapper.vm.optionId(0)).not.toBe(wrapper.vm.optionId(1))
+  })
+})

--- a/tests/unit/store/tasks.spec.js
+++ b/tests/unit/store/tasks.spec.js
@@ -127,4 +127,56 @@ describe('Tasks store', () => {
       expect(comment.replies[0].person.initials).toEqual('GA')
     })
   })
+
+  describe('updatePreviewAnnotations action', () => {
+    const annotations = [{ time: 0, drawing: { objects: [] } }]
+    const preview = { id: 'preview-1', task_id: 'task-1' }
+
+    test('commits one UPDATE_PREVIEW_ANNOTATION for the main preview', () => {
+      const commit = vi.fn()
+      tasksStore.actions.updatePreviewAnnotations(
+        { commit },
+        { preview, annotations }
+      )
+      expect(commit).toHaveBeenCalledTimes(1)
+      expect(commit).toHaveBeenCalledWith('UPDATE_PREVIEW_ANNOTATION', {
+        taskId: 'task-1',
+        preview,
+        annotations
+      })
+    })
+
+    test('commits once per extra preview with the same annotations', () => {
+      const commit = vi.fn()
+      const revisionCopy = { id: 'preview-1', revision: 2 }
+      const subPreviewParent = { id: 'preview-parent', revision: 1 }
+      tasksStore.actions.updatePreviewAnnotations(
+        { commit },
+        {
+          preview,
+          annotations,
+          extraPreviews: [
+            { taskId: 'task-1', preview: revisionCopy },
+            { taskId: 'task-1', preview: subPreviewParent }
+          ]
+        }
+      )
+      expect(commit).toHaveBeenCalledTimes(3)
+      expect(commit).toHaveBeenNthCalledWith(1, 'UPDATE_PREVIEW_ANNOTATION', {
+        taskId: 'task-1',
+        preview,
+        annotations
+      })
+      expect(commit).toHaveBeenNthCalledWith(2, 'UPDATE_PREVIEW_ANNOTATION', {
+        taskId: 'task-1',
+        preview: revisionCopy,
+        annotations
+      })
+      expect(commit).toHaveBeenNthCalledWith(3, 'UPDATE_PREVIEW_ANNOTATION', {
+        taskId: 'task-1',
+        preview: subPreviewParent,
+        annotations
+      })
+    })
+  })
 })

--- a/tests/unit/widgets/comboboxactions.spec.js
+++ b/tests/unit/widgets/comboboxactions.spec.js
@@ -1,0 +1,69 @@
+import { shallowMount } from '@vue/test-utils'
+
+import ComboboxActions from '@/components/widgets/ComboboxActions.vue'
+
+import './setup'
+
+describe('ComboboxActions', () => {
+  let handler, wrapper
+
+  beforeEach(() => {
+    handler = vi.fn()
+    const actions = [
+      { label: 'Duplicate', handler },
+      { label: 'Open docs', href: 'https://example.com/docs' }
+    ]
+
+    wrapper = shallowMount(ComboboxActions, {
+      props: { title: 'Actions', actions }
+    })
+  })
+
+  it('mounts successfully', () => {
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('exposes combobox/listbox ARIA roles', async () => {
+    const trigger = wrapper.find('.flexrow')
+    expect(trigger.attributes('role')).toBe('combobox')
+    expect(trigger.attributes('tabindex')).toBe('0')
+    await trigger.trigger('click')
+    expect(trigger.attributes('aria-expanded')).toBe('true')
+    expect(wrapper.find('.select-input').attributes('role')).toBe('listbox')
+    expect(wrapper.findAll('.option-line')[0].attributes('role')).toBe(
+      'option'
+    )
+  })
+
+  it('runs the handler and closes when selecting via keyboard', async () => {
+    const trigger = wrapper.find('.flexrow')
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'Enter' })
+    expect(handler).toHaveBeenCalled()
+    expect(wrapper.find('.select-input').exists()).toBe(false)
+  })
+
+  it('opens the href action in a new tab when selecting via keyboard', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => {})
+    const trigger = wrapper.find('.flexrow')
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'Enter' })
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://example.com/docs',
+      '_blank',
+      'noopener,noreferrer'
+    )
+    openSpy.mockRestore()
+  })
+
+  it('closes on Escape', async () => {
+    const trigger = wrapper.find('.flexrow')
+    await trigger.trigger('click')
+    expect(wrapper.find('.select-input').exists()).toBe(true)
+    await trigger.trigger('keydown', { key: 'Escape' })
+    expect(wrapper.find('.select-input').exists()).toBe(false)
+  })
+})

--- a/tests/unit/widgets/comboboxoptions.spec.js
+++ b/tests/unit/widgets/comboboxoptions.spec.js
@@ -1,0 +1,76 @@
+import { shallowMount } from '@vue/test-utils'
+
+import ComboboxOptions from '@/components/widgets/ComboboxOptions.vue'
+
+import './setup'
+
+describe('ComboboxOptions', () => {
+  const options = [
+    { label: 'Show infos', value: 'showInfos' },
+    { label: 'Big thumbnails', value: 'bigThumbnails' },
+    { label: 'Show assignations', value: 'showAssignations' }
+  ]
+
+  let wrapper
+
+  beforeEach(() => {
+    wrapper = shallowMount(ComboboxOptions, {
+      props: {
+        title: 'Display options',
+        options,
+        modelValue: { showInfos: true }
+      }
+    })
+  })
+
+  it('mounts successfully', () => {
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('exposes combobox/listbox ARIA roles with multiselectable', async () => {
+    const trigger = wrapper.find('.flexrow')
+    expect(trigger.attributes('role')).toBe('combobox')
+    expect(trigger.attributes('tabindex')).toBe('0')
+    await trigger.trigger('click')
+    const list = wrapper.find('.select-input')
+    expect(list.attributes('role')).toBe('listbox')
+    expect(list.attributes('aria-multiselectable')).toBe('true')
+  })
+
+  it('marks the checked option as aria-selected', async () => {
+    const trigger = wrapper.find('.flexrow')
+    await trigger.trigger('click')
+    const optionLines = wrapper.findAll('.option-line')
+    expect(optionLines[0].attributes('aria-selected')).toBe('true')
+    expect(optionLines[1].attributes('aria-selected')).toBe('false')
+  })
+
+  it('toggles the active option on Enter via keyboard', async () => {
+    const trigger = wrapper.find('.flexrow')
+    // 1st ArrowDown opens, the next two move the cursor to index 1
+    // (bigThumbnails).
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'Enter' })
+    expect(wrapper.emitted('update:model-value')[0]).toEqual([
+      { showInfos: true, bigThumbnails: true }
+    ])
+  })
+
+  it('keeps the list open after selecting via keyboard', async () => {
+    const trigger = wrapper.find('.flexrow')
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'Enter' })
+    expect(wrapper.find('.select-input').exists()).toBe(true)
+  })
+
+  it('closes the dropdown on Escape', async () => {
+    const trigger = wrapper.find('.flexrow')
+    await trigger.trigger('click')
+    expect(wrapper.find('.select-input').exists()).toBe(true)
+    await trigger.trigger('keydown', { key: 'Escape' })
+    expect(wrapper.find('.select-input').exists()).toBe(false)
+  })
+})

--- a/tests/unit/widgets/comboboxsimple.spec.js
+++ b/tests/unit/widgets/comboboxsimple.spec.js
@@ -86,4 +86,32 @@ describe('ComboboxSimple', () => {
   it('hides label when empty', () => {
     expect(wrapper.find('label').exists()).toBe(false)
   })
+
+  it('exposes a radiogroup with roving tabindex', () => {
+    expect(wrapper.find('.flexrow').attributes('role')).toBe('radiogroup')
+    const choices = wrapper.findAll('.choice')
+    expect(choices[0].attributes('role')).toBe('radio')
+    expect(choices[0].attributes('aria-checked')).toBe('true')
+    expect(choices[0].attributes('tabindex')).toBe('0')
+    expect(choices[1].attributes('aria-checked')).toBe('false')
+    expect(choices[1].attributes('tabindex')).toBe('-1')
+  })
+
+  it('selects the next option on ArrowRight', async () => {
+    const choices = wrapper.findAll('.choice')
+    await choices[0].trigger('keydown', { key: 'ArrowRight' })
+    expect(wrapper.emitted('update:model-value')[0]).toEqual(['month'])
+  })
+
+  it('clamps at the first option on ArrowLeft', async () => {
+    const choices = wrapper.findAll('.choice')
+    await choices[0].trigger('keydown', { key: 'ArrowLeft' })
+    expect(wrapper.emitted('update:model-value')[0]).toEqual(['week'])
+  })
+
+  it('selects an option on Enter/Space', async () => {
+    const choices = wrapper.findAll('.choice')
+    await choices[2].trigger('keydown', { key: ' ' })
+    expect(wrapper.emitted('update:model-value')[0]).toEqual(['day'])
+  })
 })

--- a/tests/unit/widgets/comboboxstatus.spec.js
+++ b/tests/unit/widgets/comboboxstatus.spec.js
@@ -122,4 +122,37 @@ describe('ComboboxStatus', () => {
     await wrapper.setProps({ label: 'Status' })
     expect(wrapper.find('label').text()).toBe('Status')
   })
+
+  it('exposes combobox/listbox ARIA roles', async () => {
+    const trigger = wrapper.find('.flexrow')
+    expect(trigger.attributes('role')).toBe('combobox')
+    expect(trigger.attributes('tabindex')).toBe('0')
+    expect(trigger.attributes('aria-expanded')).toBe('false')
+    await trigger.trigger('click')
+    expect(trigger.attributes('aria-expanded')).toBe('true')
+    expect(wrapper.find('.select-input').attributes('role')).toBe('listbox')
+    expect(wrapper.findAll('.status-line')[0].attributes('role')).toBe(
+      'option'
+    )
+  })
+
+  it('opens the dropdown and selects an option via keyboard', async () => {
+    const trigger = wrapper.find('.flexrow')
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    expect(wrapper.find('.select-input').exists()).toBe(true)
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'Enter' })
+    expect(wrapper.emitted('update:model-value')[0]).toEqual(['status-3'])
+    expect(wrapper.find('.select-input').exists()).toBe(false)
+  })
+
+  it('closes the dropdown on Escape', async () => {
+    const trigger = wrapper.find('.flexrow')
+    await trigger.trigger('click')
+    expect(wrapper.find('.select-input').exists()).toBe(true)
+    await trigger.trigger('keydown', { key: 'Escape' })
+    expect(wrapper.find('.select-input').exists()).toBe(false)
+  })
 })

--- a/tests/unit/widgets/comboboxtag.spec.js
+++ b/tests/unit/widgets/comboboxtag.spec.js
@@ -111,4 +111,44 @@ describe('ComboboxTag', () => {
     })
     expect(w.find('.selected-line').text()).toBe('')
   })
+
+  it('exposes combobox/listbox ARIA roles with multiselectable', async () => {
+    const trigger = wrapper.find('.flexrow')
+    expect(trigger.attributes('role')).toBe('combobox')
+    expect(trigger.attributes('tabindex')).toBe('0')
+    await trigger.trigger('click')
+    const list = wrapper.find('.select-input')
+    expect(list.attributes('role')).toBe('listbox')
+    expect(list.attributes('aria-multiselectable')).toBe('true')
+    const optionLines = wrapper.findAll('.option-line')
+    expect(optionLines[0].attributes('role')).toBe('option')
+  })
+
+  it('toggles the active option on Enter via keyboard', async () => {
+    const trigger = wrapper.find('.flexrow')
+    // options sorted by value: apple, banana, cherry — 1st ArrowDown opens,
+    // the next two move the cursor to index 1 (banana).
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'Enter' })
+    const emittedValue = wrapper.emitted('update:model-value')[0][0]
+    expect(emittedValue).toContain('banana')
+  })
+
+  it('keeps the list open after selecting via keyboard', async () => {
+    const trigger = wrapper.find('.flexrow')
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'Enter' })
+    expect(wrapper.find('.select-input').exists()).toBe(true)
+  })
+
+  it('closes the dropdown on Escape', async () => {
+    const trigger = wrapper.find('.flexrow')
+    await trigger.trigger('click')
+    expect(wrapper.find('.select-input').exists()).toBe(true)
+    await trigger.trigger('keydown', { key: 'Escape' })
+    expect(wrapper.find('.select-input').exists()).toBe(false)
+  })
 })

--- a/tests/unit/widgets/comboboxtasktype.spec.js
+++ b/tests/unit/widgets/comboboxtasktype.spec.js
@@ -1,0 +1,92 @@
+import { shallowMount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+
+import i18n from '@/lib/i18n'
+import ComboboxTaskType from '@/components/widgets/ComboboxTaskType.vue'
+
+import './setup'
+
+describe('ComboboxTaskType', () => {
+  let store, wrapper
+
+  const taskTypeList = [
+    { id: 'tt-1', name: 'Modeling', color: '#ECECEC' },
+    { id: 'tt-2', name: 'Animation', color: '#22D160' },
+    { id: 'tt-3', name: 'Rigging', color: '#4ABB56' }
+  ]
+
+  beforeEach(() => {
+    store = createStore({
+      strict: true,
+      getters: {
+        isDarkTheme: () => false,
+        taskTypeMap: () => new Map(taskTypeList.map(tt => [tt.id, tt]))
+      }
+    })
+
+    wrapper = shallowMount(ComboboxTaskType, {
+      props: {
+        taskTypeList,
+        modelValue: 'tt-2'
+      },
+      global: {
+        plugins: [i18n, store],
+        // The option list renders through <teleport to="body">; shallowMount
+        // stubs it out by default, so opt back into the real teleport.
+        stubs: { teleport: false }
+      }
+    })
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
+  // The option list renders through <teleport to="body">, so it lands
+  // outside wrapper.element and has to be queried on the real document.
+  const findTeleportedList = () => document.querySelector('.select-input')
+
+  it('mounts successfully', () => {
+    expect(wrapper.exists()).toBe(true)
+  })
+
+  it('exposes combobox/listbox ARIA roles', async () => {
+    const trigger = wrapper.find('.flexrow.selector')
+    expect(trigger.attributes('role')).toBe('combobox')
+    expect(trigger.attributes('tabindex')).toBe('0')
+    await trigger.trigger('click')
+    expect(trigger.attributes('aria-expanded')).toBe('true')
+    expect(findTeleportedList().getAttribute('role')).toBe('listbox')
+  })
+
+  it('opens and selects a task type via keyboard', async () => {
+    const trigger = wrapper.find('.flexrow.selector')
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'Enter' })
+    expect(wrapper.emitted('update:model-value')[0]).toEqual(['tt-3'])
+  })
+
+  it('closes on Escape', async () => {
+    const trigger = wrapper.find('.flexrow.selector')
+    await trigger.trigger('click')
+    expect(findTeleportedList()).not.toBeNull()
+    await trigger.trigger('keydown', { key: 'Escape' })
+    expect(findTeleportedList()).toBeNull()
+  })
+
+  it('removes the trigger from tab order when disabled', async () => {
+    await wrapper.setProps({ disabled: true })
+    const trigger = wrapper.find('.flexrow.selector')
+    expect(trigger.attributes('tabindex')).toBe('-1')
+  })
+
+  it('does not open when disabled', async () => {
+    await wrapper.setProps({ disabled: true })
+    const trigger = wrapper.find('.flexrow.selector')
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    expect(findTeleportedList()).toBeNull()
+  })
+})

--- a/tests/unit/widgets/searchfield.spec.js
+++ b/tests/unit/widgets/searchfield.spec.js
@@ -1,6 +1,9 @@
 import { shallowMount } from '@vue/test-utils'
 
+import i18n from '@/lib/i18n'
 import SearchField from '@/components/widgets/SearchField.vue'
+
+import './setup'
 
 describe('SearchField', () => {
   let wrapper
@@ -9,6 +12,7 @@ describe('SearchField', () => {
     wrapper = shallowMount(SearchField, {
       props: {},
       global: {
+        plugins: [i18n],
         directives: {
           focus: () => {}
         }


### PR DESCRIPTION
## Problems

- PlaylistPlayer re-created a divergent PSBrush inline and preview annotations had two concurrent store write paths; media dispatch, transport refs, read-only intent and `$socket` access were duplicated across players; annotation.js mixed tool config with canvas lifecycle.
- The task player progress bar parked mid-frame during playback.
- Keyboard/screen-reader gaps: 15 comboboxes unusable without a mouse, 185 clickable divs without keyboard equivalent, 60 images without alt, unlabeled fields, no main landmark, naked clickable icons, several h1 per view.

## Solutions

- Playlist pencil goes through the annotation composable; new `updatePreviewAnnotations` action is the single store writer; `useMediaKind`, `usePlayerTransport`, a named `readOnly`, `store.$socket` and `useDrawingTools` dedupe the player surface (façade unchanged).
- Playback fill quantized like the pause path (`ceil + 1`) — the bar fills whole frames again.
- `useComboboxKeyboard` (ARIA listbox) on the 11 non-native comboboxes; keyboard mirrors on 185 clickable elements; alt text, hidden labels, `<main>` + skip link, real buttons around icons, one h1 per view.