### PR TITLE
Schedule TV show productions by episode

### DIFF
--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -104,7 +104,6 @@
             icon="list"
             :text="$t('menu.assign_tasks')"
             @click="toggleSidePanel"
-            v-if="!isTVShow"
           />
         </div>
       </div>
@@ -120,10 +119,9 @@
         clip-children
         is-estimation-linked
         hide-man-days
-        :multiline="isTVShow"
         :reassignable="!isLockedSchedule"
         show-expand-all
-        :subchildren="!isTVShow"
+        subchildren
         :type="mode"
         @expand-all="onScheduleExpandAll"
         @item-assign="onScheduleItemAssigned"
@@ -138,10 +136,7 @@
       />
     </div>
 
-    <div
-      class="column side-column"
-      v-if="isSidePanelOpen && !isLockedSchedule && !isTVShow"
-    >
+    <div class="column side-column" v-if="isSidePanelOpen && !isLockedSchedule">
       <div class="side">
         <a
           class="close-button"
@@ -579,6 +574,7 @@ import TextField from '@/components/widgets/TextField.vue'
 
 import assetStore from '@/store/modules/assets'
 import assetTypeStore from '@/store/modules/assettypes'
+import sequenceStore from '@/store/modules/sequences'
 import shotStore from '@/store/modules/shots'
 import taskTypeStore from '@/store/modules/tasktypes'
 
