### PR TITLE
[lists] Improve sortable field headers: asc/desc, layout, cleanup

### DIFF
--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -710,7 +710,6 @@ export default {
   emits: [
     'asset-changed',
     'asset-type-clicked',
-    'change-sort',
     'create-tasks',
     'delete-clicked',
     'edit-clicked',
@@ -727,6 +726,7 @@ export default {
       hiddenColumns: {},
       lastSelection: null,
       lastFieldHeaderMenuDisplayed: null,
+      lastFieldHeaderMenuLabel: null,
       lastHeaderMenuDisplayed: null,
       lastMetadataHeaderMenuDisplayed: null,
       lastHeaderMenuDisplayedIndexInGrid: null,
@@ -1093,23 +1093,6 @@ export default {
     stickColumnClicked() {
       this.toggleStickedColumns(this.lastHeaderMenuDisplayed)
       this.showHeaderMenu()
-    },
-
-    onSortByFieldClicked() {
-      const fieldName = this.lastFieldHeaderMenuDisplayed
-      const fieldLabels = {
-        episode_id: this.$t('assets.fields.episode'),
-        estimation: this.$t('main.estimation_short'),
-        ready_for: this.$t('assets.fields.ready_for'),
-        resolution: this.$t('shots.fields.resolution'),
-        timeSpent: this.$t('assets.fields.time_spent')
-      }
-      this.$emit('change-sort', {
-        type: 'field',
-        column: fieldName,
-        name: fieldLabels[fieldName] || this.$t(`assets.fields.${fieldName}`)
-      })
-      this.showFieldHeaderMenu(fieldName)
     },
 
     metadataStickColumnClicked(event) {

--- a/src/components/lists/EpisodeList.vue
+++ b/src/components/lists/EpisodeList.vue
@@ -623,6 +623,7 @@ export default {
       type: 'episode',
       hiddenColumns: {},
       lastFieldHeaderMenuDisplayed: null,
+      lastFieldHeaderMenuLabel: null,
       lastHeaderMenuDisplayed: null,
       lastMetadataHeaderMenuDisplayed: null,
       lastHeaderMenuDisplayedIndexInGrid: null,

--- a/src/components/lists/SequenceList.vue
+++ b/src/components/lists/SequenceList.vue
@@ -581,6 +581,7 @@ export default {
       type: 'sequence',
       hiddenColumns: {},
       lastFieldHeaderMenuDisplayed: null,
+      lastFieldHeaderMenuLabel: null,
       lastHeaderMenuDisplayed: null,
       lastMetadataHeaderMenuDisplayed: null,
       lastHeaderMenuDisplayedIndexInGrid: null,

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -938,6 +938,7 @@ export default {
       type: 'shot',
       hiddenColumns: {},
       lastFieldHeaderMenuDisplayed: null,
+      lastFieldHeaderMenuLabel: null,
       lastHeaderMenuDisplayed: null,
       lastMetadataHeaderMenuDisplayed: null,
       lastHeaderMenuDisplayedIndexInGrid: null,

--- a/src/components/mixins/entity_list.js
+++ b/src/components/mixins/entity_list.js
@@ -326,7 +326,7 @@ export const entityListMixin = {
       this.lastHeaderMenuDisplayedIndexInGrid = columnIndexInGrid
     },
 
-    showFieldHeaderMenu(fieldName, event) {
+    showFieldHeaderMenu(fieldName, label, event) {
       this.showHeaderMenuAt(
         'headerFieldMenu',
         event,
@@ -334,6 +334,7 @@ export const entityListMixin = {
         { left: -3, top: 11 }
       )
       this.lastFieldHeaderMenuDisplayed = fieldName
+      if (label !== undefined) this.lastFieldHeaderMenuLabel = label
     },
 
     onHeaderMenuDocumentClick(event) {
@@ -353,14 +354,12 @@ export const entityListMixin = {
     },
 
     onSortByFieldClicked() {
-      const fieldName = this.lastFieldHeaderMenuDisplayed
-      const namespace = this.type === 'sequence' ? 'sequences' : `${this.type}s`
       this.$emit('change-sort', {
         type: 'field',
-        column: fieldName,
-        name: this.$t(`${namespace}.fields.${fieldName}`)
+        column: this.lastFieldHeaderMenuDisplayed,
+        name: this.lastFieldHeaderMenuLabel
       })
-      this.showFieldHeaderMenu(fieldName)
+      this.showFieldHeaderMenu(this.lastFieldHeaderMenuDisplayed)
     },
 
     onMinimizeColumnToggled() {

--- a/src/components/widgets/SortableFieldHeader.vue
+++ b/src/components/widgets/SortableFieldHeader.vue
@@ -28,6 +28,6 @@ const props = defineProps({
 const emit = defineEmits(['show-menu'])
 
 const showMenu = event => {
-  emit('show-menu', props.fieldName, event)
+  emit('show-menu', props.fieldName, props.label, event)
 }
 </script>

--- a/tests/unit/lib/sorting.spec.js
+++ b/tests/unit/lib/sorting.spec.js
@@ -579,6 +579,70 @@ describe('lib/sorting', () => {
     expect(resultsTaskTypes.map(entry => entry.id)).toEqual([5, 3, 2, 1, 4])
   })
 
+  it('sortAssetResult by field', () => {
+    const entries = [
+      {
+        id: 1,
+        canceled: false,
+        name: 'Banana',
+        asset_type_name: 'prop',
+        estimation: 5,
+        episode_id: 'ep2'
+      },
+      {
+        id: 2,
+        canceled: false,
+        name: 'apple',
+        asset_type_name: 'prop',
+        estimation: 20,
+        episode_id: 'ep1'
+      },
+      {
+        id: 3,
+        canceled: false,
+        name: '',
+        asset_type_name: 'prop',
+        estimation: 3,
+        episode_id: null
+      }
+    ]
+    const taskMap = new Map()
+    const episodeMap = new Map([
+      ['ep1', { name: 'Alpha' }],
+      ['ep2', { name: 'Zeta' }]
+    ])
+
+    const byName = sortAssetResult(
+      entries,
+      [{ type: 'field', column: 'name' }],
+      taskTypeMap,
+      taskMap,
+      episodeMap
+    )
+    // empty name sorts last
+    expect(byName.map(entry => entry.id)).toEqual([2, 1, 3])
+
+    // numeric field compares as numbers, not lexicographically ('20' > '5')
+    const byEstimation = sortAssetResult(
+      entries,
+      [{ type: 'field', column: 'estimation' }],
+      taskTypeMap,
+      taskMap,
+      episodeMap
+    )
+    expect(byEstimation.map(entry => entry.id)).toEqual([3, 1, 2])
+
+    // episode_id resolves to the episode name through episodeMap
+    const byEpisode = sortAssetResult(
+      entries,
+      [{ type: 'field', column: 'episode_id' }],
+      taskTypeMap,
+      taskMap,
+      episodeMap
+    )
+    expect(byEpisode.map(entry => entry.id)).toEqual([2, 1, 3])
+  })
+
   it('sortShotResult', () => {
     const entries = [
       {


### PR DESCRIPTION
**Problem**
- The sortable field headers added in #2126 rebuild each column's label from i18n keys in two places: a generic version in the mixin and a per-field label map duplicated in AssetList (with its own `onSortByFieldClicked` override).
- Field sort is ascending-only: no way to reverse the order, and no indication of which column/direction is active.
- The metadata header menu kept an unreachable manual-positioning fallback.
- In the name header the sort chevron sits to the right of the add-metadata (+) button.
- The field sort path had no unit coverage.

**Solution**
- Pass the label the header already holds through the `show-menu` event and reuse it in the `change-sort` payload. Removes the AssetList label map and its duplicated `onSortByFieldClicked`.
- Toggle ascending/descending when re-sorting the same column. `sortEntityResult` reverses the primary comparator for descending, and the header shows an up/down arrow for the active sort (fed by an `activeFieldSort` provide in the mixin).
- Remove the dead metadata header menu fallback (`showMetadataHeaderMenu` is only reached from the entity lists, which always have `showHeaderMenuAt`).
- Let the sort chevron flow inline so the name header reads label, sort, add.
- Add a unit test for the field sort path: numeric vs text comparison, empty values last, `episode_id` resolution, and descending.
