### PR TITLE
[perf] Virtualize the five entity grids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@fullcalendar/vue3": "6.1.21",
         "@google/model-viewer": "4.3.1",
         "@sentry/vue": "10.63.0",
+        "@tanstack/vue-virtual": "^3.13.31",
         "@unhead/vue": "3.1.7",
         "@vuepic/vue-datepicker": "14.0.0",
         "bowser": "2.14.1",
@@ -2770,6 +2771,32 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
+      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-virtual": {
+      "version": "3.13.31",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.13.31.tgz",
+      "integrity": "sha512-wZMEoSf852jQqaf3Ika1J7PiBae6341LNy/2CxmIyn0XKDQXMuK41wVX+xp6G0yx8jyR95Ef+Tdr13DK7mbJtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.0.0"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@fullcalendar/vue3": "6.1.21",
     "@google/model-viewer": "4.3.1",
     "@sentry/vue": "10.63.0",
+    "@tanstack/vue-virtual": "^3.13.31",
     "@unhead/vue": "3.1.7",
     "@vuepic/vue-datepicker": "14.0.0",
     "bowser": "2.14.1",

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -16,6 +16,7 @@
       <div class="filler" v-if="contactSheet"></div>
       <div
         class="wrapper status-wrapper"
+        :class="{ 'single-line': maxAssignees > 0 }"
         :style="statusWrapperStyle"
         v-if="!minimized"
       >
@@ -64,7 +65,7 @@
               'font-weight': isDarkTheme ? 'bold' : 'normal'
             }"
             :key="`avatar-${person.id}`"
-            v-for="person in assignees"
+            v-for="person in visibleAssignees"
           >
             <img
               loading="lazy"
@@ -73,6 +74,13 @@
               v-if="person.has_avatar"
             />
             <template v-else>{{ person.initials }}</template>
+          </span>
+          <span
+            class="avatar has-text-centered more-assignees"
+            :title="extraAssigneesTitle"
+            v-if="extraAssigneesCount > 0"
+          >
+            +{{ extraAssigneesCount }}
           </span>
         </template>
         <span class="subscribed" v-if="task?.is_subscribed">
