### PR TITLE
[players] Image fallback and dark-mode polish for attachment chips

### DIFF
--- a/src/components/players/viewers/AttachmentAudioPlayer.vue
+++ b/src/components/players/viewers/AttachmentAudioPlayer.vue
@@ -167,8 +167,8 @@ const onError = () => {
 
 .attachment-error {
   align-items: center;
-  background: var(--background-alt);
-  border: 1px solid var(--border);
+  background: var(--background-page);
+  border: 1px solid var(--border-alt);
   border-radius: 8px;
   color: var(--text);
   display: flex;
@@ -180,6 +180,15 @@ const onError = () => {
 .attachment-error-icon {
   color: var(--text-alt);
   flex-shrink: 0;
+}
+
+.dark .attachment-error {
+  border-color: #565a62;
+}
+
+.dark .attachment-error-icon,
+.dark .attachment-error-name {
+  opacity: 0.7;
 }
 
 .attachment-error-text {

--- a/src/components/players/viewers/AttachmentImage.vue
+++ b/src/components/players/viewers/AttachmentImage.vue
@@ -52,8 +52,8 @@ const onError = () => {
 
 .attachment-error {
   align-items: center;
-  background: var(--background-alt);
-  border: 1px solid var(--border);
+  background: var(--background-page);
+  border: 1px solid var(--border-alt);
   border-radius: 8px;
   color: var(--text);
   display: flex;
@@ -66,6 +66,15 @@ const onError = () => {
 .attachment-error-icon {
   color: var(--text-alt);
   flex-shrink: 0;
+}
+
+.dark .attachment-error {
+  border-color: #565a62;
+}
+
+.dark .attachment-error-icon,
+.dark .attachment-error-name {
+  opacity: 0.7;
 }
 
 .attachment-error-text {

--- a/src/components/players/viewers/AttachmentImage.vue
+++ b/src/components/players/viewers/AttachmentImage.vue
@@ -1,0 +1,92 @@
+<template>
+  <a
+    class="attachment-image-link"
+    :href="downloadHref || src"
+    :title="name"
+    target="_blank"
+    v-if="!hasError"
+  >
+    <img class="attachment-image" :src="src" :alt="name" @error="onError" />
+  </a>
+
+  <div class="attachment-error" v-else>
+    <image-off-icon class="attachment-error-icon" :size="18" />
+    <span class="attachment-error-text">
+      <span class="attachment-error-label">
+        {{ $t('comments.player.image_unavailable') }}
+      </span>
+      <span class="attachment-error-name" v-if="name">{{ name }}</span>
+    </span>
+  </div>
+</template>
+
+<script setup>
+import { ImageOffIcon } from 'lucide-vue-next'
+import { ref } from 'vue'
+
+defineProps({
+  src: { type: String, required: true },
+  name: { type: String, default: '' },
+  downloadHref: { type: String, default: '' }
+})
+
+const hasError = ref(false)
+
+const onError = () => {
+  hasError.value = true
+}
+</script>
+
+<style lang="scss" scoped>
+.attachment-image-link {
+  display: block;
+}
+
+.attachment-image {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: block;
+  margin: 0.5em auto;
+  max-width: 100%;
+}
+
+.attachment-error {
+  align-items: center;
+  background: var(--background-alt);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  display: flex;
+  gap: 0.6em;
+  margin: 0.5em 0;
+  max-width: 32em;
+  padding: 0.6em 0.8em;
+}
+
+.attachment-error-icon {
+  color: var(--text-alt);
+  flex-shrink: 0;
+}
+
+.attachment-error-text {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.1em;
+  margin-left: 0.3em;
+  min-width: 0;
+}
+
+.attachment-error-label {
+  font-size: 0.85em;
+  font-weight: 600;
+}
+
+.attachment-error-name {
+  color: var(--text-alt);
+  font-size: 0.8em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+</style>

--- a/src/components/players/viewers/AttachmentVideoPlayer.vue
+++ b/src/components/players/viewers/AttachmentVideoPlayer.vue
@@ -248,8 +248,8 @@ const onError = () => {
 
 .attachment-error {
   align-items: center;
-  background: var(--background-alt);
-  border: 1px solid var(--border);
+  background: var(--background-page);
+  border: 1px solid var(--border-alt);
   border-radius: 8px;
   color: var(--text);
   display: flex;
@@ -261,6 +261,15 @@ const onError = () => {
 .attachment-error-icon {
   color: var(--text-alt);
   flex-shrink: 0;
+}
+
+.dark .attachment-error {
+  border-color: #565a62;
+}
+
+.dark .attachment-error-icon,
+.dark .attachment-error-name {
+  opacity: 0.7;
 }
 
 .attachment-error-text {

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -139,19 +139,12 @@
               v-if="checklistItems.length > 0"
             />
             <p v-if="comment.attachment_files.length > 0">
-              <a
-                :href="getDownloadAttachmentPath(attachment)"
-                :key="attachment.id"
-                :title="attachment.name"
-                target="_blank"
+              <attachment-image
                 v-for="attachment in pictureAttachments"
-              >
-                <img
-                  class="attachment"
-                  :src="getDownloadAttachmentPath(attachment)"
-                  :alt="attachment.name"
-                />
-              </a>
+                :key="attachment.id"
+                :src="getDownloadAttachmentPath(attachment)"
+                :name="attachment.name"
+              />
               <attachment-audio-player
                 v-for="attachment in audioAttachments"
                 :key="attachment.id"
@@ -237,20 +230,13 @@
                 ></p>
 
                 <p>
-                  <a
-                    :href="getDownloadAttachmentPath(attachment)"
-                    :key="attachment.id"
-                    :title="attachment.name"
-                    target="_blank"
+                  <attachment-image
                     v-for="attachment in replyAttachmentMap.get(replyComment.id)
                       ?.pictures"
-                  >
-                    <img
-                      class="attachment"
-                      :src="getDownloadAttachmentPath(attachment)"
-                      :alt="attachment.name"
-                    />
-                  </a>
+                    :key="attachment.id"
+                    :src="getDownloadAttachmentPath(attachment)"
+                    :name="attachment.name"
+                  />
                   <attachment-audio-player
                     v-for="attachment in replyAttachmentMap.get(replyComment.id)
                       ?.audio"
@@ -589,6 +575,7 @@ import { domMixin } from '@/components/mixins/dom'
 
 import AddAttachmentModal from '@/components/modals/AddAttachmentModal.vue'
 import AttachmentAudioPlayer from '@/components/players/viewers/AttachmentAudioPlayer.vue'
+import AttachmentImage from '@/components/players/viewers/AttachmentImage.vue'
 import AttachmentVideoPlayer from '@/components/players/viewers/AttachmentVideoPlayer.vue'
 import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import CommentMenu from '@/components/widgets/CommentMenu.vue'
@@ -1292,14 +1279,6 @@ article.comment {
 
 p {
   margin: 0;
-}
-
-.attachment {
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  display: block;
-  margin: 0.5em auto;
-  max-width: 100%;
 }
 
 .attachment-file-link {

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -1283,8 +1283,8 @@ p {
 
 .attachment-file-link {
   align-items: center;
-  background: var(--background-alt);
-  border: 1px solid var(--border);
+  background: var(--background-page);
+  border: 1px solid var(--border-alt);
   border-radius: 8px;
   color: var(--text);
   display: flex;
@@ -1325,6 +1325,14 @@ p {
   &:focus-visible .attachment-download-icon {
     opacity: 1;
   }
+}
+
+.dark .attachment-file-link {
+  border-color: #565a62;
+}
+
+.dark .attachment-file-link .attachment-icon {
+  opacity: 0.7;
 }
 
 .copy-icon {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -260,7 +260,8 @@ export default {
       fullscreen: 'Fullscreen',
       download: 'Download',
       video_unavailable: 'Video unavailable',
-      audio_unavailable: 'Audio unavailable'
+      audio_unavailable: 'Audio unavailable',
+      image_unavailable: 'Image unavailable'
     },
     post_status: 'Post comment',
     previews: 'Preview files to publish as a new revision',

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -155,7 +155,8 @@
         "fullscreen": "Plein écran",
         "download": "Télécharger",
         "video_unavailable": "Vidéo indisponible",
-        "audio_unavailable": "Audio indisponible"
+        "audio_unavailable": "Audio indisponible",
+        "image_unavailable": "Image indisponible"
       }
     },
     "custom_actions": {


### PR DESCRIPTION
**Problem**
- A comment image attachment whose file is missing rendered the browser's broken-image icon.
- The attachment chips looked unfinished in dark mode: the fill matched the comment-card colour, the border was near-black, and the secondary text was not muted.

**Solution**
- Add an AttachmentImage component that falls back to the same "unavailable" chip as the audio/video players when an image fails to load.
- Give the chips an inset fill, a mid-grey border and a dimmed icon/filename in dark mode; light mode is unchanged.