### PR TITLE
[annotations] Delete fully erased annotations

### DIFF
--- a/src/components/players/annotations/AnnotationCanvas.vue
+++ b/src/components/players/annotations/AnnotationCanvas.vue
@@ -124,6 +124,7 @@ const createFabric = () => {
     : new Canvas(canvasEl.value, {
         fireRightClick: true,
         enablePointerEvents: true,
+        perPixelTargetFind: true,
         // Marquee must fully contain an annotation to pick it up.
         // Without this, even a 1-2 pixel jitter on click can finalise
         // a tiny marquee that grabs nearby objects whose bboxes

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -856,8 +856,11 @@ export const useAnnotation = ({
       obj.set('dirty', true)
       if (action.removedTargets.includes(t)) {
         silentAnnotation = true
-        fabricCanvas.value.add(obj)
-        silentAnnotation = false
+        try {
+          fabricCanvas.value.add(obj)
+        } finally {
+          silentAnnotation = false
+        }
         removeFromDeletions(obj)
       }
       addToUpdates(obj)

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -752,6 +752,8 @@ export const useAnnotation = ({
     }
   }
 
+  const MIN_VISIBLE_ALPHA = 16
+
   const hasVisiblePixels = obj => {
     if (!obj.toCanvasElement) return true
     try {
@@ -768,7 +770,7 @@ export const useAnnotation = ({
         canvas.height
       ).data
       for (let index = 3; index < pixels.length; index += 4) {
-        if (pixels[index] !== 0) return true
+        if (pixels[index] > MIN_VISIBLE_ALPHA) return true
       }
       return false
     } catch {

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -26,7 +26,11 @@ import {
   getAnnotationContainMapping
 } from '@/lib/players/annotation'
 import { normalizeType } from '@/lib/players/annotationTypes'
-import { Eraser, reviveObjectEraser } from '@/lib/players/eraserbrush'
+import {
+  Eraser,
+  hasVisiblePixels,
+  reviveObjectEraser
+} from '@/lib/players/eraserbrush'
 import clipboard from '@/lib/clipboard'
 import { formatFullDate } from '@/lib/time'
 import localPreferences from '@/lib/preferences'
@@ -749,32 +753,6 @@ export const useAnnotation = ({
     } else {
       addToAdditions(o)
       stackAddAction(obj)
-    }
-  }
-
-  const MIN_VISIBLE_ALPHA = 16
-
-  const hasVisiblePixels = obj => {
-    if (!obj.toCanvasElement) return true
-    try {
-      const canvas = obj.toCanvasElement({
-        enableRetinaScaling: false,
-        withoutShadow: true
-      })
-      const context = canvas.getContext('2d')
-      if (!context) return true
-      const pixels = context.getImageData(
-        0,
-        0,
-        canvas.width,
-        canvas.height
-      ).data
-      for (let index = 3; index < pixels.length; index += 4) {
-        if (pixels[index] > MIN_VISIBLE_ALPHA) return true
-      }
-      return false
-    } catch {
-      return true
     }
   }
 

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -403,6 +403,16 @@ export const useAnnotation = ({
     }
   }
 
+  const removeFromUpdates = obj => {
+    const currentTime = getCurrentTime()
+    const updatesEntry = findAnnotation(updates.value, currentTime)
+    if (updatesEntry) {
+      updatesEntry.drawing.objects = updatesEntry.drawing.objects.filter(
+        updatedObject => updatedObject.id !== obj.id
+      )
+    }
+  }
+
   const addToUpdates = obj => {
     setObjectData(obj)
     addToUpdatesSerializedObject(obj.serialize())
@@ -742,16 +752,59 @@ export const useAnnotation = ({
     }
   }
 
-  // Erasing mutates existing objects (it appends a path to each object's
-  // `eraser` mask), so it is an UPDATE, not an addition. We re-serialise the
-  // affected objects — their patched toObject() carries the new eraser — and
-  // record a single undoable 'erase' action.
+  const hasVisiblePixels = obj => {
+    if (!obj.toCanvasElement) return true
+    try {
+      const canvas = obj.toCanvasElement({
+        enableRetinaScaling: false,
+        withoutShadow: true
+      })
+      const context = canvas.getContext('2d')
+      if (!context) return true
+      const pixels = context.getImageData(
+        0,
+        0,
+        canvas.width,
+        canvas.height
+      ).data
+      for (let index = 3; index < pixels.length; index += 4) {
+        if (pixels[index] !== 0) return true
+      }
+      return false
+    } catch {
+      return true
+    }
+  }
+
+  const removeFullyErasedObject = obj => {
+    const activeObject = fabricCanvas.value.getActiveObject?.()
+    if (activeObject === obj || activeObject?._objects?.includes(obj)) {
+      fabricCanvas.value.discardActiveObject()
+    }
+    fabricCanvas.value.remove(obj)
+    removeFromUpdates(obj)
+    addToDeletions(obj)
+  }
+
   const onErasingEnd = ({ targets = [], subTargets = [], path } = {}) => {
     if (silentAnnotation) return
-    const affected = [...targets, ...subTargets]
+    const affected = [...new Set([...targets, ...subTargets])]
     if (affected.length === 0) return
-    affected.forEach(obj => addToUpdates(obj))
-    doneActionStack.push({ type: 'erase', targets: affected, path })
+    const removedTargets = []
+    affected.forEach(obj => {
+      if (hasVisiblePixels(obj)) {
+        addToUpdates(obj)
+      } else {
+        removeFullyErasedObject(obj)
+        removedTargets.push(obj)
+      }
+    })
+    doneActionStack.push({
+      type: 'erase',
+      targets: affected,
+      removedTargets,
+      path
+    })
     clearUndoneStack()
     saveAnnotationsCb()
   }
@@ -821,6 +874,12 @@ export const useAnnotation = ({
       action.removed.push({ id: obj.id, obj, path: obj.eraser._objects.pop() })
       if (obj.eraser._objects.length === 0) obj.eraser = undefined
       obj.set('dirty', true)
+      if (action.removedTargets.includes(t)) {
+        silentAnnotation = true
+        fabricCanvas.value.add(obj)
+        silentAnnotation = false
+        removeFromDeletions(obj)
+      }
       addToUpdates(obj)
     })
     fabricCanvas.value?.requestRenderAll()
@@ -835,7 +894,13 @@ export const useAnnotation = ({
       if (!target.eraser) target.eraser = new Eraser()
       target.eraser._objects.push(path)
       target.set('dirty', true)
-      addToUpdates(target)
+      if (
+        action.removedTargets.some(removedTarget => removedTarget.id === id)
+      ) {
+        removeFullyErasedObject(target)
+      } else {
+        addToUpdates(target)
+      }
     })
     fabricCanvas.value?.requestRenderAll()
   }

--- a/src/lib/players/eraserbrush.js
+++ b/src/lib/players/eraserbrush.js
@@ -13,41 +13,6 @@ import {
 // gesture is degenerate (a single point). Matches fabric's own internal check.
 const EMPTY_SVG_PATH = 'M 0 0 Q 0 0 0 0 L 0 0'
 const MIN_VISIBLE_ALPHA = 16
-const MIN_VISIBLE_STROKE_ALPHA = 128
-
-const hasVisibleStrokeCenterline = obj => {
-  obj.renderCache()
-  const canvas = obj._cacheCanvas
-  const context = canvas?.getContext('2d')
-  if (!context) return true
-  const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data
-  const getAlpha = point => {
-    const x = Math.round(
-      (point.x - obj.strokeOffset.x) * obj.zoomX + obj.cacheTranslationX
-    )
-    const y = Math.round(
-      (point.y - obj.strokeOffset.y) * obj.zoomY + obj.cacheTranslationY
-    )
-    return pixels[(y * canvas.width + x) * 4 + 3] || 0
-  }
-  return obj.strokePoints.slice(1).some((point, index) => {
-    const previous = obj.strokePoints[index]
-    const distance = Math.max(
-      Math.abs(point.x - previous.x),
-      Math.abs(point.y - previous.y),
-      1
-    )
-    return Array.from({ length: Math.ceil(distance) + 1 }).some((_, step) => {
-      const ratio = step / Math.ceil(distance)
-      return (
-        getAlpha({
-          x: previous.x + (point.x - previous.x) * ratio,
-          y: previous.y + (point.y - previous.y) * ratio
-        }) > MIN_VISIBLE_STROKE_ALPHA
-      )
-    })
-  })
-}
 
 export function hasVisiblePixels(obj) {
   if (!obj.toCanvasElement) return true
@@ -60,9 +25,7 @@ export function hasVisiblePixels(obj) {
     if (!context) return true
     const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data
     for (let index = 3; index < pixels.length; index += 4) {
-      if (pixels[index] > MIN_VISIBLE_ALPHA) {
-        return obj.type === 'PSStroke' ? hasVisibleStrokeCenterline(obj) : true
-      }
+      if (pixels[index] > MIN_VISIBLE_ALPHA) return true
     }
     return false
   } catch {

--- a/src/lib/players/eraserbrush.js
+++ b/src/lib/players/eraserbrush.js
@@ -12,6 +12,30 @@ import {
 // Signature of an "empty" SVG path produced by convertPointsToSVGPath when the
 // gesture is degenerate (a single point). Matches fabric's own internal check.
 const EMPTY_SVG_PATH = 'M 0 0 Q 0 0 0 0 L 0 0'
+const MIN_VISIBLE_ALPHA = 16
+// Destination-out compositing leaves sparse raster fragments around curved
+// pressure strokes even when no annotation is perceptible at canvas scale.
+const MIN_VISIBLE_PIXEL_RATIO = 0.03
+
+export function hasVisiblePixels(obj) {
+  if (!obj.toCanvasElement) return true
+  try {
+    const canvas = obj.toCanvasElement({
+      enableRetinaScaling: false,
+      withoutShadow: true
+    })
+    const context = canvas.getContext('2d')
+    if (!context) return true
+    const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data
+    let visiblePixels = 0
+    for (let index = 3; index < pixels.length; index += 4) {
+      if (pixels[index] > MIN_VISIBLE_ALPHA) visiblePixels += 1
+    }
+    return visiblePixels / (pixels.length / 4) > MIN_VISIBLE_PIXEL_RATIO
+  } catch {
+    return true
+  }
+}
 
 // An object's eraser: a group of paths in the object's LOCAL coordinates.
 // FixedLayout + center origin: its dimensions don't change when paths are

--- a/src/lib/players/eraserbrush.js
+++ b/src/lib/players/eraserbrush.js
@@ -13,9 +13,41 @@ import {
 // gesture is degenerate (a single point). Matches fabric's own internal check.
 const EMPTY_SVG_PATH = 'M 0 0 Q 0 0 0 0 L 0 0'
 const MIN_VISIBLE_ALPHA = 16
-// Destination-out compositing leaves sparse raster fragments around curved
-// pressure strokes even when no annotation is perceptible at canvas scale.
-const MIN_VISIBLE_PIXEL_RATIO = 0.03
+const MIN_VISIBLE_STROKE_ALPHA = 128
+
+const hasVisibleStrokeCenterline = obj => {
+  obj.renderCache()
+  const canvas = obj._cacheCanvas
+  const context = canvas?.getContext('2d')
+  if (!context) return true
+  const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data
+  const getAlpha = point => {
+    const x = Math.round(
+      (point.x - obj.strokeOffset.x) * obj.zoomX + obj.cacheTranslationX
+    )
+    const y = Math.round(
+      (point.y - obj.strokeOffset.y) * obj.zoomY + obj.cacheTranslationY
+    )
+    return pixels[(y * canvas.width + x) * 4 + 3] || 0
+  }
+  return obj.strokePoints.slice(1).some((point, index) => {
+    const previous = obj.strokePoints[index]
+    const distance = Math.max(
+      Math.abs(point.x - previous.x),
+      Math.abs(point.y - previous.y),
+      1
+    )
+    return Array.from({ length: Math.ceil(distance) + 1 }).some((_, step) => {
+      const ratio = step / Math.ceil(distance)
+      return (
+        getAlpha({
+          x: previous.x + (point.x - previous.x) * ratio,
+          y: previous.y + (point.y - previous.y) * ratio
+        }) > MIN_VISIBLE_STROKE_ALPHA
+      )
+    })
+  })
+}
 
 export function hasVisiblePixels(obj) {
   if (!obj.toCanvasElement) return true
@@ -27,11 +59,12 @@ export function hasVisiblePixels(obj) {
     const context = canvas.getContext('2d')
     if (!context) return true
     const pixels = context.getImageData(0, 0, canvas.width, canvas.height).data
-    let visiblePixels = 0
     for (let index = 3; index < pixels.length; index += 4) {
-      if (pixels[index] > MIN_VISIBLE_ALPHA) visiblePixels += 1
+      if (pixels[index] > MIN_VISIBLE_ALPHA) {
+        return obj.type === 'PSStroke' ? hasVisibleStrokeCenterline(obj) : true
+      }
     }
-    return visiblePixels / (pixels.length / 4) > MIN_VISIBLE_PIXEL_RATIO
+    return false
   } catch {
     return true
   }

--- a/tests/unit/composables/annotation.spec.js
+++ b/tests/unit/composables/annotation.spec.js
@@ -396,6 +396,55 @@ describe('composables/annotation', () => {
       wrapper.unmount()
     })
 
+    it('deletes an object with no visible pixels left', () => {
+      const canvas = createFakeCanvas()
+      const { api, postAnnotationDeletion, postAnnotationUpdate, wrapper } =
+        mountAnnotation({ canvas })
+      const obj = createSerializableObject({
+        id: 'erased',
+        toCanvasElement: () => ({
+          width: 2,
+          height: 2,
+          getContext: () => ({
+            getImageData: () => ({ data: new Uint8ClampedArray(16) })
+          })
+        })
+      })
+      canvas._objects.push(obj)
+
+      api.onErasingEnd({ targets: [obj], path: {} })
+
+      expect(canvas.remove).toHaveBeenCalledWith(obj)
+      expect(api.deletions.value[0].objects).toEqual(['erased'])
+      expect(api.updates.value).toHaveLength(0)
+      expect(postAnnotationDeletion).toHaveBeenCalledTimes(1)
+      expect(postAnnotationUpdate).not.toHaveBeenCalled()
+      wrapper.unmount()
+    })
+
+    it('keeps an object when at least one visible pixel remains', () => {
+      const canvas = createFakeCanvas()
+      const { api, postAnnotationUpdate, wrapper } = mountAnnotation({ canvas })
+      const pixels = new Uint8ClampedArray(16)
+      pixels[7] = 1
+      const obj = createSerializableObject({
+        id: 'partial',
+        toCanvasElement: () => ({
+          width: 2,
+          height: 2,
+          getContext: () => ({ getImageData: () => ({ data: pixels }) })
+        })
+      })
+      canvas._objects.push(obj)
+
+      api.onErasingEnd({ targets: [obj], path: {} })
+
+      expect(canvas.remove).not.toHaveBeenCalled()
+      expect(api.deletions.value).toHaveLength(0)
+      expect(postAnnotationUpdate).toHaveBeenCalledTimes(1)
+      wrapper.unmount()
+    })
+
     it('ignores an erasing:end that touched no object', () => {
       const { api, saveAnnotationsCb, wrapper } = mountAnnotation()
       api.onErasingEnd({ targets: [], subTargets: [] })
@@ -1040,6 +1089,34 @@ describe('composables/annotation', () => {
       expect(obj.eraser).toBeDefined()
       expect(obj.eraser.getObjects()).toHaveLength(1)
       expect(obj.eraser.getObjects()[0].path).toBe('M 0 0 L 5 5')
+      wrapper.unmount()
+    })
+
+    it('undo restores and redo removes a fully erased object', () => {
+      const canvas = createFakeCanvas()
+      const { api, wrapper } = mountAnnotation({ canvas })
+      const obj = makeErasable('e1')
+      obj.toCanvasElement = () => ({
+        width: 1,
+        height: 1,
+        getContext: () => ({
+          getImageData: () => ({ data: new Uint8ClampedArray(4) })
+        })
+      })
+      canvas._objects.push(obj)
+
+      api.onErasingEnd({ targets: [obj], path: {} })
+      expect(canvas._objects).not.toContain(obj)
+
+      api.undoLastAction()
+      expect(canvas._objects).toContain(obj)
+      expect(obj.eraser).toBeUndefined()
+      expect(api.deletions.value[0].objects).toHaveLength(0)
+
+      api.redoLastAction()
+      expect(canvas._objects).not.toContain(obj)
+      expect(obj.eraser.getObjects()).toHaveLength(1)
+      expect(api.deletions.value[0].objects).toEqual(['e1'])
       wrapper.unmount()
     })
 

--- a/tests/unit/composables/annotation.spec.js
+++ b/tests/unit/composables/annotation.spec.js
@@ -426,7 +426,7 @@ describe('composables/annotation', () => {
       const canvas = createFakeCanvas()
       const { api, postAnnotationUpdate, wrapper } = mountAnnotation({ canvas })
       const pixels = new Uint8ClampedArray(16)
-      pixels[7] = 1
+      pixels[7] = 255
       const obj = createSerializableObject({
         id: 'partial',
         toCanvasElement: () => ({
@@ -442,6 +442,28 @@ describe('composables/annotation', () => {
       expect(canvas.remove).not.toHaveBeenCalled()
       expect(api.deletions.value).toHaveLength(0)
       expect(postAnnotationUpdate).toHaveBeenCalledTimes(1)
+      wrapper.unmount()
+    })
+
+    it('deletes an object with only antialias alpha remaining', () => {
+      const canvas = createFakeCanvas()
+      const { api, wrapper } = mountAnnotation({ canvas })
+      const pixels = new Uint8ClampedArray(16)
+      pixels[7] = 16
+      const obj = createSerializableObject({
+        id: 'antialias-residue',
+        toCanvasElement: () => ({
+          width: 2,
+          height: 2,
+          getContext: () => ({ getImageData: () => ({ data: pixels }) })
+        })
+      })
+      canvas._objects.push(obj)
+
+      api.onErasingEnd({ targets: [obj], path: {} })
+
+      expect(canvas.remove).toHaveBeenCalledWith(obj)
+      expect(api.deletions.value[0].objects).toEqual(['antialias-residue'])
       wrapper.unmount()
     })
 

--- a/tests/unit/composables/annotation.spec.js
+++ b/tests/unit/composables/annotation.spec.js
@@ -467,6 +467,98 @@ describe('composables/annotation', () => {
       wrapper.unmount()
     })
 
+    it('splits a mixed gesture into deletions and updates', () => {
+      const canvas = createFakeCanvas()
+      const { api, postAnnotationDeletion, postAnnotationUpdate, wrapper } =
+        mountAnnotation({ canvas })
+      const erased = createSerializableObject({
+        id: 'erased',
+        toCanvasElement: () => ({
+          width: 1,
+          height: 1,
+          getContext: () => ({
+            getImageData: () => ({ data: new Uint8ClampedArray(4) })
+          })
+        })
+      })
+      const pixels = new Uint8ClampedArray(4)
+      pixels[3] = 255
+      const visible = createSerializableObject({
+        id: 'visible',
+        toCanvasElement: () => ({
+          width: 1,
+          height: 1,
+          getContext: () => ({ getImageData: () => ({ data: pixels }) })
+        })
+      })
+      canvas._objects.push(erased, visible)
+
+      api.onErasingEnd({ targets: [erased], subTargets: [visible], path: {} })
+
+      expect(canvas._objects).toEqual([visible])
+      expect(api.deletions.value[0].objects).toEqual(['erased'])
+      expect(api.updates.value[0].drawing.objects[0].id).toBe('visible')
+      expect(postAnnotationDeletion).toHaveBeenCalledTimes(1)
+      expect(postAnnotationUpdate).toHaveBeenCalledTimes(1)
+      wrapper.unmount()
+    })
+
+    it('processes the same target only once', () => {
+      const { api, postAnnotationUpdate, wrapper } = mountAnnotation()
+      const obj = createSerializableObject({ id: 'duplicate' })
+
+      api.onErasingEnd({ targets: [obj], subTargets: [obj], path: {} })
+
+      expect(api.updates.value[0].drawing.objects).toHaveLength(1)
+      expect(postAnnotationUpdate).toHaveBeenCalledTimes(1)
+      wrapper.unmount()
+    })
+
+    it('retains an object when visibility rendering fails', () => {
+      const canvas = createFakeCanvas()
+      const { api, postAnnotationUpdate, wrapper } = mountAnnotation({ canvas })
+      const obj = createSerializableObject({
+        id: 'render-error',
+        toCanvasElement: () => {
+          throw new Error('render failed')
+        }
+      })
+      canvas._objects.push(obj)
+
+      api.onErasingEnd({ targets: [obj], path: {} })
+
+      expect(canvas._objects).toContain(obj)
+      expect(api.deletions.value).toHaveLength(0)
+      expect(postAnnotationUpdate).toHaveBeenCalledTimes(1)
+      wrapper.unmount()
+    })
+
+    it('removes the annotation frame after its last object is fully erased', () => {
+      const serialized = { id: 'last-object', type: 'path' }
+      const annotations = ref([
+        { time: 1, frame: 24, drawing: { objects: [serialized] } }
+      ])
+      const canvas = createFakeCanvas()
+      const { api, wrapper } = mountAnnotation({ annotations, canvas })
+      const obj = createSerializableObject({
+        id: 'last-object',
+        toCanvasElement: () => ({
+          width: 1,
+          height: 1,
+          getContext: () => ({
+            getImageData: () => ({ data: new Uint8ClampedArray(4) })
+          })
+        })
+      })
+      canvas._objects.push(obj)
+
+      api.onErasingEnd({ targets: [obj], path: {} })
+      api.getNewAnnotations(1, 24, annotations.value[0])
+
+      expect(annotations.value).toHaveLength(0)
+      wrapper.unmount()
+    })
+
     it('ignores an erasing:end that touched no object', () => {
       const { api, saveAnnotationsCb, wrapper } = mountAnnotation()
       api.onErasingEnd({ targets: [], subTargets: [] })

--- a/tests/unit/lib/eraser-rendering.spec.js
+++ b/tests/unit/lib/eraser-rendering.spec.js
@@ -3,7 +3,7 @@ import { expect, it } from 'vitest'
 
 import { getEnv as getNodeEnv } from 'fabric/node'
 
-const { setEnv, StaticCanvas } = await import('fabric')
+const { Path, setEnv, StaticCanvas } = await import('fabric')
 setEnv(getNodeEnv())
 const { PSPoint, PSStroke } = await import('fabricjs-psbrush')
 const { EraserBrush, hasVisiblePixels, installEraserObjectSupport } =
@@ -121,6 +121,45 @@ it('keeps a partially erased stroke visible', async () => {
   const brush = new EraserBrush({})
   brush.width = 30
   const eraserPath = brush.createPath('M 10 10 L 45 45')
+
+  await brush._addPathToObjectEraser(stroke, eraserPath)
+
+  expect(hasVisiblePixels(stroke)).toBe(true)
+})
+
+it('keeps the remaining end of a mostly erased long thin stroke', async () => {
+  const stroke = new PSStroke(
+    [new PSPoint(20, 20, 0.5), new PSPoint(520, 520, 0.5)],
+    {
+      fill: null,
+      stroke: '#5e60ba',
+      strokeWidth: 4,
+      strokeLineCap: 'round',
+      strokeLineJoin: 'round',
+      originX: 'left',
+      originY: 'top'
+    }
+  )
+  const brush = new EraserBrush({})
+  brush.width = 10
+  const eraserPath = brush.createPath('M 15 15 L 420 420')
+
+  await brush._addPathToObjectEraser(stroke, eraserPath)
+
+  expect(hasVisiblePixels(stroke)).toBe(true)
+})
+
+it('keeps a partially erased long thin path', async () => {
+  const stroke = new Path('M 20 20 L 520 520', {
+    fill: null,
+    stroke: '#5e60ba',
+    strokeWidth: 4,
+    strokeLineCap: 'round',
+    strokeLineJoin: 'round'
+  })
+  const brush = new EraserBrush({})
+  brush.width = 10
+  const eraserPath = brush.createPath('M 15 15 L 420 420')
 
   await brush._addPathToObjectEraser(stroke, eraserPath)
 

--- a/tests/unit/lib/eraser-rendering.spec.js
+++ b/tests/unit/lib/eraser-rendering.spec.js
@@ -62,7 +62,7 @@ it('renders no pixels when a wider eraser stroke covers a color stroke', async (
   expect(countVisiblePixels(stroke)).toBe(0)
 })
 
-it('treats sparse pressure-stroke remnants as invisible', async () => {
+it('conservatively retains pressure-stroke raster remnants', async () => {
   const stroke = new PSStroke(
     [
       new PSPoint(45.485, 45.5, 0.5),
@@ -102,7 +102,7 @@ it('treats sparse pressure-stroke remnants as invisible', async () => {
   await brush._addPathToObjectEraser(stroke, eraserPath)
 
   expect(countCanvasPixels(canvas)).toBeGreaterThan(0)
-  expect(hasVisiblePixels(stroke)).toBe(false)
+  expect(hasVisiblePixels(stroke)).toBe(true)
 })
 
 it('keeps a partially erased stroke visible', async () => {

--- a/tests/unit/lib/eraser-rendering.spec.js
+++ b/tests/unit/lib/eraser-rendering.spec.js
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { expect, it } from 'vitest'
+
+import { getEnv as getNodeEnv } from 'fabric/node'
+
+const { setEnv, StaticCanvas } = await import('fabric')
+setEnv(getNodeEnv())
+const { PSPoint, PSStroke } = await import('fabricjs-psbrush')
+const { EraserBrush, hasVisiblePixels, installEraserObjectSupport } =
+  await import('@/lib/players/eraserbrush')
+
+installEraserObjectSupport()
+
+const countVisiblePixels = object => {
+  const canvas = object.toCanvasElement({
+    enableRetinaScaling: false,
+    withoutShadow: true
+  })
+  const pixels = canvas
+    .getContext('2d')
+    .getImageData(0, 0, canvas.width, canvas.height).data
+  let count = 0
+  for (let index = 3; index < pixels.length; index += 4) {
+    if (pixels[index] !== 0) count += 1
+  }
+  return count
+}
+
+const countCanvasPixels = canvas => {
+  canvas.renderAll()
+  const element = canvas.getElement()
+  const pixels = element
+    .getContext('2d')
+    .getImageData(0, 0, element.width, element.height).data
+  let count = 0
+  for (let index = 3; index < pixels.length; index += 4) {
+    if (pixels[index] !== 0) count += 1
+  }
+  return count
+}
+
+it('renders no pixels when a wider eraser stroke covers a color stroke', async () => {
+  const stroke = new PSStroke(
+    [new PSPoint(20, 20, 0.5), new PSPoint(80, 80, 0.5)],
+    {
+      fill: null,
+      stroke: '#5e60ba',
+      strokeWidth: 20,
+      strokeLineCap: 'round',
+      strokeLineJoin: 'round',
+      originX: 'left',
+      originY: 'top'
+    }
+  )
+  const brush = new EraserBrush({})
+  brush.width = 30
+  const eraserPath = brush.createPath('M 10 10 L 90 90')
+
+  expect(countVisiblePixels(stroke)).toBeGreaterThan(0)
+  await brush._addPathToObjectEraser(stroke, eraserPath)
+
+  expect(countVisiblePixels(stroke)).toBe(0)
+})
+
+it('treats sparse pressure-stroke remnants as invisible', async () => {
+  const stroke = new PSStroke(
+    [
+      new PSPoint(45.485, 45.5, 0.5),
+      new PSPoint(45.5, 45.5, 0.5),
+      new PSPoint(46.5, 45.5, 0.5),
+      new PSPoint(47.5, 46.5, 0.53),
+      new PSPoint(49.5, 50.5, 0.56),
+      new PSPoint(54.5, 55.5, 0.53),
+      new PSPoint(59.5, 60.5, 0.5),
+      new PSPoint(62.5, 63.5, 0.47),
+      new PSPoint(64.5, 66.5, 0.44),
+      new PSPoint(66.5, 67.5, 0.41),
+      new PSPoint(68.5, 68.5, 0.44),
+      new PSPoint(71.5, 70.5, 0.47),
+      new PSPoint(72.5, 71.5, 0.44),
+      new PSPoint(72.5, 72.5, 0.47)
+    ],
+    {
+      fill: null,
+      stroke: '#5e60ba',
+      strokeWidth: 30,
+      strokeLineCap: 'round',
+      strokeLineJoin: 'round',
+      originX: 'left',
+      originY: 'top'
+    }
+  )
+  const brush = new EraserBrush({})
+  brush.width = 30
+  const eraserPath = brush.createPath(
+    'M 78.5 76.53 Q 78.5 76.5 78.5 76 Q 78.5 75.5 78.5 75 Q 78.5 74.5 78.5 74 Q 78.5 73.5 77 72.5 Q 75.5 71.5 73.5 70 Q 71.5 68.5 69.5 67.5 Q 67.5 66.5 64.5 65 Q 61.5 63.5 58 60.5 Q 54.5 57.5 50.5 54 Q 46.5 50.5 43 46.5 Q 39.5 42.5 37.5 40.5 Q 35.5 38.5 34.5 38 Q 33.5 37.5 32.5 37 L 31.47 36.47',
+  )
+  const canvas = new StaticCanvas(null, { width: 150, height: 150 })
+  canvas.add(stroke)
+
+  expect(countCanvasPixels(canvas)).toBeGreaterThan(0)
+  await brush._addPathToObjectEraser(stroke, eraserPath)
+
+  expect(countCanvasPixels(canvas)).toBeGreaterThan(0)
+  expect(hasVisiblePixels(stroke)).toBe(false)
+})
+
+it('keeps a partially erased stroke visible', async () => {
+  const stroke = new PSStroke(
+    [new PSPoint(20, 20, 0.5), new PSPoint(80, 80, 0.5)],
+    {
+      fill: null,
+      stroke: '#5e60ba',
+      strokeWidth: 20,
+      strokeLineCap: 'round',
+      strokeLineJoin: 'round',
+      originX: 'left',
+      originY: 'top'
+    }
+  )
+  const brush = new EraserBrush({})
+  brush.width = 30
+  const eraserPath = brush.createPath('M 10 10 L 45 45')
+
+  await brush._addPathToObjectEraser(stroke, eraserPath)
+
+  expect(hasVisiblePixels(stroke)).toBe(true)
+})


### PR DESCRIPTION
## Problem

When erasing annotations, even after fully erasing them, they are still left as invisible selectables.

For example, given these annotations:
<img width="427" height="263" alt="imagen" src="https://github.com/user-attachments/assets/40d13df7-0ffc-4a66-9368-a73ecee50b5a" />

After erasing the 'B' letter:
<img width="415" height="266" alt="imagen" src="https://github.com/user-attachments/assets/d6eeac7b-7e26-4500-a8b9-810838d50e0c" />
<img width="399" height="271" alt="imagen" src="https://github.com/user-attachments/assets/40e38852-a028-4e0a-b97c-4acc3554cd8c" />

## Solution

When an annotation is fully erased, remove it, so it doesn't add noise when selecting.

- Render erased annotations offscreen and inspect their alpha pixels.
- Delete objects only when no meaningful pixels remain.
- Keep partially erased objects and preserve undo/redo.
- Enable per-pixel hit testing so masked areas are not selectable.
- Cover full, partial, thin-stroke, persistence, and undo/redo cases with tests.