### PR TITLE
[budget] Fall back to budget entry rate for real costs

### DIFF
--- a/src/components/pages/budget/BudgetList.vue
+++ b/src/components/pages/budget/BudgetList.vue
@@ -490,17 +490,24 @@ export default {
       return subset
     },
 
-    /* It gets the daily rate of a person, and use the salary scale if
-     * no daily rate is available.
+    /* It gets the daily rate of a person: the rate set in the People
+     * section, else the rate of the matching budget entry, else the
+     * salary scale.
      */
-    getDailyRate(deparmentId, personId) {
+    getDailyRate(departmentId, personId) {
       const person = this.personMap.get(personId)
-      if (!person) return 0
+      const budgetEntry = this.budgetDepartments
+        .find(department => department.id === departmentId)
+        ?.persons.find(entry => entry.person_id === personId)
       const salaryScale =
-        person.seniority && person.position
-          ? this.salaryScale[deparmentId]?.[person.position]?.[person.seniority]
+        person?.seniority && person?.position
+          ? this.salaryScale[departmentId]?.[person.position]?.[
+              person.seniority
+            ]
           : 0
-      return person.daily_salary || salaryScale
+      return (
+        person?.daily_salary || budgetEntry?.daily_salary || salaryScale || 0
+      )
     },
 
     /* It converts the time spent to days then multiply it with the


### PR DESCRIPTION
**Problem**
- Real costs in the Budget page are not calculated for artists who have no daily rate set in the People section: the computation only used the person rate (or the salary scale when the person has both position and seniority), ignoring the rate entered on the budget entry itself.

**Solution**
- Use the budget entry daily rate as fallback when the person has no personal rate: People rate, else budget entry rate, else salary scale.
- Stop forcing a zero rate when the person is missing from the person map, so the budget entry rate applies there too.

Fix cgwire/zou#1078