@@ -635,6 +631,7 @@ export default {
       endDate: moment().add(6, 'months').endOf('day'),
       entityType: null,
       isSidePanelOpen: false,
+      resetTimeout: null,
       scheduleItems: [],
       startDate: moment().startOf('day'),
       selectedStartDate: null,
@@ -679,6 +676,10 @@ export default {
 
   mounted() {
     this.reset()
+  },
+
+  beforeUnmount() {
+    if (this.resetTimeout) clearTimeout(this.resetTimeout)
   },
 
   computed: {
@@ -746,6 +747,16 @@ export default {
         this.currentVersion?.locked ||
         !this.isCurrentUserManager
       )
+    },
+
+    sequenceMap() {
+      return sequenceStore.cache.sequenceMap
+    },
+
+    // Concrete episode id for scoping (null for feature films or the 'all'/'main' pseudo-episodes).
+    currentEpisodeId() {
+      const id = this.currentEpisode?.id
+      return this.isTVShow && id && !['all', 'main'].includes(id) ? id : null
     },
 
     shotMap() {
@@ -838,7 +849,6 @@ export default {
       'editProduction',
       'loadAssets',
       'loadAssetTypeScheduleItems',
-      'loadEpisodeScheduleItems',
       'loadProductionDaysOff',
       'loadScheduleItems',
       'loadScheduleVersions',
@@ -949,7 +959,16 @@ export default {
         })
     },
 
-    async reset() {
+    reset() {
+      // Debounce: cross-prod navigation triggers two close currentEpisode changes (transient 'main' then 'all').
+      if (this.resetTimeout) clearTimeout(this.resetTimeout)
+      this.resetTimeout = setTimeout(() => {
+        this.resetTimeout = null
+        this.loadSchedule()
+      }, 50)
+    },
+
+    async loadSchedule() {
       this.closeSidePanel()
 
       if (this.currentProduction.start_date) {
@@ -1020,16 +1039,22 @@ export default {
           children: [],
           parentElement: taskTypeElement
         }
-        if (this.isTVShow) {
-          scheduleItem.route = getTaskTypeSchedulePath(
-            item.task_type_id,
-            this.currentProduction.id,
-            item.object_id,
-            taskTypeElement.for_entity
-          )
-        }
         return scheduleItem
       })
+    },
+
+    buildTaskFilters(taskType) {
+      const filters = {
+        project_id: this.currentProduction.id,
+        task_type_id: taskType.task_type_id,
+        relations: 'true'
+      }
+      // /tasks?episode_id= only filters shot tasks (shot → sequence → episode);
+      // asset tasks are scoped client-side via the episode-scoped assetMap.
+      if (this.currentEpisodeId && taskType.for_entity === 'Shot') {
+        filters.episode_id = this.currentEpisodeId
+      }
+      return filters
     },
 
     async expandTaskTypeElement(
@@ -1044,25 +1069,22 @@ export default {
         try {
           taskTypeElement.loading = true
 
-          this.selectedTaskType = !this.isTVShow ? taskTypeElement : null
+          this.selectedTaskType = taskTypeElement
           this.assignments.loading = resetAssignments
 
           taskTypeElement.children = []
           taskTypeElement.people = {}
           taskTypeElement.entitiesByType = {}
 
-          const loadScheduleItems = this.isTVShow
-            ? ['Asset', 'Shot'].includes(taskTypeElement.for_entity)
-              ? this.loadEpisodeScheduleItems
-              : this.loadSequenceScheduleItems
-            : taskTypeElement.for_entity === 'Shot'
-              ? this.loadSequenceScheduleItems
-              : taskTypeElement.for_entity === 'Sequence'
-                ? this.loadSequenceScheduleItems
-                : this.loadAssetTypeScheduleItems
+          const loadScheduleItems = ['Shot', 'Sequence'].includes(
+            taskTypeElement.for_entity
+          )
+            ? this.loadSequenceScheduleItems
+            : this.loadAssetTypeScheduleItems
           const parameters = {
             production: this.currentProduction,
-            taskType: this.taskTypeMap.get(taskTypeElement.task_type_id)
+            taskType: this.taskTypeMap.get(taskTypeElement.task_type_id),
+            episodeId: this.currentEpisodeId
           }
           const scheduleItems = await loadScheduleItems(parameters)
 
@@ -1074,228 +1096,227 @@ export default {
             children.map(child => [child.object_id, child])
           )
 
-          if (this.isTVShow) {
-            taskTypeElement.children = children
-          } else {
-            // load entities
-            if (taskTypeElement.for_entity === 'Asset') {
-              await this.loadAssets({ withShared: false, withTasks: false })
-            }
-            if (taskTypeElement.for_entity === 'Shot') {
-              await this.loadShots()
-            }
+          // load entities (scoped to the current episode for TV shows)
+          if (taskTypeElement.for_entity === 'Asset') {
+            await this.loadAssets({ withShared: false, withTasks: false })
+          } else if (taskTypeElement.for_entity === 'Shot') {
+            await this.loadShots()
+          }
 
-            let tasks = await this.loadTasks({
-              project_id: this.currentProduction.id,
-              task_type_id: taskTypeElement.task_type_id,
-              relations: 'true'
+          let tasks = await this.loadTasks(
+            this.buildTaskFilters(taskTypeElement)
+          )
+
+          // Update tasks for versioned schedules
+          if (this.isVersioned) {
+            const taskType = this.taskTypeMap.get(taskTypeElement.task_type_id)
+            const versionedTasks = await this.loadTasksFromScheduleVersion({
+              version: { id: this.version },
+              taskType
             })
-
-            // Update tasks for versioned schedules
-            if (this.isVersioned) {
-              const taskType = this.taskTypeMap.get(
-                taskTypeElement.task_type_id
-              )
-              const versionedTasks = await this.loadTasksFromScheduleVersion({
-                version: { id: this.version },
-                taskType
-              })
-              const versionedTaskMap = new Map(
-                versionedTasks.map(versionedTask => [
-                  versionedTask.task_id,
-                  versionedTask
-                ])
-              )
-              tasks = tasks
-                .map(task => {
-                  const versioned = versionedTaskMap.get(task.id)
-                  if (!versioned?.start_date) {
-                    return null
-                  }
-                  return {
-                    ...task,
-                    versionedTaskId: versioned.id,
-                    start_date: versioned.start_date,
-                    due_date: versioned.due_date,
-                    estimation: versioned.estimation,
-                    assignees: versioned.assignees
-                  }
-                })
-                .filter(Boolean)
-            }
-
-            this.daysOffByPerson = await this.loadProductionDaysOff({
-              startDate: this.startDate.format('YYYY-MM-DD'),
-              endDate: this.endDate.format('YYYY-MM-DD')
-            }).catch(
-              () => ({}) // fallback if not allowed to fetch days off
-            )
-
-            // group tasks by entity type and assignee
-            const tasksByType = {}
-            const people = {}
-            tasks.forEach(task => {
-              if (!task.start_date) {
-                return
-              }
-
-              // link entity to task
-              if (taskTypeElement.for_entity === 'Asset') {
-                task.entity = this.assetMap.get(task.entity_id)
-                task.entity_type_id = task.entity.asset_type_id
-              } else if (taskTypeElement.for_entity === 'Shot') {
-                task.entity = this.shotMap.get(task.entity_id)
-                task.entity_type_id = task.entity.sequence_id
-              } else {
-                task.entity_type_id = taskTypeElement.for_entity
-              }
-              if (task.entity?.canceled) {
-                return
-              }
-
-              if (!tasksByType[task.entity_type_id]) {
-                tasksByType[task.entity_type_id] = {}
-              }
-
-              if (!task.assignees.length) {
-                task.assignees = ['unassigned']
-              }
-
-              task.assignees.forEach(assigneeId => {
-                const entityTypeItem = childrenById.get(task.entity_type_id)
-
-                // populate task with start and end dates
-
-                let startDate
-                if (this.mode === 'real') {
-                  if (!task.real_start_date) {
-                    return
-                  }
-                  startDate = parseDate(task.real_start_date)
-                } else {
-                  startDate = parseDate(task.start_date)
-                }
-                if (startDate.isAfter(this.endDate)) {
-                  return
-                }
-                if (startDate.isBefore(entityTypeItem.startDate)) {
-                  entityTypeItem.startDate = startDate.clone()
-                }
-                task.startDate = startDate
-
-                let endDate
-                if (this.mode === 'real') {
-                  endDate = task.done_date
-                    ? parseDate(task.done_date)
-                    : moment.tz()
-                } else if (task.due_date) {
-                  endDate = parseDate(task.due_date)
-                } else if (task.end_date) {
-                  endDate = parseDate(task.end_date)
-                } else if (task.estimation) {
-                  endDate = addBusinessDays(
-                    task.startDate,
-                    Math.ceil(
-                      minutesToDays(this.organisation, task.estimation)
-                    ) - 1,
-                    this.daysOffByPerson[assigneeId]
-                  )
-                }
-                if (!endDate || endDate.isBefore(startDate)) {
-                  const nbDays = startDate.isoWeekday() === 5 ? 3 : 1
-                  endDate = startDate.clone().add(nbDays, 'days')
-                }
-                if (!endDate.isSameOrAfter(startDate)) {
-                  const nbDays = startDate.isoWeekday() === 5 ? 3 : 1
-                  endDate = startDate.clone().add(nbDays, 'days')
-                }
-                if (endDate.isBefore(this.startDate)) {
-                  return
-                }
-                if (endDate.isAfter(entityTypeItem.endDate)) {
-                  entityTypeItem.endDate = endDate.clone()
-                }
-                task.endDate = endDate
-
-                if (!tasksByType[task.entity_type_id][assigneeId]) {
-                  tasksByType[task.entity_type_id][assigneeId] = []
-                  people[assigneeId] =
-                    assigneeId !== 'unassigned'
-                      ? {
-                          ...this.personMap.get(assigneeId),
-                          daysOff: this.daysOffByPerson[assigneeId]
-                        }
-                      : {
-                          id: assigneeId,
-                          avatar: false,
-                          color: '#888',
-                          full_name: this.$t('main.unassigned')
-                        }
-                }
-
-                task.editable = !this.isLockedSchedule
-                task.unresizable = false
-                task.parentElement = entityTypeItem
-
-                tasksByType[task.entity_type_id][assigneeId].push(task)
-              })
-            })
-
-            if (taskTypeElement.for_entity === 'Asset') {
-              // filtering following custom asset types workflow
-              children = children.filter(item => {
-                const assetType = this.assetTypeMap.get(item.object_id)
-                return (
-                  assetType &&
-                  (!assetType.task_types.length ||
-                    assetType.task_types.includes(taskTypeElement.task_type_id))
-                )
-              })
-            }
-
-            // sort grouped tasks
-            const sortEntitiesByUserName = ([keyA], [keyB]) => {
-              if (keyA === 'unassigned') return 1
-              if (keyB === 'unassigned') return -1
-              return people[keyA].full_name.localeCompare(
-                people[keyB].full_name
-              )
-            }
-            const sortTasksByEntityName = (a, b) =>
-              a.entity?.name.localeCompare(b.entity?.name, undefined, {
-                numeric: true
-              })
-            children.forEach(child => {
-              const items = tasksByType[child.object_id] || {}
-              const sortedChildren = new Map(
-                Object.entries(items)
-                  .sort(sortEntitiesByUserName)
-                  .map(([key, tasks]) => [
-                    key,
-                    tasks.sort(sortTasksByEntityName)
-                  ])
-              )
-
-              child.children = sortedChildren
-            })
-
-            taskTypeElement.children = sortByName(children)
-            taskTypeElement.people = people
-
-            // group all assigned entities by type
-            taskTypeElement.entitiesByType = Object.fromEntries(
-              Object.entries(tasksByType).map(([entityTypeId, byAssignee]) => [
-                entityTypeId,
-                Object.entries(byAssignee)
-                  .flatMap(([assignee, items]) =>
-                    assignee !== 'unassigned'
-                      ? items.map(item => item.entity_id)
-                      : undefined
-                  )
-                  .filter(Boolean)
+            const versionedTaskMap = new Map(
+              versionedTasks.map(versionedTask => [
+                versionedTask.task_id,
+                versionedTask
               ])
             )
+            tasks = tasks
+              .map(task => {
+                const versioned = versionedTaskMap.get(task.id)
+                if (!versioned?.start_date) {
+                  return null
+                }
+                return {
+                  ...task,
+                  versionedTaskId: versioned.id,
+                  start_date: versioned.start_date,
+                  due_date: versioned.due_date,
+                  estimation: versioned.estimation,
+                  assignees: versioned.assignees
+                }
+              })
+              .filter(Boolean)
           }
+
+          this.daysOffByPerson = await this.loadProductionDaysOff({
+            startDate: this.startDate.format('YYYY-MM-DD'),
+            endDate: this.endDate.format('YYYY-MM-DD')
+          }).catch(
+            () => ({}) // fallback if not allowed to fetch days off
+          )
+
+          // group tasks by entity type and assignee
+          const tasksByType = {}
+          const people = {}
+          tasks.forEach(task => {
+            if (!task.start_date) {
+              return
+            }
+
+            // link entity to task; skip tasks whose entity is not in the
+            // current episode (loadTasks is not episode-scoped, but
+            // assetMap/shotMap are for TV shows)
+            if (taskTypeElement.for_entity === 'Asset') {
+              task.entity = this.assetMap.get(task.entity_id)
+              if (!task.entity) return
+              task.entity_type_id = task.entity.asset_type_id
+            } else if (taskTypeElement.for_entity === 'Shot') {
+              task.entity = this.shotMap.get(task.entity_id)
+              if (!task.entity) return
+              task.entity_type_id = task.entity.sequence_id
+            } else {
+              task.entity_type_id = taskTypeElement.for_entity
+            }
+            if (task.entity?.canceled) {
+              return
+            }
+
+            if (!tasksByType[task.entity_type_id]) {
+              tasksByType[task.entity_type_id] = {}
+            }
+
+            if (!task.assignees.length) {
+              task.assignees = ['unassigned']
+            }
+
+            task.assignees.forEach(assigneeId => {
+              const entityTypeItem = childrenById.get(task.entity_type_id)
+              if (!entityTypeItem) return
+
+              // populate task with start and end dates
+
+              let startDate
+              if (this.mode === 'real') {
+                if (!task.real_start_date) {
+                  return
+                }
+                startDate = parseDate(task.real_start_date)
+              } else {
+                startDate = parseDate(task.start_date)
+              }
+              if (startDate.isAfter(this.endDate)) {
+                return
+              }
+              if (startDate.isBefore(entityTypeItem.startDate)) {
+                entityTypeItem.startDate = startDate.clone()
+              }
+              task.startDate = startDate
+
+              let endDate
+              if (this.mode === 'real') {
+                endDate = task.done_date
+                  ? parseDate(task.done_date)
+                  : moment.tz()
+              } else if (task.due_date) {
+                endDate = parseDate(task.due_date)
+              } else if (task.end_date) {
+                endDate = parseDate(task.end_date)
+              } else if (task.estimation) {
+                endDate = addBusinessDays(
+                  task.startDate,
+                  Math.ceil(minutesToDays(this.organisation, task.estimation)) -
+                    1,
+                  this.daysOffByPerson[assigneeId]
+                )
+              }
+              if (!endDate || endDate.isBefore(startDate)) {
+                const nbDays = startDate.isoWeekday() === 5 ? 3 : 1
+                endDate = startDate.clone().add(nbDays, 'days')
+              }
+              if (!endDate.isSameOrAfter(startDate)) {
+                const nbDays = startDate.isoWeekday() === 5 ? 3 : 1
+                endDate = startDate.clone().add(nbDays, 'days')
+              }
+              if (endDate.isBefore(this.startDate)) {
+                return
+              }
+              if (endDate.isAfter(entityTypeItem.endDate)) {
+                entityTypeItem.endDate = endDate.clone()
+              }
+              task.endDate = endDate
+
+              if (!tasksByType[task.entity_type_id][assigneeId]) {
+                tasksByType[task.entity_type_id][assigneeId] = []
+                people[assigneeId] =
+                  assigneeId !== 'unassigned'
+                    ? {
+                        ...this.personMap.get(assigneeId),
+                        daysOff: this.daysOffByPerson[assigneeId]
+                      }
+                    : {
+                        id: assigneeId,
+                        avatar: false,
+                        color: '#888',
+                        full_name: this.$t('main.unassigned')
+                      }
+              }
+
+              task.editable = !this.isLockedSchedule
+              task.unresizable = false
+              task.parentElement = entityTypeItem
+
+              tasksByType[task.entity_type_id][assigneeId].push(task)
+            })
+          })
+
+          if (taskTypeElement.for_entity === 'Asset') {
+            // filtering following custom asset types workflow
+            children = children.filter(item => {
+              const assetType = this.assetTypeMap.get(item.object_id)
+              return (
+                assetType &&
+                (!assetType.task_types.length ||
+                  assetType.task_types.includes(taskTypeElement.task_type_id))
+              )
+            })
+          } else if (
+            taskTypeElement.for_entity === 'Shot' &&
+            this.currentEpisodeId
+          ) {
+            // keep only the sequences of the current episode
+            children = children.filter(item => {
+              const sequence = this.sequenceMap.get(item.object_id)
+              return sequence && sequence.episode_id === this.currentEpisodeId
+            })
+          }
+
+          // sort grouped tasks
+          const sortEntitiesByUserName = ([keyA], [keyB]) => {
+            if (keyA === 'unassigned') return 1
+            if (keyB === 'unassigned') return -1
+            return people[keyA].full_name.localeCompare(people[keyB].full_name)
+          }
+          const sortTasksByEntityName = (a, b) =>
+            a.entity?.name.localeCompare(b.entity?.name, undefined, {
+              numeric: true
+            })
+          children.forEach(child => {
+            const items = tasksByType[child.object_id] || {}
+            const sortedChildren = new Map(
+              Object.entries(items)
+                .sort(sortEntitiesByUserName)
+                .map(([key, tasks]) => [key, tasks.sort(sortTasksByEntityName)])
+            )
+
+            child.children = sortedChildren
+          })
+
+          taskTypeElement.children = sortByName(children)
+          taskTypeElement.people = people
+
+          // group all assigned entities by type
+          taskTypeElement.entitiesByType = Object.fromEntries(
+            Object.entries(tasksByType).map(([entityTypeId, byAssignee]) => [
+              entityTypeId,
+              Object.entries(byAssignee)
+                .flatMap(([assignee, items]) =>
+                  assignee !== 'unassigned'
+                    ? items.map(item => item.entity_id)
+                    : undefined
+                )
+                .filter(Boolean)
+            ])
+          )
         } catch (err) {
           console.error(err)
           taskTypeElement.children = []
@@ -1559,10 +1580,6 @@ export default {
       selectedEntityType = undefined,
       resetAssignments = true
     ) {
-      if (this.isTVShow) {
-        return
-      }
-
       this.selectedTaskType = taskType
 
       if (resetAssignments) {
@@ -1572,11 +1589,9 @@ export default {
       this.assignments.loading = true
 
       // load tasks
-      const tasks = await this.loadTasks({
-        project_id: this.currentProduction.id,
-        task_type_id: this.selectedTaskType.task_type_id,
-        relations: 'true'
-      })
+      const tasks = await this.loadTasks(
+        this.buildTaskFilters(this.selectedTaskType)
+      )
 
       // load entity types
       if (taskType.for_entity === 'Asset') {
@@ -1730,11 +1745,9 @@ export default {
       this.assignments.saving = true
 
       // load tasks
-      const tasks = await this.loadTasks({
-        project_id: this.currentProduction.id,
-        task_type_id: this.selectedTaskType.task_type_id,
-        relations: 'true'
-      })
+      const tasks = await this.loadTasks(
+        this.buildTaskFilters(this.selectedTaskType)
+      )
 
       const dailyQuota =
         this.assignments.forcedDailyQuota ?? this.estimatedDailyQuota
@@ -2362,12 +2375,21 @@ export default {
     currentProduction(value) {
       if (!value) return
       this.reset()
+    },
+
+    currentEpisode(value) {
+      if (!value || ['all', 'main'].includes(value.id)) return
+      if (this.isTVShow) this.reset()
     }
   },
 
   head() {
+    const context =
+      this.isTVShow && this.currentEpisode?.name
+        ? `${this.currentProduction.name} | ${this.currentEpisode.name}`
+        : this.currentProduction.name
     return {
-      title: `${this.currentProduction.name} | ${this.$t('schedule.title')} - Kitsu`
+      title: `${context} | ${this.$t('schedule.title')} - Kitsu`
     }
   }
 }

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -849,9 +849,11 @@ export default {
       'editProduction',
       'loadAssets',
       'loadAssetTypeScheduleItems',
+      'loadEpisodeScheduleItems',
       'loadProductionDaysOff',
       'loadScheduleItems',
       'loadScheduleVersions',
+      'loadSequences',
       'loadSequenceScheduleItems',
       'loadShots',
       'loadTasks',
@@ -1076,11 +1078,12 @@ export default {
           taskTypeElement.people = {}
           taskTypeElement.entitiesByType = {}
 
-          const loadScheduleItems = ['Shot', 'Sequence'].includes(
-            taskTypeElement.for_entity
-          )
-            ? this.loadSequenceScheduleItems
-            : this.loadAssetTypeScheduleItems
+          const loadScheduleItems =
+            taskTypeElement.for_entity === 'Episode'
+              ? this.loadEpisodeScheduleItems
+              : ['Shot', 'Sequence'].includes(taskTypeElement.for_entity)
+                ? this.loadSequenceScheduleItems
+                : this.loadAssetTypeScheduleItems
           const parameters = {
             production: this.currentProduction,
             taskType: this.taskTypeMap.get(taskTypeElement.task_type_id),
@@ -1101,6 +1104,12 @@ export default {
             await this.loadAssets({ withShared: false, withTasks: false })
           } else if (taskTypeElement.for_entity === 'Shot') {
             await this.loadShots()
+          } else if (
+            taskTypeElement.for_entity === 'Sequence' &&
+            this.currentEpisodeId
+          ) {
+            // populate the episode-scoped sequenceMap for the client-side filter
+            await this.loadSequences()
           }
 
           let tasks = await this.loadTasks(
@@ -1270,7 +1279,7 @@ export default {
               )
             })
           } else if (
-            taskTypeElement.for_entity === 'Shot' &&
+            ['Shot', 'Sequence'].includes(taskTypeElement.for_entity) &&
             this.currentEpisodeId
           ) {
             // keep only the sequences of the current episode

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -574,6 +574,8 @@ import TextField from '@/components/widgets/TextField.vue'
 
 import assetStore from '@/store/modules/assets'
 import assetTypeStore from '@/store/modules/assettypes'
+import editStore from '@/store/modules/edits'
+import episodeStore from '@/store/modules/episodes'
 import sequenceStore from '@/store/modules/sequences'
 import shotStore from '@/store/modules/shots'
 import taskTypeStore from '@/store/modules/tasktypes'
@@ -709,14 +711,6 @@ export default {
       return nbDays && nbAssignees ? nbEntities / nbDays / nbAssignees : 0
     },
 
-    assetMap() {
-      return assetStore.cache.assetMap
-    },
-
-    assets() {
-      return assetStore.cache.assets
-    },
-
     assetTypeMap() {
       return assetTypeStore.cache.assetTypeMap
     },
@@ -749,22 +743,10 @@ export default {
       )
     },
 
-    sequenceMap() {
-      return sequenceStore.cache.sequenceMap
-    },
-
     // Concrete episode id for scoping (null for feature films or the 'all'/'main' pseudo-episodes).
     currentEpisodeId() {
       const id = this.currentEpisode?.id
       return this.isTVShow && id && !['all', 'main'].includes(id) ? id : null
-    },
-
-    shotMap() {
-      return shotStore.cache.shotMap
-    },
-
-    shots() {
-      return shotStore.cache.shots
     },
 
     taskTypeMap() {
@@ -849,7 +831,10 @@ export default {
       'editProduction',
       'loadAssets',
       'loadAssetTypeScheduleItems',
+      'loadEdits',
+      'loadEditScheduleItems',
       'loadEpisodeScheduleItems',
+      'loadEpisodes',
       'loadProductionDaysOff',
       'loadScheduleItems',
       'loadScheduleVersions',
@@ -1078,12 +1063,18 @@ export default {
           taskTypeElement.people = {}
           taskTypeElement.entitiesByType = {}
 
+          // one row per asset type (Asset), sequence (Shot/Sequence),
+          // episode (Episode) or edit (Edit)
+          const scheduleItemLoaders = {
+            Asset: this.loadAssetTypeScheduleItems,
+            Shot: this.loadSequenceScheduleItems,
+            Sequence: this.loadSequenceScheduleItems,
+            Episode: this.loadEpisodeScheduleItems,
+            Edit: this.loadEditScheduleItems
+          }
           const loadScheduleItems =
-            taskTypeElement.for_entity === 'Episode'
-              ? this.loadEpisodeScheduleItems
-              : ['Shot', 'Sequence'].includes(taskTypeElement.for_entity)
-                ? this.loadSequenceScheduleItems
-                : this.loadAssetTypeScheduleItems
+            scheduleItemLoaders[taskTypeElement.for_entity] ??
+            this.loadAssetTypeScheduleItems
           const parameters = {
             production: this.currentProduction,
             taskType: this.taskTypeMap.get(taskTypeElement.task_type_id),
@@ -1099,17 +1090,18 @@ export default {
             children.map(child => [child.object_id, child])
           )
 
-          // load entities (scoped to the current episode for TV shows)
+          // load entities (scoped to the current episode for TV shows) that
+          // back the row grouping, the entity name and the episode filter
           if (taskTypeElement.for_entity === 'Asset') {
             await this.loadAssets({ withShared: false, withTasks: false })
           } else if (taskTypeElement.for_entity === 'Shot') {
             await this.loadShots()
-          } else if (
-            taskTypeElement.for_entity === 'Sequence' &&
-            this.currentEpisodeId
-          ) {
-            // populate the episode-scoped sequenceMap for the client-side filter
+          } else if (taskTypeElement.for_entity === 'Sequence') {
             await this.loadSequences()
+          } else if (taskTypeElement.for_entity === 'Episode') {
+            await this.loadEpisodes()
+          } else if (taskTypeElement.for_entity === 'Edit') {
+            await this.loadEdits()
           }
 
           let tasks = await this.loadTasks(
@@ -1154,6 +1146,16 @@ export default {
             () => ({}) // fallback if not allowed to fetch days off
           )
 
+          // Read the entity maps fresh from the store cache. They are plain,
+          // non-reactive Maps replaced on each episode-scoped load, so a cached
+          // computed would keep returning the first episode's Map and empty the
+          // drill-down after switching episode.
+          const assetMap = assetStore.cache.assetMap
+          const shotMap = shotStore.cache.shotMap
+          const sequenceMap = sequenceStore.cache.sequenceMap
+          const episodeMap = episodeStore.cache.episodeMap
+          const editMap = editStore.cache.editMap
+
           // group tasks by entity type and assignee
           const tasksByType = {}
           const people = {}
@@ -1163,17 +1165,32 @@ export default {
             }
 
             // link entity to task; skip tasks whose entity is not in the
-            // current episode (loadTasks is not episode-scoped, but
-            // assetMap/shotMap are for TV shows)
+            // current episode (loadTasks is not episode-scoped, but the entity
+            // maps are for TV shows). Sequence/Episode/Edit task types group
+            // under their own entity id.
             if (taskTypeElement.for_entity === 'Asset') {
-              task.entity = this.assetMap.get(task.entity_id)
+              task.entity = assetMap.get(task.entity_id)
               if (!task.entity) return
               task.entity_type_id = task.entity.asset_type_id
             } else if (taskTypeElement.for_entity === 'Shot') {
-              task.entity = this.shotMap.get(task.entity_id)
+              task.entity = shotMap.get(task.entity_id)
               if (!task.entity) return
               task.entity_type_id = task.entity.sequence_id
+            } else if (taskTypeElement.for_entity === 'Sequence') {
+              task.entity = sequenceMap.get(task.entity_id)
+              if (!task.entity) return
+              task.entity_type_id = task.entity_id
+            } else if (taskTypeElement.for_entity === 'Episode') {
+              task.entity = episodeMap.get(task.entity_id)
+              if (!task.entity) return
+              task.entity_type_id = task.entity_id
+            } else if (taskTypeElement.for_entity === 'Edit') {
+              task.entity = editMap.get(task.entity_id)
+              if (!task.entity) return
+              task.entity_type_id = task.entity_id
             } else {
+              // unknown for_entity: the task will be dropped by the
+              // childrenById guard below
               task.entity_type_id = taskTypeElement.for_entity
             }
             if (task.entity?.canceled) {
@@ -1284,8 +1301,17 @@ export default {
           ) {
             // keep only the sequences of the current episode
             children = children.filter(item => {
-              const sequence = this.sequenceMap.get(item.object_id)
+              const sequence = sequenceMap.get(item.object_id)
               return sequence && sequence.episode_id === this.currentEpisodeId
+            })
+          } else if (
+            taskTypeElement.for_entity === 'Edit' &&
+            this.currentEpisodeId
+          ) {
+            // keep only the edits of the current episode
+            children = children.filter(item => {
+              const edit = editMap.get(item.object_id)
+              return edit && edit.episode_id === this.currentEpisodeId
             })
           }
 
@@ -1621,7 +1647,7 @@ export default {
               for_entity: taskType.for_entity,
               expanded: assetType.id === selectedEntityType?.object_id,
               entity_type_id: assetType.id,
-              children: this.assets
+              children: assetStore.cache.assets
                 .filter(
                   asset =>
                     asset.asset_type_id === assetType.id &&
@@ -1640,7 +1666,7 @@ export default {
       } else if (taskType.for_entity === 'Shot') {
         await this.loadShots()
 
-        const shotsBySequence = this.shots
+        const shotsBySequence = shotStore.cache.shots
           .filter(shot => tasks.some(task => task.entity_id === shot.id))
           .reduce((acc, shot) => {
             if (!acc[shot.parent_id]) {
@@ -1662,6 +1688,107 @@ export default {
               for_entity: taskType.for_entity,
               expanded: sequenceId === selectedEntityType?.object_id,
               children: shots
+            }
+          }
+        )
+      } else if (taskType.for_entity === 'Sequence') {
+        await this.loadSequences()
+
+        // sequences are the assignable entities, grouped by episode
+        const sequencesByEpisode = [...sequenceStore.cache.sequenceMap.values()]
+          .filter(
+            sequence =>
+              !sequence.canceled &&
+              (!this.currentEpisodeId ||
+                sequence.episode_id === this.currentEpisodeId) &&
+              tasks.some(task => task.entity_id === sequence.id)
+          )
+          .reduce((acc, sequence) => {
+            const groupId = sequence.episode_id || taskType.for_entity
+            if (!acc[groupId]) {
+              acc[groupId] = []
+            }
+            sequence.assigned = taskType.entitiesByType?.[
+              sequence.id
+            ]?.includes(sequence.id)
+            acc[groupId].push(sequence)
+            return acc
+          }, {})
+
+        this.assignments.entityTypes = Object.keys(sequencesByEpisode).map(
+          groupId => {
+            const sequences = sequencesByEpisode[groupId]
+            return {
+              id: groupId,
+              name: sequences[0].episode_name || this.currentProduction.name,
+              for_entity: taskType.for_entity,
+              expanded: groupId === selectedEntityType?.object_id,
+              children: sequences
+            }
+          }
+        )
+      } else if (taskType.for_entity === 'Episode') {
+        await this.loadEpisodes()
+
+        // episodes are the assignable entities, under a single production group
+        const episodes = [...episodeStore.cache.episodeMap.values()]
+          .filter(
+            episode =>
+              !episode.canceled &&
+              !['all', 'main'].includes(episode.id) &&
+              (!this.currentEpisodeId ||
+                episode.id === this.currentEpisodeId) &&
+              tasks.some(task => task.entity_id === episode.id)
+          )
+          .map(episode => ({
+            ...episode,
+            assigned: taskType.entitiesByType?.[episode.id]?.includes(
+              episode.id
+            )
+          }))
+
+        this.assignments.entityTypes = [
+          {
+            id: taskType.for_entity,
+            name: this.currentProduction.name,
+            for_entity: taskType.for_entity,
+            expanded: true,
+            children: episodes
+          }
+        ]
+      } else if (taskType.for_entity === 'Edit') {
+        await this.loadEdits()
+
+        // edits are the assignable entities, grouped by episode
+        const editsByEpisode = [...editStore.cache.editMap.values()]
+          .filter(
+            edit =>
+              !edit.canceled &&
+              (!this.currentEpisodeId ||
+                edit.episode_id === this.currentEpisodeId) &&
+              tasks.some(task => task.entity_id === edit.id)
+          )
+          .reduce((acc, edit) => {
+            const groupId = edit.episode_id || taskType.for_entity
+            if (!acc[groupId]) {
+              acc[groupId] = []
+            }
+            edit.assigned = taskType.entitiesByType?.[edit.id]?.includes(
+              edit.id
+            )
+            acc[groupId].push(edit)
+            return acc
+          }, {})
+
+        this.assignments.entityTypes = Object.keys(editsByEpisode).map(
+          groupId => {
+            const edits = editsByEpisode[groupId]
+            return {
+              id: groupId,
+              name: edits[0].episode_name || this.currentProduction.name,
+              for_entity: taskType.for_entity,
+              expanded: groupId === selectedEntityType?.object_id,
+              children: edits
             }
           }
         )

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -969,7 +969,6 @@ export default {
         isTVShow &&
         section !== 'team' &&
         section !== 'news-feed' &&
-        section !== 'schedule' &&
         section !== 'production-settings' &&
         section !== 'brief' &&
         section !== 'budget' &&

--- a/src/components/tops/TopbarEpisodeList.vue
+++ b/src/components/tops/TopbarEpisodeList.vue
@@ -123,6 +123,7 @@ export default {
       const currentProduction = this.currentProduction
       const section = this.section
       const pluginId = this.$route.params.plugin_id
+      const currentQuery = this.$route.query
       return episodeId => {
         const path = getProductionPath(
           currentProduction,
@@ -130,6 +131,10 @@ export default {
           episodeId,
           pluginId
         )
+        if (section === 'schedule') {
+          // The production schedule keeps its view state (mode, version, ...) in the URL query.
+          path.query = { ...currentQuery }
+        }
         return path
       }
     }

--- a/src/lib/path.js
+++ b/src/lib/path.js
@@ -137,7 +137,6 @@ const SECTION_NAME_MAP = {
 
 const TVSHOW_NON_EPISODIC_SECTIONS = [
   'news-feed',
-  'schedule',
   'production-settings',
   'quota',
   'budget',

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -485,6 +485,12 @@ export const routes = [
       },
 
       {
+        path: 'productions/:production_id/episodes/:episode_id/schedule',
+        component: ProductionSchedule,
+        name: 'episode-schedule'
+      },
+
+      {
         path: 'productions/:production_id/production-settings',
         component: ProductionSettings,
         name: 'production-settings'

--- a/src/store/api/schedule.js
+++ b/src/store/api/schedule.js
@@ -79,6 +79,10 @@ export default {
     )
   },
 
+  getEditScheduleItems(production, taskType, episodeId = null) {
+    return this.getEntityScheduleItems(production, taskType, 'edits', episodeId)
+  },
+
   getEpisodeScheduleItems(production, taskType, episodeId = null) {
     return this.getEntityScheduleItems(
       production,

--- a/src/store/api/schedule.js
+++ b/src/store/api/schedule.js
@@ -61,23 +61,37 @@ export default {
     return client.pdel(path)
   },
 
-  getAssetTypeScheduleItems(production, taskType) {
-    return this.getEntityScheduleItems(production, taskType, 'asset-types')
-  },
-
-  getSequenceScheduleItems(production, taskType) {
-    return this.getEntityScheduleItems(production, taskType, 'sequences')
-  },
-
-  getEpisodeScheduleItems(production, taskType) {
-    return this.getEntityScheduleItems(production, taskType, 'episodes')
-  },
-
-  getEntityScheduleItems(production, taskType, entity) {
-    return client.pget(
-      `/api/data/projects/${production.id}/schedule-items/` +
-        `${taskType.id}/${entity}`
+  getAssetTypeScheduleItems(production, taskType, episodeId = null) {
+    return this.getEntityScheduleItems(
+      production,
+      taskType,
+      'asset-types',
+      episodeId
     )
+  },
+
+  getSequenceScheduleItems(production, taskType, episodeId = null) {
+    return this.getEntityScheduleItems(
+      production,
+      taskType,
+      'sequences',
+      episodeId
+    )
+  },
+
+  getEpisodeScheduleItems(production, taskType, episodeId = null) {
+    return this.getEntityScheduleItems(
+      production,
+      taskType,
+      'episodes',
+      episodeId
+    )
+  },
+
+  getEntityScheduleItems(production, taskType, entity, episodeId = null) {
+    let path = `/api/data/projects/${production.id}/schedule-items/${taskType.id}/${entity}`
+    if (episodeId) path += `?episode_id=${episodeId}`
+    return client.pget(path)
   },
 
   updateScheduleItem(scheduleItem) {

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -69,6 +69,8 @@ import {
 const cache = {
   edits: [],
   editIndex: [],
+  editsLoadingPromise: null,
+  editsLoadingKey: null,
   editMap: new Map(),
   result: []
 }
@@ -345,11 +347,23 @@ const actions = {
       episode = null
     }
 
+    const loadingKey = `${production.id}/${episode?.id ?? ''}`
     if (state.isEditsLoading) {
-      return cache.editsLoadingPromise || Promise.resolve([])
+      if (cache.editsLoadingKey === loadingKey) {
+        // Same production+episode already loading: share the in-flight load
+        // so concurrent callers (e.g. schedule expands) await the same edits.
+        return cache.editsLoadingPromise || Promise.resolve([])
+      }
+      // A different production/episode is in flight (e.g. the user switched
+      // episode mid-load): wait for it to settle, then run our own load so
+      // the newly selected episode's edits are actually fetched.
+      return (cache.editsLoadingPromise || Promise.resolve([])).then(() =>
+        dispatch('loadEdits')
+      )
     }
 
     commit(LOAD_EDITS_START)
+    cache.editsLoadingKey = loadingKey
     const loadingPromise = editsApi
       .getEdits(production, episode)
       .then(edits => {

--- a/src/store/modules/schedule.js
+++ b/src/store/modules/schedule.js
@@ -49,6 +49,10 @@ const actions = {
     return scheduleApi.getSequenceScheduleItems(production, taskType, episodeId)
   },
 
+  loadEditScheduleItems({}, { production, taskType, episodeId = null }) {
+    return scheduleApi.getEditScheduleItems(production, taskType, episodeId)
+  },
+
   loadEpisodeScheduleItems({}, { production, taskType, episodeId = null }) {
     return scheduleApi.getEpisodeScheduleItems(production, taskType, episodeId)
   },

--- a/src/store/modules/schedule.js
+++ b/src/store/modules/schedule.js
@@ -37,16 +37,20 @@ const actions = {
     commit(SET_CURRENT_SCHEDULE_ITEMS, scheduleItems)
   },
 
-  loadAssetTypeScheduleItems({}, { production, taskType }) {
-    return scheduleApi.getAssetTypeScheduleItems(production, taskType)
+  loadAssetTypeScheduleItems({}, { production, taskType, episodeId = null }) {
+    return scheduleApi.getAssetTypeScheduleItems(
+      production,
+      taskType,
+      episodeId
+    )
   },
 
-  loadSequenceScheduleItems({}, { production, taskType }) {
-    return scheduleApi.getSequenceScheduleItems(production, taskType)
+  loadSequenceScheduleItems({}, { production, taskType, episodeId = null }) {
+    return scheduleApi.getSequenceScheduleItems(production, taskType, episodeId)
   },
 
-  loadEpisodeScheduleItems({}, { production, taskType }) {
-    return scheduleApi.getEpisodeScheduleItems(production, taskType)
+  loadEpisodeScheduleItems({}, { production, taskType, episodeId = null }) {
+    return scheduleApi.getEpisodeScheduleItems(production, taskType, episodeId)
   },
 
   createScheduleItem({ commit, state }, scheduleItem) {

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -86,6 +86,7 @@ import {
 
 const cache = {
   shots: [],
+  shotsLoadingPromise: null,
   shotMap: new Map(),
   shotIndex: {},
   result: []
@@ -426,10 +427,15 @@ const actions = {
       commit(SET_CURRENT_EPISODE, null)
     }
 
-    if (state.isShotsLoading) return Promise.resolve()
+    if (state.isShotsLoading) {
+      // Return the in-flight load so concurrent callers await the same shots
+      // (e.g. parallel expands in the schedule) instead of racing ahead with
+      // an empty shotMap/sequenceMap.
+      return cache.shotsLoadingPromise || Promise.resolve()
+    }
 
     commit(LOAD_SHOTS_START)
-    return dispatch('loadSequencesWithTasks')
+    const loadingPromise = dispatch('loadSequencesWithTasks')
       .then(() => {
         return shotsApi.getShots(production, episode)
       })
@@ -466,6 +472,8 @@ const actions = {
         commit(LOAD_SHOTS_ERROR)
         console.error(err)
       })
+    cache.shotsLoadingPromise = loadingPromise
+    return loadingPromise
   },
 
   /*

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -87,6 +87,7 @@ import {
 const cache = {
   shots: [],
   shotsLoadingPromise: null,
+  shotsLoadingKey: null,
   shotMap: new Map(),
   shotIndex: {},
   result: []
@@ -427,14 +428,26 @@ const actions = {
       commit(SET_CURRENT_EPISODE, null)
     }
 
+    const loadingKey = `${production.id}/${episode?.id ?? ''}`
     if (state.isShotsLoading) {
-      // Return the in-flight load so concurrent callers await the same shots
-      // (e.g. parallel expands in the schedule) instead of racing ahead with
-      // an empty shotMap/sequenceMap.
-      return cache.shotsLoadingPromise || Promise.resolve()
+      if (cache.shotsLoadingKey === loadingKey) {
+        // Same production+episode already loading: share it so concurrent
+        // callers (e.g. parallel schedule expands) await the same shots
+        // instead of racing ahead with an empty shotMap/sequenceMap.
+        return cache.shotsLoadingPromise || Promise.resolve()
+      }
+      // A different production/episode is in flight (e.g. the user switched
+      // episode mid-load): wait for it to settle, then run our own load so the
+      // newly selected episode's shots are actually fetched, instead of
+      // adopting a load whose stale response gets discarded and leaves this
+      // caller with an empty map.
+      return (cache.shotsLoadingPromise || Promise.resolve()).then(() =>
+        dispatch('loadShots')
+      )
     }
 
     commit(LOAD_SHOTS_START)
+    cache.shotsLoadingKey = loadingKey
     const loadingPromise = dispatch('loadSequencesWithTasks')
       .then(() => {
         return shotsApi.getShots(production, episode)

--- a/tests/unit/store/edits.spec.js
+++ b/tests/unit/store/edits.spec.js
@@ -1,0 +1,92 @@
+import { vi } from 'vitest'
+
+// Importing the edits module transitively pulls in the root store
+// (lib/models → timezone → @/store); stub it so no Vuex store is built.
+vi.mock('@/store', () => ({ default: {} }))
+// Keep the loads in flight without hitting the network.
+vi.mock('@/store/api/edits', () => ({
+  default: { getEdits: vi.fn(() => new Promise(() => {})) }
+}))
+
+import editsStore from '@/store/modules/edits'
+
+describe('Edits store', () => {
+  describe('loading flag lifecycle', () => {
+    test('a concurrent same-scope caller shares the in-flight load instead of starting a second one', () => {
+      const state = { isEditsLoading: false }
+      const commit = vi.fn()
+      const dispatch = vi.fn()
+      const rootGetters = {
+        currentProduction: { id: 'p-share' },
+        episodes: [],
+        userFilters: {},
+        taskTypeMap: new Map(),
+        taskMap: new Map(),
+        personMap: new Map(),
+        isTVShow: false,
+        currentEpisode: null
+      }
+
+      // First call kicks off the load and stores the in-flight promise/key.
+      const first = editsStore.actions.loadEdits({
+        commit,
+        dispatch,
+        state,
+        rootGetters
+      })
+      expect(commit.mock.calls.map(c => c[0])).toContain('LOAD_EDITS_START')
+
+      // Simulate the mutation the mocked commit did not apply.
+      state.isEditsLoading = true
+      commit.mockClear()
+
+      // A concurrent caller for the same production+episode must get the very
+      // same promise and must not start a second load.
+      const second = editsStore.actions.loadEdits({
+        commit,
+        dispatch,
+        state,
+        rootGetters
+      })
+      expect(second).toBe(first)
+      expect(commit.mock.calls.map(c => c[0])).not.toContain('LOAD_EDITS_START')
+    })
+
+    test('a caller for a different episode does not adopt the in-flight load', () => {
+      const commit = vi.fn()
+      const dispatch = vi.fn()
+      const baseGetters = {
+        currentProduction: { id: 'p-switch' },
+        episodes: [{ id: 'ep-a' }, { id: 'ep-b' }],
+        userFilters: {},
+        taskTypeMap: new Map(),
+        taskMap: new Map(),
+        personMap: new Map(),
+        isTVShow: true
+      }
+      const state = { isEditsLoading: false }
+
+      // Load episode A, then leave it in flight.
+      const loadA = editsStore.actions.loadEdits({
+        commit,
+        dispatch,
+        state,
+        rootGetters: { ...baseGetters, currentEpisode: { id: 'ep-a' } }
+      })
+      state.isEditsLoading = true
+      commit.mockClear()
+
+      // Switching to episode B must NOT return A's promise: B would await a
+      // load whose result belongs to A and read stale edits. Instead B gets a
+      // distinct promise that fetches B once A settles.
+      const loadB = editsStore.actions.loadEdits({
+        commit,
+        dispatch,
+        state,
+        rootGetters: { ...baseGetters, currentEpisode: { id: 'ep-b' } }
+      })
+      expect(loadB).not.toBe(loadA)
+      expect(commit.mock.calls.map(c => c[0])).not.toContain('LOAD_EDITS_START')
+    })
+  })
+})

--- a/tests/unit/store/shots.spec.js
+++ b/tests/unit/store/shots.spec.js
@@ -17,12 +17,13 @@ describe('Shots store', () => {
       expect(state.isShotsLoadingError).toBe(false)
     })
 
-    test('loadShots does not start a second load while one is in flight (BUG-4)', async () => {
-      const state = { isShotsLoading: true }
+    test('a concurrent same-scope caller shares the in-flight load instead of starting a second one (BUG-4)', async () => {
+      const state = { isShotsLoading: false }
       const commit = vi.fn()
-      const dispatch = vi.fn()
+      // Never resolves: keeps the first load "in flight" for the assertions.
+      const dispatch = vi.fn(() => new Promise(() => {}))
       const rootGetters = {
-        currentProduction: { id: 'p1' },
+        currentProduction: { id: 'p-share' },
         episodes: [],
         userFilters: {},
         userFilterGroups: {},
@@ -33,10 +34,67 @@ describe('Shots store', () => {
         currentEpisode: null
       }
 
-      // Guard resolves immediately without kicking off another load.
-      await shotsStore.actions.loadShots({ commit, dispatch, state, rootGetters })
+      // First call kicks off the load and stores the in-flight promise/key.
+      const first = shotsStore.actions.loadShots({
+        commit,
+        dispatch,
+        state,
+        rootGetters
+      })
+      expect(commit.mock.calls.map(c => c[0])).toContain('LOAD_SHOTS_START')
 
-      expect(dispatch).not.toHaveBeenCalled()
+      // Simulate the mutation the mocked commit did not apply.
+      state.isShotsLoading = true
+      commit.mockClear()
+
+      // A concurrent caller for the same production+episode must get the very
+      // same promise (not a fresh Promise.resolve()) and must not start a
+      // second load — otherwise it races ahead with an empty shotMap.
+      const second = shotsStore.actions.loadShots({
+        commit,
+        dispatch,
+        state,
+        rootGetters
+      })
+      expect(second).toBe(first)
+      expect(commit.mock.calls.map(c => c[0])).not.toContain('LOAD_SHOTS_START')
+    })
+
+    test('a caller for a different episode does not adopt the in-flight load (BUG-4)', async () => {
+      const commit = vi.fn()
+      const dispatch = vi.fn(() => new Promise(() => {}))
+      const baseGetters = {
+        currentProduction: { id: 'p-switch' },
+        episodes: [{ id: 'ep-a' }, { id: 'ep-b' }],
+        userFilters: {},
+        userFilterGroups: {},
+        taskTypeMap: new Map(),
+        personMap: new Map(),
+        taskMap: new Map(),
+        isTVShow: true
+      }
+      const state = { isShotsLoading: false }
+
+      // Load episode A, then leave it in flight.
+      const loadA = shotsStore.actions.loadShots({
+        commit,
+        dispatch,
+        state,
+        rootGetters: { ...baseGetters, currentEpisode: { id: 'ep-a' } }
+      })
+      state.isShotsLoading = true
+      commit.mockClear()
+
+      // Switching to episode B must NOT return A's promise: A's result would be
+      // discarded by the episode stale-guard, leaving B with an empty shotMap.
+      // Instead B gets a distinct promise that fetches B once A settles.
+      const loadB = shotsStore.actions.loadShots({
+        commit,
+        dispatch,
+        state,
+        rootGetters: { ...baseGetters, currentEpisode: { id: 'ep-b' } }
+      })
+      expect(loadB).not.toBe(loadA)
       expect(commit.mock.calls.map(c => c[0])).not.toContain('LOAD_SHOTS_START')
     })
   })


### PR DESCRIPTION
**Problem**
- On a TV show, the production schedule showed the whole production at once, with no way to focus on a single episode.
- Sequence, Episode, and Edit task types couldn't be expanded, and work couldn't be assigned from the schedule, so planning was incomplete for TV shows.
- Switching episode resets the schedule's display options (mode, version, …), forcing a manual reconfiguration each time.
- Loading or switching episode quickly could leave the schedule showing another episode's data, or nothing at all.

**Solution**
- Add an episode selector to the schedule so you can view and plan one episode at a time, each with its own address.
- Allow the full drill-down for Sequence, Episode, and Edit task types, with the assignment panel available for every task type.
- Keep the schedule's display options when switching episodes, and show the current episode in the page title.
- Always load the selected episode's data, so the schedule stays correct even when switching quickly.
