### PR TITLE
[ui] Comment thread polish and date-preference fixes

### DIFF
--- a/src/components/lists/PeopleTimesheetList.vue
+++ b/src/components/lists/PeopleTimesheetList.vue
@@ -179,6 +179,7 @@ import moment from 'moment-timezone'
 import { mapGetters } from 'vuex'
 
 import {
+  formatDisplayDate,
   getMonthRange,
   getWeekRange,
   getDayRange,
@@ -250,7 +251,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['dayOffMap', 'organisation', 'route']),
+    ...mapGetters(['dateFormat', 'dayOffMap', 'organisation', 'route']),
 
     yearRange() {
       return range(2018, moment().year())
@@ -371,7 +372,11 @@ export default {
     getWeekTitle(week) {
       const beginning = moment(this.year + '-' + week, 'YYYY-W')
       const end = beginning.clone().add(6, 'days')
-      return beginning.format('YYYY-MM-DD') + ' - ' + end.format('YYYY-MM-DD')
+      return (
+        formatDisplayDate(beginning, this.dateFormat) +
+        ' - ' +
+        formatDisplayDate(end, this.dateFormat)
+      )
     },
 
     getYearDetailRoute(person, year) {

--- a/src/components/lists/PreviewFileList.vue
+++ b/src/components/lists/PreviewFileList.vue
@@ -89,7 +89,7 @@ import { useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 
 import { getTaskPath } from '@/lib/path'
-import { formatDate } from '@/lib/time'
+import { formatDate as formatDateBase } from '@/lib/time'
 
 import ProductionNameCell from '@/components/cells/ProductionNameCell.vue'
 import TaskTypeCell from '@/components/cells/TaskTypeCell.vue'
@@ -117,8 +117,13 @@ const headerWrapper = ref(null)
 
 const productionMap = computed(() => store.getters.productionMap)
 const taskTypeMap = computed(() => store.getters.taskTypeMap)
+const dateFormat = computed(() => store.getters.dateFormat)
+const use12HourClock = computed(() => store.getters.use12HourClock)
 
 // Functions
+
+const formatDate = date =>
+  formatDateBase(date, dateFormat.value, use12HourClock.value)
 
 const onBodyScroll = event => {
   headerWrapper.value.style.left = `-${event.target.scrollLeft}px`

--- a/src/components/mixins/format.js
+++ b/src/components/mixins/format.js
@@ -13,7 +13,7 @@ import {
 
 export const formatListMixin = {
   computed: {
-    ...mapGetters(['dateFormat', 'organisation']),
+    ...mapGetters(['dateFormat', 'organisation', 'use12HourClock']),
 
     isDurationInHours() {
       return this.organisation.format_duration_in_hours
@@ -31,9 +31,12 @@ export const formatListMixin = {
       return booleanValue ? this.$t('main.yes') : this.$t('main.no')
     },
 
-    formatDate,
     formatFullDate,
     formatSimpleDate,
+
+    formatDate(date) {
+      return formatDate(date, this.dateFormat, this.use12HourClock)
+    },
 
     formatDisplayDate(date) {
       return formatDisplayDate(date, this.dateFormat)

--- a/src/components/modals/EditHistoryModal.vue
+++ b/src/components/modals/EditHistoryModal.vue
@@ -52,7 +52,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useStore } from 'vuex'
 
-import { formatDate } from '@/lib/time'
+import { formatDate as formatDateBase } from '@/lib/time'
 
 import BaseModal from '@/components/modals/BaseModal.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
@@ -77,8 +77,13 @@ const versions = ref([])
 // Computed
 
 const personMap = computed(() => store.getters.personMap)
+const dateFormat = computed(() => store.getters.dateFormat)
+const use12HourClock = computed(() => store.getters.use12HourClock)
 
 // Functions
+
+const formatDate = date =>
+  formatDateBase(date, dateFormat.value, use12HourClock.value)
 
 const getPersonFullName = personId =>
   personMap.value.get(personId)?.full_name || ''

--- a/src/components/modals/SharePlaylistModal.vue
+++ b/src/components/modals/SharePlaylistModal.vue
@@ -210,7 +210,7 @@ import Multiselect from 'vue-multiselect'
 import 'vue-multiselect/dist/vue-multiselect.min.css'
 
 import { useTime } from '@/composables/time'
-import { formatSimpleDate } from '@/lib/time'
+import { formatDisplayDate, formatSimpleDate } from '@/lib/time'
 
 import BaseModal from '@/components/modals/BaseModal.vue'
 import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
@@ -218,7 +218,7 @@ import Checkbox from '@/components/widgets/Checkbox.vue'
 import DateField from '@/components/widgets/DateField.vue'
 
 const { t } = useI18n()
-const { tomorrow } = useTime()
+const { tomorrow, dateFormat } = useTime()
 const store = useStore()
 
 const props = defineProps({
@@ -422,7 +422,7 @@ const copyLink = token => {
 
 const formatDate = dateStr => {
   if (!dateStr) return ''
-  return new Date(dateStr).toLocaleDateString()
+  return formatDisplayDate(dateStr, dateFormat.value)
 }
 
 onMounted(() => {

--- a/src/components/modals/ShotHistoryModal.vue
+++ b/src/components/modals/ShotHistoryModal.vue
@@ -60,7 +60,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useStore } from 'vuex'
 
-import { formatDate } from '@/lib/time'
+import { formatDate as formatDateBase } from '@/lib/time'
 
 import BaseModal from '@/components/modals/BaseModal.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
@@ -85,8 +85,13 @@ const versions = ref([])
 // Computed
 
 const personMap = computed(() => store.getters.personMap)
+const dateFormat = computed(() => store.getters.dateFormat)
+const use12HourClock = computed(() => store.getters.use12HourClock)
 
 // Functions
+
+const formatDate = date =>
+  formatDateBase(date, dateFormat.value, use12HourClock.value)
 
 const getPersonFullName = personId =>
   personMap.value.get(personId)?.full_name || ''

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -623,7 +623,7 @@ import { mapGetters, mapActions } from 'vuex'
 import { PlusIcon, XIcon } from 'lucide-vue-next'
 
 import { DEFAULT_NB_FRAMES_PICTURE } from '@/lib/playlist'
-import { formatDate } from '@/lib/time'
+import { formatDate as formatDateBase } from '@/lib/time'
 import { getPlaylistPath } from '@/lib/path'
 import { updateModelFromList, removeModelFromList } from '@/lib/models'
 import { sortAssets, sortShots } from '@/lib/sorting'
@@ -725,6 +725,7 @@ export default {
       'assetSearchText',
       'currentEpisode',
       'currentProduction',
+      'dateFormat',
       'displayedAssets',
       'displayedAssetsByType',
       'displayedEdits',
@@ -747,7 +748,8 @@ export default {
       'shotSearchText',
       'taskMap',
       'taskStatusMap',
-      'taskTypeMap'
+      'taskTypeMap',
+      'use12HourClock'
     ]),
 
     isAdditionLoading() {
@@ -895,7 +897,7 @@ export default {
     // Helpers
 
     formatDate(dateString) {
-      return formatDate(dateString)
+      return formatDateBase(dateString, this.dateFormat, this.use12HourClock)
     },
 
     isCurrentProjectEvent(eventData) {

--- a/src/components/pages/entities/EntityNews.vue
+++ b/src/components/pages/entities/EntityNews.vue
@@ -17,7 +17,7 @@
           }"
         ></span>
         <span class="date flexrow-item">
-          {{ formatFullDate(news.created_at).substring(10, 0) }}
+          {{ formatDisplayDate(news.created_at) }}
         </span>
 
         <people-avatar

--- a/src/components/pages/entities/EntityPreviewFiles.vue
+++ b/src/components/pages/entities/EntityPreviewFiles.vue
@@ -132,7 +132,7 @@ import { DownloadIcon } from 'lucide-vue-next'
 import { mapGetters, mapActions } from 'vuex'
 
 import { renderFileSize } from '@/lib/render'
-import { formatDate } from '@/lib/time'
+import { formatDate as formatDateBase } from '@/lib/time'
 import preferences from '@/lib/preferences'
 import { getTaskTypePriorityOfProd } from '@/lib/productions'
 
@@ -184,10 +184,12 @@ export default {
   computed: {
     ...mapGetters([
       'currentProduction',
+      'dateFormat',
       'isCurrentUserArtist',
       'personMap',
       'taskMap',
-      'taskTypeMap'
+      'taskTypeMap',
+      'use12HourClock'
     ]),
 
     taskTypePreviewFileGroups() {
@@ -239,7 +241,9 @@ export default {
 
     renderFileSize,
 
-    formatDate,
+    formatDate(date) {
+      return formatDateBase(date, this.dateFormat, this.use12HourClock)
+    },
 
     reset() {
       this.isLoading = true

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -945,6 +945,7 @@ import {
   isMoviePreview,
   isPicturePreview
 } from '@/lib/preview'
+import { formatDisplayDate, formatTimeOfDay } from '@/lib/time'
 import {
   ceilToFrame,
   floorToFrame,
@@ -1482,6 +1483,8 @@ const deleteText = computed(() => {
 })
 
 const timezone = computed(() => user.value?.timezone || moment.tz.guess())
+const dateFormat = computed(() => store.getters.dateFormat)
+const use12HourClock = computed(() => store.getters.use12HourClock)
 
 const entityTaskTypes = computed(() => {
   switch (props.playlist?.for_entity) {
@@ -3733,7 +3736,7 @@ const getBuildPath = job =>
 
 const formatDate = creationDate => {
   const date = moment.tz(creationDate, 'UTC').tz(timezone.value)
-  return date.format('YYYY-MM-DD HH:mm')
+  return `${formatDisplayDate(date, dateFormat.value)} ${formatTimeOfDay(date, use12HourClock.value)}`
 }
 
 const setPlaylistProgress = time => {

--- a/src/components/players/viewers/AttachmentAudioPlayer.vue
+++ b/src/components/players/viewers/AttachmentAudioPlayer.vue
@@ -1,20 +1,18 @@
 <template>
   <div class="attachment-audio-player">
-    <div class="attachment-audio">
-      <audio ref="mediaEl" :src="src" preload="metadata" @error="onError" />
+    <div class="attachment-error" v-if="hasError">
+      <volume-x-icon class="attachment-error-icon" :size="18" />
+      <span class="attachment-error-text">
+        <span class="attachment-error-label">
+          {{ $t('comments.player.audio_unavailable') }}
+        </span>
+        <span class="attachment-error-name" v-if="name">{{ name }}</span>
+      </span>
+    </div>
 
-      <a
-        class="flexrow attachment-fallback"
-        :href="downloadHref || src"
-        :title="name"
-        target="_blank"
-        v-if="hasError"
-      >
-        <paperclip-icon class="flexrow-item attachment-icon icon-1x" />
-        <span class="flexrow-item">{{ name }}</span>
-      </a>
-
-      <template v-else>
+    <template v-else>
+      <div class="attachment-audio">
+        <audio ref="mediaEl" :src="src" preload="metadata" @error="onError" />
         <button
           class="player-button play-button"
           :aria-label="
@@ -55,21 +53,17 @@
         >
           <download-icon :size="14" />
         </a>
-      </template>
-    </div>
-    <span
-      class="attachment-name"
-      :title="name"
-      v-if="showName && name && !hasError"
-      >{{ name }}</span
-    >
+      </div>
+      <span class="attachment-name" :title="name" v-if="showName && name">{{
+        name
+      }}</span>
+    </template>
   </div>
 </template>
 
 <script setup>
 import {
   DownloadIcon,
-  PaperclipIcon,
   PauseIcon,
   PlayIcon,
   Volume2Icon,
@@ -171,7 +165,42 @@ const onError = () => {
   white-space: nowrap;
 }
 
-.attachment-fallback {
+.attachment-error {
+  align-items: center;
+  background: var(--background-alt);
+  border: 1px solid var(--border);
+  border-radius: 8px;
   color: var(--text);
+  display: flex;
+  gap: 0.6em;
+  max-width: 32em;
+  padding: 0.6em 0.8em;
+}
+
+.attachment-error-icon {
+  color: var(--text-alt);
+  flex-shrink: 0;
+}
+
+.attachment-error-text {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.1em;
+  margin-left: 0.3em;
+  min-width: 0;
+}
+
+.attachment-error-label {
+  font-size: 0.85em;
+  font-weight: 600;
+}
+
+.attachment-error-name {
+  color: var(--text-alt);
+  font-size: 0.8em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 </style>

--- a/src/components/players/viewers/AttachmentVideoPlayer.vue
+++ b/src/components/players/viewers/AttachmentVideoPlayer.vue
@@ -1,22 +1,21 @@
 <template>
   <div class="attachment-video-player">
-    <div
-      class="attachment-video"
-      :class="{ 'is-paused': !isPlaying }"
-      ref="wrapperEl"
-    >
-      <a
-        class="flexrow attachment-fallback"
-        :href="downloadHref || src"
-        :title="name"
-        target="_blank"
-        v-if="hasError"
-      >
-        <paperclip-icon class="flexrow-item attachment-icon icon-1x" />
-        <span class="flexrow-item">{{ name }}</span>
-      </a>
+    <div class="attachment-error" v-if="hasError">
+      <video-off-icon class="attachment-error-icon" :size="18" />
+      <span class="attachment-error-text">
+        <span class="attachment-error-label">
+          {{ $t('comments.player.video_unavailable') }}
+        </span>
+        <span class="attachment-error-name" v-if="name">{{ name }}</span>
+      </span>
+    </div>
 
-      <template v-else>
+    <template v-else>
+      <div
+        class="attachment-video"
+        :class="{ 'is-paused': !isPlaying }"
+        ref="wrapperEl"
+      >
         <video
           class="attachment-video-el"
           ref="mediaEl"
@@ -77,14 +76,11 @@
             <download-icon :size="14" />
           </a>
         </div>
-      </template>
-    </div>
-    <span
-      class="attachment-name"
-      :title="name"
-      v-if="showName && name && !hasError"
-      >{{ name }}</span
-    >
+      </div>
+      <span class="attachment-name" :title="name" v-if="showName && name">{{
+        name
+      }}</span>
+    </template>
   </div>
 </template>
 
@@ -92,9 +88,9 @@
 import {
   DownloadIcon,
   MaximizeIcon,
-  PaperclipIcon,
   PauseIcon,
   PlayIcon,
+  VideoOffIcon,
   Volume2Icon,
   VolumeXIcon
 } from 'lucide-vue-next'
@@ -250,7 +246,42 @@ const onError = () => {
   white-space: nowrap;
 }
 
-.attachment-fallback {
+.attachment-error {
+  align-items: center;
+  background: var(--background-alt);
+  border: 1px solid var(--border);
+  border-radius: 8px;
   color: var(--text);
+  display: flex;
+  gap: 0.6em;
+  max-width: 32em;
+  padding: 0.6em 0.8em;
+}
+
+.attachment-error-icon {
+  color: var(--text-alt);
+  flex-shrink: 0;
+}
+
+.attachment-error-text {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.1em;
+  margin-left: 0.3em;
+  min-width: 0;
+}
+
+.attachment-error-label {
+  font-size: 0.85em;
+  font-weight: 600;
+}
+
+.attachment-error-name {
+  color: var(--text-alt);
+  font-size: 0.8em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 </style>

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -150,6 +150,7 @@
       </div>
       <div class="post-area">
         <checklist
+          class="checklist"
           :checklist="checklistItems"
           :frame="frame + 1"
           :revision="revision"
@@ -1242,6 +1243,10 @@ article.add-comment {
 .post-area {
   position: relative;
   padding: 0 0.5em 0.2em 0.5em;
+}
+
+.checklist {
+  margin-top: 0.5em;
 }
 
 .progress-wrapper {

--- a/src/components/widgets/Checklist.vue
+++ b/src/components/widgets/Checklist.vue
@@ -47,6 +47,7 @@
         v{{ entry.revision }} - {{ formatFrame(entry.frame) }}
       </span>
       <span
+        class="checklist-clock"
         role="button"
         tabindex="0"
         @click="setFrame(entry)"
@@ -259,33 +260,79 @@ const toggleEntryChecked = entry => {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
+  gap: 0.2em;
   margin-bottom: 0.3em;
 
+  // Single-line clickable columns share one 20px line box so the checkbox,
+  // frame badge and clock stay centered on the label's first line. They are
+  // never multi-line, so centering them is safe.
+  .checklist-checkbox,
+  .checklist-clock,
+  .frame {
+    display: inline-flex;
+    align-items: center;
+    min-height: 20px;
+    cursor: pointer;
+
+    .icon {
+      width: 20px;
+    }
+
+    .clock {
+      width: 16px;
+    }
+  }
+
+  .frame {
+    justify-content: center;
+    border: 1px solid var(--border-alt);
+    border-radius: 4px;
+    width: 70px;
+    padding: 0 0.3em;
+    font-size: 0.85em;
+    white-space: nowrap;
+
+    // The a11y pass made this a focusable button; its own border already
+    // signals focus, so darken it instead of stacking the default outline.
+    &:focus-visible {
+      outline: none;
+      border-color: var(--text-alt);
+    }
+  }
+
+  // Text columns keep a matching 20px line box on their first line, but stay
+  // flow-content (not flex) so multi-line values grow downward with their
+  // first line still aligned to the checkbox (align-items: flex-start).
   .checklist-label,
   .checklist-text {
     font-size: 0.9em;
-    padding: 0.2em;
+    line-height: 20px;
+    padding: 0 0.3em;
   }
 
   .checklist-label {
     color: #333;
     cursor: default;
-    margin-right: 0;
   }
 
   .checklist-text {
-    padding-top: 0;
-    margin-right: 0.5em;
-    margin-top: 4px;
     width: 100%;
     min-height: 20px;
+    margin-right: 0.5em;
     border: 1px solid transparent;
+    border-radius: 4px;
     resize: none;
 
     &:focus,
     &:active,
     &:hover {
       border: 1px solid $light-grey;
+    }
+
+    // The focus border is the visible indicator; suppress the default
+    // outline the a11y pass left doubled on top of it.
+    &:focus {
+      outline: none;
     }
 
     &:disabled {
@@ -312,31 +359,6 @@ const toggleEntryChecked = entry => {
         fill: rgba($light-grey-2, 0.15);
       }
     }
-  }
-
-  span {
-    cursor: pointer;
-    padding: 0.2em 0 0 0;
-    margin-right: 0.2em;
-    margin-left: 0;
-
-    .icon {
-      width: 20px;
-    }
-
-    .clock {
-      width: 16px;
-    }
-  }
-
-  .frame {
-    border: 1px solid var(--border-alt);
-    border-radius: 4px;
-    width: 70px;
-    margin-top: 2px;
-    padding: 0 0.2em;
-    text-align: center;
-    white-space: nowrap;
   }
 }
 </style>

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -170,14 +170,13 @@
                 :href="getDownloadAttachmentPath(attachment)"
                 :key="attachment.id"
                 :title="attachment.name"
-                class="flexrow"
+                class="attachment-file-link"
                 target="_blank"
                 v-for="attachment in fileAttachments"
               >
-                <paperclip-icon class="flexrow-item attachment-icon icon-1x" />
-                <span class="flexrow-item">
-                  {{ attachment.name }}
-                </span>
+                <paperclip-icon class="attachment-icon" :size="16" />
+                <span class="attachment-file-name">{{ attachment.name }}</span>
+                <download-icon class="attachment-download-icon" :size="15" />
               </a>
             </p>
             <div class="replies">
@@ -272,17 +271,19 @@
                     :href="getDownloadAttachmentPath(attachment)"
                     :key="attachment.id"
                     :title="attachment.name"
-                    class="flexrow"
+                    class="attachment-file-link"
                     target="_blank"
                     v-for="attachment in replyAttachmentMap.get(replyComment.id)
                       ?.files"
                   >
-                    <paperclip-icon
-                      class="flexrow-item attachment-icon icon-1x"
+                    <paperclip-icon class="attachment-icon" :size="16" />
+                    <span class="attachment-file-name">{{
+                      attachment.name
+                    }}</span>
+                    <download-icon
+                      class="attachment-download-icon"
+                      :size="15"
                     />
-                    <span class="flexrow-item">
-                      {{ attachment.name }}
-                    </span>
                   </a>
                 </p>
               </div>
@@ -564,6 +565,7 @@ import moment from 'moment'
 import {
   ChevronDownIcon,
   CopyIcon,
+  DownloadIcon,
   LinkIcon,
   PaperclipIcon,
   ThumbsUpIcon
@@ -1288,13 +1290,57 @@ p {
 }
 
 .attachment {
+  border: 1px solid var(--border);
+  border-radius: 8px;
   display: block;
-  text-align: center;
-  margin: 0.4em auto;
+  margin: 0.5em auto;
+  max-width: 100%;
 }
 
-.attachment-icon {
-  margin: 0.6em;
+.attachment-file-link {
+  align-items: center;
+  background: var(--background-alt);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  display: flex;
+  gap: 0.5em;
+  margin: 0.4em 0;
+  padding: 0.5em 0.7em;
+  text-decoration: none;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--background-hover);
+    border-color: var(--border-alt);
+  }
+
+  .attachment-icon {
+    color: var(--text-alt);
+    flex-shrink: 0;
+  }
+
+  .attachment-file-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .attachment-download-icon {
+    color: var(--text-alt);
+    flex-shrink: 0;
+    opacity: 0.5;
+    transition: opacity 0.15s ease;
+  }
+
+  &:hover .attachment-download-icon,
+  &:focus-visible .attachment-download-icon {
+    opacity: 1;
+  }
 }
 
 .copy-icon {

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -576,7 +576,12 @@ import { remove } from '@/lib/models'
 import { getDownloadAttachmentPath, pluralizeEntityType } from '@/lib/path'
 import { renderComment, replaceTimeWithTimecode, safeUrl } from '@/lib/render'
 import { sortByName } from '@/lib/sorting'
-import { formatShortDate, formatTimeOfDay, parseDate } from '@/lib/time'
+import {
+  formatDisplayDate,
+  formatShortDate,
+  formatTimeOfDay,
+  parseDate
+} from '@/lib/time'
 import stringHelpers from '@/lib/string'
 
 import { useAtMentionsMembers } from '@/composables/atMentions'
@@ -838,7 +843,8 @@ const commentDate = computed(() => {
 })
 
 const fullDate = computed(() => {
-  return commentDate.value.tz(user.value.timezone).format('YYYY-MM-DD HH:mm:ss')
+  const date = commentDate.value.tz(user.value.timezone)
+  return `${formatDisplayDate(date, dateFormat.value)} ${formatTimeOfDay(date, use12HourClock.value)}`
 })
 
 const shortDate = computed(() => {
@@ -861,9 +867,8 @@ const shortenText = (text, length) => {
 }
 
 const replyFullDate = date => {
-  return moment(parseDate(date))
-    .tz(user.value.timezone)
-    .format('YYYY-MM-DD HH:mm:ss')
+  const d = moment(parseDate(date)).tz(user.value.timezone)
+  return `${formatDisplayDate(d, dateFormat.value)} ${formatTimeOfDay(d, use12HourClock.value)}`
 }
 
 const replyShortDate = date => {

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -453,7 +453,7 @@
                   :class="{
                     thinner: multiline
                   }"
-                  :title="`${rootElement.name} (${rootElement.startDate?.format('YYYY-MM-DD')} - ${rootElement.endDate?.format('YYYY-MM-DD')})`"
+                  :title="`${rootElement.name} (${displayDate(rootElement.startDate)} - ${displayDate(rootElement.endDate)})`"
                   :style="timebarStyle(rootElement, true)"
                 >
                   <div
@@ -590,7 +590,7 @@
 
                   <div
                     class="timebar timebar-ghost timebar-ghost-before"
-                    :title="`${childElement.previousElement.name} (${childElement.previousElement.startDate.format('YYYY-MM-DD')} - ${childElement.previousElement.endDate.format('YYYY-MM-DD')})`"
+                    :title="`${childElement.previousElement.name} (${displayDate(childElement.previousElement.startDate)} - ${displayDate(childElement.previousElement.endDate)})`"
                     :class="{
                       'with-timesheets': withTimesheets
                     }"
@@ -607,7 +607,7 @@
 
                   <div
                     class="timebar timebar-ghost timebar-ghost-after"
-                    :title="`${childElement.nextElement.name} (${childElement.nextElement.startDate.format('YYYY-MM-DD')} - ${childElement.nextElement.endDate.format('YYYY-MM-DD')})`"
+                    :title="`${childElement.nextElement.name} (${displayDate(childElement.nextElement.startDate)} - ${displayDate(childElement.nextElement.endDate)})`"
                     :class="{
                       'with-timesheets': withTimesheets
                     }"
@@ -630,7 +630,7 @@
                       'with-timesheets': withTimesheets,
                       invalid: isOverlapping(childElement)
                     }"
-                    :title="`${multiline && childElement.project_name ? `${childElement.project_name} - ` : ''}${childElement.name} (${childElement.startDate.format('YYYY-MM-DD')} - ${childElement.endDate.format('YYYY-MM-DD')})`"
+                    :title="`${multiline && childElement.project_name ? `${childElement.project_name} - ` : ''}${childElement.name} (${displayDate(childElement.startDate)} - ${displayDate(childElement.endDate)})`"
                     :style="
                       timebarChildStyle(
                         childElement,
@@ -831,6 +831,7 @@ import colors from '@/lib/colors'
 import {
   addBusinessDays,
   daysToMinutes,
+  formatDisplayDate,
   formatFullDate,
   getBusinessDays,
   getDayOffRange,
@@ -980,7 +981,10 @@ const timelinePositionRef = ref(null)
 
 // Store getters
 const currentProduction = computed(() => store.getters.currentProduction)
+const dateFormat = computed(() => store.getters.dateFormat)
 const departmentMap = computed(() => store.getters.departmentMap)
+
+const displayDate = date => formatDisplayDate(date, dateFormat.value)
 const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
 const isDarkTheme = computed(() => store.getters.isDarkTheme)
 const milestones = computed(() => store.getters.milestones)

--- a/src/components/widgets/TwoFactorAuthenticationSetup.vue
+++ b/src/components/widgets/TwoFactorAuthenticationSetup.vue
@@ -124,13 +124,13 @@
           </p>
           <div class="two-fa-flow-actions">
             <button
-              class="button cancel-flow-button is-medium"
+              class="button cancel-flow-button"
               @click="cancelCurrentTwoFactorAuthAction"
             >
               {{ $t('main.cancel') }}
             </button>
             <button
-              class="button save-button is-medium"
+              class="button save-button"
               :class="{ 'is-loading': twoFA.loadingAction === 'enableTOTP' }"
               @click="nextEnable()"
             >
@@ -156,7 +156,7 @@
         <div v-else class="two-fa-card-actions">
           <button
             v-if="!user.totp_enabled"
-            class="button two-fa-action enable-action is-medium"
+            class="button two-fa-action enable-action"
             :class="{
               'is-disabled': twoFAButtonsDisabled,
               'is-loading': twoFA.loadingAction === 'preEnableTOTP'
@@ -167,7 +167,7 @@
           </button>
           <button
             v-else
-            class="button two-fa-action disable-action is-medium"
+            class="button two-fa-action disable-action"
             :class="{
               'is-disabled': twoFAButtonsDisabled
             }"
@@ -227,13 +227,13 @@
           </p>
           <div class="two-fa-flow-actions">
             <button
-              class="button cancel-flow-button is-medium"
+              class="button cancel-flow-button"
               @click="cancelCurrentTwoFactorAuthAction"
             >
               {{ $t('main.cancel') }}
             </button>
             <button
-              class="button save-button is-medium"
+              class="button save-button"
               :class="{
                 'is-loading': twoFA.loadingAction === 'enableEmailOTP'
               }"
@@ -261,7 +261,7 @@
         <div v-else class="two-fa-card-actions">
           <button
             v-if="!user.email_otp_enabled"
-            class="button two-fa-action enable-action is-medium"
+            class="button two-fa-action enable-action"
             :class="{
               'is-disabled': twoFAButtonsDisabled,
               'is-loading': twoFA.loadingAction === 'preEnableEmailOTP'
@@ -274,7 +274,7 @@
           </button>
           <button
             v-else
-            class="button two-fa-action disable-action is-medium"
+            class="button two-fa-action disable-action"
             :class="{
               'is-disabled': twoFAButtonsDisabled
             }"
@@ -338,13 +338,13 @@
           </p>
           <div class="two-fa-flow-actions">
             <button
-              class="button cancel-flow-button is-medium"
+              class="button cancel-flow-button"
               @click="cancelCurrentTwoFactorAuthAction"
             >
               {{ $t('main.cancel') }}
             </button>
             <button
-              class="button save-button is-medium"
+              class="button save-button"
               :class="{ 'is-loading': twoFA.loadingAction === 'registerFIDO' }"
               @click="registerFIDORequested()"
             >
@@ -355,7 +355,7 @@
 
         <div v-else class="two-fa-card-actions">
           <button
-            class="button two-fa-action enable-action is-medium"
+            class="button two-fa-action enable-action"
             :class="{
               'is-disabled': twoFAButtonsDisabled
             }"
@@ -369,7 +369,7 @@
 
     <button
       v-if="twoFAEnabled && !twoFA.newRecoveryCodesNeedTwoFA"
-      class="two-fa-button button save-button is-medium"
+      class="two-fa-button button save-button"
       :class="{
         'is-disabled': twoFAButtonsDisabled
       }"

--- a/src/composables/time.js
+++ b/src/composables/time.js
@@ -6,7 +6,7 @@ import { useStore } from 'vuex'
 import moment from 'moment-timezone'
 
 import {
-  formatFullDateWithTimezone,
+  formatDisplayDate,
   formatTimeOfDay,
   formatVerboseDate
 } from '@/lib/time'
@@ -27,7 +27,8 @@ export function useTime() {
   const tomorrow = computed(() => moment().add(1, 'day').toDate())
 
   function formatDate(eventDate) {
-    return formatFullDateWithTimezone(eventDate, timezone.value)
+    const date = moment.tz(eventDate, 'UTC').tz(timezone.value)
+    return `${formatDisplayDate(date, dateFormat.value)} ${formatTimeOfDay(date, use12HourClock.value, true)}`
   }
 
   function formatTime(eventDate) {

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -56,8 +56,18 @@ export const formatSimpleDate = date => {
   else return ''
 }
 
-export const formatTimeOfDay = (date, use12HourClock = false) => {
-  return moment(date).format(use12HourClock ? 'h:mm A' : 'HH:mm')
+export const formatTimeOfDay = (
+  date,
+  use12HourClock = false,
+  withSeconds = false
+) => {
+  let format
+  if (use12HourClock) {
+    format = withSeconds ? 'h:mm:ss A' : 'h:mm A'
+  } else {
+    format = withSeconds ? 'HH:mm:ss' : 'HH:mm'
+  }
+  return moment(date).format(format)
 }
 
 export const formatFullDate = date => {
@@ -85,10 +95,14 @@ export const formatFullDateWithRevertedTimezone = (date, timezone) => {
   return moment.tz(dateString, timezone).tz('UTC').format('YYYY-MM-DDTHH:mm:ss')
 }
 
-export const formatDate = date => {
+export const formatDate = (
+  date,
+  dateFormat = 'YYYY-MM-DD',
+  use12HourClock = false
+) => {
   const utcDate = moment.tz(date, 'UTC')
   if (moment().diff(utcDate, 'days') > 1) {
-    return utcDate.format('YYYY-MM-DD HH:mm')
+    return `${formatDisplayDate(utcDate, dateFormat)} ${formatTimeOfDay(utcDate, use12HourClock)}`
   } else {
     return utcDate.fromNow()
   }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -258,7 +258,9 @@ export default {
       mute: 'Mute',
       unmute: 'Unmute',
       fullscreen: 'Fullscreen',
-      download: 'Download'
+      download: 'Download',
+      video_unavailable: 'Video unavailable',
+      audio_unavailable: 'Audio unavailable'
     },
     post_status: 'Post comment',
     previews: 'Preview files to publish as a new revision',

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -153,7 +153,9 @@
         "mute": "Couper le son",
         "unmute": "Rétablir le son",
         "fullscreen": "Plein écran",
-        "download": "Télécharger"
+        "download": "Télécharger",
+        "video_unavailable": "Vidéo indisponible",
+        "audio_unavailable": "Audio indisponible"
       }
     },
     "custom_actions": {

--- a/tests/unit/widgets/comment-attachments.spec.js
+++ b/tests/unit/widgets/comment-attachments.spec.js
@@ -111,14 +111,14 @@ describe('Comment attachments', () => {
   })
 
   it('renders a paperclip download link for other files', () => {
-    const links = wrapper.findAll('a.flexrow')
+    const links = wrapper.findAll('a.attachment-file-link')
     const pdfLink = links.find(link => link.text().includes('doc.pdf'))
     expect(pdfLink).toBeTruthy()
   })
 
   it('does not render a paperclip download link for audio/video files', () => {
     const linkText = wrapper
-      .findAll('a.flexrow')
+      .findAll('a.attachment-file-link')
       .map(link => link.text())
       .join(' ')
     expect(linkText).not.toContain('voice.wav')


### PR DESCRIPTION
**Problem**
- Comment thread had rough edges since the accessibility pass: checklist entries misaligned with a doubled focus outline, file attachments shown as bare links, unavailable audio/video/image attachments shown as a broken or stray placeholder, and no spacing above the add-comment checklist.
- 2FA action buttons rendered larger than the other settings buttons.
- Many date/time displays ignored the date-format and 12-hour-clock preferences: comment tooltips, preview-file and revision-history dates, playlist dates, entity news, share-link expiry, timesheet and gantt tooltips.

**Solution**
- Realign the checklist on a shared line box and drop the redundant outline, style file attachments as chips, show a clear "unavailable" chip for missing audio/video/image attachments, and add top spacing to the add-comment checklist.
- Drop `is-medium` from the 2FA buttons so they match the standard button size.
- Thread the preferences through the shared date helpers and the remaining call sites; exports, API serialization and axis labels stay ISO.