### PR TITLE
[annotations] Preserve pressure stroke round caps

### DIFF
--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -52,15 +52,7 @@ Text.prototype._calculateCurrentDimensions = function () {
   )
 }
 
-/* Monkey patch _getTransformedDimensions() to return a proper fabric point */
 if (PSStroke) {
-  PSStroke.prototype._getTransformedDimensions = function () {
-    const width = this.width * this.scaleX
-    const height = this.height * this.scaleY
-    const dimensions = new Point(width, height)
-    return dimensions
-  }
-
   /* Monkey patches needed to make PSStroke work correctly by adding missing
    * expected methods to deal with Fabric and pressure.
    */

--- a/tests/unit/composables/annotation.spec.js
+++ b/tests/unit/composables/annotation.spec.js
@@ -53,6 +53,23 @@ const createFakeCanvas = (overrides = {}) => {
   return canvas
 }
 
+describe('PSStroke dimensions', () => {
+  it('includes stroke width in transformed and cache bounds', () => {
+    const stroke = new PSStroke(
+      [new PSPoint(0, 0, 1), new PSPoint(100, 0, 1)],
+      { stroke: '#000', strokeWidth: 20, strokeLineCap: 'round' }
+    )
+
+    expect(stroke._getTransformedDimensions()).toEqual(new Point(120, 20))
+    expect(stroke._getCacheCanvasDimensions()).toMatchObject({
+      width: 122,
+      height: 22,
+      x: 120,
+      y: 20
+    })
+  })
+})
+
 const createSerializableObject = (props = {}) => {
   const obj = {
     id: props.id ?? 'obj-1',


### PR DESCRIPTION
## Problem

The bounding-box around the annotation stroke wasn't accounting for the full stroke width, showing a "cut" stroke.

Before:
<img width="362" height="74" alt="imagen" src="https://github.com/user-attachments/assets/b2efe989-49e5-4088-b60a-184126ced245" />

After:
<img width="325" height="67" alt="imagen" src="https://github.com/user-attachments/assets/0c7ebcf2-c347-46c3-bf31-13569d565664" />

## Solution

Remove a monkey-patch that was affecting this calculation.

I couldn't find if there was an (still existing) reason for it. I see it was when Kitsu was using Fabric 5. But not sure of the exact reason.