### PR TITLE
[lists] Improve sortable field headers: asc/desc, layout, cleanup

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1730,11 +1730,6 @@ tbody:last-child .empty-line:last-child {
   }
 }
 
-.datatable th .field-header {
-  padding-right: 20px;
-  position: relative;
-}
-
 .datatable th .field-header .flexrow-item:first-child {
   flex: 1;
 }
@@ -1748,8 +1743,6 @@ tbody:last-child .empty-line:last-child {
   height: 16px;
   justify-content: center;
   padding: 1px;
-  position: absolute;
-  right: 0;
   width: 16px;
 }
 

--- a/src/components/mixins/descriptors.js
+++ b/src/components/mixins/descriptors.js
@@ -150,29 +150,12 @@ export const descriptorMixin = {
     },
 
     showMetadataHeaderMenu(columnId, event) {
-      if (this.showHeaderMenuAt) {
-        this.showHeaderMenuAt(
-          'headerMetadataMenu',
-          event,
-          event => event.srcElement.parentNode.parentNode,
-          { left: -3, top: 11 }
-        )
-      } else {
-        const headerMenuEl = this.$refs.headerMetadataMenu.$el
-        if (headerMenuEl.className === 'header-menu') {
-          headerMenuEl.className = 'header-menu hidden'
-        } else {
-          headerMenuEl.className = 'header-menu'
-          const headerElement = event.srcElement.parentNode.parentNode
-          const headerBox = headerElement.getBoundingClientRect()
-          const left = headerBox.left - 3
-          const top = headerBox.bottom + 11
-          const width = Math.max(100, headerBox.width - 1)
-          headerMenuEl.style.left = left + 'px'
-          headerMenuEl.style.top = top + 'px'
-          headerMenuEl.style.width = width + 'px'
-        }
-      }
+      this.showHeaderMenuAt(
+        'headerMetadataMenu',
+        event,
+        event => event.srcElement.parentNode.parentNode,
+        { left: -3, top: 11 }
+      )
       this.lastMetadataHeaderMenuDisplayed = columnId
     },
 

--- a/src/components/mixins/entity_list.js
+++ b/src/components/mixins/entity_list.js
@@ -1,3 +1,5 @@
+import { computed } from 'vue'
+
 import colors from '@/lib/colors'
 import preferences from '@/lib/preferences'
 import stringHelpers from '@/lib/string'
@@ -16,6 +18,15 @@ export const entityListMixin = {
     'keep-task-panel-open',
     'scroll'
   ],
+
+  provide() {
+    return {
+      activeFieldSort: computed(() => {
+        const current = this.$store.getters[`${this.type}Sorting`]?.[0]
+        return current && current.type === 'field' ? current : null
+      })
+    }
+  },
 
   created() {
     this.initHiddenColumns(this.validationColumns, this.hiddenColumns)
@@ -354,12 +365,19 @@ export const entityListMixin = {
     },
 
     onSortByFieldClicked() {
+      const column = this.lastFieldHeaderMenuDisplayed
+      const current = this.$store.getters[`${this.type}Sorting`]?.[0]
+      const ascending =
+        current && current.type === 'field' && current.column === column
+          ? !current.ascending
+          : true
       this.$emit('change-sort', {
         type: 'field',
-        column: this.lastFieldHeaderMenuDisplayed,
-        name: this.lastFieldHeaderMenuLabel
+        column,
+        name: this.lastFieldHeaderMenuLabel,
+        ascending
       })
-      this.showFieldHeaderMenu(this.lastFieldHeaderMenuDisplayed)
+      this.showFieldHeaderMenu(column)
     },
 
     onMinimizeColumnToggled() {

--- a/src/components/widgets/SortableFieldHeader.vue
+++ b/src/components/widgets/SortableFieldHeader.vue
@@ -2,6 +2,16 @@
   <div class="flexrow field-header">
     <span class="flexrow-item">
       <slot>{{ label }}</slot>
+      <arrow-up-icon
+        class="sort-direction-icon"
+        :size="12"
+        v-if="sortDirection === 'asc'"
+      />
+      <arrow-down-icon
+        class="sort-direction-icon"
+        :size="12"
+        v-else-if="sortDirection === 'desc'"
+      />
     </span>
     <span
       class="asset-field-menu-button header-icon pointer"
@@ -18,7 +28,8 @@
 </template>
 
 <script setup>
-import { ChevronDownIcon } from 'lucide-vue-next'
+import { ArrowDownIcon, ArrowUpIcon, ChevronDownIcon } from 'lucide-vue-next'
+import { computed, inject } from 'vue'
 
 const props = defineProps({
   fieldName: { type: String, required: true },
@@ -27,7 +38,25 @@ const props = defineProps({
 
 const emit = defineEmits(['show-menu'])
 
+// Provided by entityListMixin: the active { column, ascending } field sort.
+const activeFieldSort = inject('activeFieldSort', null)
+
+const sortDirection = computed(() => {
+  const sort = activeFieldSort?.value
+  if (sort && sort.column === props.fieldName) {
+    return sort.ascending === false ? 'desc' : 'asc'
+  }
+  return null
+})
+
 const showMenu = event => {
   emit('show-menu', props.fieldName, props.label, event)
 }
 </script>
+
+<style lang="scss" scoped>
+.sort-direction-icon {
+  margin-left: 0.2em;
+  vertical-align: middle;
+}
+</style>

--- a/src/lib/sorting.js
+++ b/src/lib/sorting.js
@@ -333,7 +333,11 @@ const sortEntityResult = (
         : sortInfo.type === 'field'
           ? sortByField(sortInfo, taskTypeMap, episodeMap)
           : sortByTaskType(taskMap, sortInfo)
-    let sorter = firstBy('canceled').thenBy(sortEntities)
+    // ponytail: descending reverses the whole comparator, so empty values
+    // land first instead of last. Special-case empties per direction if that
+    // ordering matters.
+    const direction = sortInfo.ascending === false ? -1 : 1
+    let sorter = firstBy('canceled').thenBy(sortEntities, direction)
     for (const step of thenBySteps) {
       sorter = sorter.thenBy(step)
     }

--- a/tests/unit/lib/sorting.spec.js
+++ b/tests/unit/lib/sorting.spec.js
@@ -641,6 +641,16 @@ describe('lib/sorting', () => {
       episodeMap
     )
     expect(byEpisode.map(entry => entry.id)).toEqual([2, 1, 3])
+
+    // ascending: false reverses the order
+    const byNameDesc = sortAssetResult(
+      entries,
+      [{ type: 'field', column: 'name', ascending: false }],
+      taskTypeMap,
+      taskMap,
+      episodeMap
+    )
+    expect(byNameDesc.map(entry => entry.id)).toEqual([3, 1, 2])
   })
 
   it('sortShotResult', () => {


### PR DESCRIPTION
**Problem**
- Field sort was ascending-only, with no way to reverse order or see the active sort direction.
- The metadata header menu kept an unreachable manual-positioning fallback.
- In the name header the sort chevron sat to the right of the add-metadata (+) button.

**Solution**
- Toggle ascending/descending when re-sorting the same column; the active header shows an up/down arrow. Covered by a unit test.
- Remove the dead metadata header menu fallback.
- Let the sort chevron flow inline so the name header reads label, sort, add.
