### PR TITLE
[players] Trim-end playback fixes and annotation author tooltip

### DIFF
--- a/src/components/players/annotations/AnnotationCanvas.vue
+++ b/src/components/players/annotations/AnnotationCanvas.vue
@@ -11,15 +11,25 @@
     >
       <canvas ref="canvasEl" :id="canvasId" />
     </div>
+    <div
+      class="annotation-author"
+      v-if="hoverInfo"
+      :style="{ left: `${hoverInfo.x}px`, top: `${hoverInfo.y}px` }"
+    >
+      {{ hoverInfo.label }}
+    </div>
   </div>
 </template>
 
 <script setup>
 import { Canvas, StaticCanvas } from 'fabric'
 import { PSBrush } from 'fabricjs-psbrush'
+import moment from 'moment'
 import { computed, markRaw, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useStore } from 'vuex'
 
 import { lockBrushToFirstPointer } from '@/lib/players/annotation'
+import { formatDisplayDate, formatTimeOfDay } from '@/lib/time'
 
 const props = defineProps({
   canvasId: { type: String, required: true },
@@ -40,12 +50,15 @@ const props = defineProps({
   wheelTarget: { type: HTMLElement, default: null }
 })
 
+const store = useStore()
+
 const emit = defineEmits(['click', 'resized'])
 
 const bounds = ref({ top: 0, left: 0, width: 0, height: 0 })
 const canvasEl = ref(null)
 const clip = ref(null)
 const fabricCanvas = ref(null)
+const hoverInfo = ref(null)
 const overlay = ref(null)
 
 let resizeObserver = null
@@ -144,8 +157,39 @@ const createFabric = () => {
     brush.strokeLineJoin = 'round'
     lockBrushToFirstPointer(brush)
     canvas.freeDrawingBrush = brush
+    canvas.on('mouse:over', onObjectHover)
+    canvas.on('mouse:out', onObjectHoverEnd)
   }
   fabricCanvas.value = markRaw(canvas)
+}
+
+// Author/date chip on hover. personMap and the display settings are read
+// at event time: personMap is a non-reactive store cache and would freeze
+// on the pre-load empty map if wrapped in a computed. Degrades silently
+// (no chip) when neither author nor date is known — e.g. guest views or
+// annotations older than the createdAt field.
+const onObjectHover = event => {
+  if (!props.interactive || !event.target) return
+  const person = store.getters.personMap.get(event.target.createdBy)
+  let date = null
+  if (event.target.createdAt) {
+    const user = store.getters.user
+    const d = moment(event.target.createdAt).tz(user.timezone)
+    date = `${formatDisplayDate(d, store.getters.dateFormat)} ${formatTimeOfDay(d, store.getters.use12HourClock)}`
+  }
+  const label = [person?.full_name, date].filter(Boolean).join(' · ')
+  if (!label) return
+  const rect = clip.value?.getBoundingClientRect()
+  if (!rect) return
+  hoverInfo.value = {
+    label,
+    x: event.e.clientX - rect.left,
+    y: event.e.clientY - rect.top
+  }
+}
+
+const onObjectHoverEnd = () => {
+  hoverInfo.value = null
 }
 
 // Re-dispatch the wheel event on wheelTarget so its panzoom listener
@@ -240,6 +284,21 @@ defineExpose({
   // .video-container — both with overflow: hidden) so the overlay
   // can extend with the panzoom transform without being cropped to
   // the media's un-zoomed bounds.
+  pointer-events: none;
+}
+
+.annotation-author {
+  position: absolute;
+  z-index: 600;
+  transform: translate(-50%, calc(-100% - 8px));
+  padding: 2px 8px;
+  border-radius: 4px;
+  // Constant dark chip: it floats over media content, same look in both
+  // themes.
+  background: rgba(0, 0, 0, 0.75);
+  color: white;
+  font-size: 0.75rem;
+  white-space: nowrap;
   pointer-events: none;
 }
 

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -255,6 +255,8 @@
           }"
           :entities="entityList"
           :full-screen="fullScreen"
+          :handle-in="handleIn"
+          :handle-out="handleOut"
           :is-hd="isHd"
           :is-repeating="isRepeating"
           :current-preview-index="currentPreviewIndex"
@@ -2663,14 +2665,20 @@ const onFrameUpdate = frame => {
       ['shot', 'edit', 'episode'].includes(props.playlist.for_entity) &&
       currentPreviewIndex.value === 0 &&
       handleOut.value < nbFrames.value
+    // With rVFC the trim loop is enforced inside MultiVideoViewer at the
+    // paint decision; this detection only remains the fallback for the
+    // rAF pipeline and the entity-chaining (non-repeat) path.
     const reachedEnd = hasHandles
       ? frameNumber.value >= handleOut.value
       : frameNumber.value >= nbFrames.value - 1
     if (reachedEnd) {
       if (isRepeating.value) {
         const startFrame = hasHandles ? handleIn.value : 0
-        rawPlayer.value?.setCurrentFrame(startFrame)
-        rawPlayerComparison.value?.setCurrentFrame(startFrame)
+        // Raw frame-start seek: setCurrentFrame goes through
+        // runSetCurrentTime, whose re-entrancy gate can drop the loop
+        // seek and let the clip play through to its real end.
+        rawPlayer.value?.setCurrentTimeRaw(startFrame / fps.value)
+        rawPlayerComparison.value?.setCurrentTimeRaw(startFrame / fps.value)
       } else {
         onPlayNext()
       }
@@ -3377,7 +3385,20 @@ const getFileFromCanvas = (canvas, filename) => {
 }
 
 const updateProgressBar = f => {
-  const frame = f !== undefined ? f : frameNumber.value
+  let frame = f !== undefined ? f : frameNumber.value
+  // While playing a trimmed main preview, never paint the fill past the
+  // handle-out marker: near the trim end the frame channel runs ahead of
+  // the painted frame and the +1 fill convention lands one frame beyond
+  // the marker on every loop. Paused stepping onto the excluded frame
+  // stays untouched.
+  if (
+    isPlaying.value &&
+    currentPreviewIndex.value === 0 &&
+    ['shot', 'edit', 'episode'].includes(props.playlist?.for_entity) &&
+    handleOut.value < nbFrames.value
+  ) {
+    frame = Math.min(frame, handleOut.value - 1)
+  }
   if (progress.value) progress.value.updateProgressBar(frame + 1)
   // The playlist playhead position is driven by the continuous time-update
   // channel (onRawPlayerTimeUpdate) so it stays smooth, not by the rounded

--- a/src/components/players/viewers/MultiVideoViewer.vue
+++ b/src/components/players/viewers/MultiVideoViewer.vue
@@ -158,6 +158,13 @@ let renderLoopHandle = null
 let renderLoopIsRvfc = false
 let renderLoopPlayer = null
 let renderLoopGeneration = 0
+// Target of a seek issued while playing — the render loop skips stale
+// presentations until the target frame lands (same guard as VideoViewer).
+let seekGuardTarget = null
+// One play-next per trim end: entity switches to non-movie previews are
+// asynchronous, and extra presentations past the handle-out would emit
+// again and skip entities.
+let trimEndFired = false
 let lastEmittedFrame = null
 let rate = 1
 let silent = false
@@ -239,8 +246,42 @@ const startRenderLoop = () => {
   const generation = renderLoopGeneration
   if (supportsVideoFrameCallback()) {
     renderLoopIsRvfc = true
-    const tick = () => {
+    const tick = (now, metadata) => {
       if (renderLoopGeneration !== generation) return
+      // Skip presentations far from an in-flight seek target (loop on
+      // handle-in, handle-in jump): frames queued behind the seek point
+      // keep presenting for a tick or two and painting them overflows
+      // past the trim before the seek lands.
+      if (
+        seekGuardTarget !== null &&
+        Math.abs(metadata.mediaTime - seekGuardTarget) > 2 * frameDuration.value
+      ) {
+        renderLoopHandle = player.requestVideoFrameCallback(tick)
+        return
+      }
+      seekGuardTarget = null
+      // Enforce the trim end at the paint decision: the parent detects
+      // it through the time channel, which lags the presented frame by
+      // one, so it always paints the first excluded frame. Here the
+      // presented frame is known exactly — loop or chain before painting.
+      if (
+        isPlaying.value &&
+        props.handleOut > 0 &&
+        Math.round(metadata.mediaTime * fps.value) >= props.handleOut
+      ) {
+        if (props.isRepeating) {
+          const target = props.handleIn / fps.value
+          seekGuardTarget = target
+          player.currentTime = target
+          emit('repeat')
+        } else if (!trimEndFired) {
+          trimEndFired = true
+          emit('play-next')
+        }
+        renderLoopHandle = player.requestVideoFrameCallback(tick)
+        return
+      }
+      trimEndFired = false
       renderer?.drawFrame(player)
       if (isPlaying.value && props.name === 'main') {
         updateTime(player.currentTime)
@@ -253,6 +294,13 @@ const startRenderLoop = () => {
     let lastDrawnTime = -1
     const tick = () => {
       if (renderLoopGeneration !== generation) return
+      // Mid-seek (no rVFC, e.g. Firefox): currentTime already reads the
+      // target while the decoder still holds the old position — drawing
+      // would paint stale frames past the trim and emit stale times.
+      if (player.seeking) {
+        renderLoopHandle = requestAnimationFrame(tick)
+        return
+      }
       if (player.currentTime !== lastDrawnTime) {
         lastDrawnTime = player.currentTime
         renderer?.drawFrame(player)
@@ -483,6 +531,7 @@ const loadEntity = (index = 0, currentTime = 0, silentLoad = false) => {
 // Playing
 
 const pause = () => {
+  seekGuardTarget = null
   if (currentPlayer.value) {
     currentPlayer.value.pause()
     currentPlayer.value.currentTime = roundToFrame(
@@ -552,6 +601,7 @@ const getCurrentTimeRaw = () =>
 
 const setCurrentTimeRaw = currentTime => {
   if (currentPlayer.value) {
+    if (isPlaying.value) seekGuardTarget = currentTime
     currentPlayer.value.currentTime = currentTime
   }
 }
@@ -587,6 +637,7 @@ const runSetCurrentTime = currentTime => {
   if (currentPlayer.value && currentPlayer.value.currentTime !== currentTime) {
     isSeeking = true
     try {
+      if (isPlaying.value) seekGuardTarget = currentTime
       // tweaks needed because the html video player is messy with frames
       currentPlayer.value.currentTime = currentTime + 0.001
       onTimeUpdate()

--- a/src/components/players/viewers/VideoViewer.vue
+++ b/src/components/players/viewers/VideoViewer.vue
@@ -408,13 +408,18 @@ const startRenderLoop = () => {
     renderLoopIsRvfc = false
     let lastDrawnTime = -1
     const tick = () => {
-      if (video.value && video.value.currentTime !== lastDrawnTime) {
-        hasPaintedVideoFrame = true
-        lastDrawnTime = video.value.currentTime
-        currentTimeRaw.value = lastDrawnTime
-        renderer?.drawFrame()
-        if (!video.value.paused) {
-          emitFrameSignals(lastDrawnTime)
+      // Mid-seek (no rVFC, e.g. Firefox): currentTime already reads the
+      // target while the decoder still holds the old position — drawing
+      // would paint stale frames past the trim and emit stale times.
+      if (video.value && !video.value.seeking) {
+        if (video.value.currentTime !== lastDrawnTime) {
+          hasPaintedVideoFrame = true
+          lastDrawnTime = video.value.currentTime
+          currentTimeRaw.value = lastDrawnTime
+          renderer?.drawFrame()
+          if (!video.value.paused) {
+            emitFrameSignals(lastDrawnTime)
+          }
         }
       }
       renderLoopHandle = requestAnimationFrame(tick)

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -214,11 +214,13 @@ export const useAnnotation = ({
         object.set('canvasHeight', fabricCanvas.value.height)
       }
       if (!object.createdBy) object.set('createdBy', userId.value)
+      if (!object.createdAt) object.set('createdAt', new Date().toISOString())
     } else {
       if (!object.id) object.id = uuidv4()
       if (!object.canvasWidth) object.canvasWidth = fabricCanvas.value.width
       if (!object.canvasHeight) object.canvasHeight = fabricCanvas.value.height
       if (!object.createdBy) object.createdBy = userId.value
+      if (!object.createdAt) object.createdAt = new Date().toISOString()
     }
     addSerialization(object)
     return object
@@ -578,6 +580,10 @@ export const useAnnotation = ({
 
     const base = {
       id: obj.id,
+      // Authorship metadata must survive the reload, or the next save
+      // re-attributes the object to the current user via setObjectData.
+      createdAt: obj.createdAt,
+      createdBy: obj.createdBy,
       fill: 'transparent',
       left: obj.left * scale + offsetX,
       top: obj.top * scale + offsetY,

--- a/src/lib/players/annotation.js
+++ b/src/lib/players/annotation.js
@@ -159,6 +159,7 @@ export const addSerialization = object => {
     result.angle = this.angle
     result.scale = this.scale
     result.createdBy = this.createdBy
+    result.createdAt = this.createdAt
     // Persist the eraser mask centrally: PSStroke's custom toObject() goes
     // through the psbrush callSuper shim and doesn't reliably reach the patched
     // fabric.Object.prototype.toObject, so relying on that alone loses the mask
@@ -196,6 +197,10 @@ export const setObjectData = (object, canvas, userId) => {
   if (userId && !object.createdBy) {
     if (object.set) object.set('createdBy', userId)
     else object.createdBy = userId
+  }
+  if (!object.createdAt) {
+    if (object.set) object.set('createdAt', new Date().toISOString())
+    else object.createdAt = new Date().toISOString()
   }
   addSerialization(object)
   return object

--- a/tests/unit/composables/annotation.spec.js
+++ b/tests/unit/composables/annotation.spec.js
@@ -270,6 +270,41 @@ describe('composables/annotation', () => {
       })
       wrapper.unmount()
     })
+
+    it('stamps and persists createdBy and createdAt', () => {
+      const { api, wrapper } = mountAnnotation()
+      const obj = createSerializableObject({ id: 'meta-1' })
+      api.setObjectData(obj)
+      expect(obj.createdBy).toBe('user-1')
+      expect(obj.createdAt).toBeTruthy()
+      const result = obj.serialize()
+      expect(result.createdBy).toBe('user-1')
+      expect(result.createdAt).toBe(obj.createdAt)
+      wrapper.unmount()
+    })
+
+    it('revives createdBy and createdAt onto reloaded objects', async () => {
+      const canvas = createFakeCanvas()
+      const { api, wrapper } = mountAnnotation({ canvas })
+      await api.addObjectToCanvas(null, {
+        id: 'r1',
+        type: 'path',
+        path: 'M 0 0 L 5 5',
+        createdBy: 'author-9',
+        createdAt: '2026-07-14T10:00:00.000Z',
+        canvasWidth: 800,
+        canvasHeight: 600,
+        left: 0,
+        top: 0,
+        scaleX: 1,
+        scaleY: 1
+      })
+      const revived = canvas._objects.find(o => o.id === 'r1')
+      expect(revived.createdBy).toBe('author-9')
+      expect(revived.createdAt).toBe('2026-07-14T10:00:00.000Z')
+      expect(revived.serialize().createdAt).toBe('2026-07-14T10:00:00.000Z')
+      wrapper.unmount()
+    })
   })
 
   describe('clearModifications', () => {


### PR DESCRIPTION
**Problem**
- The playlist trim end played the first excluded frame on every loop and when chaining entities: the check ran on the frame channel, which lags the presented frame; unbound handles and a dropped loop seek could restart clips at frame 0 or let them play to their real end
- Without rVFC, the fallback render loop painted stale frames and emitted stale times during seeks
- Nothing showed who drew an annotation or when, and createdBy was lost on reload, re-attributing objects to the last editor on save

**Solution**
- MultiVideoViewer enforces the trim at the paint decision in the render tick: reaching handle-out seeks handle-in on repeat or emits a single play-next when chaining; handles are bound, loop seeks bypass the re-entrancy gate, and the bar fill is clamped to the handle-out marker
- Both video pipelines skip mid-seek presentations
- AnnotationCanvas shows an author/date chip on hover, formatted per the user's settings; createdAt is now persisted and createdBy/createdAt survive reloads