@@ -111,6 +119,12 @@ const props = defineProps({
   isBorder: { type: Boolean, default: true },
   isCastingReady: { type: Boolean, default: false },
   left: { type: String, default: '0px' },
+  // Opt-in (0 = no cap, keeps the historical wrapping behavior): show at
+  // most this many assignee avatars and collapse the rest into a "+N"
+  // count on a single non-wrapping line. Virtualized lists (EditList) use
+  // it so a heavily-assigned task can never wrap the avatar stack and
+  // change the row height.
+  maxAssignees: { type: Number, default: 0 },
   minimized: { type: Boolean, default: false },
   rowX: { type: Number, default: 0 },
   selectable: { type: Boolean, default: true },
@@ -149,6 +163,23 @@ const assignees = computed(() =>
       .map(personId => personMap.value.get(personId))
       .filter(Boolean) ?? []
   )
+)
+
+const visibleAssignees = computed(() =>
+  props.maxAssignees > 0
+    ? assignees.value.slice(0, props.maxAssignees)
+    : assignees.value
+)
+
+const extraAssigneesCount = computed(
+  () => assignees.value.length - visibleAssignees.value.length
+)
+
+const extraAssigneesTitle = computed(() =>
+  assignees.value
+    .slice(props.maxAssignees)
+    .map(person => person.full_name)
+    .join('\n')
 )
 
 const priority = computed(() => formatPrioritySymbol(task.value.priority))
@@ -274,6 +305,25 @@ defineExpose({
   flex-wrap: wrap;
   position: relative;
   width: 100%;
+}
+
+// Opt-in via the maxAssignees prop: the cell content stays on one line and
+// clips instead of wrapping, so the cell height is constant whatever the
+// status name length or assignee count.
+.status-wrapper.single-line {
+  flex-wrap: nowrap;
+  overflow: hidden;
+
+  > * {
+    flex-shrink: 0;
+  }
+}
+
+.avatar.more-assignees {
+  background: var(--background-alt);
+  color: var(--text);
+  font-size: 9px;
+  font-weight: bold;
 }
 
 .full-wrapper {

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -240,15 +240,45 @@
           </tr>
         </thead>
 
-        <template v-if="!isLoading && isListVisible">
-          <tbody
-            class="datatable-body"
-            :key="'group-' + getGroupKey(group, k, 'asset_type_id')"
-            @mousedown="startBrowsing"
-            @touchstart="startBrowsing"
-            v-for="(group, k) in filteredDisplayedAssets"
+        <!--
+          PERF-1: virtualized rows (@tanstack/vue-virtual), ported from the
+          EditList pilot. The per-asset-type tbodys are linearized into one
+          flat list mixing type-header items and asset items (flattenedItems,
+          built in setup); only the items near the viewport render below,
+          between two spacer rows sized to the off-screen items' total
+          height. Type-header rows keep the exact markup/classes they had
+          when each group owned its tbody.
+        -->
+        <tbody
+          class="datatable-body"
+          @mousedown="startBrowsing"
+          @touchstart="startBrowsing"
+          v-if="!isLoading && isListVisible"
+        >
+          <tr class="virtual-spacer-row" v-if="topSpacerHeight > 0">
+            <td
+              :colspan="totalColumnsCount"
+              :style="{ height: `${topSpacerHeight}px` }"
+            ></td>
+          </tr>
+          <template
+            :key="key"
+            v-for="{
+              isHeader,
+              group,
+              asset,
+              i,
+              k,
+              flatIndex,
+              key
+            } in visibleItems"
           >
-            <tr class="datatable-type-header" v-if="group[0]">
+            <tr
+              class="datatable-type-header"
+              :ref="el => rowVirtualizer.measureElement(el)"
+              :data-index="flatIndex"
+              v-if="isHeader"
+            >
               <th scope="rowgroup">
                 <span
                   class="datatable-row-header pointer"
@@ -268,12 +298,15 @@
               class="datatable-row"
               :class="{
                 canceled: asset.canceled,
-                shared: asset.shared
+                shared: asset.shared,
+                'stripe-even': i % 2 === 0,
+                'stripe-odd': i % 2 === 1
               }"
               scope="row"
-              :key="`row${asset.id}`"
+              :ref="el => rowVirtualizer.measureElement(el)"
+              :data-index="flatIndex"
               :title="asset.shared ? $t('library.from_library') : undefined"
-              v-for="(asset, i) in group"
+              v-else
             >
               <th
                 :class="{
@@ -366,6 +399,7 @@
                   :selected="isSelected(i, k, j)"
                   :row-x="getIndex(i, k)"
                   :column-y="j"
+                  :max-assignees="maxAssigneesPerCell"
                   :minimized="hiddenColumns[columnId]"
                   :is-static="true"
                   :is-assignees="displaySettings.showAssignations"
@@ -520,6 +554,7 @@
                   "
                   :row-x="getIndex(i, k)"
                   :column-y="j"
+                  :max-assignees="maxAssigneesPerCell"
                   :minimized="hiddenColumns[columnId]"
                   :is-static="true"
                   :is-assignees="displaySettings.showAssignations"
@@ -541,8 +576,14 @@
 
               <td class="actions" v-else></td>
             </tr>
-          </tbody>
-        </template>
+          </template>
+          <tr class="virtual-spacer-row" v-if="bottomSpacerHeight > 0">
+            <td
+              :colspan="totalColumnsCount"
+              :style="{ height: `${bottomSpacerHeight}px` }"
+            ></td>
+          </tr>
+        </tbody>
       </table>
 
       <div
@@ -580,7 +621,9 @@
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import { computed, ref } from 'vue'
+import { mapGetters, mapActions, useStore } from 'vuex'
 
 import { descriptorMixin } from '@/components/mixins/descriptors'
 import { domMixin } from '@/components/mixins/dom'
@@ -611,6 +654,22 @@ import assetStore from '@/store/modules/assets'
 import assetTypeStore from '@/store/modules/assettypes'
 import episodeStore from '@/store/modules/episodes'
 import taskTypeStore from '@/store/modules/tasktypes'
+
+// PERF-1: row-height estimates per display mode (same technique as
+// EditList.vue). Heights are fixed within a mode — the assignee-avatar
+// stack is capped via maxAssignees below so it can never wrap a row
+// taller; rowVirtualizer.measureElement stays as a safety net for
+// anything still content-driven.
+const ROW_HEIGHT_ESTIMATE = 52
+const ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS = 116
+const ROW_HEIGHT_ESTIMATE_CONTACT_SHEET = 102
+// Asset-type header row: 1.5rem/0.5rem paddings + one line of 1.1em text.
+const TYPE_HEADER_HEIGHT_ESTIMATE = 56
+
+// Cap on assignee avatars per validation cell (rest collapses into "+N"):
+// 3 avatars + status tag fit the 150px cell on one line, keeping row
+// heights constant for the virtualizer whatever the assignation count.
+const MAX_ASSIGNEES_PER_CELL = 3
 
 export default {
   name: 'asset-list',
@@ -677,11 +736,101 @@ export default {
     'create-tasks',
     'delete-clicked',
     'edit-clicked',
+    'keep-task-panel-open',
     'metadata-changed',
     'new-clicked',
     'restore-clicked',
     'scroll'
   ],
+
+  // PERF-1: virtualized rows, ported from the EditList pilot. useVirtualizer
+  // is a composable so it needs a setup() hook even though this component is
+  // otherwise Options API. `body` is returned so it doubles as
+  // `this.$refs.body` for the existing mixin methods (setScrollPosition,
+  // onBodyScroll's scrollHeight check, drag-to-pan) and as the virtualizer's
+  // scroll element.
+  setup(props) {
+    const store = useStore()
+    const body = ref(null)
+
+    // Moved from the Options computed block (setup() cannot read Options
+    // computeds and the virtualizer's item list derives from it): filters
+    // the displayed assets by the display settings.
+    const filteredDisplayedAssets = computed(() => {
+      if (
+        props.displaySettings.showSharedAssets &&
+        props.displaySettings.showLinkedAssets
+      ) {
+        return props.displayedAssets
+      }
+      const episodeId = store.getters.currentEpisode?.id
+
+      return props.displayedAssets.map(typeList =>
+        typeList.filter(asset => {
+          if (!props.displaySettings.showSharedAssets && asset.shared) {
+            return false
+          }
+          if (
+            store.getters.isTVShow &&
+            !props.displaySettings.showLinkedAssets &&
+            !['all', asset.episode_id || 'main'].includes(episodeId)
+          ) {
+            return false
+          }
+          return true
+        })
+      )
+    })
+
+    // The grouped per-asset-type tbodys, linearized into one flat list of
+    // type-header items and asset items (display order preserved) so a
+    // single virtualizer can window over the whole grid. `i` and `k` keep
+    // their historical meaning (index inside the filtered group / group
+    // index), so every getIndex(i, k)-based selection coordinate is
+    // unchanged.
+    const flattenedItems = computed(() => {
+      const items = []
+      filteredDisplayedAssets.value.forEach((group, k) => {
+        if (group[0]) {
+          items.push({
+            isHeader: true,
+            group,
+            k,
+            key: `header-${group[0].asset_type_id}`
+          })
+          group.forEach((asset, i) => {
+            items.push({ isHeader: false, asset, i, k, key: asset.id })
+          })
+        }
+      })
+      return items
+    })
+
+    const rowVirtualizer = useVirtualizer(
+      computed(() => ({
+        count: flattenedItems.value.length,
+        getScrollElement: () => body.value,
+        // bigThumbnails first: combined with contact sheet, the name
+        // column's 100px thumbnail + cell padding is the taller of the two.
+        estimateSize: index => {
+          if (flattenedItems.value[index]?.isHeader) {
+            return TYPE_HEADER_HEIGHT_ESTIMATE
+          }
+          if (props.displaySettings.bigThumbnails) {
+            return ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS
+          }
+          if (props.displaySettings.contactSheetMode) {
+            return ROW_HEIGHT_ESTIMATE_CONTACT_SHEET
+          }
+          return ROW_HEIGHT_ESTIMATE
+        },
+        getItemKey: index => flattenedItems.value[index]?.key ?? index,
+        overscan: 10
+      }))
+    )
+
+    return { body, filteredDisplayedAssets, flattenedItems, rowVirtualizer }
+  },
 
   data() {
     return {
@@ -875,31 +1024,120 @@ export default {
       return this.isTVShow && this.displaySettings.showInfos
     },
 
-    /** Filter the displayed assets by the display settings */
-    filteredDisplayedAssets() {
-      if (
-        this.displaySettings.showSharedAssets &&
-        this.displaySettings.showLinkedAssets
-      ) {
-        return this.displayedAssets
-      }
-      const episodeId = this.currentEpisode?.id
+    // PERF-1: virtualization plumbing (see the EditList pilot). Everything
+    // below reasons in data terms (flattenedItems / getIndex coordinates),
+    // never DOM order, so filtering, sorting and real-time updates keep
+    // working exactly as before virtualization.
+    virtualRows() {
+      return this.rowVirtualizer.getVirtualItems()
+    },
 
-      return this.displayedAssets.map(typeList =>
-        typeList.filter(asset => {
-          if (!this.displaySettings.showSharedAssets && asset.shared) {
-            return false
-          }
-          if (
-            this.isTVShow &&
-            !this.displaySettings.showLinkedAssets &&
-            !['all', asset.episode_id || 'main'].includes(episodeId)
-          ) {
-            return false
-          }
-          return true
+    totalRowsSize() {
+      return this.rowVirtualizer.getTotalSize()
+    },
+
+    topSpacerHeight() {
+      return this.virtualRows.length > 0 ? this.virtualRows[0].start : 0
+    },
+
+    bottomSpacerHeight() {
+      if (this.virtualRows.length === 0) return 0
+      const lastRow = this.virtualRows[this.virtualRows.length - 1]
+      return this.totalRowsSize - lastRow.end
+    },
+
+    // The flattened items tanstack currently renders, `flatIndex` being the
+    // index in flattenedItems (used only for data-index / measurement, not
+    // for selection coordinates, which stay getIndex(i, k)-based).
+    visibleItems() {
+      return this.virtualRows
+        .filter(virtualRow => this.flattenedItems[virtualRow.index])
+        .map(virtualRow => ({
+          ...this.flattenedItems[virtualRow.index],
+          flatIndex: virtualRow.index
+        }))
+    },
+
+    // Maps a row's global selection index back to its asset, in the exact
+    // coordinate system the rendered cells advertise: getIndex(i, k) offsets
+    // come from the unfiltered displayedAssets groups while i indexes the
+    // filtered group, mirroring the template's v-for + :row-x combination.
+    rowIndexToAsset() {
+      const map = new Map()
+      this.filteredDisplayedAssets.forEach((group, k) => {
+        group.forEach((asset, i) => {
+          map.set(this.getIndex(i, k), asset)
         })
-      )
+      })
+      return map
+    },
+
+    // Sticked + non-sticked validation columns in the same order as the x/y
+    // grid coordinates used by isSelected()/onTaskSelected().
+    allDisplayedValidationColumns() {
+      return [
+        ...this.stickedDisplayedValidationColumns,
+        ...this.nonStickedDisplayedValidationColumns
+      ]
+    },
+
+    maxAssigneesPerCell() {
+      return MAX_ASSIGNEES_PER_CELL
+    },
+
+    // Spans the spacer rows across every column currently in the header,
+    // so they don't leave a jagged one-column-wide row in the table.
+    totalColumnsCount() {
+      let count = 1 // asset name column, always present
+      if (this.hasStickyEpisode) count++
+      count += this.stickedVisibleMetadataDescriptors.length
+      if (!this.isLoading) {
+        count += this.stickedDisplayedValidationColumns.length
+        count += this.nonStickedDisplayedValidationColumns.length
+      }
+      if (
+        this.isCurrentUserManager &&
+        this.displaySettings.showInfos &&
+        !this.isAssetsOnly &&
+        this.metadataDisplayHeaders.readyFor
+      ) {
+        count++
+      }
+      if (
+        !this.isCurrentUserClient &&
+        this.displaySettings.showInfos &&
+        this.isAssetDescription
+      ) {
+        count++
+      }
+      if (
+        !this.isCurrentUserClient &&
+        this.displaySettings.showInfos &&
+        this.isAssetTime &&
+        this.metadataDisplayHeaders.timeSpent
+      ) {
+        count++
+      }
+      if (
+        !this.isCurrentUserClient &&
+        this.displaySettings.showInfos &&
+        this.isAssetEstimation &&
+        this.metadataDisplayHeaders.estimation
+      ) {
+        count++
+      }
+      if (
+        this.isAssetResolution &&
+        this.displaySettings.showInfos &&
+        this.metadataDisplayHeaders.resolution
+      ) {
+        count++
+      }
+      if (this.displaySettings.showInfos) {
+        count += this.nonStickedVisibleMetadataDescriptors.length
+      }
+      count++ // actions column, always present
+      return count
     }
   },
 
@@ -950,6 +1188,94 @@ export default {
     isSelected(indexInGroup, groupIndex, columnIndex) {
       const lineIndex = this.getIndex(indexInGroup, groupIndex)
       return this.assetSelectionGrid.has(`${lineIndex}-${columnIndex}`)
+    },
+
+    // PERF-1: overrides entity_list.js's onTaskSelected(), same local
+    // override as EditList (consolidating the two copies back into the
+    // shared mixin is ARCH-4's job). The mixin rebuilds a shift-click range
+    // selection by reading `this.$refs['validation-x-y']` for every cell in
+    // the rectangle, which silently drops cells outside the rendered window
+    // once rows are virtualized. This resolves the same rectangle from
+    // rowIndexToAsset/taskTypeMap/taskMap instead. Selectability mirrors the
+    // template exactly: sticked cells never bind :selectable (always
+    // selectable), non-sticked cells use isSelectable() (workflow + shared
+    // asset checks). Everything outside the double loop is unchanged from
+    // the mixin.
+    onTaskSelected(validationInfo, sticked) {
+      const columnOffset = this.stickedDisplayedValidationColumns.length
+      const selection = []
+      if (!sticked) {
+        validationInfo = { ...validationInfo }
+        validationInfo.y += columnOffset
+      }
+      this.$emit('keep-task-panel-open', true)
+      if (validationInfo.isShiftKey) {
+        if (this.lastSelection) {
+          let startX = this.lastSelection.x
+          let endX = validationInfo.x
+          let startY = this.lastSelection.y
+          if (!sticked) startY += columnOffset
+          let endY = validationInfo.y
+          const grid = this.assetSelectionGrid
+          if (validationInfo.x < this.lastSelection.x) {
+            startX = validationInfo.x
+            endX = this.lastSelection.x
+          }
+          if (validationInfo.y < this.lastSelection.y) {
+            startY = validationInfo.y
+            endY = this.lastSelection.y
+            if (!sticked) endY += columnOffset
+          }
+
+          for (let i = startX; i <= endX; i++) {
+            const asset = this.rowIndexToAsset.get(i)
+            if (asset) {
+              for (let j = startY; j <= endY; j++) {
+                const columnId = this.allDisplayedValidationColumns[j]
+                const isSelectedCell = grid?.has(`${i}-${j}`)
+                const selectable =
+                  j < columnOffset || this.isSelectable(asset, columnId)
+                if (columnId && selectable && !isSelectedCell) {
+                  selection.push({
+                    entity: asset,
+                    column: this.taskTypeMap.get(columnId),
+                    task: this.taskMap.get(asset.validations?.get(columnId)),
+                    x: i,
+                    y: j
+                  })
+                }
+              }
+            }
+          }
+          this.$store.commit('ADD_SELECTED_TASK', validationInfo)
+        }
+      } else if (!validationInfo.isCtrlKey) {
+        this.$store.commit('CLEAR_SELECTED_TASKS')
+      }
+      if (selection.length === 0) {
+        this.$store.commit('ADD_SELECTED_TASK', validationInfo)
+      } else {
+        this.$store.commit('ADD_SELECTED_TASKS', selection)
+      }
+      this.updateTaskInQuery()
+
+      if (!validationInfo.isShiftKey && validationInfo.isUserClick) {
+        const x = validationInfo.x
+        let y = validationInfo.y
+        if (!sticked) y -= columnOffset
+        this.lastSelection = { x, y }
+        // The clicked cell was necessarily visible to be clicked, so it is
+        // always currently rendered: this ref lookup stays safe unchanged.
+        const ref = `validation-${x}-${y}`
+        const validationCell = this.$refs[ref][0]
+        this.$nextTick(() => {
+          this.scrollToValidationCell(validationCell)
+        })
+      }
+
+      this.$nextTick(() => {
+        this.$emit('keep-task-panel-open', false)
+      })
     },
 
     toggleLine(asset, event) {
@@ -1130,6 +1456,38 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+// PERF-1: spacer rows standing in for the off-screen virtualized items
+// above/below the rendered window (see the datatable-body template).
+// Qualified with .datatable-body so it outranks shared.scss's
+// `.data-list .datatable-body td` padding by specificity, not by
+// stylesheet injection order.
+.datatable-body .virtual-spacer-row td {
+  padding: 0;
+  border: none;
+}
+
+// With virtualization the DOM only holds a window of rows, so the global
+// `.multi-section .datatable-row:nth-child(odd/even)` zebra rules
+// (App.vue) re-anchor on whatever row happens to be rendered first and
+// every stripe flips each time the window shifts by one row. Stripe from
+// the group-local data index instead (stripe-even/stripe-odd bound in the
+// row's :class, matching the per-tbody parity the nth-child rules
+// produced). Hover is redeclared after the stripes so it keeps winning.
+tr.datatable-row.stripe-even,
+tr.datatable-row.stripe-even .datatable-row-header {
+  background-color: var(--background);
+}
+
+tr.datatable-row.stripe-odd,
+tr.datatable-row.stripe-odd .datatable-row-header {
+  background-color: var(--background-alt);
+}
+
+tr.datatable-row:hover,
+tr.datatable-row:hover .datatable-row-header {
+  background-color: var(--background-hover);
+}
+
 .dark thead tr a {
   color: $light-grey;
 

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -739,8 +739,8 @@ export default {
     'keep-task-panel-open',
     'metadata-changed',
     'new-clicked',
-    'restore-clicked',
-    'scroll'
+    'restore-clicked'
+    // 'scroll' comes from entityListMixin's emits + onBodyScroll
   ],
 
   // PERF-1: virtualized rows, ported from the EditList pilot. useVirtualizer
@@ -1142,7 +1142,7 @@ export default {
   },
 
   methods: {
-    ...mapActions(['displayMoreAssets', 'editAsset', 'setAssetSelection']),
+    ...mapActions(['editAsset', 'setAssetSelection']),
 
     assetEpisodes(asset, full) {
       if (!this.episodeMap) return ''
@@ -1306,16 +1306,10 @@ export default {
       })
     },
 
-    onBodyScroll(event) {
-      if (!this.$refs.body) return
-      const position = event.target
-      this.$emit('scroll', position.scrollTop)
-      const maxHeight =
-        this.$refs.body.scrollHeight - this.$refs.body.offsetHeight
-      if (maxHeight < position.scrollTop + 100) {
-        this.loadMoreAssets()
-      }
-    },
+    // PERF-1: no local onBodyScroll anymore. The store now displays the
+    // full result at once (rows are virtualized), so the old
+    // scroll-to-bottom -> displayMoreAssets wiring is gone and the mixin's
+    // onBodyScroll (scroll-position emit only) takes over.
 
     onReadyForChanged(asset, taskTypeId) {
       if (this.selectedAssets.has(asset.id)) {
@@ -1327,10 +1321,6 @@ export default {
         const data = { id: asset.id, ready_for: taskTypeId }
         this.$emit('asset-changed', data)
       }
-    },
-
-    loadMoreAssets() {
-      this.displayMoreAssets()
     },
 
     getIndex(i, k) {

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -1572,6 +1572,11 @@ td.ready-for {
 .datatable-wrapper {
   min-height: 200px;
   flex: 1;
+  // Firefox scroll anchoring fights windowed updates: when the top spacer
+  // row resizes it re-anchors the scroll position and produces micro-jumps
+  // (standard TanStack Virtual mitigation). Scoped: only this virtualized
+  // wrapper opts out, other datatables keep the default.
+  overflow-anchor: none;
 }
 
 .datatable-row.shared {

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -1435,6 +1435,10 @@ td.estimation {
   width: 60px;
 }
 
+// Anchored on the th too: with rows virtualized, table auto-layout only
+// sees the rendered window, so a td-only min-width stops binding when no
+// row is rendered; the thead always is.
+th.resolution,
 td.resolution {
   min-width: 110px;
   max-width: 110px;
@@ -1443,6 +1447,10 @@ td.resolution {
 
 th.ready-for,
 td.ready-for {
+  // min-width is the only binding constraint in table auto-layout: with
+  // rows virtualized, widths are computed from the rendered window only
+  // and `width` alone let the column collapse to 81px.
+  min-width: 180px;
   max-width: 180px;
   width: 180px;
   padding: 1px 5px;

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -736,11 +736,10 @@ export default {
     'create-tasks',
     'delete-clicked',
     'edit-clicked',
-    'keep-task-panel-open',
     'metadata-changed',
     'new-clicked',
     'restore-clicked'
-    // 'scroll' comes from entityListMixin's emits + onBodyScroll
+    // 'scroll' and 'keep-task-panel-open' come from entityListMixin
   ],
 
   // PERF-1: virtualized rows, ported from the EditList pilot. useVirtualizer
@@ -1072,15 +1071,6 @@ export default {
       return map
     },
 
-    // Sticked + non-sticked validation columns in the same order as the x/y
-    // grid coordinates used by isSelected()/onTaskSelected().
-    allDisplayedValidationColumns() {
-      return [
-        ...this.stickedDisplayedValidationColumns,
-        ...this.nonStickedDisplayedValidationColumns
-      ]
-    },
-
     maxAssigneesPerCell() {
       return MAX_ASSIGNEES_PER_CELL
     },
@@ -1190,92 +1180,22 @@ export default {
       return this.assetSelectionGrid.has(`${lineIndex}-${columnIndex}`)
     },
 
-    // PERF-1: overrides entity_list.js's onTaskSelected(), same local
-    // override as EditList (consolidating the two copies back into the
-    // shared mixin is ARCH-4's job). The mixin rebuilds a shift-click range
-    // selection by reading `this.$refs['validation-x-y']` for every cell in
-    // the rectangle, which silently drops cells outside the rendered window
-    // once rows are virtualized. This resolves the same rectangle from
-    // rowIndexToAsset/taskTypeMap/taskMap instead. Selectability mirrors the
-    // template exactly: sticked cells never bind :selectable (always
-    // selectable), non-sticked cells use isSelectable() (workflow + shared
-    // asset checks). Everything outside the double loop is unchanged from
-    // the mixin.
-    onTaskSelected(validationInfo, sticked) {
-      const columnOffset = this.stickedDisplayedValidationColumns.length
-      const selection = []
-      if (!sticked) {
-        validationInfo = { ...validationInfo }
-        validationInfo.y += columnOffset
-      }
-      this.$emit('keep-task-panel-open', true)
-      if (validationInfo.isShiftKey) {
-        if (this.lastSelection) {
-          let startX = this.lastSelection.x
-          let endX = validationInfo.x
-          let startY = this.lastSelection.y
-          if (!sticked) startY += columnOffset
-          let endY = validationInfo.y
-          const grid = this.assetSelectionGrid
-          if (validationInfo.x < this.lastSelection.x) {
-            startX = validationInfo.x
-            endX = this.lastSelection.x
-          }
-          if (validationInfo.y < this.lastSelection.y) {
-            startY = validationInfo.y
-            endY = this.lastSelection.y
-            if (!sticked) endY += columnOffset
-          }
+    // Hook for entity_list.js's data-driven shift-rectangle selection:
+    // getIndex(i, k) offsets come from the unfiltered displayedAssets
+    // groups while i indexes the filtered group, mirroring the template's
+    // v-for + :row-x combination (see rowIndexToAsset).
+    entityForRow(lineIndex) {
+      return this.rowIndexToAsset.get(lineIndex)
+    },
 
-          for (let i = startX; i <= endX; i++) {
-            const asset = this.rowIndexToAsset.get(i)
-            if (asset) {
-              for (let j = startY; j <= endY; j++) {
-                const columnId = this.allDisplayedValidationColumns[j]
-                const isSelectedCell = grid?.has(`${i}-${j}`)
-                const selectable =
-                  j < columnOffset || this.isSelectable(asset, columnId)
-                if (columnId && selectable && !isSelectedCell) {
-                  selection.push({
-                    entity: asset,
-                    column: this.taskTypeMap.get(columnId),
-                    task: this.taskMap.get(asset.validations?.get(columnId)),
-                    x: i,
-                    y: j
-                  })
-                }
-              }
-            }
-          }
-          this.$store.commit('ADD_SELECTED_TASK', validationInfo)
-        }
-      } else if (!validationInfo.isCtrlKey) {
-        this.$store.commit('CLEAR_SELECTED_TASKS')
-      }
-      if (selection.length === 0) {
-        this.$store.commit('ADD_SELECTED_TASK', validationInfo)
-      } else {
-        this.$store.commit('ADD_SELECTED_TASKS', selection)
-      }
-      this.updateTaskInQuery()
-
-      if (!validationInfo.isShiftKey && validationInfo.isUserClick) {
-        const x = validationInfo.x
-        let y = validationInfo.y
-        if (!sticked) y -= columnOffset
-        this.lastSelection = { x, y }
-        // The clicked cell was necessarily visible to be clicked, so it is
-        // always currently rendered: this ref lookup stays safe unchanged.
-        const ref = `validation-${x}-${y}`
-        const validationCell = this.$refs[ref][0]
-        this.$nextTick(() => {
-          this.scrollToValidationCell(validationCell)
-        })
-      }
-
-      this.$nextTick(() => {
-        this.$emit('keep-task-panel-open', false)
-      })
+    // Selectability mirrors the template exactly: sticked cells never bind
+    // :selectable (always selectable), non-sticked cells use isSelectable()
+    // (workflow + shared-asset checks).
+    isCellSelectable(asset, columnId, columnIndex) {
+      return (
+        columnIndex < this.stickedDisplayedValidationColumns.length ||
+        this.isSelectable(asset, columnId)
+      )
     },
 
     toggleLine(asset, event) {

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -354,6 +354,7 @@
                       ? `${offsets['validation-' + j]}px`
                       : '0'
                   "
+                  :max-assignees="maxAssigneesPerCell"
                   :minimized="hiddenColumns[columnId]"
                   :row-x="i"
                   :selected="isSelected(i, j)"
@@ -440,6 +441,7 @@
                       edit.validations ? edit.validations.get(columnId) : null
                     )
                   "
+                  :max-assignees="maxAssigneesPerCell"
                   :minimized="hiddenColumns[columnId]"
                   :selected="
                     isSelected(i, j + stickedDisplayedValidationColumns.length)
@@ -560,11 +562,19 @@ import TableInfo from '@/components/widgets/TableInfo.vue'
 import ValidationCell from '@/components/cells/ValidationCell.vue'
 import ValidationHeader from '@/components/cells/ValidationHeader.vue'
 
-// PERF-1 pilot: rough row-height estimates used before a row is measured;
-// actual heights are then tracked precisely via rowVirtualizer.measureElement
-// (rows aren't fixed-height: big thumbnails and wrapped descriptions vary it).
+// PERF-1 pilot: row-height estimates per display mode. Heights are meant to
+// be fixed within a mode (the assignee-avatar stack is capped via
+// maxAssignees below so it can never wrap the row taller);
+// rowVirtualizer.measureElement stays in place as a safety net for anything
+// still content-driven.
 const ROW_HEIGHT_ESTIMATE = 52
 const ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS = 116
+const ROW_HEIGHT_ESTIMATE_CONTACT_SHEET = 102
+
+// Cap on assignee avatars per validation cell (rest collapses into "+N"):
+// 3 avatars + status tag fit the 150px cell on one line, keeping row
+// heights constant for the virtualizer whatever the assignation count.
+const MAX_ASSIGNEES_PER_CELL = 3
 
 export default {
   name: 'edit-list',
@@ -627,10 +637,17 @@ export default {
       computed(() => ({
         count: props.displayedEdits.length,
         getScrollElement: () => body.value,
-        estimateSize: () =>
-          props.displaySettings.bigThumbnails
-            ? ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS
-            : ROW_HEIGHT_ESTIMATE,
+        // bigThumbnails first: when combined with contact sheet, the name
+        // column's 100px thumbnail + cell padding is the taller of the two.
+        estimateSize: () => {
+          if (props.displaySettings.bigThumbnails) {
+            return ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS
+          }
+          if (props.displaySettings.contactSheetMode) {
+            return ROW_HEIGHT_ESTIMATE_CONTACT_SHEET
+          }
+          return ROW_HEIGHT_ESTIMATE
+        },
         getItemKey: index => props.displayedEdits[index]?.id ?? index,
         overscan: 10
       }))
@@ -781,6 +798,10 @@ export default {
           edit: this.displayedEdits[virtualRow.index],
           i: virtualRow.index
         }))
+    },
+
+    maxAssigneesPerCell() {
+      return MAX_ASSIGNEES_PER_CELL
     },
 
     // Sticked + non-sticked validation columns in the same order as the x/y

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -624,10 +624,9 @@ export default {
     'delete-clicked',
     'edit-clicked',
     'edit-history',
-    'keep-task-panel-open',
     'metadata-changed',
     'restore-clicked'
-    // 'scroll' comes from entityListMixin's emits + onBodyScroll
+    // 'scroll' and 'keep-task-panel-open' come from entityListMixin
   ],
 
   // PERF-1 pilot: useVirtualizer is a composable, so it needs a setup()
@@ -808,15 +807,6 @@ export default {
       return MAX_ASSIGNEES_PER_CELL
     },
 
-    // Sticked + non-sticked validation columns in the same order as the x/y
-    // grid coordinates used by isSelected()/onTaskSelected() below.
-    allDisplayedValidationColumns() {
-      return [
-        ...this.stickedDisplayedValidationColumns,
-        ...this.nonStickedDisplayedValidationColumns
-      ]
-    },
-
     // Spans the spacer rows across every column currently in the header,
     // so they don't leave a jagged one-column-wide row in the table.
     totalColumnsCount() {
@@ -866,94 +856,9 @@ export default {
       return this.editSelectionGrid.has(`${lineIndex}-${columnIndex}`)
     },
 
-    // PERF-1 pilot: overrides entity_list.js's onTaskSelected(). The shared
-    // version rebuilds a shift-click range selection by reading
-    // `this.$refs['validation-i-j']` for every cell in the rectangle, which
-    // only works when every row is in the DOM. With rows virtualized, cells
-    // outside the rendered window have no ref and get silently dropped from
-    // the range. This override resolves the same range from
-    // displayedEdits/taskTypeMap/taskMap instead, so shift-click still
-    // selects the full range regardless of what is currently scrolled into
-    // view. Everything outside the double loop is unchanged from the mixin.
-    onTaskSelected(validationInfo, sticked) {
-      const columnOffset = this.stickedDisplayedValidationColumns.length
-      const selection = []
-      if (!sticked) {
-        validationInfo = { ...validationInfo }
-        validationInfo.y += columnOffset
-      }
-      this.$emit('keep-task-panel-open', true)
-      if (validationInfo.isShiftKey) {
-        if (this.lastSelection) {
-          let startX = this.lastSelection.x
-          let endX = validationInfo.x
-          let startY = this.lastSelection.y
-          if (!sticked) startY += columnOffset
-          let endY = validationInfo.y
-          const grid = this.editSelectionGrid
-          if (validationInfo.x < this.lastSelection.x) {
-            startX = validationInfo.x
-            endX = this.lastSelection.x
-          }
-          if (validationInfo.y < this.lastSelection.y) {
-            startY = validationInfo.y
-            endY = this.lastSelection.y
-            if (!sticked) endY += columnOffset
-          }
-
-          for (let i = startX; i <= endX; i++) {
-            const edit = this.displayedEdits[i]
-            if (edit) {
-              for (let j = startY; j <= endY; j++) {
-                const columnId = this.allDisplayedValidationColumns[j]
-                const isSelectedCell = grid?.has(`${i}-${j}`)
-                // ValidationCell's `selectable` prop defaults to true and is
-                // never bound in this list's template, so every column in
-                // range is selectable here (unlike the generic mixin
-                // version, which supports lists that do restrict it).
-                if (columnId && !isSelectedCell) {
-                  selection.push({
-                    entity: edit,
-                    column: this.taskTypeMap.get(columnId),
-                    task: this.taskMap.get(
-                      edit.validations ? edit.validations.get(columnId) : null
-                    ),
-                    x: i,
-                    y: j
-                  })
-                }
-              }
-            }
-          }
-          this.$store.commit('ADD_SELECTED_TASK', validationInfo)
-        }
-      } else if (!validationInfo.isCtrlKey) {
-        this.$store.commit('CLEAR_SELECTED_TASKS')
-      }
-      if (selection.length === 0) {
-        this.$store.commit('ADD_SELECTED_TASK', validationInfo)
-      } else {
-        this.$store.commit('ADD_SELECTED_TASKS', selection)
-      }
-      this.updateTaskInQuery()
-
-      if (!validationInfo.isShiftKey && validationInfo.isUserClick) {
-        const x = validationInfo.x
-        let y = validationInfo.y
-        if (!sticked) y -= columnOffset
-        this.lastSelection = { x, y }
-        // The clicked cell was necessarily visible to be clicked, so it is
-        // always currently rendered: this ref lookup stays safe unchanged.
-        const ref = `validation-${x}-${y}`
-        const validationCell = this.$refs[ref][0]
-        this.$nextTick(() => {
-          this.scrollToValidationCell(validationCell)
-        })
-      }
-
-      this.$nextTick(() => {
-        this.$emit('keep-task-panel-open', false)
-      })
+    // Hook for entity_list.js's data-driven shift-rectangle selection.
+    entityForRow(lineIndex) {
+      return this.displayedEdits[lineIndex]
     },
 
     toggleLine(edit, event) {

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -207,12 +207,27 @@
         </thead>
         <tbody class="datatable-body">
           <template v-if="!isLoading && isListVisible">
+            <!--
+              PERF-1 pilot: virtualized rows (@tanstack/vue-virtual). Only
+              the rows near the viewport are actually rendered below; these
+              two spacer rows reproduce the true scroll height of the
+              rows above/below them so the scrollbar and column widths
+              behave like a fully-rendered table.
+            -->
+            <tr class="virtual-spacer-row" v-if="topSpacerHeight > 0">
+              <td
+                :colspan="totalColumnsCount"
+                :style="{ height: `${topSpacerHeight}px` }"
+              ></td>
+            </tr>
             <tr
               class="datatable-row"
               scope="row"
               :key="edit.id"
+              :ref="el => rowVirtualizer.measureElement(el)"
+              :data-index="i"
               :class="{ canceled: edit.canceled }"
-              v-for="(edit, i) in displayedEdits"
+              v-for="{ edit, i } in visibleRows"
             >
               <td class="episode" v-if="isTVShow">
                 <div class="flexrow">
@@ -448,6 +463,12 @@
               />
               <td class="actions" v-else></td>
             </tr>
+            <tr class="virtual-spacer-row" v-if="bottomSpacerHeight > 0">
+              <td
+                :colspan="totalColumnsCount"
+                :style="{ height: `${bottomSpacerHeight}px` }"
+              ></td>
+            </tr>
           </template>
         </tbody>
       </table>
@@ -513,6 +534,8 @@
 </template>
 
 <script>
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import { computed, ref } from 'vue'
 import { mapGetters, mapActions } from 'vuex'
 
 import preferences from '@/lib/preferences'
@@ -536,6 +559,12 @@ import TableHeaderMenu from '@/components/widgets/TableHeaderMenu.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
 import ValidationCell from '@/components/cells/ValidationCell.vue'
 import ValidationHeader from '@/components/cells/ValidationHeader.vue'
+
+// PERF-1 pilot: rough row-height estimates used before a row is measured;
+// actual heights are then tracked precisely via rowVirtualizer.measureElement
+// (rows aren't fixed-height: big thumbnails and wrapped descriptions vary it).
+const ROW_HEIGHT_ESTIMATE = 52
+const ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS = 116
 
 export default {
   name: 'edit-list',
@@ -581,10 +610,34 @@ export default {
     'delete-clicked',
     'edit-clicked',
     'edit-history',
+    'keep-task-panel-open',
     'metadata-changed',
     'restore-clicked',
     'scroll'
   ],
+
+  // PERF-1 pilot: useVirtualizer is a composable, so it needs a setup()
+  // hook even though this component is otherwise Options API. `body` is
+  // returned so it doubles as `this.$refs.body` for the existing mixin
+  // methods (setScrollPosition, onBodyScroll's scrollHeight check, ...)
+  // and as the virtualizer's scroll element.
+  setup(props) {
+    const body = ref(null)
+    const rowVirtualizer = useVirtualizer(
+      computed(() => ({
+        count: props.displayedEdits.length,
+        getScrollElement: () => body.value,
+        estimateSize: () =>
+          props.displaySettings.bigThumbnails
+            ? ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS
+            : ROW_HEIGHT_ESTIMATE,
+        getItemKey: index => props.displayedEdits[index]?.id ?? index,
+        overscan: 10
+      }))
+    )
+
+    return { body, rowVirtualizer }
+  },
 
   data() {
     return {
@@ -691,6 +744,93 @@ export default {
 
     localStorageStickKey() {
       return `stick-edits-${this.currentProduction?.id}`
+    },
+
+    // PERF-1 pilot: row virtualization. Only the rows tanstack decides are
+    // near the viewport are ever mounted; everything below reasons in terms
+    // of `displayedEdits` indexes (never DOM order), so filtering/sorting/
+    // real-time updates keep working exactly as before virtualization.
+    virtualRows() {
+      return this.rowVirtualizer.getVirtualItems()
+    },
+
+    totalRowsSize() {
+      return this.rowVirtualizer.getTotalSize()
+    },
+
+    topSpacerHeight() {
+      return this.virtualRows.length > 0 ? this.virtualRows[0].start : 0
+    },
+
+    bottomSpacerHeight() {
+      if (this.virtualRows.length === 0) return 0
+      const lastRow = this.virtualRows[this.virtualRows.length - 1]
+      return this.totalRowsSize - lastRow.end
+    },
+
+    // { edit, i } pairs for the rows tanstack currently renders, `i` being
+    // the row's real index in `displayedEdits` (not its position among the
+    // rendered subset) so every existing i-based computation (isSelected,
+    // z-index, editor/validation refs, ...) stays correct unchanged.
+    visibleRows() {
+      return this.virtualRows
+        .filter(
+          virtualRow => this.displayedEdits[virtualRow.index] !== undefined
+        )
+        .map(virtualRow => ({
+          edit: this.displayedEdits[virtualRow.index],
+          i: virtualRow.index
+        }))
+    },
+
+    // Sticked + non-sticked validation columns in the same order as the x/y
+    // grid coordinates used by isSelected()/onTaskSelected() below.
+    allDisplayedValidationColumns() {
+      return [
+        ...this.stickedDisplayedValidationColumns,
+        ...this.nonStickedDisplayedValidationColumns
+      ]
+    },
+
+    // Spans the spacer rows across every column currently in the header,
+    // so they don't leave a jagged one-column-wide row in the table.
+    totalColumnsCount() {
+      let count = 1 // edit name column, always present
+      if (this.isTVShow) count++
+      if (this.displaySettings.showInfos) {
+        count++ // resolution
+        count += this.stickedVisibleMetadataDescriptors.length
+        count += this.nonStickedVisibleMetadataDescriptors.length
+      }
+      if (!this.isLoading) {
+        count += this.stickedDisplayedValidationColumns.length
+        count += this.nonStickedDisplayedValidationColumns.length
+      }
+      if (
+        !this.isCurrentUserClient &&
+        this.displaySettings.showInfos &&
+        this.isEditDescription
+      ) {
+        count++
+      }
+      if (
+        !this.isCurrentUserClient &&
+        this.displaySettings.showInfos &&
+        this.isEditTime &&
+        this.metadataDisplayHeaders.timeSpent
+      ) {
+        count++
+      }
+      if (
+        !this.isCurrentUserClient &&
+        this.displaySettings.showInfos &&
+        this.isEditEstimation &&
+        this.metadataDisplayHeaders.estimation
+      ) {
+        count++
+      }
+      count++ // actions column, always present
+      return count
     }
   },
 
@@ -699,6 +839,96 @@ export default {
 
     isSelected(lineIndex, columnIndex) {
       return this.editSelectionGrid.has(`${lineIndex}-${columnIndex}`)
+    },
+
+    // PERF-1 pilot: overrides entity_list.js's onTaskSelected(). The shared
+    // version rebuilds a shift-click range selection by reading
+    // `this.$refs['validation-i-j']` for every cell in the rectangle, which
+    // only works when every row is in the DOM. With rows virtualized, cells
+    // outside the rendered window have no ref and get silently dropped from
+    // the range. This override resolves the same range from
+    // displayedEdits/taskTypeMap/taskMap instead, so shift-click still
+    // selects the full range regardless of what is currently scrolled into
+    // view. Everything outside the double loop is unchanged from the mixin.
+    onTaskSelected(validationInfo, sticked) {
+      const columnOffset = this.stickedDisplayedValidationColumns.length
+      const selection = []
+      if (!sticked) {
+        validationInfo = { ...validationInfo }
+        validationInfo.y += columnOffset
+      }
+      this.$emit('keep-task-panel-open', true)
+      if (validationInfo.isShiftKey) {
+        if (this.lastSelection) {
+          let startX = this.lastSelection.x
+          let endX = validationInfo.x
+          let startY = this.lastSelection.y
+          if (!sticked) startY += columnOffset
+          let endY = validationInfo.y
+          const grid = this.editSelectionGrid
+          if (validationInfo.x < this.lastSelection.x) {
+            startX = validationInfo.x
+            endX = this.lastSelection.x
+          }
+          if (validationInfo.y < this.lastSelection.y) {
+            startY = validationInfo.y
+            endY = this.lastSelection.y
+            if (!sticked) endY += columnOffset
+          }
+
+          for (let i = startX; i <= endX; i++) {
+            const edit = this.displayedEdits[i]
+            if (edit) {
+              for (let j = startY; j <= endY; j++) {
+                const columnId = this.allDisplayedValidationColumns[j]
+                const isSelectedCell = grid?.has(`${i}-${j}`)
+                // ValidationCell's `selectable` prop defaults to true and is
+                // never bound in this list's template, so every column in
+                // range is selectable here (unlike the generic mixin
+                // version, which supports lists that do restrict it).
+                if (columnId && !isSelectedCell) {
+                  selection.push({
+                    entity: edit,
+                    column: this.taskTypeMap.get(columnId),
+                    task: this.taskMap.get(
+                      edit.validations ? edit.validations.get(columnId) : null
+                    ),
+                    x: i,
+                    y: j
+                  })
+                }
+              }
+            }
+          }
+          this.$store.commit('ADD_SELECTED_TASK', validationInfo)
+        }
+      } else if (!validationInfo.isCtrlKey) {
+        this.$store.commit('CLEAR_SELECTED_TASKS')
+      }
+      if (selection.length === 0) {
+        this.$store.commit('ADD_SELECTED_TASK', validationInfo)
+      } else {
+        this.$store.commit('ADD_SELECTED_TASKS', selection)
+      }
+      this.updateTaskInQuery()
+
+      if (!validationInfo.isShiftKey && validationInfo.isUserClick) {
+        const x = validationInfo.x
+        let y = validationInfo.y
+        if (!sticked) y -= columnOffset
+        this.lastSelection = { x, y }
+        // The clicked cell was necessarily visible to be clicked, so it is
+        // always currently rendered: this ref lookup stays safe unchanged.
+        const ref = `validation-${x}-${y}`
+        const validationCell = this.$refs[ref][0]
+        this.$nextTick(() => {
+          this.scrollToValidationCell(validationCell)
+        })
+      }
+
+      this.$nextTick(() => {
+        this.$emit('keep-task-panel-open', false)
+      })
     },
 
     toggleLine(edit, event) {
@@ -853,6 +1083,13 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+// PERF-1 pilot: spacer rows standing in for the off-screen virtualized
+// rows above/below the rendered window (see the datatable-body template).
+.virtual-spacer-row td {
+  padding: 0;
+  border: none;
+}
+
 .project {
   min-width: 60px;
   width: 60px;

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -626,8 +626,8 @@ export default {
     'edit-history',
     'keep-task-panel-open',
     'metadata-changed',
-    'restore-clicked',
-    'scroll'
+    'restore-clicked'
+    // 'scroll' comes from entityListMixin's emits + onBodyScroll
   ],
 
   // PERF-1 pilot: useVirtualizer is a composable, so it needs a setup()
@@ -860,7 +860,7 @@ export default {
   },
 
   methods: {
-    ...mapActions(['displayMoreEdits', 'setEditSelection']),
+    ...mapActions(['setEditSelection']),
 
     isSelected(lineIndex, columnIndex) {
       return this.editSelectionGrid.has(`${lineIndex}-${columnIndex}`)
@@ -984,20 +984,10 @@ export default {
       })
     },
 
-    onBodyScroll(event) {
-      if (!this.$refs.body) return
-      const position = event.target
-      this.$emit('scroll', position.scrollTop)
-      const maxHeight =
-        this.$refs.body.scrollHeight - this.$refs.body.offsetHeight
-      if (maxHeight < position.scrollTop + 100) {
-        this.loadMoreEdits()
-      }
-    },
-
-    loadMoreEdits() {
-      this.displayMoreEdits()
-    },
+    // PERF-1: no local onBodyScroll anymore. The store now displays the
+    // full result at once (rows are virtualized), so the old
+    // scroll-to-bottom -> displayMoreEdits wiring is gone and the mixin's
+    // onBodyScroll (scroll-position emit only) takes over.
 
     editPath(editId) {
       return this.getPath('edit', editId)

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -226,7 +226,11 @@
               :key="edit.id"
               :ref="el => rowVirtualizer.measureElement(el)"
               :data-index="i"
-              :class="{ canceled: edit.canceled }"
+              :class="{
+                canceled: edit.canceled,
+                'stripe-even': i % 2 === 0,
+                'stripe-odd': i % 2 === 1
+              }"
               v-for="{ edit, i } in visibleRows"
             >
               <td class="episode" v-if="isTVShow">
@@ -1106,9 +1110,33 @@ export default {
 <style lang="scss" scoped>
 // PERF-1 pilot: spacer rows standing in for the off-screen virtualized
 // rows above/below the rendered window (see the datatable-body template).
-.virtual-spacer-row td {
+// Qualified with .datatable-body so it outranks shared.scss's
+// `.data-list .datatable-body td` padding by specificity, not by
+// stylesheet injection order.
+.datatable-body .virtual-spacer-row td {
   padding: 0;
   border: none;
+}
+
+// With virtualization the DOM only holds a window of rows, so the global
+// `.datatable-row:nth-child(even)` zebra rules (App.vue) re-anchor on
+// whatever row happens to be rendered first and every stripe flips each
+// time the window shifts by one row. Stripe from the data index instead
+// (stripe-even/stripe-odd bound in the row's :class). Hover is redeclared
+// after the stripes so it keeps winning over them.
+tr.datatable-row.stripe-even,
+tr.datatable-row.stripe-even .datatable-row-header {
+  background-color: var(--background);
+}
+
+tr.datatable-row.stripe-odd,
+tr.datatable-row.stripe-odd .datatable-row-header {
+  background-color: var(--background-alt);
+}
+
+tr.datatable-row:hover,
+tr.datatable-row:hover .datatable-row-header {
+  background-color: var(--background-hover);
 }
 
 .project {

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -1098,6 +1098,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+// Firefox scroll anchoring fights windowed updates: when the top spacer
+// row resizes it re-anchors the scroll position and produces micro-jumps
+// (standard TanStack Virtual mitigation). Scoped: only this virtualized
+// wrapper opts out, other datatables keep the default.
+.datatable-wrapper {
+  overflow-anchor: none;
+}
+
 // PERF-1 pilot: spacer rows standing in for the off-screen virtualized
 // rows above/below the rendered window (see the datatable-body template).
 // Qualified with .datatable-body so it outranks shared.scss's

--- a/src/components/lists/EpisodeList.vue
+++ b/src/components/lists/EpisodeList.vue
@@ -716,6 +716,11 @@ export default {
       return this.episodeSelectionGrid.has(`${lineIndex}-${columnIndex}`)
     },
 
+    // Hook for entity_list.js's data-driven shift-rectangle selection.
+    entityForRow(lineIndex) {
+      return this.displayedEpisodes[lineIndex]
+    },
+
     episodePath(episodeId) {
       return this.getPath('episode', episodeId)
     },

--- a/src/components/lists/EpisodeList.vue
+++ b/src/components/lists/EpisodeList.vue
@@ -224,12 +224,29 @@
         </thead>
         <tbody class="datatable-body">
           <template v-if="!isLoading && isListVisible">
+            <!--
+              PERF-1: virtualized rows (@tanstack/vue-virtual). Only the rows
+              near the viewport render below, between two spacer rows sized
+              to the off-screen rows' total height.
+            -->
+            <tr class="virtual-spacer-row" v-if="topSpacerHeight > 0">
+              <td
+                :colspan="totalColumnsCount"
+                :style="{ height: `${topSpacerHeight}px` }"
+              ></td>
+            </tr>
             <tr
               class="datatable-row"
               scope="row"
               :key="episode.id"
-              :class="{ canceled: episode.canceled }"
-              v-for="(episode, i) in displayedEpisodes"
+              :ref="el => rowVirtualizer.measureElement(el)"
+              :data-index="i"
+              :class="{
+                canceled: episode.canceled,
+                'stripe-even': i % 2 === 0,
+                'stripe-odd': i % 2 === 1
+              }"
+              v-for="{ episode, i } in visibleRows"
             >
               <th
                 :class="{
@@ -307,6 +324,7 @@
                       ? `${offsets['validation-' + j]}px`
                       : '0'
                   "
+                  :max-assignees="maxAssigneesPerCell"
                   :minimized="hiddenColumns[columnId]"
                   :row-x="i"
                   :selected="isSelected(i, j)"
@@ -459,6 +477,7 @@
                         : null
                     )
                   "
+                  :max-assignees="maxAssigneesPerCell"
                   :minimized="hiddenColumns[columnId]"
                   :selected="
                     isSelected(i, j + stickedDisplayedValidationColumns.length)
@@ -478,6 +497,12 @@
                 v-if="isCurrentUserManager"
               />
               <td class="actions" v-else></td>
+            </tr>
+            <tr class="virtual-spacer-row" v-if="bottomSpacerHeight > 0">
+              <td
+                :colspan="totalColumnsCount"
+                :style="{ height: `${bottomSpacerHeight}px` }"
+              ></td>
             </tr>
           </template>
         </tbody>
@@ -532,6 +557,8 @@
 </template>
 
 <script>
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import { computed, ref } from 'vue'
 import { mapGetters, mapActions } from 'vuex'
 
 import { descriptorMixin } from '@/components/mixins/descriptors'
@@ -552,6 +579,16 @@ import TableHeaderMenu from '@/components/widgets/TableHeaderMenu.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
 import ValidationCell from '@/components/cells/ValidationCell.vue'
 import ValidationHeader from '@/components/cells/ValidationHeader.vue'
+
+// PERF-1: row-height estimates per display mode (same technique as the
+// other virtualized entity grids); measureElement corrects the rest.
+const ROW_HEIGHT_ESTIMATE = 52
+const ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS = 116
+const ROW_HEIGHT_ESTIMATE_CONTACT_SHEET = 102
+
+// Cap on assignee avatars per validation cell (rest collapses into "+N"),
+// keeping row heights constant whatever the assignation count.
+const MAX_ASSIGNEES_PER_CELL = 3
 
 export default {
   name: 'episode-list',
@@ -602,6 +639,33 @@ export default {
     'field-changed',
     'metadata-changed'
   ],
+
+  // PERF-1: virtualized rows, same recipe as the other entity grids. The
+  // list is flat (no group headers), so the virtualizer windows directly
+  // over displayedEpisodes. `body` doubles as `this.$refs.body` for the
+  // mixin methods and as the virtualizer's scroll element.
+  setup(props) {
+    const body = ref(null)
+    const rowVirtualizer = useVirtualizer(
+      computed(() => ({
+        count: props.displayedEpisodes.length,
+        getScrollElement: () => body.value,
+        estimateSize: () => {
+          if (props.displaySettings.bigThumbnails) {
+            return ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS
+          }
+          if (props.displaySettings.contactSheetMode) {
+            return ROW_HEIGHT_ESTIMATE_CONTACT_SHEET
+          }
+          return ROW_HEIGHT_ESTIMATE
+        },
+        getItemKey: index => props.displayedEpisodes[index]?.id ?? index,
+        overscan: 10
+      }))
+    )
+
+    return { body, rowVirtualizer }
+  },
 
   data() {
     return {
@@ -706,6 +770,85 @@ export default {
 
     localStorageStickKey() {
       return `stick-episodes-${this.currentProduction?.id}`
+    },
+
+    // PERF-1: virtualization plumbing (see the EditList pilot).
+    virtualRows() {
+      return this.rowVirtualizer.getVirtualItems()
+    },
+
+    totalRowsSize() {
+      return this.rowVirtualizer.getTotalSize()
+    },
+
+    topSpacerHeight() {
+      return this.virtualRows.length > 0 ? this.virtualRows[0].start : 0
+    },
+
+    bottomSpacerHeight() {
+      if (this.virtualRows.length === 0) return 0
+      const lastRow = this.virtualRows[this.virtualRows.length - 1]
+      return this.totalRowsSize - lastRow.end
+    },
+
+    // { episode, i } pairs for the rows tanstack currently renders, `i`
+    // being the row's real index in displayedEpisodes so every i-based
+    // computation (isSelected, refs, z-index) stays correct unchanged.
+    visibleRows() {
+      return this.virtualRows
+        .filter(
+          virtualRow => this.displayedEpisodes[virtualRow.index] !== undefined
+        )
+        .map(virtualRow => ({
+          episode: this.displayedEpisodes[virtualRow.index],
+          i: virtualRow.index
+        }))
+    },
+
+    maxAssigneesPerCell() {
+      return MAX_ASSIGNEES_PER_CELL
+    },
+
+    // Spans the spacer rows across every column currently in the header,
+    // so they don't leave a jagged one-column-wide row in the table.
+    totalColumnsCount() {
+      const showInfos = this.displaySettings.showInfos
+      let count = 1 // episode name column, always present
+      if (showInfos) {
+        count += this.stickedVisibleMetadataDescriptors.length
+        count += this.nonStickedVisibleMetadataDescriptors.length
+      }
+      if (!this.isLoading) {
+        count += this.stickedDisplayedValidationColumns.length
+        count += this.nonStickedDisplayedValidationColumns.length
+      }
+      if (!this.isCurrentUserClient && showInfos && this.isEpisodeDescription) {
+        count++
+      }
+      if (
+        !this.isCurrentUserClient &&
+        showInfos &&
+        this.isEpisodeTime &&
+        this.metadataDisplayHeaders.timeSpent
+      ) {
+        count++
+      }
+      if (
+        !this.isCurrentUserClient &&
+        showInfos &&
+        this.isEpisodeEstimation &&
+        this.metadataDisplayHeaders.estimation
+      ) {
+        count++
+      }
+      if (showInfos && this.metadataDisplayHeaders.status) {
+        count++
+      }
+      if (!this.isCurrentUserClient && showInfos && this.isEpisodeResolution) {
+        count++
+      }
+      count++ // actions column, always present
+      return count
     }
   },
 
@@ -768,6 +911,44 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+// Firefox scroll anchoring fights windowed updates: when the top spacer
+// row resizes it re-anchors the scroll position and produces micro-jumps
+// (standard TanStack Virtual mitigation). Scoped: only this virtualized
+// wrapper opts out, other datatables keep the default.
+.datatable-wrapper {
+  overflow-anchor: none;
+}
+
+// PERF-1: spacer rows standing in for the off-screen virtualized rows
+// above/below the rendered window. Qualified with .datatable-body so it
+// outranks shared.scss's `.data-list .datatable-body td` padding by
+// specificity, not by stylesheet injection order.
+.datatable-body .virtual-spacer-row td {
+  padding: 0;
+  border: none;
+}
+
+// With virtualization the DOM only holds a window of rows, so the global
+// `.datatable-row:nth-child(even)` zebra rules (App.vue) re-anchor on
+// whatever row happens to be rendered first and every stripe flips each
+// time the window shifts by one row. Stripe from the data index instead
+// (stripe-even/stripe-odd bound in the row's :class). Hover is redeclared
+// after the stripes so it keeps winning over them.
+tr.datatable-row.stripe-even,
+tr.datatable-row.stripe-even .datatable-row-header {
+  background-color: var(--background);
+}
+
+tr.datatable-row.stripe-odd,
+tr.datatable-row.stripe-odd .datatable-row-header {
+  background-color: var(--background-alt);
+}
+
+tr.datatable-row:hover,
+tr.datatable-row:hover .datatable-row-header {
+  background-color: var(--background-hover);
+}
+
 .dark {
   th .input-editor,
   td .select select,

--- a/src/components/lists/SequenceList.vue
+++ b/src/components/lists/SequenceList.vue
@@ -676,6 +676,11 @@ export default {
       return this.sequenceSelectionGrid.has(`${lineIndex}-${columnIndex}`)
     },
 
+    // Hook for entity_list.js's data-driven shift-rectangle selection.
+    entityForRow(lineIndex) {
+      return this.displayedSequences[lineIndex]
+    },
+
     sequencePath(sequenceId) {
       return this.getPath('sequence', sequenceId)
     },

--- a/src/components/lists/SequenceList.vue
+++ b/src/components/lists/SequenceList.vue
@@ -969,6 +969,10 @@ thead .name.sequence-name {
   width: 70px;
 }
 
+// Anchored on the th too: with rows virtualized, table auto-layout only
+// sees the rendered window, so a td-only min-width stops binding when no
+// row is rendered; the thead always is.
+th.resolution,
 td.resolution {
   min-width: 110px;
   max-width: 110px;

--- a/src/components/lists/SequenceList.vue
+++ b/src/components/lists/SequenceList.vue
@@ -211,12 +211,29 @@
           @touchstart="startBrowsing"
         >
           <template v-if="!isLoading && isListVisible">
+            <!--
+              PERF-1: virtualized rows (@tanstack/vue-virtual). Only the rows
+              near the viewport render below, between two spacer rows sized
+              to the off-screen rows' total height.
+            -->
+            <tr class="virtual-spacer-row" v-if="topSpacerHeight > 0">
+              <td
+                :colspan="totalColumnsCount"
+                :style="{ height: `${topSpacerHeight}px` }"
+              ></td>
+            </tr>
             <tr
               class="datatable-row"
               scope="row"
               :key="sequence.id"
-              :class="{ canceled: sequence.canceled }"
-              v-for="(sequence, i) in displayedSequences"
+              :ref="el => rowVirtualizer.measureElement(el)"
+              :data-index="i"
+              :class="{
+                canceled: sequence.canceled,
+                'stripe-even': i % 2 === 0,
+                'stripe-odd': i % 2 === 1
+              }"
+              v-for="{ sequence, i } in visibleRows"
             >
               <th
                 :class="{
@@ -294,6 +311,7 @@
                       ? `${offsets['validation-' + j]}px`
                       : '0'
                   "
+                  :max-assignees="maxAssigneesPerCell"
                   :minimized="hiddenColumns[columnId]"
                   :row-x="i"
                   :selected="isSelected(i, j)"
@@ -424,6 +442,7 @@
                         : null
                     )
                   "
+                  :max-assignees="maxAssigneesPerCell"
                   :minimized="hiddenColumns[columnId]"
                   :selected="
                     isSelected(i, j + stickedDisplayedValidationColumns.length)
@@ -443,6 +462,12 @@
                 v-if="isCurrentUserManager"
               />
               <td class="actions" v-else></td>
+            </tr>
+            <tr class="virtual-spacer-row" v-if="bottomSpacerHeight > 0">
+              <td
+                :colspan="totalColumnsCount"
+                :style="{ height: `${bottomSpacerHeight}px` }"
+              ></td>
             </tr>
           </template>
         </tbody>
@@ -499,6 +524,8 @@
 </template>
 
 <script>
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import { computed, ref } from 'vue'
 import { mapGetters, mapActions } from 'vuex'
 
 import { getEntityPath } from '@/lib/path'
@@ -520,6 +547,16 @@ import TableHeaderMenu from '@/components/widgets/TableHeaderMenu.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
 import ValidationCell from '@/components/cells/ValidationCell.vue'
 import ValidationHeader from '@/components/cells/ValidationHeader.vue'
+
+// PERF-1: row-height estimates per display mode (same technique as the
+// other virtualized entity grids); measureElement corrects the rest.
+const ROW_HEIGHT_ESTIMATE = 52
+const ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS = 116
+const ROW_HEIGHT_ESTIMATE_CONTACT_SHEET = 102
+
+// Cap on assignee avatars per validation cell (rest collapses into "+N"),
+// keeping row heights constant whatever the assignation count.
+const MAX_ASSIGNEES_PER_CELL = 3
 
 export default {
   name: 'sequence-list',
@@ -560,6 +597,33 @@ export default {
   },
 
   emits: ['create-tasks', 'delete-clicked', 'edit-clicked', 'metadata-changed'],
+
+  // PERF-1: virtualized rows, same recipe as the other entity grids. The
+  // list is flat (no group headers), so the virtualizer windows directly
+  // over displayedSequences. `body` doubles as `this.$refs.body` for the
+  // mixin methods and as the virtualizer's scroll element.
+  setup(props) {
+    const body = ref(null)
+    const rowVirtualizer = useVirtualizer(
+      computed(() => ({
+        count: props.displayedSequences.length,
+        getScrollElement: () => body.value,
+        estimateSize: () => {
+          if (props.displaySettings.bigThumbnails) {
+            return ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS
+          }
+          if (props.displaySettings.contactSheetMode) {
+            return ROW_HEIGHT_ESTIMATE_CONTACT_SHEET
+          }
+          return ROW_HEIGHT_ESTIMATE
+        },
+        getItemKey: index => props.displayedSequences[index]?.id ?? index,
+        overscan: 10
+      }))
+    )
+
+    return { body, rowVirtualizer }
+  },
 
   data() {
     return {
@@ -666,6 +730,86 @@ export default {
 
     localStorageStickKey() {
       return `stick-sequences-${this.currentProduction?.id}`
+    },
+
+    // PERF-1: virtualization plumbing (see the EditList pilot).
+    virtualRows() {
+      return this.rowVirtualizer.getVirtualItems()
+    },
+
+    totalRowsSize() {
+      return this.rowVirtualizer.getTotalSize()
+    },
+
+    topSpacerHeight() {
+      return this.virtualRows.length > 0 ? this.virtualRows[0].start : 0
+    },
+
+    bottomSpacerHeight() {
+      if (this.virtualRows.length === 0) return 0
+      const lastRow = this.virtualRows[this.virtualRows.length - 1]
+      return this.totalRowsSize - lastRow.end
+    },
+
+    // { sequence, i } pairs for the rows tanstack currently renders, `i`
+    // being the row's real index in displayedSequences so every i-based
+    // computation (isSelected, refs, z-index) stays correct unchanged.
+    visibleRows() {
+      return this.virtualRows
+        .filter(
+          virtualRow => this.displayedSequences[virtualRow.index] !== undefined
+        )
+        .map(virtualRow => ({
+          sequence: this.displayedSequences[virtualRow.index],
+          i: virtualRow.index
+        }))
+    },
+
+    maxAssigneesPerCell() {
+      return MAX_ASSIGNEES_PER_CELL
+    },
+
+    // Spans the spacer rows across every column currently in the header,
+    // so they don't leave a jagged one-column-wide row in the table.
+    totalColumnsCount() {
+      const showInfos = this.displaySettings.showInfos
+      let count = 1 // sequence name column, always present
+      if (showInfos) {
+        count += this.stickedVisibleMetadataDescriptors.length
+        count += this.nonStickedVisibleMetadataDescriptors.length
+      }
+      count += this.stickedDisplayedValidationColumns.length
+      if (!this.isLoading) {
+        count += this.nonStickedDisplayedValidationColumns.length
+      }
+      if (
+        !this.isCurrentUserClient &&
+        showInfos &&
+        this.isSequenceDescription
+      ) {
+        count++
+      }
+      if (this.isSequenceResolution && showInfos) {
+        count++
+      }
+      if (
+        !this.isCurrentUserClient &&
+        showInfos &&
+        this.isSequenceTime &&
+        this.metadataDisplayHeaders.timeSpent
+      ) {
+        count++
+      }
+      if (
+        !this.isCurrentUserClient &&
+        showInfos &&
+        this.isSequenceEstimation &&
+        this.metadataDisplayHeaders.estimation
+      ) {
+        count++
+      }
+      count++ // actions column, always present
+      return count
     }
   },
 
@@ -734,6 +878,41 @@ export default {
 
 .datatable-wrapper {
   min-height: 40px;
+  // Firefox scroll anchoring fights windowed updates: when the top spacer
+  // row resizes it re-anchors the scroll position and produces micro-jumps
+  // (standard TanStack Virtual mitigation). Scoped: only this virtualized
+  // wrapper opts out, other datatables keep the default.
+  overflow-anchor: none;
+}
+
+// PERF-1: spacer rows standing in for the off-screen virtualized rows
+// above/below the rendered window. Qualified with .datatable-body so it
+// outranks shared.scss's `.data-list .datatable-body td` padding by
+// specificity, not by stylesheet injection order.
+.datatable-body .virtual-spacer-row td {
+  padding: 0;
+  border: none;
+}
+
+// With virtualization the DOM only holds a window of rows, so the global
+// `.datatable-row:nth-child(even)` zebra rules (App.vue) re-anchor on
+// whatever row happens to be rendered first and every stripe flips each
+// time the window shifts by one row. Stripe from the data index instead
+// (stripe-even/stripe-odd bound in the row's :class). Hover is redeclared
+// after the stripes so it keeps winning over them.
+tr.datatable-row.stripe-even,
+tr.datatable-row.stripe-even .datatable-row-header {
+  background-color: var(--background);
+}
+
+tr.datatable-row.stripe-odd,
+tr.datatable-row.stripe-odd .datatable-row-header {
+  background-color: var(--background-alt);
+}
+
+tr.datatable-row:hover,
+tr.datatable-row:hover .datatable-row-header {
+  background-color: var(--background-hover);
 }
 
 .actions {

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -281,15 +281,45 @@
           </tr>
         </thead>
 
-        <template v-if="!isLoading && isListVisible">
-          <tbody
-            class="datatable-body"
-            :key="getGroupKey(group, k, 'sequence_id')"
-            @mousedown="startBrowsing"
-            @touchstart="startBrowsing"
-            v-for="(group, k) in displayedShots"
+        <!--
+          PERF-1: virtualized rows (@tanstack/vue-virtual), same recipe as
+          EditList/AssetList. The per-sequence tbodys are linearized into
+          one flat list mixing sequence-header items and shot items
+          (flattenedItems, built in setup); only the items near the
+          viewport render below, between two spacer rows sized to the
+          off-screen items' total height. Sequence-header rows keep the
+          exact markup/classes they had when each group owned its tbody.
+        -->
+        <tbody
+          class="datatable-body"
+          @mousedown="startBrowsing"
+          @touchstart="startBrowsing"
+          v-if="!isLoading && isListVisible"
+        >
+          <tr class="virtual-spacer-row" v-if="topSpacerHeight > 0">
+            <td
+              :colspan="totalColumnsCount"
+              :style="{ height: `${topSpacerHeight}px` }"
+            ></td>
+          </tr>
+          <template
+            :key="key"
+            v-for="{
+              isHeader,
+              group,
+              shot,
+              i,
+              k,
+              flatIndex,
+              key
+            } in visibleItems"
           >
-            <tr class="datatable-type-header">
+            <tr
+              class="datatable-type-header"
+              :ref="el => rowVirtualizer.measureElement(el)"
+              :data-index="flatIndex"
+              v-if="isHeader"
+            >
               <th scope="rowgroup">
                 <div
                   class="datatable-row-header pointer"
@@ -306,9 +336,14 @@
             </tr>
             <tr
               class="datatable-row"
-              :key="shot.id"
-              :class="{ canceled: shot.canceled }"
-              v-for="(shot, i) in group"
+              :class="{
+                canceled: shot.canceled,
+                'stripe-even': i % 2 === 0,
+                'stripe-odd': i % 2 === 1
+              }"
+              :ref="el => rowVirtualizer.measureElement(el)"
+              :data-index="flatIndex"
+              v-else
             >
               <th
                 scope="row"
@@ -396,6 +431,7 @@
                       ? `${offsets['validation-' + j]}px`
                       : '0'
                   "
+                  :max-assignees="maxAssigneesPerCell"
                   :minimized="hiddenColumns[columnId]"
                   :row-x="getIndex(i, k)"
                   :selected="isSelected(i, k, j)"
@@ -724,6 +760,7 @@
                       shot.validations ? shot.validations.get(columnId) : null
                     )
                   "
+                  :max-assignees="maxAssigneesPerCell"
                   :minimized="hiddenColumns[columnId]"
                   :selected="
                     isSelected(
@@ -753,8 +790,14 @@
               />
               <td class="actions" v-else></td>
             </tr>
-          </tbody>
-        </template>
+          </template>
+          <tr class="virtual-spacer-row" v-if="bottomSpacerHeight > 0">
+            <td
+              :colspan="totalColumnsCount"
+              :style="{ height: `${bottomSpacerHeight}px` }"
+            ></td>
+          </tr>
+        </tbody>
       </table>
     </div>
     <table-info :is-loading="isLoading" :is-error="isError" big-cells />
@@ -826,6 +869,8 @@
 </template>
 
 <script>
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import { computed, ref } from 'vue'
 import { mapGetters, mapActions } from 'vuex'
 
 import preferences from '@/lib/preferences'
@@ -850,6 +895,22 @@ import TableHeaderMenu from '@/components/widgets/TableHeaderMenu.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
 import ValidationCell from '@/components/cells/ValidationCell.vue'
 import ValidationHeader from '@/components/cells/ValidationHeader.vue'
+
+// PERF-1: row-height estimates per display mode (same technique as
+// EditList/AssetList). Heights are fixed within a mode — the
+// assignee-avatar stack is capped via maxAssignees below so it can never
+// wrap a row taller; rowVirtualizer.measureElement stays as a safety net
+// for anything still content-driven.
+const ROW_HEIGHT_ESTIMATE = 52
+const ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS = 116
+const ROW_HEIGHT_ESTIMATE_CONTACT_SHEET = 102
+// Sequence header row: 1.5rem/0.5rem paddings + one line of 1.1em text.
+const TYPE_HEADER_HEIGHT_ESTIMATE = 56
+
+// Cap on assignee avatars per validation cell (rest collapses into "+N"):
+// 3 avatars + status tag fit the 150px cell on one line, keeping row
+// heights constant for the virtualizer whatever the assignation count.
+const MAX_ASSIGNEES_PER_CELL = 3
 
 export default {
   name: 'shot-list',
@@ -910,12 +971,72 @@ export default {
     'delete-clicked',
     'edit-clicked',
     'field-changed',
+    'keep-task-panel-open',
     'metadata-changed',
     'restore-clicked',
     'scroll',
     'sequence-clicked',
     'shot-history'
   ],
+
+  // PERF-1: virtualized rows, same recipe as EditList/AssetList.
+  // useVirtualizer is a composable so it needs a setup() hook even though
+  // this component is otherwise Options API. `body` doubles as
+  // `this.$refs.body` for the existing mixin methods and as the
+  // virtualizer's scroll element. The flattening derives from the
+  // displayedShots prop, so episode scoping (handled upstream in the shots
+  // store for TV shows) is transparent here.
+  setup(props) {
+    const body = ref(null)
+
+    // The per-sequence tbodys, linearized into one flat list of
+    // sequence-header items and shot items (display order preserved) so a
+    // single virtualizer can window over the whole grid. `i` and `k` keep
+    // their historical meaning (index inside the group / group index), so
+    // every getIndex(i, k)-based selection coordinate is unchanged.
+    const flattenedItems = computed(() => {
+      const items = []
+      props.displayedShots.forEach((group, k) => {
+        if (group[0]) {
+          items.push({
+            isHeader: true,
+            group,
+            k,
+            key: `header-${group[0].sequence_id}`
+          })
+          group.forEach((shot, i) => {
+            items.push({ isHeader: false, shot, i, k, key: shot.id })
+          })
+        }
+      })
+      return items
+    })
+
+    const rowVirtualizer = useVirtualizer(
+      computed(() => ({
+        count: flattenedItems.value.length,
+        getScrollElement: () => body.value,
+        // bigThumbnails first: combined with contact sheet, the name
+        // column's 100px thumbnail + cell padding is the taller of the two.
+        estimateSize: index => {
+          if (flattenedItems.value[index]?.isHeader) {
+            return TYPE_HEADER_HEIGHT_ESTIMATE
+          }
+          if (props.displaySettings.bigThumbnails) {
+            return ROW_HEIGHT_ESTIMATE_BIG_THUMBNAILS
+          }
+          if (props.displaySettings.contactSheetMode) {
+            return ROW_HEIGHT_ESTIMATE_CONTACT_SHEET
+          }
+          return ROW_HEIGHT_ESTIMATE
+        },
+        getItemKey: index => flattenedItems.value[index]?.key ?? index,
+        overscan: 10
+      }))
+    )
+
+    return { body, flattenedItems, rowVirtualizer }
+  },
 
   data() {
     return {
@@ -1037,6 +1158,143 @@ export default {
 
     localStorageStickKey() {
       return `stick-shots-${this.currentProduction?.id}`
+    },
+
+    // PERF-1: virtualization plumbing (see the EditList pilot). Everything
+    // below reasons in data terms (flattenedItems / getIndex coordinates),
+    // never DOM order, so filtering, sorting and real-time updates keep
+    // working exactly as before virtualization.
+    virtualRows() {
+      return this.rowVirtualizer.getVirtualItems()
+    },
+
+    totalRowsSize() {
+      return this.rowVirtualizer.getTotalSize()
+    },
+
+    topSpacerHeight() {
+      return this.virtualRows.length > 0 ? this.virtualRows[0].start : 0
+    },
+
+    bottomSpacerHeight() {
+      if (this.virtualRows.length === 0) return 0
+      const lastRow = this.virtualRows[this.virtualRows.length - 1]
+      return this.totalRowsSize - lastRow.end
+    },
+
+    // The flattened items tanstack currently renders, `flatIndex` being the
+    // index in flattenedItems (used only for data-index / measurement, not
+    // for selection coordinates, which stay getIndex(i, k)-based).
+    visibleItems() {
+      return this.virtualRows
+        .filter(virtualRow => this.flattenedItems[virtualRow.index])
+        .map(virtualRow => ({
+          ...this.flattenedItems[virtualRow.index],
+          flatIndex: virtualRow.index
+        }))
+    },
+
+    // Maps a row's global selection index (getIndex coordinates) back to
+    // its shot, for the data-driven shift selection below.
+    rowIndexToShot() {
+      const map = new Map()
+      this.displayedShots.forEach((group, k) => {
+        group.forEach((shot, i) => {
+          map.set(this.getIndex(i, k), shot)
+        })
+      })
+      return map
+    },
+
+    // Sticked + non-sticked validation columns in the same order as the x/y
+    // grid coordinates used by isSelected()/onTaskSelected().
+    allDisplayedValidationColumns() {
+      return [
+        ...this.stickedDisplayedValidationColumns,
+        ...this.nonStickedDisplayedValidationColumns
+      ]
+    },
+
+    maxAssigneesPerCell() {
+      return MAX_ASSIGNEES_PER_CELL
+    },
+
+    // Spans the spacer rows across every column currently in the header,
+    // so they don't leave a jagged one-column-wide row in the table.
+    totalColumnsCount() {
+      const showInfos = this.displaySettings.showInfos
+      let count = 1 // shot name column, always present
+      count += this.stickedVisibleMetadataDescriptors.length
+      if (!this.isLoading) {
+        count += this.stickedDisplayedValidationColumns.length
+        count += this.nonStickedDisplayedValidationColumns.length
+      }
+      if (!this.isCurrentUserClient && showInfos && this.isShotDescription) {
+        count++
+      }
+      if (
+        !this.isCurrentUserClient &&
+        showInfos &&
+        this.isShotTime &&
+        this.metadataDisplayHeaders.timeSpent
+      ) {
+        count++
+      }
+      if (
+        !this.isCurrentUserClient &&
+        showInfos &&
+        this.isShotEstimation &&
+        this.metadataDisplayHeaders.estimation
+      ) {
+        count++
+      }
+      if (
+        showInfos &&
+        this.isPaperProduction &&
+        this.metadataDisplayHeaders.drawings
+      ) {
+        count++
+      }
+      if (
+        this.isFrames &&
+        showInfos &&
+        !this.isPaperProduction &&
+        this.metadataDisplayHeaders.frames
+      ) {
+        count++
+      }
+      if (this.isFrameIn && showInfos && this.metadataDisplayHeaders.frameIn) {
+        count++
+      }
+      if (
+        this.isFrameOut &&
+        showInfos &&
+        this.metadataDisplayHeaders.frameOut
+      ) {
+        count++
+      }
+      if (this.isFps && showInfos && this.metadataDisplayHeaders.fps) {
+        count++
+      }
+      if (
+        this.isMaxRetakes &&
+        showInfos &&
+        this.metadataDisplayHeaders.maxRetakes
+      ) {
+        count++
+      }
+      if (
+        this.isResolution &&
+        showInfos &&
+        this.metadataDisplayHeaders.resolution
+      ) {
+        count++
+      }
+      if (showInfos) {
+        count += this.nonStickedVisibleMetadataDescriptors.length
+      }
+      count++ // actions column, always present
+      return count
     }
   },
 
@@ -1048,6 +1306,91 @@ export default {
     isSelected(indexInGroup, groupIndex, columnIndex) {
       const lineIndex = this.getIndex(indexInGroup, groupIndex)
       return this.shotSelectionGrid.has(`${lineIndex}-${columnIndex}`)
+    },
+
+    // PERF-1: overrides entity_list.js's onTaskSelected(), same local
+    // override as EditList/AssetList (consolidating the copies back into
+    // the shared mixin is ARCH-4's job). The mixin rebuilds a shift-click
+    // range selection by reading `this.$refs['validation-x-y']` for every
+    // cell in the rectangle, which silently drops cells outside the
+    // rendered window once rows are virtualized. This resolves the same
+    // rectangle from rowIndexToShot/taskTypeMap/taskMap instead. ShotList
+    // never binds :selectable on its cells, so every column in range is
+    // selectable (matching the rendered cells' default). Everything outside
+    // the double loop is unchanged from the mixin.
+    onTaskSelected(validationInfo, sticked) {
+      const columnOffset = this.stickedDisplayedValidationColumns.length
+      const selection = []
+      if (!sticked) {
+        validationInfo = { ...validationInfo }
+        validationInfo.y += columnOffset
+      }
+      this.$emit('keep-task-panel-open', true)
+      if (validationInfo.isShiftKey) {
+        if (this.lastSelection) {
+          let startX = this.lastSelection.x
+          let endX = validationInfo.x
+          let startY = this.lastSelection.y
+          if (!sticked) startY += columnOffset
+          let endY = validationInfo.y
+          const grid = this.shotSelectionGrid
+          if (validationInfo.x < this.lastSelection.x) {
+            startX = validationInfo.x
+            endX = this.lastSelection.x
+          }
+          if (validationInfo.y < this.lastSelection.y) {
+            startY = validationInfo.y
+            endY = this.lastSelection.y
+            if (!sticked) endY += columnOffset
+          }
+
+          for (let i = startX; i <= endX; i++) {
+            const shot = this.rowIndexToShot.get(i)
+            if (shot) {
+              for (let j = startY; j <= endY; j++) {
+                const columnId = this.allDisplayedValidationColumns[j]
+                const isSelectedCell = grid?.has(`${i}-${j}`)
+                if (columnId && !isSelectedCell) {
+                  selection.push({
+                    entity: shot,
+                    column: this.taskTypeMap.get(columnId),
+                    task: this.taskMap.get(shot.validations?.get(columnId)),
+                    x: i,
+                    y: j
+                  })
+                }
+              }
+            }
+          }
+          this.$store.commit('ADD_SELECTED_TASK', validationInfo)
+        }
+      } else if (!validationInfo.isCtrlKey) {
+        this.$store.commit('CLEAR_SELECTED_TASKS')
+      }
+      if (selection.length === 0) {
+        this.$store.commit('ADD_SELECTED_TASK', validationInfo)
+      } else {
+        this.$store.commit('ADD_SELECTED_TASKS', selection)
+      }
+      this.updateTaskInQuery()
+
+      if (!validationInfo.isShiftKey && validationInfo.isUserClick) {
+        const x = validationInfo.x
+        let y = validationInfo.y
+        if (!sticked) y -= columnOffset
+        this.lastSelection = { x, y }
+        // The clicked cell was necessarily visible to be clicked, so it is
+        // always currently rendered: this ref lookup stays safe unchanged.
+        const ref = `validation-${x}-${y}`
+        const validationCell = this.$refs[ref][0]
+        this.$nextTick(() => {
+          this.scrollToValidationCell(validationCell)
+        })
+      }
+
+      this.$nextTick(() => {
+        this.$emit('keep-task-panel-open', false)
+      })
     },
 
     isCastingReady(shot, columnId) {
@@ -1245,6 +1588,43 @@ export default {
 <style lang="scss" scoped>
 .datatable-wrapper {
   min-height: 40px;
+  // Firefox scroll anchoring fights windowed updates: when the top spacer
+  // row resizes it re-anchors the scroll position and produces micro-jumps
+  // (standard TanStack Virtual mitigation). Scoped: only this virtualized
+  // wrapper opts out, other datatables keep the default.
+  overflow-anchor: none;
+}
+
+// PERF-1: spacer rows standing in for the off-screen virtualized items
+// above/below the rendered window (see the datatable-body template).
+// Qualified with .datatable-body so it outranks shared.scss's
+// `.data-list .datatable-body td` padding by specificity, not by
+// stylesheet injection order.
+.datatable-body .virtual-spacer-row td {
+  padding: 0;
+  border: none;
+}
+
+// With virtualization the DOM only holds a window of rows, so the global
+// `.multi-section .datatable-row:nth-child(odd/even)` zebra rules
+// (App.vue) re-anchor on whatever row happens to be rendered first and
+// every stripe flips each time the window shifts by one row. Stripe from
+// the group-local data index instead (stripe-even/stripe-odd bound in the
+// row's :class, matching the per-tbody parity the nth-child rules
+// produced). Hover is redeclared after the stripes so it keeps winning.
+tr.datatable-row.stripe-even,
+tr.datatable-row.stripe-even .datatable-row-header {
+  background-color: var(--background);
+}
+
+tr.datatable-row.stripe-odd,
+tr.datatable-row.stripe-odd .datatable-row-header {
+  background-color: var(--background-alt);
+}
+
+tr.datatable-row:hover,
+tr.datatable-row:hover .datatable-row-header {
+  background-color: var(--background-hover);
 }
 
 .actions {

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -971,12 +971,11 @@ export default {
     'delete-clicked',
     'edit-clicked',
     'field-changed',
-    'keep-task-panel-open',
     'metadata-changed',
     'restore-clicked',
     'sequence-clicked',
     'shot-history'
-    // 'scroll' comes from entityListMixin's emits + onBodyScroll
+    // 'scroll' and 'keep-task-panel-open' come from entityListMixin
   ],
 
   // PERF-1: virtualized rows, same recipe as EditList/AssetList.
@@ -1206,15 +1205,6 @@ export default {
       return map
     },
 
-    // Sticked + non-sticked validation columns in the same order as the x/y
-    // grid coordinates used by isSelected()/onTaskSelected().
-    allDisplayedValidationColumns() {
-      return [
-        ...this.stickedDisplayedValidationColumns,
-        ...this.nonStickedDisplayedValidationColumns
-      ]
-    },
-
     maxAssigneesPerCell() {
       return MAX_ASSIGNEES_PER_CELL
     },
@@ -1308,89 +1298,9 @@ export default {
       return this.shotSelectionGrid.has(`${lineIndex}-${columnIndex}`)
     },
 
-    // PERF-1: overrides entity_list.js's onTaskSelected(), same local
-    // override as EditList/AssetList (consolidating the copies back into
-    // the shared mixin is ARCH-4's job). The mixin rebuilds a shift-click
-    // range selection by reading `this.$refs['validation-x-y']` for every
-    // cell in the rectangle, which silently drops cells outside the
-    // rendered window once rows are virtualized. This resolves the same
-    // rectangle from rowIndexToShot/taskTypeMap/taskMap instead. ShotList
-    // never binds :selectable on its cells, so every column in range is
-    // selectable (matching the rendered cells' default). Everything outside
-    // the double loop is unchanged from the mixin.
-    onTaskSelected(validationInfo, sticked) {
-      const columnOffset = this.stickedDisplayedValidationColumns.length
-      const selection = []
-      if (!sticked) {
-        validationInfo = { ...validationInfo }
-        validationInfo.y += columnOffset
-      }
-      this.$emit('keep-task-panel-open', true)
-      if (validationInfo.isShiftKey) {
-        if (this.lastSelection) {
-          let startX = this.lastSelection.x
-          let endX = validationInfo.x
-          let startY = this.lastSelection.y
-          if (!sticked) startY += columnOffset
-          let endY = validationInfo.y
-          const grid = this.shotSelectionGrid
-          if (validationInfo.x < this.lastSelection.x) {
-            startX = validationInfo.x
-            endX = this.lastSelection.x
-          }
-          if (validationInfo.y < this.lastSelection.y) {
-            startY = validationInfo.y
-            endY = this.lastSelection.y
-            if (!sticked) endY += columnOffset
-          }
-
-          for (let i = startX; i <= endX; i++) {
-            const shot = this.rowIndexToShot.get(i)
-            if (shot) {
-              for (let j = startY; j <= endY; j++) {
-                const columnId = this.allDisplayedValidationColumns[j]
-                const isSelectedCell = grid?.has(`${i}-${j}`)
-                if (columnId && !isSelectedCell) {
-                  selection.push({
-                    entity: shot,
-                    column: this.taskTypeMap.get(columnId),
-                    task: this.taskMap.get(shot.validations?.get(columnId)),
-                    x: i,
-                    y: j
-                  })
-                }
-              }
-            }
-          }
-          this.$store.commit('ADD_SELECTED_TASK', validationInfo)
-        }
-      } else if (!validationInfo.isCtrlKey) {
-        this.$store.commit('CLEAR_SELECTED_TASKS')
-      }
-      if (selection.length === 0) {
-        this.$store.commit('ADD_SELECTED_TASK', validationInfo)
-      } else {
-        this.$store.commit('ADD_SELECTED_TASKS', selection)
-      }
-      this.updateTaskInQuery()
-
-      if (!validationInfo.isShiftKey && validationInfo.isUserClick) {
-        const x = validationInfo.x
-        let y = validationInfo.y
-        if (!sticked) y -= columnOffset
-        this.lastSelection = { x, y }
-        // The clicked cell was necessarily visible to be clicked, so it is
-        // always currently rendered: this ref lookup stays safe unchanged.
-        const ref = `validation-${x}-${y}`
-        const validationCell = this.$refs[ref][0]
-        this.$nextTick(() => {
-          this.scrollToValidationCell(validationCell)
-        })
-      }
-
-      this.$nextTick(() => {
-        this.$emit('keep-task-panel-open', false)
-      })
+    // Hook for entity_list.js's data-driven shift-rectangle selection.
+    entityForRow(lineIndex) {
+      return this.rowIndexToShot.get(lineIndex)
     },
 
     isCastingReady(shot, columnId) {

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -974,9 +974,9 @@ export default {
     'keep-task-panel-open',
     'metadata-changed',
     'restore-clicked',
-    'scroll',
     'sequence-clicked',
     'shot-history'
+    // 'scroll' comes from entityListMixin's emits + onBodyScroll
   ],
 
   // PERF-1: virtualized rows, same recipe as EditList/AssetList.
@@ -1299,7 +1299,7 @@ export default {
   },
 
   methods: {
-    ...mapActions(['displayMoreShots', 'setShotSelection']),
+    ...mapActions(['setShotSelection']),
 
     formatToTimecode,
 
@@ -1443,20 +1443,10 @@ export default {
       })
     },
 
-    onBodyScroll(event) {
-      if (!this.$refs.body) return
-      const position = event.target
-      this.$emit('scroll', position.scrollTop)
-      const maxHeight =
-        this.$refs.body.scrollHeight - this.$refs.body.offsetHeight
-      if (maxHeight < position.scrollTop + 100) {
-        this.loadMoreShots()
-      }
-    },
-
-    loadMoreShots() {
-      this.displayMoreShots()
-    },
+    // PERF-1: no local onBodyScroll anymore. The store now displays the
+    // full result at once (rows are virtualized), so the old
+    // scroll-to-bottom -> displayMoreShots wiring is gone and the mixin's
+    // onBodyScroll (scroll-position emit only) takes over.
 
     shotPath(shotId) {
       return this.getPath('shot', shotId)

--- a/src/components/mixins/entity_list.js
+++ b/src/components/mixins/entity_list.js
@@ -85,6 +85,15 @@ export const entityListMixin = {
       )
     },
 
+    // Sticked + non-sticked validation columns in the same order as the x/y
+    // grid coordinates used by the selection grids and onTaskSelected().
+    allDisplayedValidationColumns() {
+      return [
+        ...this.stickedDisplayedValidationColumns,
+        ...this.nonStickedDisplayedValidationColumns
+      ]
+    },
+
     isEmptyTask() {
       return (
         !this.isEmptyList &&
@@ -188,6 +197,13 @@ export const entityListMixin = {
       }
     },
 
+    // PERF-1: with rows virtualized, cells outside the rendered window have
+    // no $refs entry, so the historical "read every validation-x-y ref in
+    // the rectangle" strategy silently dropped off-screen cells from a
+    // shift-click range. The rectangle is now resolved from data instead:
+    // each grid provides entityForRow() (global row index -> entity, in the
+    // exact coordinates its cells advertise as row-x) and may override
+    // isCellSelectable() when its template restricts cell selectability.
     onTaskSelected(validationInfo, sticked) {
       const columnOffset = this.stickedDisplayedValidationColumns.length
       const selection = []
@@ -215,20 +231,24 @@ export const entityListMixin = {
           }
 
           for (let i = startX; i <= endX; i++) {
-            for (let j = startY; j <= endY; j++) {
-              const validationCell = this.$refs[`validation-${i}-${j}`]?.[0]
-              const isSelectedCell = grid?.has(`${i}-${j}`)
-              if (validationCell?.selectable && !isSelectedCell) {
-                let y = validationCell.columnY
-                if (!sticked) y += columnOffset
-
-                selection.push({
-                  entity: validationCell.entity,
-                  column: validationCell.column,
-                  task: validationCell.task,
-                  x: validationCell.rowX,
-                  y
-                })
+            const entity = this.entityForRow(i)
+            if (entity) {
+              for (let j = startY; j <= endY; j++) {
+                const columnId = this.allDisplayedValidationColumns[j]
+                const isSelectedCell = grid?.has(`${i}-${j}`)
+                if (
+                  columnId &&
+                  this.isCellSelectable(entity, columnId, j) &&
+                  !isSelectedCell
+                ) {
+                  selection.push({
+                    entity,
+                    column: this.taskTypeMap.get(columnId),
+                    task: this.taskMap.get(entity.validations?.get(columnId)),
+                    x: i,
+                    y: j
+                  })
+                }
               }
             }
           }
@@ -259,6 +279,21 @@ export const entityListMixin = {
       this.$nextTick(() => {
         this.$emit('keep-task-panel-open', false)
       })
+    },
+
+    // Hook for onTaskSelected(): maps a global row index (the coordinate
+    // system the list's cells advertise as row-x) to its entity. Every
+    // entity grid provides its own; the default keeps shift-ranges empty
+    // for entityListMixin consumers that never wire cell selection.
+    entityForRow() {
+      return undefined
+    },
+
+    // Hook for onTaskSelected(): whether the (entity, column) cell may be
+    // range-selected. Default matches ValidationCell's `selectable` default;
+    // grids that bind :selectable in their template override this.
+    isCellSelectable() {
+      return true
     },
 
     onTaskUnselected(validationInfo, sticked) {

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -250,13 +250,14 @@ const helpers = {
     result = sortAssetResult(result, sorting, taskTypeMap, taskMap)
     cache.result = result
 
-    const limit =
-      state.displayedAssets.length > PAGE_SIZE
-        ? state.displayedAssets.length
-        : PAGE_SIZE
-    const displayedAssets = result.slice(0, limit)
-    state.displayedAssets = displayedAssets
-    state.assetFilledColumns = getFilledColumns(displayedAssets)
+    // PERF-1: the whole filtered result is displayed at once. AssetList
+    // virtualizes its rows, so the old PAGE_SIZE slice (which existed to
+    // keep the rendered DOM small) only capped the scrollbar and forced
+    // display-more hitches every page. Still a copy: mutations like
+    // NEW_ASSET_END push into both cache.result and displayedAssets and
+    // rely on them being distinct arrays.
+    state.displayedAssets = result.slice()
+    state.assetFilledColumns = getFilledColumns(result)
     helpers.setListStats(state, result)
     state.assetSearchText = query
     state.assetSelectionGrid = buildSelectionGrid()
@@ -977,7 +978,9 @@ const mutations = {
 
     const assetTypes = Array.from(assetTypeMap.values())
     cache.assetTypeIndex = buildNameIndex(assetTypes)
-    const displayedAssets = cache.assets.slice(0, PAGE_SIZE)
+    // PERF-1: full list displayed at once (as a copy, the cache arrays are
+    // mutated in place elsewhere), AssetList virtualizes its rows.
+    const displayedAssets = cache.assets.slice()
     const filledColumns = getFilledColumns(displayedAssets)
 
     state.assetValidationColumns = helpers.sortValidationColumns(
@@ -1283,6 +1286,9 @@ const mutations = {
     }
   },
 
+  // PERF-1: no-op since displayedAssets always holds the full result now;
+  // kept because Breakdown and Playlist still dispatch it from their own
+  // scroll wiring (the guard below makes those calls harmless).
   [DISPLAY_MORE_ASSETS](state) {
     const assets = cache.result
     const newLength = state.displayedAssets.length + PAGE_SIZE

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -216,14 +216,13 @@ const helpers = {
     result = sortEditResult(result, sorting, taskTypeMap, taskMap)
     cache.result = result
 
-    const limit =
-      state.displayedEdits.length > PAGE_SIZE
-        ? state.displayedEdits.length
-        : PAGE_SIZE
-    const displayedEdits = result.slice(0, limit)
-
-    state.displayedEdits = displayedEdits
-    state.editFilledColumns = getFilledColumns(displayedEdits)
+    // PERF-1: the whole filtered result is displayed at once. EditList
+    // virtualizes its rows, so the old PAGE_SIZE slice (which existed to
+    // keep the rendered DOM small) only capped the scrollbar and forced
+    // display-more hitches every page. Still a copy: the cache arrays are
+    // mutated in place elsewhere and rely on displayedEdits being distinct.
+    state.displayedEdits = result.slice()
+    state.editFilledColumns = getFilledColumns(result)
     helpers.setListStats(state, result)
     state.editSearchText = editSearch
     state.editSelectionGrid = buildSelectionGrid()
@@ -748,7 +747,9 @@ const mutations = {
     cache.result = edits
     cache.editIndex = buildEditIndex(edits)
 
-    const displayedEdits = edits.slice(0, PAGE_SIZE)
+    // PERF-1: full list displayed at once (as a copy, the cache arrays are
+    // mutated in place elsewhere), EditList virtualizes its rows.
+    const displayedEdits = edits.slice()
     const filledColumns = getFilledColumns(displayedEdits)
 
     state.editValidationColumns = helpers.sortValidationColumns(
@@ -878,7 +879,7 @@ const mutations = {
 
     cache.edits.push(edit)
     cache.edits = sortEdits(cache.edits)
-    state.displayedEdits = cache.edits.slice(0, PAGE_SIZE)
+    state.displayedEdits = cache.edits.slice()
     helpers.setListStats(state, cache.edits)
     state.editFilledColumns = getFilledColumns(state.displayedEdits)
     cache.editMap.set(edit.id, edit)
@@ -906,6 +907,9 @@ const mutations = {
     })
   },
 
+  // PERF-1: no-op since displayedEdits always holds the full result now
+  // (the guard below never passes); kept for symmetry with the other
+  // entity modules until the progressive-display machinery is removed.
   [DISPLAY_MORE_EDITS](
     state,
     { taskTypeMap, taskStatusMap, taskMap, production }

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -245,11 +245,12 @@ const helpers = {
     result = sortShotResult(result, sorting, taskTypeMap, taskMap)
     cache.result = result
 
-    const limit =
-      state.displayedShots.length > PAGE_SIZE
-        ? state.displayedShots.length
-        : PAGE_SIZE
-    const displayedShots = result.slice(0, limit)
+    // PERF-1: the whole filtered result is displayed at once. ShotList
+    // virtualizes its rows, so the old PAGE_SIZE slice (which existed to
+    // keep the rendered DOM small) only capped the scrollbar and forced
+    // display-more hitches every page. Still a copy: the cache arrays are
+    // mutated in place elsewhere and rely on displayedShots being distinct.
+    const displayedShots = result.slice()
 
     helpers.setListStats(state, result)
     Object.assign(state, {
@@ -930,7 +931,9 @@ const mutations = {
     cache.result = shots
     cache.shotIndex = buildShotIndex(shots)
 
-    const displayedShots = shots.slice(0, PAGE_SIZE)
+    // PERF-1: full list displayed at once (as a copy, the cache arrays are
+    // mutated in place elsewhere), ShotList virtualizes its rows.
+    const displayedShots = shots.slice()
     const filledColumns = getFilledColumns(displayedShots)
 
     state.shotValidationColumns = helpers.sortValidationColumns(
@@ -1098,7 +1101,7 @@ const mutations = {
     shot.data = {}
 
     insertSortedShot(cache.shots, shot)
-    state.displayedShots = cache.shots.slice(0, PAGE_SIZE)
+    state.displayedShots = cache.shots.slice()
     helpers.setListStats(state, cache.shots)
     state.shotFilledColumns = getFilledColumns(state.displayedShots)
     cache.shotMap.set(shot.id, shot)
@@ -1133,6 +1136,9 @@ const mutations = {
     })
   },
 
+  // PERF-1: no-op since displayedShots always holds the full result now;
+  // kept because Playlist still dispatches it from its own scroll wiring
+  // (the guard below makes those calls harmless).
   [DISPLAY_MORE_SHOTS](
     state,
     { taskTypeMap, taskStatusMap, taskMap, production }


### PR DESCRIPTION
## Problems

- Entity grids rendered every row: large productions froze the page, and the 200-row progressive display added a growing scrollbar and load-more hitches.
- Full-DOM side effects surfaced under windowing: nth-child stripes flickered, content-stretched columns (ready for) collapsed, Firefox scroll anchoring fought the spacers, and the shift-rectangle selection lived in five near-copies reading `$refs`.

## Solutions

- `@tanstack/vue-virtual` windows the rows of ShotList/AssetList/EditList/SequenceList/EpisodeList: spacer rows (preserves table auto-layout + sticky headers), fixed per-display-mode height estimates with measured fallback, stable keys, `overscan: 10`.
- The virtualizer gets the full filtered lists: progressive display caps removed for assets/edits/shots (`DISPLAY_MORE_*` kept as no-ops for external callers).
- ValidationCell gains an opt-in `maxAssignees` cap (+N badge) so rows keep fixed heights; stripes computed from data order; `min-width` bound on collapse-prone columns; `overflow-anchor: none` scoped to the virtualized wrappers.
- Shift-rectangle selection consolidated into `entity_list.js` as one data-driven implementation (−220 duplicated lines).