### PR TITLE
Batch multi-selection actions into single requests

### DIFF
--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -594,7 +594,7 @@ export default {
       'addSelectedTasks',
       'clearSelectedTasks',
       'updateTask',
-      'unassignPersonFromTask',
+      'unassignPersonFromTasks',
       'removeSelectedTask'
     ]),
 
@@ -633,12 +633,11 @@ export default {
     },
 
     onUnassign(task, person) {
-      if (this.selectedTasks.size > 0) {
-        this.selectedTasks.forEach(t => {
-          this.unassignPersonFromTask({ task: t, person })
-        })
+      const tasks = Array.from(this.selectedTasks.values())
+      if (!this.selectedTasks.has(task.id)) {
+        tasks.push(task)
       }
-      this.unassignPersonFromTask({ task, person })
+      this.unassignPersonFromTasks({ tasks, person })
     },
 
     updateStartDate(date) {

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -772,6 +772,7 @@ export default {
       'loadSequences',
       'saveBreakdownSearchFilterGroup',
       'saveCasting',
+      'saveCastings',
       'setAssetLinkLabel',
       'setAssetSearch',
       'setCastingEpisodes',
@@ -953,23 +954,24 @@ export default {
         key => this.selection[key]
       )
 
-      for (const entityId of entityIds) {
+      entityIds.forEach(entityId => {
         this.addAssetToCasting({
           entityId,
           assetId,
           nbOccurences: amount,
           label: this.castingType === 'shot' ? 'animate' : 'fixed'
         })
-
         delete this.saveErrors[entityId]
+      })
 
-        try {
-          await this.saveCasting(entityId)
-          this.setLock()
-        } catch (err) {
+      try {
+        await this.saveCastings(entityIds)
+        this.setLock()
+      } catch (err) {
+        entityIds.forEach(entityId => {
           this.saveErrors[entityId] = true
-          console.error(err)
-        }
+        })
+        console.error(err)
       }
     },
 
@@ -1008,13 +1010,38 @@ export default {
       const entityIds = Object.keys(this.selection).filter(
         key => this.selection[key]
       )
+      const removals = []
       for (const entityId of entityIds) {
         const asset = this.casting[entityId].find(
           asset => asset.asset_id === assetId
         )
         if (asset) {
-          await this.removeOneAsset(assetId, entityId, asset.nb_occurences)
+          if (this.isEpisodeCasting && asset.nb_occurences === 1) {
+            // The confirmation modal flow handles this entity on its own.
+            await this.removeOneAsset(assetId, entityId, asset.nb_occurences)
+          } else {
+            removals.push(entityId)
+          }
         }
+      }
+      if (removals.length === 0) return
+      this.isLocked = true
+      this.loading.remove = true
+      removals.forEach(entityId => {
+        this.removeAssetFromCasting({ entityId, assetId, nbOccurences: 1 })
+        delete this.saveErrors[entityId]
+      })
+      try {
+        await this.saveCastings(removals)
+        this.setLock()
+      } catch (err) {
+        removals.forEach(entityId => {
+          this.saveErrors[entityId] = true
+        })
+        this.errors.remove = true
+        console.error(err)
+      } finally {
+        this.loading.remove = false
       }
     },
 
@@ -1284,18 +1311,21 @@ export default {
       const selectedElements = Object.keys(this.selection).filter(
         key => this.selection[key]
       )
-      for (const entityId of selectedElements) {
+      selectedElements.forEach(entityId => {
         this.setEntityCasting({
           entityId,
           casting: castingToPaste
         })
         delete this.saveErrors[entityId]
-        await this.saveCasting(entityId)
-          .then(this.setLock)
-          .catch(err => {
-            this.saveErrors[entityId] = true
-            console.error(err)
-          })
+      })
+      try {
+        await this.saveCastings(selectedElements)
+        this.setLock()
+      } catch (err) {
+        selectedElements.forEach(entityId => {
+          this.saveErrors[entityId] = true
+        })
+        console.error(err)
       }
       return castingToPaste
     },

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -848,6 +848,7 @@ export default {
 
   methods: {
     ...mapActions([
+      'addEntitiesToPlaylist',
       'changePlaylistOrder',
       'changePlaylistPreview',
       'changePlaylistType',
@@ -1424,9 +1425,30 @@ export default {
       // Captured once: keep adding to the playlist the user started from,
       // even if they switch playlists mid-sequence.
       const playlist = this.currentPlaylist
-      for (const entity of entities || []) {
-        this.entitiesAddedWhilePanelOpen = true
-        await this.addEntity(entity, playlist)
+      if (!entities?.length) return
+      this.entitiesAddedWhilePanelOpen = true
+      entities.forEach(entity => {
+        this.entityLoading[entity.id] = true
+      })
+      try {
+        await this.addEntitiesToPlaylist({
+          playlist,
+          entityIds: entities.map(entity => entity.id)
+        })
+        if (playlist.id === this.currentPlaylist.id) {
+          const loadedPlaylist = await this.loadPlaylist(playlist)
+          this.currentPlaylist = ref(loadedPlaylist)
+          this.rebuildCurrentEntities()
+          this.$nextTick(() => {
+            this.playlistPlayer?.scrollToRight()
+          })
+        }
+      } catch (err) {
+        console.error(err)
+      } finally {
+        entities.forEach(entity => {
+          this.entityLoading[entity.id] = false
+        })
       }
     },
 

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -1693,6 +1693,11 @@ export default {
         const startDate = parseDate(this.assignments.startDate)
         const endDate = parseDate(this.assignments.endDate)
 
+        // accumulated during the distribution loop, flushed as one
+        // clear-assignation request plus one assign request per assignee
+        const taskIdsToUnassign = []
+        const taskIdsByAssignee = new Map()
+
         let cumulatedTasks = 0
         let nextAssigneeIndex = 0
         let nextStartDate = startDate.clone()
@@ -1722,7 +1727,7 @@ export default {
             if (this.isVersioned) {
               versionedTask.assignees = []
             } else {
-              await this.unassignSelectedTasks({ taskIds: [task.id] })
+              taskIdsToUnassign.push(task.id)
             }
           }
 
@@ -1771,25 +1776,23 @@ export default {
                   await this.updateScheduleVersionedTask(versionedTask)
                 }
               } else {
-                await Promise.all([
-                  // assign task to the current assignee
-                  this.assignSelectedTasks({
-                    personId: taskAssignee.id,
-                    taskIds: [task.id]
-                  }),
-                  // save task dates & estimation
-                  this.updateTask({
-                    taskId: task.id,
-                    data: {
-                      estimation: daysToMinutes(
-                        this.organisation,
-                        taskEstimation
-                      ),
-                      start_date: taskStartDate.format('YYYY-MM-DD'),
-                      due_date: taskEndDate.format('YYYY-MM-DD')
-                    }
-                  })
-                ])
+                // assignation to the current assignee is batched after the loop
+                if (!taskIdsByAssignee.has(taskAssignee.id)) {
+                  taskIdsByAssignee.set(taskAssignee.id, [])
+                }
+                taskIdsByAssignee.get(taskAssignee.id).push(task.id)
+                // save task dates & estimation
+                await this.updateTask({
+                  taskId: task.id,
+                  data: {
+                    estimation: daysToMinutes(
+                      this.organisation,
+                      taskEstimation
+                    ),
+                    start_date: taskStartDate.format('YYYY-MM-DD'),
+                    due_date: taskEndDate.format('YYYY-MM-DD')
+                  }
+                })
               }
               // set next start date
               if ((cumulatedTasks * taskEstimation) % 1 !== 0) {
@@ -1801,6 +1804,16 @@ export default {
             }
           }
         }
+
+        // unassign first so batched assignations are not cleared right after
+        if (taskIdsToUnassign.length > 0) {
+          await this.unassignSelectedTasks({ taskIds: taskIdsToUnassign })
+        }
+        await Promise.all(
+          Array.from(taskIdsByAssignee, ([personId, taskIds]) =>
+            this.assignSelectedTasks({ personId, taskIds })
+          )
+        )
 
         // refresh schedule
         this.expandTaskTypeElement(

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -1809,11 +1809,10 @@ export default {
         if (taskIdsToUnassign.length > 0) {
           await this.unassignSelectedTasks({ taskIds: taskIdsToUnassign })
         }
-        await Promise.all(
-          Array.from(taskIdsByAssignee, ([personId, taskIds]) =>
-            this.assignSelectedTasks({ personId, taskIds })
-          )
-        )
+        // Sequence the per-assignee requests instead of firing them at once.
+        for (const [personId, taskIds] of taskIdsByAssignee) {
+          await this.assignSelectedTasks({ personId, taskIds })
+        }
 
         // refresh schedule
         this.expandTaskTypeElement(

--- a/src/components/pages/ProductionSettings.vue
+++ b/src/components/pages/ProductionSettings.vue
@@ -281,15 +281,12 @@ const removeTaskStatus = async id => {
 }
 
 const updateTaskStatusPriorities = async taskStatuses => {
-  const taskStatusLinks = taskStatuses.map((status, index) => ({
-    ...currentProduction.value.task_statuses_link[status.id],
-    priority: index + 1,
-    project_id: currentProduction.value.id,
-    task_status_id: status.id
-  }))
-  for (const taskStatusLink of taskStatusLinks) {
-    await store.dispatch('editTaskStatusLink', taskStatusLink)
-  }
+  // The batch route sets each priority from the list order and preserves
+  // the board roles of every link.
+  await store.dispatch('reorderTaskStatusLinks', {
+    projectId: currentProduction.value.id,
+    taskStatusIds: taskStatuses.map(status => status.id)
+  })
   await store.dispatch('loadContext')
 }
 

--- a/src/components/pages/ProjectTemplateSettings.vue
+++ b/src/components/pages/ProjectTemplateSettings.vue
@@ -623,13 +623,10 @@ const removeTaskType = async taskTypeId => {
 }
 
 const reorderTaskTypes = async ordered => {
-  for (const { taskTypeId, priority } of ordered) {
-    await store.dispatch('addTaskTypeToTemplate', {
-      templateId: templateId.value,
-      taskTypeId,
-      priority
-    })
-  }
+  await store.dispatch('reorderTemplateTaskTypes', {
+    templateId: templateId.value,
+    taskTypeIds: ordered.map(item => item.taskTypeId)
+  })
   await loadTemplateData()
 }
 
@@ -650,13 +647,10 @@ const removeTaskStatus = async taskStatusId => {
 }
 
 const reorderTaskStatuses = async ordered => {
-  for (const { taskStatusId, priority } of ordered) {
-    await store.dispatch('addTaskStatusToTemplate', {
-      templateId: templateId.value,
-      taskStatusId,
-      priority
-    })
-  }
+  await store.dispatch('reorderTemplateTaskStatuses', {
+    templateId: templateId.value,
+    taskStatusIds: ordered.map(item => item.taskStatusId)
+  })
   await loadTemplateData()
 }
 

--- a/src/components/pages/TaskTypes.vue
+++ b/src/components/pages/TaskTypes.vue
@@ -51,7 +51,6 @@ import { useRoute } from 'vue-router'
 import { useStore } from 'vuex'
 
 import csv from '@/lib/csv'
-import func from '@/lib/func'
 import stringHelpers from '@/lib/string'
 
 // eslint-disable-next-line no-unused-vars
@@ -168,9 +167,10 @@ const savePriorities = forms => {
   if (now - lastCall > 1000 && !isSaving) {
     lastCall = now
     isSaving = true
-    func
-      .runPromiseMapAsSeries(forms, form =>
-        store.dispatch('editTaskType', form)
+    store
+      .dispatch(
+        'reorderTaskTypes',
+        forms.map(form => form.id)
       )
       .then(() => {
         isSaving = false

--- a/src/components/pages/production/NewProduction.vue
+++ b/src/components/pages/production/NewProduction.vue
@@ -828,28 +828,25 @@ const deleteFromList = (object, listName) => {
 }
 
 const createTaskTypesAndStatuses = async () => {
-  await func.runPromiseAsSeries(
-    productionToCreate.assetTaskTypes
-      .concat(productionToCreate.shotTaskTypes)
-      .map(async (taskType, index) => {
-        const finalIndex =
-          taskType.for_entity === 'Shot'
-            ? index - productionToCreate.assetTaskTypes.length
-            : index
-        return await store.dispatch('addTaskTypeToProduction', {
-          taskTypeId: taskType.id,
-          priority: finalIndex + 1
-        })
+  const calls = productionToCreate.assetTaskTypes
+    .concat(productionToCreate.shotTaskTypes)
+    .map((taskType, index) => () => {
+      const finalIndex =
+        taskType.for_entity === 'Shot'
+          ? index - productionToCreate.assetTaskTypes.length
+          : index
+      return store.dispatch('addTaskTypeToProduction', {
+        taskTypeId: taskType.id,
+        priority: finalIndex + 1
       })
-      .concat(
-        productionToCreate.taskStatuses.map(async taskStatus => {
-          return await store.dispatch(
-            'addTaskStatusToProduction',
-            taskStatus.id
-          )
-        })
+    })
+    .concat(
+      productionToCreate.taskStatuses.map(
+        taskStatus => () =>
+          store.dispatch('addTaskStatusToProduction', taskStatus.id)
       )
-  )
+    )
+  await func.runPromiseMapAsSeries(calls, call => call())
 }
 
 const createAssets = async () => {

--- a/src/components/pages/production/ProductionTaskTypes.vue
+++ b/src/components/pages/production/ProductionTaskTypes.vue
@@ -104,7 +104,6 @@ import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 import { useStore } from 'vuex'
 
-import func from '@/lib/func'
 import { sortByName, sortTaskTypes } from '@/lib/sorting'
 import { formatFullDate } from '@/lib/time'
 import stringHelper from '@/lib/string'
@@ -305,9 +304,10 @@ const savePriorities = async forms => {
   if (now - lastCall > 1000 && !isSaving) {
     lastCall = now
     isSaving = true
-    await func.runPromiseMapAsSeries(forms, form =>
-      store.dispatch('editTaskTypeLink', form)
-    )
+    await store.dispatch('reorderTaskTypeLinks', {
+      projectId: currentProduction.value.id,
+      taskTypeIds: forms.map(form => form.taskTypeId)
+    })
     isSaving = false
     if (newSaveCall) {
       await savePriorities(forms)

--- a/src/components/pages/production/ProductionTaskTypes.vue
+++ b/src/components/pages/production/ProductionTaskTypes.vue
@@ -305,8 +305,8 @@ const savePriorities = async forms => {
   if (now - lastCall > 1000 && !isSaving) {
     lastCall = now
     isSaving = true
-    await func.runPromiseAsSeries(
-      forms.map(async form => store.dispatch('editTaskTypeLink', form))
+    await func.runPromiseMapAsSeries(forms, form =>
+      store.dispatch('editTaskTypeLink', form)
     )
     isSaving = false
     if (newSaveCall) {

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -1553,10 +1553,8 @@ export default {
     confirmTasksSubscription() {
       this.loading.tasksSubscription = true
       func
-        .runPromiseAsSeries(
-          Array.from(this.selectedTasks.values()).map(task => {
-            return this.subscribeToTask(task.id)
-          })
+        .runPromiseMapAsSeries(Array.from(this.selectedTasks.values()), task =>
+          this.subscribeToTask(task.id)
         )
         .then(() => {
           this.loading.tasksSubscription = false
@@ -1571,10 +1569,8 @@ export default {
     confirmTasksUnsubscription() {
       this.loading.tasksSubscription = true
       func
-        .runPromiseAsSeries(
-          Array.from(this.selectedTasks.values()).map(task => {
-            return this.unsubscribeFromTask(task.id)
-          })
+        .runPromiseMapAsSeries(Array.from(this.selectedTasks.values()), task =>
+          this.unsubscribeFromTask(task.id)
         )
         .then(() => {
           this.loading.tasksSubscription = false
@@ -1600,10 +1596,9 @@ export default {
         this.loading.setThumbnails = false
       } else {
         func
-          .runPromiseAsSeries(
-            Array.from(this.selectedTasks.values()).map(task => {
-              return this.setLastTaskPreview(task.id)
-            })
+          .runPromiseMapAsSeries(
+            Array.from(this.selectedTasks.values()),
+            task => this.setLastTaskPreview(task.id)
           )
           .then(() => {
             this.loading.setThumbnails = false

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -923,7 +923,6 @@ import { mapGetters, mapActions } from 'vuex'
 
 import assetsStore from '@/store/modules/assets.js'
 import { intersection } from '@/lib/array'
-import func from '@/lib/func'
 
 import BuildFilterModal from '@/components/modals/BuildFilterModal.vue'
 import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
@@ -1365,10 +1364,13 @@ export default {
       'postCustomAction',
       'setAssetSearch',
       'setLastTaskPreview',
+      'setTasksMainPreview',
       'subscribeToTask',
+      'subscribeToTasks',
       'unassignPersonFromTasks',
       'unassignSelectedTasks',
-      'unsubscribeFromTask'
+      'unsubscribeFromTask',
+      'unsubscribeFromTasks'
     ]),
 
     getLinkedEntities(concept) {
@@ -1552,33 +1554,25 @@ export default {
 
     confirmTasksSubscription() {
       this.loading.tasksSubscription = true
-      func
-        .runPromiseMapAsSeries(Array.from(this.selectedTasks.values()), task =>
-          this.subscribeToTask(task.id)
-        )
-        .then(() => {
-          this.loading.tasksSubscription = false
-        })
+      this.subscribeToTasks(Array.from(this.selectedTasks.keys()))
         .catch(err => {
           console.error(err)
-          this.loading.tasksSubscription = false
           this.errors.tasksSubscription = false
+        })
+        .finally(() => {
+          this.loading.tasksSubscription = false
         })
     },
 
     confirmTasksUnsubscription() {
       this.loading.tasksSubscription = true
-      func
-        .runPromiseMapAsSeries(Array.from(this.selectedTasks.values()), task =>
-          this.unsubscribeFromTask(task.id)
-        )
-        .then(() => {
-          this.loading.tasksSubscription = false
-        })
+      this.unsubscribeFromTasks(Array.from(this.selectedTasks.keys()))
         .catch(err => {
           console.error(err)
-          this.loading.tasksSubscription = false
           this.errors.tasksSubscription = false
+        })
+        .finally(() => {
+          this.loading.tasksSubscription = false
         })
     },
 
@@ -1595,12 +1589,9 @@ export default {
         )
         this.loading.setThumbnails = false
       } else {
-        func
-          .runPromiseMapAsSeries(
-            Array.from(this.selectedTasks.values()),
-            task => this.setLastTaskPreview(task.id)
-          )
-          .then(() => {
+        this.setTasksMainPreview(Array.from(this.selectedTasks.keys()))
+          .catch(console.error)
+          .finally(() => {
             this.loading.setThumbnails = false
           })
       }

--- a/src/components/tops/ActionPanel.vue
+++ b/src/components/tops/ActionPanel.vue
@@ -1366,7 +1366,7 @@ export default {
       'setAssetSearch',
       'setLastTaskPreview',
       'subscribeToTask',
-      'unassignPersonFromTask',
+      'unassignPersonFromTasks',
       'unassignSelectedTasks',
       'unsubscribeFromTask'
     ]),
@@ -1420,16 +1420,14 @@ export default {
       const person = this.isCurrentUserArtist ? this.user : this.person
       if (person) {
         this.loading.assignation = true
-        func
-          .runPromiseAsSeries(
-            Array.from(this.selectedTasks.values()).map(task => {
-              return this.unassignPersonFromTask({ task, person })
-            })
-          )
-          .then(() => {
+        this.unassignPersonFromTasks({
+          tasks: Array.from(this.selectedTasks.values()),
+          person
+        })
+          .catch(console.error)
+          .finally(() => {
             this.loading.assignation = false
           })
-          .catch(console.error)
       }
     },
 

--- a/src/lib/func.js
+++ b/src/lib/func.js
@@ -5,12 +5,6 @@ export default {
     }, Promise.resolve())
   },
 
-  runPromiseAsSeries(promises) {
-    return promises.reduce((accumulatorPromise, promise) => {
-      return accumulatorPromise.then(() => promise)
-    }, Promise.resolve())
-  },
-
   throttle(fn, delay) {
     let lastCall = 0
     return function (...args) {

--- a/src/store/api/breakdown.js
+++ b/src/store/api/breakdown.js
@@ -24,6 +24,11 @@ export default {
     return client.pput(path, casting)
   },
 
+  updateCastings(productionId, castings) {
+    const path = `/api/data/projects/${productionId}/entities/casting`
+    return client.pput(path, castings)
+  },
+
   postCastingCsv(production, formData) {
     const path = `/api/import/csv/projects/${production.id}/casting`
     return client.ppost(path, formData)

--- a/src/store/api/entities.js
+++ b/src/store/api/entities.js
@@ -5,6 +5,13 @@ export default {
     return client.pget(`/api/data/entities/${entityId}/news`)
   },
 
+  deleteEntities(projectId, entityIds) {
+    return client.ppost(
+      `/api/actions/projects/${projectId}/delete-entities`,
+      entityIds
+    )
+  },
+
   getEntityPreviewFiles(entityId) {
     return client.pget(`/api/data/entities/${entityId}/preview-files`)
   },

--- a/src/store/api/playlists.js
+++ b/src/store/api/playlists.js
@@ -25,8 +25,10 @@ export default {
   },
 
   addEntitiesToPlaylist(playlist, entityIds) {
+    // Send (entity, preview) couples. No preview_file_id: the server resolves
+    // each entity's latest preview for the playlist task type.
     return client.ppost(`/api/actions/playlists/${playlist.id}/add-entities`, {
-      entity_ids: entityIds
+      entities: entityIds.map(entityId => ({ entity_id: entityId }))
     })
   },
 

--- a/src/store/api/playlists.js
+++ b/src/store/api/playlists.js
@@ -24,6 +24,12 @@ export default {
     return client.pget(path)
   },
 
+  addEntitiesToPlaylist(playlist, entityIds) {
+    return client.ppost(`/api/actions/playlists/${playlist.id}/add-entities`, {
+      entity_ids: entityIds
+    })
+  },
+
   getPreviewFile(previewFileId) {
     return client.pget(`/api/data/preview-files/${previewFileId}`)
   },

--- a/src/store/api/productions.js
+++ b/src/store/api/productions.js
@@ -219,9 +219,12 @@ export default {
   },
 
   reorderMetadataDescriptorsOnAllProjects(entityType, fieldOrder) {
-    return client.ppost('/api/data/metadata-descriptors/all-projects/reorder', {
-      entity_type: entityType,
-      field_order: fieldOrder
-    })
+    return client.ppost(
+      '/api/actions/metadata-descriptors/all-projects/reorder',
+      {
+        entity_type: entityType,
+        field_order: fieldOrder
+      }
+    )
   }
 }

--- a/src/store/api/productions.js
+++ b/src/store/api/productions.js
@@ -183,5 +183,45 @@ export default {
       `/api/data/projects/${productionId}/metadata-descriptors/reorder`,
       data
     )
+  },
+
+  addMetadataDescriptorToAllProjects(descriptor) {
+    const data = {
+      name: descriptor.name,
+      data_type: descriptor.data_type,
+      choices: descriptor.values,
+      for_client: toBoolean(descriptor.for_client),
+      entity_type: descriptor.entity_type,
+      departments: descriptor.departments
+    }
+    return client.ppost('/api/data/metadata-descriptors/all-projects', data)
+  },
+
+  updateMetadataDescriptorOnAllProjects(fieldName, descriptor) {
+    const data = {
+      name: descriptor.name,
+      data_type: descriptor.data_type,
+      choices: descriptor.values,
+      for_client: toBoolean(descriptor.for_client),
+      entity_type: descriptor.entity_type,
+      departments: descriptor.departments
+    }
+    return client.pput(
+      `/api/data/metadata-descriptors/all-projects/${fieldName}`,
+      data
+    )
+  },
+
+  deleteMetadataDescriptorOnAllProjects(fieldName, entityType) {
+    return client.pdel(
+      `/api/data/metadata-descriptors/all-projects/${fieldName}?entity_type=${entityType}`
+    )
+  },
+
+  reorderMetadataDescriptorsOnAllProjects(entityType, fieldOrder) {
+    return client.ppost('/api/data/metadata-descriptors/all-projects/reorder', {
+      entity_type: entityType,
+      field_order: fieldOrder
+    })
   }
 }

--- a/src/store/api/projecttemplates.js
+++ b/src/store/api/projecttemplates.js
@@ -85,6 +85,13 @@ export default {
     )
   },
 
+  reorderTemplateTaskTypes(templateId, taskTypeIds) {
+    return client.ppost(
+      `/api/data/project-templates/${templateId}/task-types/reorder`,
+      { task_type_ids: taskTypeIds }
+    )
+  },
+
   // Task status links
   getTemplateTaskStatuses(templateId) {
     return client.pget(
@@ -105,6 +112,13 @@ export default {
   removeTaskStatusFromTemplate(templateId, taskStatusId) {
     return client.pdel(
       `/api/data/project-templates/${templateId}/task-statuses/${taskStatusId}`
+    )
+  },
+
+  reorderTemplateTaskStatuses(templateId, taskStatusIds) {
+    return client.ppost(
+      `/api/data/project-templates/${templateId}/task-statuses/reorder`,
+      { task_status_ids: taskStatusIds }
     )
   },
 

--- a/src/store/api/projecttemplates.js
+++ b/src/store/api/projecttemplates.js
@@ -87,7 +87,7 @@ export default {
 
   reorderTemplateTaskTypes(templateId, taskTypeIds) {
     return client.ppost(
-      `/api/data/project-templates/${templateId}/task-types/reorder`,
+      `/api/actions/project-templates/${templateId}/task-types/reorder`,
       { task_type_ids: taskTypeIds }
     )
   },
@@ -117,7 +117,7 @@ export default {
 
   reorderTemplateTaskStatuses(templateId, taskStatusIds) {
     return client.ppost(
-      `/api/data/project-templates/${templateId}/task-statuses/reorder`,
+      `/api/actions/project-templates/${templateId}/task-statuses/reorder`,
       { task_status_ids: taskStatusIds }
     )
   },

--- a/src/store/api/tasks.js
+++ b/src/store/api/tasks.js
@@ -228,9 +228,9 @@ export default {
     })
   },
 
-  unassignPersonFromTask(taskId, personId) {
+  unassignPersonFromTasks(taskIds, personId) {
     return client.pput('/api/actions/tasks/clear-assignation', {
-      task_ids: [taskId],
+      task_ids: taskIds,
       person_id: personId
     })
   },

--- a/src/store/api/tasks.js
+++ b/src/store/api/tasks.js
@@ -146,6 +146,12 @@ export default {
     return client.ppost(url, {})
   },
 
+  createEntityTasks(entityId, taskTypeIds) {
+    return client.ppost(`/api/data/entities/${entityId}/tasks`, {
+      task_type_ids: taskTypeIds
+    })
+  },
+
   deleteTask(task) {
     return client.pdel(`/api/data/tasks/${task.id}?force=true`)
   },

--- a/src/store/api/tasks.js
+++ b/src/store/api/tasks.js
@@ -234,6 +234,13 @@ export default {
     })
   },
 
+  setTasksPriority(taskIds, priority) {
+    return client.pput('/api/actions/tasks/set-priority', {
+      task_ids: taskIds,
+      priority
+    })
+  },
+
   unassignPersonFromTasks(taskIds, personId) {
     return client.pput('/api/actions/tasks/clear-assignation', {
       task_ids: taskIds,

--- a/src/store/api/tasks.js
+++ b/src/store/api/tasks.js
@@ -33,6 +33,18 @@ export default {
     return client.pdel(`/api/actions/user/tasks/${taskId}/unsubscribe`)
   },
 
+  subscribeToTasks(taskIds) {
+    return client.ppost('/api/actions/user/tasks/subscribe', {
+      task_ids: taskIds
+    })
+  },
+
+  unsubscribeFromTasks(taskIds) {
+    return client.ppost('/api/actions/user/tasks/unsubscribe', {
+      task_ids: taskIds
+    })
+  },
+
   getTaskComments(taskId) {
     return client.pget(`/api/data/tasks/${taskId}/comments`)
   },
@@ -202,6 +214,12 @@ export default {
 
   setLastTaskPreviewAsEntityThumbnail(taskId) {
     return client.pput(`/api/actions/tasks/${taskId}/set-main-preview`, {})
+  },
+
+  setTasksMainPreview(taskIds) {
+    return client.pput('/api/actions/tasks/set-main-preview', {
+      task_ids: taskIds
+    })
   },
 
   uploadPreview(previewId, formData) {

--- a/src/store/api/taskstatus.js
+++ b/src/store/api/taskstatus.js
@@ -53,6 +53,13 @@ export default {
     return await client.ppost('/api/data/task-status-links', data)
   },
 
+  reorderTaskStatusLinks(projectId, taskStatusIds) {
+    return client.ppost(
+      `/api/data/projects/${projectId}/task-status-links/batch`,
+      { task_status_ids: taskStatusIds }
+    )
+  },
+
   deleteTaskStatus(taskStatus) {
     return client.pdel(`/api/data/task-status/${taskStatus.id}`)
   }

--- a/src/store/api/taskstatus.js
+++ b/src/store/api/taskstatus.js
@@ -55,7 +55,7 @@ export default {
 
   reorderTaskStatusLinks(projectId, taskStatusIds) {
     return client.ppost(
-      `/api/data/projects/${projectId}/task-status-links/batch`,
+      `/api/data/projects/${projectId}/task-status-links/reorder`,
       { task_status_ids: taskStatusIds }
     )
   },

--- a/src/store/api/taskstatus.js
+++ b/src/store/api/taskstatus.js
@@ -55,7 +55,7 @@ export default {
 
   reorderTaskStatusLinks(projectId, taskStatusIds) {
     return client.ppost(
-      `/api/data/projects/${projectId}/task-status-links/reorder`,
+      `/api/actions/projects/${projectId}/task-status-links/reorder`,
       { task_status_ids: taskStatusIds }
     )
   },

--- a/src/store/api/tasktypes.js
+++ b/src/store/api/tasktypes.js
@@ -50,7 +50,7 @@ export default {
 
   reorderTaskTypeLinks(projectId, taskTypeIds) {
     return client.ppost(
-      `/api/data/projects/${projectId}/task-type-links/batch`,
+      `/api/data/projects/${projectId}/task-type-links/reorder`,
       { task_type_ids: taskTypeIds }
     )
   },

--- a/src/store/api/tasktypes.js
+++ b/src/store/api/tasktypes.js
@@ -50,13 +50,13 @@ export default {
 
   reorderTaskTypeLinks(projectId, taskTypeIds) {
     return client.ppost(
-      `/api/data/projects/${projectId}/task-type-links/reorder`,
+      `/api/actions/projects/${projectId}/task-type-links/reorder`,
       { task_type_ids: taskTypeIds }
     )
   },
 
   reorderTaskTypes(taskTypeIds) {
-    return client.ppost('/api/data/task-types/reorder', {
+    return client.ppost('/api/actions/task-types/reorder', {
       task_type_ids: taskTypeIds
     })
   },

--- a/src/store/api/tasktypes.js
+++ b/src/store/api/tasktypes.js
@@ -48,6 +48,13 @@ export default {
     return await client.ppost('/api/data/task-type-links', data)
   },
 
+  reorderTaskTypeLinks(projectId, taskTypeIds) {
+    return client.ppost(
+      `/api/data/projects/${projectId}/task-type-links/batch`,
+      { task_type_ids: taskTypeIds }
+    )
+  },
+
   deleteTaskType(taskType) {
     return client.pdel(`/api/data/task-types/${taskType.id}`)
   },

--- a/src/store/api/tasktypes.js
+++ b/src/store/api/tasktypes.js
@@ -55,6 +55,12 @@ export default {
     )
   },
 
+  reorderTaskTypes(taskTypeIds) {
+    return client.ppost('/api/data/task-types/reorder', {
+      task_type_ids: taskTypeIds
+    })
+  },
+
   deleteTaskType(taskType) {
     return client.pdel(`/api/data/task-types/${taskType.id}`)
   },

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -1,6 +1,7 @@
 import moment from 'moment'
 
 import assetsApi from '@/store/api/assets'
+import entitiesApi from '@/store/api/entities'
 import peopleApi from '@/store/api/people'
 
 import assetTypeStore from '@/store/modules/assettypes'
@@ -818,19 +819,28 @@ const actions = {
     commit(CLEAR_SELECTED_ASSETS)
   },
 
-  async deleteSelectedAssets({ state, dispatch }) {
+  async deleteSelectedAssets({ state, commit, rootGetters }) {
     let selectedAssetIds = [...state.selectedAssets.values()]
       .filter(asset => !asset.canceled)
       .map(asset => asset.id)
     if (selectedAssetIds.length === 0) {
       selectedAssetIds = [...state.selectedAssets.keys()]
     }
-    for (const assetId of selectedAssetIds) {
-      const asset = cache.assetMap.get(assetId)
-      if (asset) {
-        await dispatch('deleteAsset', asset)
+    const assets = selectedAssetIds
+      .map(assetId => cache.assetMap.get(assetId))
+      .filter(asset => asset)
+    if (assets.length === 0) return
+    await entitiesApi.deleteEntities(
+      rootGetters.currentProduction.id,
+      assets.map(asset => asset.id)
+    )
+    assets.forEach(asset => {
+      if (asset.tasks.length > 0 && !asset.canceled) {
+        commit(CANCEL_ASSET, asset)
+      } else {
+        commit(REMOVE_ASSET, asset)
       }
-    }
+    })
   },
 
   async loadSharedAssets({ commit, rootGetters }, { production }) {

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -11,7 +11,6 @@ import tasksStore from '@/store/modules/tasks'
 import taskStatusStore from '@/store/modules/taskstatus'
 import taskTypesStore from '@/store/modules/tasktypes'
 
-import func from '@/lib/func'
 import { getTaskTypePriorityOfProd } from '@/lib/productions'
 import { minutesToDays } from '@/lib/time'
 import { PAGE_SIZE } from '@/lib/pagination'
@@ -551,16 +550,9 @@ const actions = {
           return workflow.includes(taskTypeId)
         })
       }
-      const createTaskPromises = taskTypeIds.map(taskTypeId => {
-        dispatch('createTask', {
-          entityId: asset.id,
-          projectId: asset.project_id,
-          taskTypeId,
-          type: 'assets'
-        })
-      })
-      return func
-        .runPromiseAsSeries(createTaskPromises)
+      // An empty list means "all valid task types" server-side: skip the call.
+      if (taskTypeIds.length === 0) return asset
+      return dispatch('createEntityTasks', { entityId: asset.id, taskTypeIds })
         .then(() => asset)
         .catch(console.error)
     })

--- a/src/store/modules/breakdown.js
+++ b/src/store/modules/breakdown.js
@@ -191,6 +191,22 @@ const actions = {
     return breakdownApi.updateCasting(production.id, entityId, casting)
   },
 
+  saveCastings({ rootGetters }, entityIds) {
+    if (!entityIds?.length) return Promise.resolve()
+    const production = rootGetters.currentProduction
+    const castings = {}
+    entityIds.forEach(entityId => {
+      castings[entityId] = Object.values(state.casting[entityId]).map(
+        asset => ({
+          asset_id: asset.asset_id,
+          nb_occurences: asset.nb_occurences || 1,
+          label: asset.label
+        })
+      )
+    })
+    return breakdownApi.updateCastings(production.id, castings)
+  },
+
   uploadCastingFile({ commit, state, rootGetters }, formData) {
     const currentProduction = rootGetters.currentProduction
     return breakdownApi.postCastingCsv(currentProduction, formData)

--- a/src/store/modules/concepts.js
+++ b/src/store/modules/concepts.js
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid'
 
 import conceptsApi from '@/store/api/concepts'
+import entitiesApi from '@/store/api/entities'
 
 import {
   LOAD_CONCEPTS_START,
@@ -132,19 +133,24 @@ const actions = {
     commit(ADD_SELECTED_CONCEPTS, concept)
   },
 
-  async deleteSelectedConcepts({ state, dispatch }) {
+  async deleteSelectedConcepts({ state, commit, rootGetters }) {
     let selectedConceptIds = [...state.selectedConcepts.values()]
       .filter(concept => !concept.canceled)
       .map(concept => concept.id)
     if (selectedConceptIds.length === 0) {
       selectedConceptIds = [...state.selectedConcepts.keys()]
     }
-    for (const conceptId of selectedConceptIds) {
-      const concept = state.conceptMap.get(conceptId)
-      if (concept) {
-        await dispatch('deleteConcept', concept)
-      }
-    }
+    const concepts = selectedConceptIds
+      .map(conceptId => state.conceptMap.get(conceptId))
+      .filter(concept => concept)
+    if (concepts.length === 0) return
+    await entitiesApi.deleteEntities(
+      rootGetters.currentProduction.id,
+      concepts.map(concept => concept.id)
+    )
+    concepts.forEach(concept => {
+      commit(DELETE_CONCEPT_END, concept)
+    })
   },
 
   clearSelectedConcepts({ commit }) {

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -9,7 +9,6 @@ import tasksStore from '@/store/modules/tasks'
 import taskTypesStore from '@/store/modules/tasktypes'
 import taskStatusStore from '@/store/modules/taskstatus'
 
-import func from '@/lib/func'
 import { PAGE_SIZE } from '@/lib/pagination'
 import { getTaskTypePriorityOfProd } from '@/lib/productions'
 import {
@@ -421,16 +420,9 @@ const actions = {
     return editsApi.newEdit(edit).then(edit => {
       commit(NEW_EDIT_END, edit)
       const taskTypeIds = rootGetters.productionEditTaskTypeIds
-      const createTaskPromises = taskTypeIds.map(taskTypeId =>
-        dispatch('createTask', {
-          entityId: edit.id,
-          projectId: edit.project_id,
-          taskTypeId: taskTypeId,
-          type: 'edits'
-        })
-      )
-      return func
-        .runPromiseAsSeries(createTaskPromises)
+      // An empty list means "all valid task types" server-side: skip the call.
+      if (taskTypeIds.length === 0) return edit
+      return dispatch('createEntityTasks', { entityId: edit.id, taskTypeIds })
         .then(() => edit)
         .catch(console.error)
     })

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -1,7 +1,8 @@
 import moment from 'moment'
 
-import peopleApi from '@/store/api/people'
 import editsApi from '@/store/api/edits'
+import entitiesApi from '@/store/api/entities'
+import peopleApi from '@/store/api/people'
 
 import peopleStore from '@/store/modules/people'
 import productionsStore from '@/store/modules/productions'
@@ -645,19 +646,28 @@ const actions = {
     commit(CLEAR_SELECTED_EDITS)
   },
 
-  async deleteSelectedEdits({ state, dispatch }) {
+  async deleteSelectedEdits({ state, commit, rootGetters }) {
     let selectedEditIds = [...state.selectedEdits.values()]
       .filter(edit => !edit.canceled)
       .map(edit => edit.id)
     if (selectedEditIds.length === 0) {
       selectedEditIds = [...state.selectedEdits.keys()]
     }
-    for (const editId of selectedEditIds) {
-      const edit = cache.editMap.get(editId)
-      if (edit) {
-        await dispatch('deleteEdit', edit)
+    const edits = selectedEditIds
+      .map(editId => cache.editMap.get(editId))
+      .filter(edit => edit)
+    if (edits.length === 0) return
+    await entitiesApi.deleteEntities(
+      rootGetters.currentProduction.id,
+      edits.map(edit => edit.id)
+    )
+    edits.forEach(edit => {
+      if (edit.tasks.length > 0 && !edit.canceled) {
+        commit(CANCEL_EDIT, edit)
+      } else {
+        commit(REMOVE_EDIT, edit)
       }
-    }
+    })
   }
 }
 

--- a/src/store/modules/episodes.js
+++ b/src/store/modules/episodes.js
@@ -2,7 +2,6 @@ import peopleApi from '@/store/api/people'
 import shotsApi from '@/store/api/shots'
 import shotStore from '@/store/modules/shots'
 
-import func from '@/lib/func'
 import { getTaskTypePriorityOfProd } from '@/lib/productions'
 import { buildEpisodeIndex, indexSearch } from '@/lib/indexing'
 import {
@@ -441,16 +440,12 @@ const actions = {
     return shotsApi.newEpisode(episode).then(episode => {
       commit(NEW_EPISODE_END, episode)
       const taskTypeIds = rootGetters.productionEpisodeTaskTypeIds
-      const createTaskPromises = taskTypeIds.map(taskTypeId =>
-        dispatch('createTask', {
-          entityId: episode.id,
-          projectId: episode.project_id,
-          taskTypeId: taskTypeId,
-          type: 'episodes'
-        })
-      )
-      return func
-        .runPromiseAsSeries(createTaskPromises)
+      // An empty list means "all valid task types" server-side: skip the call.
+      if (taskTypeIds.length === 0) return episode
+      return dispatch('createEntityTasks', {
+        entityId: episode.id,
+        taskTypeIds
+      })
         .then(() => episode)
         .catch(console.error)
     })

--- a/src/store/modules/playlists.js
+++ b/src/store/modules/playlists.js
@@ -202,6 +202,15 @@ const actions = {
     return playlist
   },
 
+  async addEntitiesToPlaylist({ commit }, { playlist, entityIds }) {
+    const updatedPlaylist = await playlistsApi.addEntitiesToPlaylist(
+      playlist,
+      entityIds
+    )
+    commit(EDIT_PLAYLIST_END, updatedPlaylist)
+    return updatedPlaylist
+  },
+
   async pushEntityToPlaylist(
     { commit, dispatch },
     { playlist, entity, previewFiles, task, entityMap }

--- a/src/store/modules/productions.js
+++ b/src/store/modules/productions.js
@@ -12,7 +12,6 @@ import {
   removeModelFromList,
   updateModelFromList
 } from '@/lib/models'
-import stringHelpers from '@/lib/string'
 import {
   LOAD_PRODUCTIONS_START,
   LOAD_PRODUCTIONS_ERROR,
@@ -670,81 +669,48 @@ const actions = {
     { commit, state },
     descriptor
   ) {
-    // Drop projectId — this action fans out to every loaded project.
+    // Drop projectId — one request applies the column to every accessible
+    // project server-side, skipping those that already own it.
     // eslint-disable-next-line no-unused-vars
     const { projectId, ...toSend } = descriptor
-    // Cell rendering and the update/delete fan-outs key on field_name (Zou
-    // slugifies it from the name), so dedupe on it too; the name check stays
-    // as a guard for slugs that diverge from Zou's.
-    const fieldName = stringHelpers.slugify(toSend.name)
-    const targets = (state.productions || []).filter(
-      production =>
-        !(production.descriptors || []).some(
-          d =>
-            d.entity_type === 'Project' &&
-            (d.field_name === fieldName || d.name === toSend.name)
-        )
-    )
-    await Promise.all(
-      targets.map(async production => {
-        const created = await productionsApi.addMetadataDescriptor(
-          production.id,
-          toSend
-        )
-        const target =
-          findProductionInState(state, created.project_id) || production
+    const created =
+      await productionsApi.addMetadataDescriptorToAllProjects(toSend)
+    created.forEach(newDescriptor => {
+      const production = findProductionInState(state, newDescriptor.project_id)
+      if (production) {
         commit(ADD_METADATA_DESCRIPTOR_END, {
-          production: target,
-          descriptor: created
+          production,
+          descriptor: newDescriptor
         })
-      })
-    )
+      }
+    })
   },
 
   async updateProjectMetadataOnAll({ commit, state }, { fieldName, form }) {
-    // Strip id/projectId — each pair gets its own descriptor id below.
     // eslint-disable-next-line no-unused-vars
     const { id, projectId, ...formFields } = form
-    const pairs = (state.productions || [])
-      .map(production => {
-        const descriptor = (production.descriptors || []).find(
-          d => d.entity_type === 'Project' && d.field_name === fieldName
-        )
-        return descriptor ? { production, descriptor } : null
-      })
-      .filter(Boolean)
-    await Promise.all(
-      pairs.map(async ({ production, descriptor }) => {
-        const updated = await productionsApi.updateMetadataDescriptor(
-          production.id,
-          { ...formFields, id: descriptor.id, entity_type: 'Project' }
-        )
-        commit(UPDATE_METADATA_DESCRIPTOR_END, {
-          production: findProductionInState(state, production.id) || production,
-          descriptor: updated
-        })
-      })
+    const updated = await productionsApi.updateMetadataDescriptorOnAllProjects(
+      fieldName,
+      {
+        ...formFields,
+        entity_type: 'Project'
+      }
     )
+    updated.forEach(descriptor => {
+      const production = findProductionInState(state, descriptor.project_id)
+      if (production) {
+        commit(UPDATE_METADATA_DESCRIPTOR_END, { production, descriptor })
+      }
+    })
   },
 
-  async deleteProjectMetadataByFieldName({ commit, state }, fieldName) {
-    const pairs = (state.productions || [])
-      .map(production => {
-        const descriptor = (production.descriptors || []).find(
-          d => d.entity_type === 'Project' && d.field_name === fieldName
-        )
-        return descriptor ? { production, descriptor } : null
-      })
-      .filter(Boolean)
-    await Promise.all(
-      pairs.map(async ({ production, descriptor }) => {
-        await productionsApi.deleteMetadataDescriptor(
-          production.id,
-          descriptor.id
-        )
-        commit(DELETE_METADATA_DESCRIPTOR_END, { id: descriptor.id })
-      })
-    )
+  async deleteProjectMetadataByFieldName({ commit }, fieldName) {
+    const removedIds =
+      await productionsApi.deleteMetadataDescriptorOnAllProjects(
+        fieldName,
+        'Project'
+      )
+    removedIds.forEach(id => commit(DELETE_METADATA_DESCRIPTOR_END, { id }))
   },
 
   /**
@@ -847,35 +813,19 @@ const actions = {
     { entityType, fieldOrder }
   ) {
     if (!fieldOrder?.length || !entityType) return
-    const projects = (state.productions || []).filter(production =>
-      (production.descriptors || []).some(d => d.entity_type === entityType)
-    )
-    await Promise.all(
-      projects.map(async production => {
-        const projectDescs = production.descriptors.filter(
-          d => d.entity_type === entityType
-        )
-        const byField = new Map(projectDescs.map(d => [d.field_name, d]))
-        const orderedIds = fieldOrder
-          .map(fieldName => byField.get(fieldName)?.id)
-          .filter(Boolean)
-        const remaining = projectDescs
-          .map(d => d.id)
-          .filter(id => !orderedIds.includes(id))
-        const updated = await productionsApi.reorderMetadataDescriptors(
-          production.id,
-          entityType,
-          [...orderedIds, ...remaining]
-        )
-        updated.forEach(descriptor => {
-          commit(UPDATE_METADATA_DESCRIPTOR_END, {
-            production:
-              findProductionInState(state, descriptor.project_id) || production,
-            descriptor
-          })
-        })
-      })
-    )
+    // The server applies the field order on every accessible project and
+    // keeps unlisted columns at trailing positions.
+    const updated =
+      await productionsApi.reorderMetadataDescriptorsOnAllProjects(
+        entityType,
+        fieldOrder
+      )
+    updated.forEach(descriptor => {
+      const production = findProductionInState(state, descriptor.project_id)
+      if (production) {
+        commit(UPDATE_METADATA_DESCRIPTOR_END, { production, descriptor })
+      }
+    })
   },
 
   async addBackgroundToProduction({ commit, state }, backgroundId) {

--- a/src/store/modules/projecttemplates.js
+++ b/src/store/modules/projecttemplates.js
@@ -90,6 +90,11 @@ const actions = {
     )
   },
 
+  reorderTemplateTaskTypes(_, { templateId, taskTypeIds }) {
+    if (!taskTypeIds?.length) return Promise.resolve()
+    return projectTemplatesApi.reorderTemplateTaskTypes(templateId, taskTypeIds)
+  },
+
   loadTemplateTaskStatuses(_, templateId) {
     return projectTemplatesApi.getTemplateTaskStatuses(templateId)
   },
@@ -110,6 +115,14 @@ const actions = {
     return projectTemplatesApi.removeTaskStatusFromTemplate(
       templateId,
       taskStatusId
+    )
+  },
+
+  reorderTemplateTaskStatuses(_, { templateId, taskStatusIds }) {
+    if (!taskStatusIds?.length) return Promise.resolve()
+    return projectTemplatesApi.reorderTemplateTaskStatuses(
+      templateId,
+      taskStatusIds
     )
   },
 

--- a/src/store/modules/sequences.js
+++ b/src/store/modules/sequences.js
@@ -2,7 +2,6 @@ import peopleApi from '@/store/api/people'
 import shotsApi from '@/store/api/shots'
 import shotStore from '@/store/modules/shots'
 
-import func from '@/lib/func'
 import { getTaskTypePriorityOfProd } from '@/lib/productions'
 import { buildSequenceIndex, indexSearch } from '@/lib/indexing'
 import {
@@ -458,16 +457,12 @@ const actions = {
     return shotsApi.newSequence(sequence).then(sequence => {
       commit(NEW_SEQUENCE_END, { sequence, episodeMap })
       const taskTypeIds = rootGetters.productionSequenceTaskTypeIds
-      const createTaskPromises = taskTypeIds.map(taskTypeId =>
-        dispatch('createTask', {
-          entityId: sequence.id,
-          projectId: sequence.project_id,
-          taskTypeId: taskTypeId,
-          type: 'sequences'
-        })
-      )
-      return func
-        .runPromiseAsSeries(createTaskPromises)
+      // An empty list means "all valid task types" server-side: skip the call.
+      if (taskTypeIds.length === 0) return sequence
+      return dispatch('createEntityTasks', {
+        entityId: sequence.id,
+        taskTypeIds
+      })
         .then(() => sequence)
         .catch(console.error)
     })

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -11,7 +11,6 @@ import tasksStore from '@/store/modules/tasks'
 import taskStatusStore from '@/store/modules/taskstatus'
 import taskTypesStore from '@/store/modules/tasktypes'
 
-import func from '@/lib/func'
 import { PAGE_SIZE } from '@/lib/pagination'
 import { getTaskTypePriorityOfProd } from '@/lib/productions'
 import {
@@ -509,16 +508,9 @@ const actions = {
     return shotsApi.newShot(shot).then(shot => {
       commit(NEW_SHOT_END, { shot })
       const taskTypeIds = rootGetters.productionShotTaskTypeIds
-      const createTaskPromises = taskTypeIds.map(taskTypeId =>
-        dispatch('createTask', {
-          entityId: shot.id,
-          projectId: shot.project_id,
-          taskTypeId: taskTypeId,
-          type: 'shots'
-        })
-      )
-      return func
-        .runPromiseAsSeries(createTaskPromises)
+      // An empty list means "all valid task types" server-side: skip the call.
+      if (taskTypeIds.length === 0) return shot
+      return dispatch('createEntityTasks', { entityId: shot.id, taskTypeIds })
         .then(() => shot)
         .catch(console.error)
     })

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -1,5 +1,6 @@
 import moment from 'moment'
 
+import entitiesApi from '@/store/api/entities'
 import peopleApi from '@/store/api/people'
 import shotsApi from '@/store/api/shots'
 
@@ -763,19 +764,28 @@ const actions = {
     commit(CLEAR_SELECTED_SHOTS)
   },
 
-  async deleteSelectedShots({ state, dispatch }) {
+  async deleteSelectedShots({ state, commit, rootGetters }) {
     let selectedShotIds = [...state.selectedShots.values()]
       .filter(shot => !shot.canceled)
       .map(shot => shot.id)
     if (selectedShotIds.length === 0) {
       selectedShotIds = [...state.selectedShots.keys()]
     }
-    for (const shotId of selectedShotIds) {
-      const shot = cache.shotMap.get(shotId)
-      if (shot) {
-        await dispatch('deleteShot', shot)
+    const shots = selectedShotIds
+      .map(shotId => cache.shotMap.get(shotId))
+      .filter(shot => shot)
+    if (shots.length === 0) return
+    await entitiesApi.deleteEntities(
+      rootGetters.currentProduction.id,
+      shots.map(shot => shot.id)
+    )
+    shots.forEach(shot => {
+      if (shot.tasks.length > 0 && !shot.canceled) {
+        commit(CANCEL_SHOT, shot)
+      } else {
+        commit(REMOVE_SHOT, shot)
       }
-    }
+    })
   },
 
   async setNbFramesFromTaskTypePreviews(

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -377,6 +377,23 @@ const actions = {
     })
   },
 
+  createEntityTasks({ commit, rootGetters }, { entityId, taskTypeIds }) {
+    const production = rootGetters.currentProduction
+    const taskTypeMap = taskTypeStore.cache.taskTypeMap
+    const taskStatusMap = taskStatusStore.cache.taskStatusMap
+    return tasksApi.createEntityTasks(entityId, taskTypeIds).then(tasks => {
+      tasks.forEach(task => {
+        commit(NEW_TASK_END, {
+          task,
+          production,
+          taskTypeMap,
+          taskStatusMap
+        })
+      })
+      return tasks
+    })
+  },
+
   changeSelectedTaskStatus(
     { commit, state, rootGetters },
     { taskStatusId, comment }

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -291,8 +291,9 @@ const actions = {
       }
       entityIdsByTaskType[taskTypeId].push(entityId)
     })
-    return func.runPromiseAsSeries(
-      Object.keys(entityIdsByTaskType).map(taskTypeId => {
+    return func.runPromiseMapAsSeries(
+      Object.keys(entityIdsByTaskType),
+      taskTypeId => {
         const data = {
           task_type_id: taskTypeId,
           type,
@@ -323,7 +324,7 @@ const actions = {
             console.error(err)
             return []
           })
-      })
+      }
     )
   },
 

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -761,11 +761,21 @@ const actions = {
     })
   },
 
-  unassignPersonFromTask({ commit }, { task, person }) {
+  unassignPersonFromTask({ dispatch }, { task, person }) {
+    return dispatch('unassignPersonFromTasks', { tasks: [task], person })
+  },
+
+  unassignPersonFromTasks({ commit }, { tasks, person }) {
+    if (tasks.length === 0) return Promise.resolve()
     return tasksApi
-      .unassignPersonFromTask(task.id, person.id)
+      .unassignPersonFromTasks(
+        tasks.map(task => task.id),
+        person.id
+      )
       .then(() => {
-        commit(UNASSIGN_TASK, { task, person })
+        tasks.forEach(task => {
+          commit(UNASSIGN_TASK, { task, person })
+        })
       })
       .catch(console.error)
   },

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -430,13 +430,15 @@ const actions = {
     const tasksToUpdate = Array.from(state.selectedTasks.keys())
       .map(taskId => state.taskMap.get(taskId))
       .filter(task => task && task.priority !== priority)
-    // No batch endpoint for priorities: keep the requests serial to avoid
-    // hammering the server with parallel writes.
-    for (const task of tasksToUpdate) {
-      const taskType = rootGetters.taskTypeMap.get(task.task_type_id)
-      const updatedTask = await tasksApi.updateTask(task.id, { priority })
+    if (tasksToUpdate.length === 0) return
+    const updatedTasks = await tasksApi.setTasksPriority(
+      tasksToUpdate.map(task => task.id),
+      priority
+    )
+    updatedTasks.forEach(updatedTask => {
+      const taskType = rootGetters.taskTypeMap.get(updatedTask.task_type_id)
       commit(EDIT_TASK_END, { task: updatedTask, taskType })
-    }
+    })
   },
 
   updateTask({ commit, state }, { taskId, data }) {

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -194,6 +194,24 @@ const actions = {
     })
   },
 
+  subscribeToTasks({ commit }, taskIds) {
+    if (taskIds.length === 0) return Promise.resolve()
+    return tasksApi.subscribeToTasks(taskIds).then(() => {
+      taskIds.forEach(taskId =>
+        commit(LOAD_TASK_SUBSCRIBE_END, { taskId, subscribed: true })
+      )
+    })
+  },
+
+  unsubscribeFromTasks({ commit }, taskIds) {
+    if (taskIds.length === 0) return Promise.resolve()
+    return tasksApi.unsubscribeFromTasks(taskIds).then(() => {
+      taskIds.forEach(taskId =>
+        commit(LOAD_TASK_SUBSCRIBE_END, { taskId, subscribed: false })
+      )
+    })
+  },
+
   loadTaskComments({ commit, dispatch }, { taskId, entityId }) {
     return tasksApi.getTaskComments(taskId).then(comments => {
       commit(LOAD_TASK_COMMENTS_END, { comments, taskId })
@@ -689,6 +707,27 @@ const actions = {
         entityId: entity.id,
         previewId: entity.preview_file_id,
         taskMap
+      })
+    })
+  },
+
+  setTasksMainPreview({ commit, state }, taskIds) {
+    if (taskIds.length === 0) return Promise.resolve()
+    const taskMap = state.taskMap
+    return tasksApi.setTasksMainPreview(taskIds).then(entities => {
+      // The route returns a flat entity list; match each back to its task
+      // through the entity id. Tasks without a preview are skipped server-side.
+      const entityMap = new Map(entities.map(entity => [entity.id, entity]))
+      taskIds.forEach(taskId => {
+        const entity = entityMap.get(taskMap.get(taskId)?.entity?.id)
+        if (entity) {
+          commit(SET_PREVIEW, {
+            taskId,
+            entityId: entity.id,
+            previewId: entity.preview_file_id,
+            taskMap
+          })
+        }
       })
     })
   },

--- a/src/store/modules/taskstatus.js
+++ b/src/store/modules/taskstatus.js
@@ -126,6 +126,11 @@ const actions = {
     return taskStatusApi.updateTaskStatusLink(data)
   },
 
+  reorderTaskStatusLinks({ commit }, { projectId, taskStatusIds }) {
+    if (!taskStatusIds?.length) return Promise.resolve()
+    return taskStatusApi.reorderTaskStatusLinks(projectId, taskStatusIds)
+  },
+
   deleteTaskStatus({ commit, state }, taskStatus) {
     return taskStatusApi.deleteTaskStatus(taskStatus).then(() => {
       commit(DELETE_TASK_STATUS_END, taskStatus)

--- a/src/store/modules/tasktypes.js
+++ b/src/store/modules/tasktypes.js
@@ -178,6 +178,11 @@ const actions = {
     return taskTypesApi.reorderTaskTypeLinks(projectId, taskTypeIds)
   },
 
+  reorderTaskTypes({ commit }, taskTypeIds) {
+    if (!taskTypeIds?.length) return Promise.resolve()
+    return taskTypesApi.reorderTaskTypes(taskTypeIds)
+  },
+
   deleteTaskType({ commit, state }, taskType) {
     commit(DELETE_TASK_TYPE_START)
     return taskTypesApi.deleteTaskType(taskType).then(() => {

--- a/src/store/modules/tasktypes.js
+++ b/src/store/modules/tasktypes.js
@@ -173,6 +173,11 @@ const actions = {
     return await taskTypesApi.updateTaskTypeLink(data)
   },
 
+  reorderTaskTypeLinks({ commit }, { projectId, taskTypeIds }) {
+    if (!taskTypeIds?.length) return Promise.resolve()
+    return taskTypesApi.reorderTaskTypeLinks(projectId, taskTypeIds)
+  },
+
   deleteTaskType({ commit, state }, taskType) {
     commit(DELETE_TASK_TYPE_START)
     return taskTypesApi.deleteTaskType(taskType).then(() => {

--- a/tests/unit/lib/func.spec.js
+++ b/tests/unit/lib/func.spec.js
@@ -20,13 +20,12 @@ describe('func', () => {
     expect(count).toBe(1) // throttled
   })
 
-  test('runPromiseAsSeries', async () => {
-    let counter = 0
-    const promises = [
-      Promise.resolve().then(() => { counter += 1; return undefined }),
-      Promise.resolve().then(() => { counter += 5; return undefined })
-    ]
-    await func.runPromiseAsSeries(promises)
-    expect(counter).toEqual(6)
+  test('runPromiseMapAsSeries starts a call only after the previous one', async () => {
+    const order = []
+    await func.runPromiseMapAsSeries([1, 2], item => {
+      order.push(`start-${item}`)
+      return Promise.resolve().then(() => order.push(`end-${item}`))
+    })
+    expect(order).toEqual(['start-1', 'end-1', 'start-2', 'end-2'])
   })
 })

--- a/tests/unit/store/productions.spec.js
+++ b/tests/unit/store/productions.spec.js
@@ -442,41 +442,37 @@ describe('Productions store', () => {
       ).rejects.toEqual({ response: { status: 500 } })
     })
 
-    test('addProjectMetadataDescriptorToAllProductions skips productions owning the field_name', async () => {
+    test('addProjectMetadataDescriptorToAllProductions applies the column in one request', async () => {
       const mockCommit = vi.fn()
       const state = {
         productions: [
-          {
-            id: 'production-1',
-            descriptors: [
-              {
-                id: 'descriptor-1',
-                entity_type: 'Project',
-                name: 'studio location',
-                field_name: 'studio_location'
-              }
-            ]
-          },
+          { id: 'production-1', descriptors: [] },
           { id: 'production-2', descriptors: [] }
         ],
-        productionMap: new Map()
+        productionMap: new Map([
+          ['production-1', { id: 'production-1', descriptors: [] }],
+          ['production-2', { id: 'production-2', descriptors: [] }]
+        ])
       }
-      productionApi.addMetadataDescriptor = vi.fn((productionId, descriptor) =>
-        Promise.resolve({
-          ...descriptor,
-          id: 'descriptor-2',
-          project_id: productionId
-        })
+      productionApi.addMetadataDescriptorToAllProjects = vi.fn(() =>
+        Promise.resolve([
+          { id: 'descriptor-1', project_id: 'production-1' },
+          { id: 'descriptor-2', project_id: 'production-2' }
+        ])
       )
       await store.actions.addProjectMetadataDescriptorToAllProductions(
         { commit: mockCommit, state },
-        { name: 'Studio Location', data_type: 'string' }
+        { name: 'Studio Location', data_type: 'string', projectId: 'x' }
       )
-      expect(productionApi.addMetadataDescriptor).toBeCalledTimes(1)
-      expect(productionApi.addMetadataDescriptor).toHaveBeenCalledWith(
-        'production-2',
-        { name: 'Studio Location', data_type: 'string' }
-      )
+      expect(
+        productionApi.addMetadataDescriptorToAllProjects
+      ).toBeCalledTimes(1)
+      // projectId is stripped from the payload before it is sent.
+      expect(
+        productionApi.addMetadataDescriptorToAllProjects
+      ).toHaveBeenCalledWith({ name: 'Studio Location', data_type: 'string' })
+      // One commit per created descriptor.
+      expect(mockCommit).toHaveBeenCalledTimes(2)
     })
 
     describe('editProduction', () => {

--- a/tests/unit/store/tasks.spec.js
+++ b/tests/unit/store/tasks.spec.js
@@ -8,6 +8,9 @@ vi.mock('@/store/api/tasks', () => ({
     unassignPersonFromTasks: vi.fn(() => Promise.resolve()),
     createEntityTasks: vi.fn(() =>
       Promise.resolve([{ id: 'task-1' }, { id: 'task-2' }])
+    ),
+    setTasksPriority: vi.fn(() =>
+      Promise.resolve([{ id: 'task-1', priority: 2, task_type_id: 'type-1' }])
     )
   }
 }))
@@ -170,6 +173,31 @@ describe('Tasks store', () => {
       )
       expect(tasksApi.unassignPersonFromTasks).not.toHaveBeenCalled()
       expect(commit).not.toHaveBeenCalled()
+    })
+
+    test('changeSelectedPriorities updates the selection in one request', async () => {
+      const commit = vi.fn()
+      const state = {
+        selectedTasks: new Map([
+          ['task-1', true],
+          ['task-2', true]
+        ]),
+        taskMap: new Map([
+          ['task-1', { id: 'task-1', priority: 0 }],
+          // Already at the target priority: must be excluded from the call.
+          ['task-2', { id: 'task-2', priority: 2 }]
+        ])
+      }
+      const rootGetters = { taskTypeMap: new Map() }
+      await tasksStore.actions.changeSelectedPriorities(
+        { commit, state, rootGetters },
+        { priority: 2 }
+      )
+      expect(tasksApi.setTasksPriority).toHaveBeenCalledTimes(1)
+      expect(tasksApi.setTasksPriority).toHaveBeenCalledWith(['task-1'], 2)
+      expect(commit).toHaveBeenCalledTimes(1)
+      expect(commit.mock.calls[0][0]).toEqual('EDIT_TASK_END')
+      expect(commit.mock.calls[0][1].task.priority).toEqual(2)
     })
 
     test('createEntityTasks commits NEW_TASK_END for each created task', async () => {

--- a/tests/unit/store/tasks.spec.js
+++ b/tests/unit/store/tasks.spec.js
@@ -5,7 +5,10 @@ import { vi } from 'vitest'
 vi.mock('@/store', () => ({ default: {} }))
 vi.mock('@/store/api/tasks', () => ({
   default: {
-    unassignPersonFromTasks: vi.fn(() => Promise.resolve())
+    unassignPersonFromTasks: vi.fn(() => Promise.resolve()),
+    createEntityTasks: vi.fn(() =>
+      Promise.resolve([{ id: 'task-1' }, { id: 'task-2' }])
+    )
   }
 }))
 
@@ -167,6 +170,24 @@ describe('Tasks store', () => {
       )
       expect(tasksApi.unassignPersonFromTasks).not.toHaveBeenCalled()
       expect(commit).not.toHaveBeenCalled()
+    })
+
+    test('createEntityTasks commits NEW_TASK_END for each created task', async () => {
+      const commit = vi.fn()
+      const rootGetters = { currentProduction: { id: 'prod-1' } }
+      const tasks = await tasksStore.actions.createEntityTasks(
+        { commit, rootGetters },
+        { entityId: 'entity-1', taskTypeIds: ['type-1', 'type-2'] }
+      )
+      expect(tasksApi.createEntityTasks).toHaveBeenCalledTimes(1)
+      expect(tasksApi.createEntityTasks).toHaveBeenCalledWith('entity-1', [
+        'type-1',
+        'type-2'
+      ])
+      expect(tasks.map(task => task.id)).toEqual(['task-1', 'task-2'])
+      expect(commit).toHaveBeenCalledTimes(2)
+      expect(commit.mock.calls[0][0]).toEqual('NEW_TASK_END')
+      expect(commit.mock.calls[0][1].task).toEqual(tasks[0])
     })
   })
 

--- a/tests/unit/store/tasks.spec.js
+++ b/tests/unit/store/tasks.spec.js
@@ -3,7 +3,13 @@ import { vi } from 'vitest'
 // Importing the tasks module transitively pulls in the root store
 // (lib/models → timezone → @/store); stub it so no Vuex store is built.
 vi.mock('@/store', () => ({ default: {} }))
+vi.mock('@/store/api/tasks', () => ({
+  default: {
+    unassignPersonFromTasks: vi.fn(() => Promise.resolve())
+  }
+}))
 
+import tasksApi from '@/store/api/tasks'
 import tasksStore from '@/store/modules/tasks'
 import peopleStore from '@/store/modules/people'
 
@@ -125,6 +131,42 @@ describe('Tasks store', () => {
       tasksStore.mutations.ADD_REPLY_TO_COMMENT({}, { comment, reply })
       expect(comment.replies[0].person.full_name).toEqual('Guest Author')
       expect(comment.replies[0].person.initials).toEqual('GA')
+    })
+  })
+
+  describe('batch actions', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+    })
+
+    test('unassignPersonFromTasks sends one request and commits per task', async () => {
+      const commit = vi.fn()
+      const person = { id: 'person-1' }
+      const tasks = [{ id: 'task-1' }, { id: 'task-2' }]
+      await tasksStore.actions.unassignPersonFromTasks(
+        { commit },
+        { tasks, person }
+      )
+      expect(tasksApi.unassignPersonFromTasks).toHaveBeenCalledTimes(1)
+      expect(tasksApi.unassignPersonFromTasks).toHaveBeenCalledWith(
+        ['task-1', 'task-2'],
+        'person-1'
+      )
+      expect(commit).toHaveBeenCalledTimes(2)
+      expect(commit).toHaveBeenNthCalledWith(1, 'UNASSIGN_TASK', {
+        task: tasks[0],
+        person
+      })
+    })
+
+    test('unassignPersonFromTasks skips the request on an empty selection', async () => {
+      const commit = vi.fn()
+      await tasksStore.actions.unassignPersonFromTasks(
+        { commit },
+        { tasks: [], person: { id: 'person-1' } }
+      )
+      expect(tasksApi.unassignPersonFromTasks).not.toHaveBeenCalled()
+      expect(commit).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/unit/store/tasks.spec.js
+++ b/tests/unit/store/tasks.spec.js
@@ -11,6 +11,11 @@ vi.mock('@/store/api/tasks', () => ({
     ),
     setTasksPriority: vi.fn(() =>
       Promise.resolve([{ id: 'task-1', priority: 2, task_type_id: 'type-1' }])
+    ),
+    subscribeToTasks: vi.fn(() => Promise.resolve()),
+    unsubscribeFromTasks: vi.fn(() => Promise.resolve()),
+    setTasksMainPreview: vi.fn(() =>
+      Promise.resolve([{ id: 'entity-1', preview_file_id: 'preview-1' }])
     )
   }
 }))
@@ -198,6 +203,55 @@ describe('Tasks store', () => {
       expect(commit).toHaveBeenCalledTimes(1)
       expect(commit.mock.calls[0][0]).toEqual('EDIT_TASK_END')
       expect(commit.mock.calls[0][1].task.priority).toEqual(2)
+    })
+
+    test('subscribeToTasks sends one request and commits per task', async () => {
+      const commit = vi.fn()
+      await tasksStore.actions.subscribeToTasks({ commit }, ['task-1', 'task-2'])
+      expect(tasksApi.subscribeToTasks).toHaveBeenCalledTimes(1)
+      expect(tasksApi.subscribeToTasks).toHaveBeenCalledWith(['task-1', 'task-2'])
+      expect(commit).toHaveBeenCalledTimes(2)
+      expect(commit).toHaveBeenNthCalledWith(1, 'LOAD_TASK_SUBSCRIBE_END', {
+        taskId: 'task-1',
+        subscribed: true
+      })
+    })
+
+    test('unsubscribeFromTasks commits subscribed=false per task', async () => {
+      const commit = vi.fn()
+      await tasksStore.actions.unsubscribeFromTasks(
+        { commit },
+        ['task-1', 'task-2']
+      )
+      expect(tasksApi.unsubscribeFromTasks).toHaveBeenCalledTimes(1)
+      expect(commit).toHaveBeenCalledTimes(2)
+      expect(commit.mock.calls[0][1].subscribed).toBe(false)
+    })
+
+    test('setTasksMainPreview maps returned entities back to their task', async () => {
+      const commit = vi.fn()
+      const state = {
+        taskMap: new Map([
+          ['task-1', { id: 'task-1', entity: { id: 'entity-1' } }],
+          // No preview for this task's entity: skipped server-side.
+          ['task-2', { id: 'task-2', entity: { id: 'entity-2' } }]
+        ])
+      }
+      await tasksStore.actions.setTasksMainPreview(
+        { commit, state },
+        ['task-1', 'task-2']
+      )
+      expect(tasksApi.setTasksMainPreview).toHaveBeenCalledWith([
+        'task-1',
+        'task-2'
+      ])
+      expect(commit).toHaveBeenCalledTimes(1)
+      expect(commit).toHaveBeenCalledWith('SET_PREVIEW', {
+        taskId: 'task-1',
+        entityId: 'entity-1',
+        previewId: 'preview-1',
+        taskMap: state.taskMap
+      })
     })
 
     test('createEntityTasks commits NEW_TASK_END for each created task', async () => {


### PR DESCRIPTION
**Problem**
- Many multi-selection actions fired one HTTP request per selected item (or per production), N requests where a single one suffices: clearing a person's assignation on a selection, the schedule auto-distribution, creating an entity's default tasks, adding selections/episodes/movies to a playlist, deleting a selection of entities, saving casting on a selection, and changing task priority on a selection.
- `runPromiseAsSeries` received already-created promises, so its call sites fired in parallel despite reading as serialized; the "add movie" playlist path also rewrote the whole playlist once per shot, racing against concurrent edits.

**Solution**
- Clear a person's assignation on a selection, change priority on a selection, and create an entity's default tasks now each use a single request (via the existing clear-assignation route, the new set-priority route, and the entity tasks route respectively).
- Batch the schedule auto-distribution's assign/unassign into one request per assignee instead of one per task.
- Add a selection, an episode or a whole movie to a playlist, delete a selection of assets/shots/edits/concepts, and save casting on a selection now each use one request via the new zou batch routes.
- Replace `runPromiseAsSeries` with real serialization (`runPromiseMapAsSeries`), which creates each promise only after the previous resolves, and drop the misleading helper.
- The playlist, delete-entities, casting and set-priority parts depend on the new routes in cgwire/zou#1145.