### PR TITLE
[a11y] Empty redundant alts and fix the search field focus indicator

### DIFF
--- a/src/components/cells/ProductionNameCell.vue
+++ b/src/components/cells/ProductionNameCell.vue
@@ -13,7 +13,7 @@
         <template v-if="!entry.has_avatar">
           {{ generatedAvatar }}
         </template>
-        <img :src="thumbnailPath" :alt="entry.name" v-else />
+        <img :src="thumbnailPath" :alt="onlyAvatar ? entry.name : ''" v-else />
       </div>
       <span class="flexrow-item" v-if="!onlyAvatar">
         {{ entry.name }}
@@ -28,7 +28,7 @@
         <template v-if="!entry.has_avatar">
           {{ generatedAvatar }}
         </template>
-        <img :src="thumbnailPath" :alt="entry.name" v-else />
+        <img :src="thumbnailPath" :alt="onlyAvatar ? entry.name : ''" v-else />
       </div>
       <span class="flexrow-item" v-if="!onlyAvatar">
         {{ entry.name }}

--- a/src/components/modals/AddThumbnailsModal.vue
+++ b/src/components/modals/AddThumbnailsModal.vue
@@ -63,7 +63,7 @@
         :src="thumbnailInfo.src"
         width="150"
         height="100"
-        :alt="thumbnailInfo.name"
+        alt=""
         v-if="thumbnailInfo.src"
       />
       <span class="flexrow-item">

--- a/src/components/pages/OpenProductions.vue
+++ b/src/components/pages/OpenProductions.vue
@@ -68,7 +68,7 @@
       class="flexrow open-productions-header"
       v-if="!isOpenProductionsLoading && openProductions.length > 0"
     >
-      <img class="logo" src="../../assets/kitsu.png" width="23" alt="Kitsu" />
+      <img class="logo" src="../../assets/kitsu.png" width="23" alt="" />
       <h1 class="title filler">
         {{ $t('productions.home.title') }}
       </h1>
@@ -120,11 +120,7 @@
               <template v-if="!production.has_avatar">
                 {{ generateAvatar(production) }}
               </template>
-              <img
-                :src="getThumbnailPath(production)"
-                :alt="production.name"
-                v-else
-              />
+              <img :src="getThumbnailPath(production)" alt="" v-else />
             </div>
             <div class="production-name">
               {{ production.name }}

--- a/src/components/pages/breakdown/AssetBlock.vue
+++ b/src/components/pages/breakdown/AssetBlock.vue
@@ -251,6 +251,7 @@ export default {
   text-align: center;
   justify-content: center;
   align-items: center;
+  overflow: hidden;
   z-index: 1;
   width: 100%;
   height: 100%;

--- a/src/components/pages/breakdown/AvailableAssetBlock.vue
+++ b/src/components/pages/breakdown/AvailableAssetBlock.vue
@@ -203,6 +203,7 @@ export default {
   text-align: center;
   justify-content: center;
   align-items: center;
+  overflow: hidden;
   z-index: 2;
   width: 60px;
   height: 60px;

--- a/src/components/pages/entities/EntityChatDays.vue
+++ b/src/components/pages/entities/EntityChatDays.vue
@@ -319,6 +319,7 @@ export default {
       height: 100px;
       margin-right: 5px;
       margin-top: 10px;
+      overflow: hidden;
       width: 100px;
     }
 

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -1258,6 +1258,7 @@ export default {
 .studio-logo-wrapper {
   margin: 8px 8px;
   margin-right: 1em;
+  overflow: hidden;
   padding: 0;
 
   .studio-logo {

--- a/src/components/widgets/EntityPreview.vue
+++ b/src/components/widgets/EntityPreview.vue
@@ -47,7 +47,7 @@
           'max-height': `${emptyHeight}px`
         }"
         :width="width || ''"
-        :alt="entity?.name"
+        alt=""
       />
       <a
         class="view-icon"

--- a/src/components/widgets/EntityThumbnail.vue
+++ b/src/components/widgets/EntityThumbnail.vue
@@ -22,7 +22,7 @@
       :src="thumbnailPath"
       :style="imgStyle"
       :width="width || ''"
-      :alt="entity?.name"
+      alt=""
     />
   </a>
 
@@ -33,7 +33,7 @@
     :key="thumbnailKey"
     :src="thumbnailPath"
     :style="imgStyle"
-    :alt="entity?.name"
+    alt=""
   />
 
   <span

--- a/src/components/widgets/PeopleAvatar.vue
+++ b/src/components/widgets/PeopleAvatar.vue
@@ -14,7 +14,7 @@
   >
     <img
       :loading="isLazy ? 'lazy' : undefined"
-      :alt="person.full_name"
+      alt=""
       :src="person.avatarPath"
       v-if="person.has_avatar"
     />
@@ -30,7 +30,7 @@
   >
     <img
       :loading="isLazy ? 'lazy' : undefined"
-      :alt="person.full_name"
+      alt=""
       :src="person.avatarPath"
       v-if="person.has_avatar"
     />

--- a/src/components/widgets/ProductionName.vue
+++ b/src/components/widgets/ProductionName.vue
@@ -15,7 +15,7 @@
       <template v-if="!production.has_avatar">{{ avatar }}</template>
       <img
         :src="thumbnailPath"
-        :alt="production.name"
+        :alt="onlyAvatar ? production.name : ''"
         :style="{
           width: `${size}px`,
           height: `${size}px`

--- a/src/components/widgets/SearchField.vue
+++ b/src/components/widgets/SearchField.vue
@@ -149,6 +149,12 @@ defineExpose({ getValue, setValue, focus, clearSearch })
   color: var(--text);
 }
 
+// The wrapper's focus-within green border is the focus indicator here;
+// the global :focus-visible outline would double it.
+.search-input:focus-visible {
+  outline: none;
+}
+
 .search-icon {
   width: 20px;
   margin-top: 5px;
@@ -195,7 +201,7 @@ defineExpose({ getValue, setValue, focus, clearSearch })
   }
 }
 
-.search-field-wrapper:focus,
+.search-field-wrapper:focus-within,
 .search-field-wrapper:hover {
   border-color: $green;
 }


### PR DESCRIPTION
## Problems

- Thumbnails and avatars sitting next to the printed entity/person name carried the same name as `alt`: double screen-reader announcement, and broken images overflowed their box with the alt text.
- The search field stacked the global purple focus outline on top of its own green border — which only reacted to hover (`:focus` sat on a non-focusable wrapper div).

## Solutions

- `alt=""` where a visible name sits next to the image, conditional alt where components render avatar-only, 18 sole-carrier alts kept (justified in the commit), overflow containment on the remaining boxes.
- Wrapper switched to `:focus-within` so the green border lights on keyboard focus, and the global outline suppressed for that input only (WCAG indicator preserved, global rule untouched).