### PR TITLE
[schedule] Fix drag, locking, quota and error-handling bugs

### DIFF
--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -2259,7 +2259,8 @@ export default {
           id: task.versionedTaskId,
           assignees: task.assignees
         })
-      } else {
+      } else if (personId !== 'unassigned') {
+        // 'unassigned' is a local placeholder, not a person known to the API
         await this.unassignPersonFromTask({
           person: { id: personId },
           task

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -2453,11 +2453,17 @@ export default {
         data.hierarchy.forEach(item => {
           endRowLevel1 = startRowLevel1
 
+          // ExcelJS expects 8-digit ARGB values, 6-digit hex shifts the
+          // channels and renders wrong colors
+          const lightened = colors.lightenColor(item.color, 0.2).hex()
+          const color = `FF${item.color.slice(1)}`.toUpperCase()
+          const color2 = `FF${lightened.slice(1)}`.toUpperCase()
+
           const row = sheet.addRow([null, item.name])
           row.getCell(1).fill = {
             type: 'pattern',
             pattern: 'solid',
-            fgColor: { argb: item.color.slice(1) }
+            fgColor: { argb: color }
           }
           row.getCell(2).alignment = { vertical: 'top' }
           row.getCell(2).note =
@@ -2467,8 +2473,6 @@ export default {
           // fill timebar
           const start = dates.indexOf(item.start_date)
           const end = dates.indexOf(item.end_date)
-          const color = item.color.slice(1)
-          const color2 = colors.lightenColor(item.color, 0.2).hex().slice(1)
           for (let i = start; i > -1 && i <= end; i++) {
             const cell = row.getCell(5 + i)
             cell.fill = {

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -638,6 +638,7 @@ export default {
       draggedEntities: [],
       endDate: moment().add(6, 'months').endOf('day'),
       entityType: null,
+      expandAll: false,
       isSidePanelOpen: false,
       resetTimeout: null,
       scheduleItems: [],
@@ -1369,10 +1370,6 @@ export default {
                 )
               }
               if (!endDate || endDate.isBefore(startDate)) {
-                const nbDays = startDate.isoWeekday() === 5 ? 3 : 1
-                endDate = startDate.clone().add(nbDays, 'days')
-              }
-              if (!endDate.isSameOrAfter(startDate)) {
                 const nbDays = startDate.isoWeekday() === 5 ? 3 : 1
                 endDate = startDate.clone().add(nbDays, 'days')
               }

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -661,6 +661,7 @@ export default {
       version: DEFAULT_VERSION,
       loading: {
         schedule: false,
+        delete: false,
         editScheduleVersion: false,
         applyScheduleVersion: false,
         expandSchedule: false,
@@ -908,75 +909,78 @@ export default {
 
     async loadData() {
       this.loading.schedule = true
+      this.errors.schedule = false
       this.availableTaskTypes = []
 
-      await this.loadScheduleVersions(this.currentProduction)
+      try {
+        await this.loadScheduleVersions(this.currentProduction)
 
-      return this.loadScheduleItems(this.currentProduction)
-        .then(scheduleItems => {
-          const scheduleStartDate = parseDate(this.selectedStartDate)
-          const scheduleEndDate = parseDate(this.selectedEndDate)
-          scheduleItems = scheduleItems.map(item => {
-            const taskType = this.taskTypeMap.get(item.task_type_id)
-            let startDate, endDate
-            if (item.start_date) {
-              startDate = parseDate(item.start_date)
-            } else {
-              startDate = moment()
-            }
-            if (startDate.isSameOrAfter(scheduleEndDate)) {
-              startDate = scheduleEndDate.clone().add(-1, 'days')
-            }
+        const items = await this.loadScheduleItems(this.currentProduction)
+        const scheduleStartDate = parseDate(this.selectedStartDate)
+        const scheduleEndDate = parseDate(this.selectedEndDate)
+        const scheduleItems = items.map(item => {
+          const taskType = this.taskTypeMap.get(item.task_type_id)
+          let startDate, endDate
+          if (item.start_date) {
+            startDate = parseDate(item.start_date)
+          } else {
+            startDate = moment()
+          }
+          if (startDate.isSameOrAfter(scheduleEndDate)) {
+            startDate = scheduleEndDate.clone().add(-1, 'days')
+          }
 
-            if (startDate.isBefore(scheduleStartDate)) {
-              startDate = scheduleStartDate.clone()
-            }
+          if (startDate.isBefore(scheduleStartDate)) {
+            startDate = scheduleStartDate.clone()
+          }
 
-            if (item.end_date) {
-              endDate = parseDate(item.end_date)
-            } else {
-              endDate = startDate.clone().add(1, 'days')
-            }
-            if (endDate.isSameOrAfter(scheduleEndDate)) {
-              endDate = scheduleEndDate.clone()
-            }
+          if (item.end_date) {
+            endDate = parseDate(item.end_date)
+          } else {
+            endDate = startDate.clone().add(1, 'days')
+          }
+          if (endDate.isSameOrAfter(scheduleEndDate)) {
+            endDate = scheduleEndDate.clone()
+          }
 
-            const path = getTaskTypeSchedulePath(
-              taskType.id,
-              this.currentProduction.id,
-              this.linkedEpisodeId,
-              taskType.for_entity
-            )
-
-            return {
-              ...item,
-              color: taskType.color,
-              for_entity: taskType.for_entity,
-              name: `${taskType.for_entity} / ${taskType.name}`,
-              priority: taskType.priority,
-              startDate,
-              endDate,
-              editable: this.isInDepartment(taskType) && !this.isLockedSchedule,
-              expanded: false,
-              loading: false,
-              route: path,
-              children: []
-            }
-          })
-          this.scheduleItems = sortTaskTypeScheduleItems(
-            scheduleItems,
-            this.currentProduction,
-            this.taskTypeMap
+          const path = getTaskTypeSchedulePath(
+            taskType.id,
+            this.currentProduction.id,
+            this.linkedEpisodeId,
+            taskType.for_entity
           )
 
-          this.availableTaskTypes = this.scopedScheduleItems.map(item => ({
-            ...this.taskTypeMap.get(item.task_type_id),
-            name: item.name
-          }))
+          return {
+            ...item,
+            color: taskType.color,
+            for_entity: taskType.for_entity,
+            name: `${taskType.for_entity} / ${taskType.name}`,
+            priority: taskType.priority,
+            startDate,
+            endDate,
+            editable: this.isInDepartment(taskType) && !this.isLockedSchedule,
+            expanded: false,
+            loading: false,
+            route: path,
+            children: []
+          }
         })
-        .finally(() => {
-          this.loading.schedule = false
-        })
+        this.scheduleItems = sortTaskTypeScheduleItems(
+          scheduleItems,
+          this.currentProduction,
+          this.taskTypeMap
+        )
+
+        this.availableTaskTypes = this.scopedScheduleItems.map(item => ({
+          ...this.taskTypeMap.get(item.task_type_id),
+          name: item.name
+        }))
+      } catch (err) {
+        console.error(err)
+        this.errors.schedule = true
+      } finally {
+        this.loading.schedule = false
+      }
     },
 
     reset() {
@@ -2328,28 +2332,46 @@ export default {
     },
 
     async editVersion(version) {
-      this.modals.editScheduleVersion = false
-      if (!version.id) {
-        const newVersion = await this.createScheduleVersion({
-          production: this.currentProduction,
-          version
-        })
-        this.version = newVersion.id
-        this.onVersionChanged(this.version)
-      } else {
-        await this.updateScheduleVersion(version)
+      this.loading.editScheduleVersion = true
+      this.errors.editScheduleVersion = false
+      try {
+        if (!version.id) {
+          const newVersion = await this.createScheduleVersion({
+            production: this.currentProduction,
+            version
+          })
+          this.version = newVersion.id
+          this.onVersionChanged(this.version)
+        } else {
+          await this.updateScheduleVersion(version)
+        }
+        this.modals.editScheduleVersion = false
+        this.scheduleVersionToEdit = {}
+      } catch (err) {
+        console.error(err)
+        this.errors.editScheduleVersion = true
+      } finally {
+        this.loading.editScheduleVersion = false
       }
-      this.scheduleVersionToEdit = {}
     },
 
     async deleteVersion(version) {
-      this.modals.deleteScheduleVersion = false
-      await this.deleteScheduleVersion(version)
-      if (this.version === version.id) {
-        this.version = DEFAULT_VERSION
-        this.onVersionChanged(this.version)
+      this.loading.delete = true
+      this.errors.deleteScheduleVersion = false
+      try {
+        await this.deleteScheduleVersion(version)
+        if (this.version === version.id) {
+          this.version = DEFAULT_VERSION
+          this.onVersionChanged(this.version)
+        }
+        this.modals.deleteScheduleVersion = false
+        this.scheduleVersionToEdit = {}
+      } catch (err) {
+        console.error(err)
+        this.errors.deleteScheduleVersion = true
+      } finally {
+        this.loading.delete = false
       }
-      this.scheduleVersionToEdit = {}
     },
 
     async applyToProduction() {

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -2011,8 +2011,15 @@ export default {
         this.buildTaskFilters(this.selectedTaskType)
       )
 
+      // a zero or empty quota would make taskEstimation infinite and hang
+      // the distribution loop in addBusinessDays
       const dailyQuota =
-        this.assignments.forcedDailyQuota ?? this.estimatedDailyQuota
+        parseFloat(this.assignments.forcedDailyQuota) ||
+        this.estimatedDailyQuota
+      if (dailyQuota <= 0) {
+        this.assignments.saving = false
+        return
+      }
       const taskEstimation = 1 / dailyQuota
 
       // assign each selected entity to each selected assignee

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -1019,6 +1019,17 @@ export default {
       this.zoomLevel = this.zoomOptions.map(o => o.value).includes(zoom)
         ? zoom
         : DEFAULT_ZOOM
+
+      // loadData computed the editable flags with the default mode/version,
+      // before the query params were applied
+      this.refreshScheduleItemsEditable()
+    },
+
+    refreshScheduleItemsEditable() {
+      this.scheduleItems.forEach(item => {
+        const taskType = this.taskTypeMap.get(item.task_type_id)
+        item.editable = this.isInDepartment(taskType) && !this.isLockedSchedule
+      })
     },
 
     convertScheduleItems(taskTypeElement, scheduleItems) {
@@ -2266,12 +2277,14 @@ export default {
 
     onModeChanged(mode) {
       this.updateRoute({ mode })
+      this.refreshScheduleItemsEditable()
       this.closeSidePanel()
       this.refreshSchedule()
     },
 
     onVersionChanged(version) {
       this.updateRoute({ version })
+      this.refreshScheduleItemsEditable()
       this.closeSidePanel()
       this.refreshSchedule()
     },

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -1976,8 +1976,11 @@ export default {
       this.assignments.startDate = item.start_date || today
       this.assignments.endDate = item.end_date || today
 
-      item.children = this.filteredAssignments(item.children)
-      this.draggedEntities = [item]
+      // copy: filtering item.children in place permanently dropped the
+      // assigned entities from the side panel list
+      this.draggedEntities = [
+        { ...item, children: this.filteredAssignments(item.children) }
+      ]
     },
 
     onAssignmentItemDragStart(event, item, type) {
@@ -1988,8 +1991,9 @@ export default {
       event.dataTransfer.setData('taskTypeId', type.task_type_id)
       event.dataTransfer.setData('entityId', item.id)
 
-      item.children = this.filteredAssignments(item.children)
-      this.draggedEntities = [item]
+      this.draggedEntities = [
+        { ...item, children: this.filteredAssignments(item.children) }
+      ]
     },
 
     onScheduleItemDropped(event, item) {

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1435,12 +1435,14 @@ const getDisplayedDaysIndex = date => {
 }
 
 const getDisplayedWeeksIndex = date => {
-  const dateString = date.startOf('isoweek').format('YYYY-MM-DD')
-  const index = displayedWeeksIndex.value[dateString]
+  // clone before startOf: moment mutates in place and callers pass the
+  // items' own dates, which snapped them back to their week's Monday
+  const monday = date.clone().startOf('isoweek')
+  const index = displayedWeeksIndex.value[monday.format('YYYY-MM-DD')]
   if (index !== undefined) {
     return index
   }
-  return date.isBefore(weeksAvailable.value[0])
+  return monday.isBefore(weeksAvailable.value[0])
     ? 0
     : weeksAvailable.value.length - 1
 }
@@ -1582,8 +1584,10 @@ const changeDates = event => {
     if (newStartDate) {
       const newEndDate = weeksAvailable.value[currentIndex + length]
       if (isValidItemDates(newStartDate, newEndDate)) {
-        currentElement.value.startDate = newStartDate
-        currentElement.value.endDate = newEndDate
+        // clone: assigning the weeksAvailable moments directly aliases the
+        // header entries with the item dates
+        currentElement.value.startDate = newStartDate.clone()
+        currentElement.value.endDate = newEndDate.clone()
       }
     }
   }

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1423,14 +1423,26 @@ const isValidItemDates = (startDate, endDate) => {
   )
 }
 
+// dates outside the displayed range (e.g. a task due after the production
+// end) resolve to the nearest boundary instead of undefined, which made the
+// drag computations crash or silently no-op
 const getDisplayedDaysIndex = date => {
-  const dateString = date.format('YYYY-MM-DD')
-  return displayedDaysIndex.value[dateString]
+  const index = displayedDaysIndex.value[date.format('YYYY-MM-DD')]
+  if (index !== undefined) {
+    return index
+  }
+  return date.isBefore(props.startDate) ? 0 : displayedDays.value.length - 1
 }
 
 const getDisplayedWeeksIndex = date => {
   const dateString = date.startOf('isoweek').format('YYYY-MM-DD')
-  return displayedWeeksIndex.value[dateString]
+  const index = displayedWeeksIndex.value[dateString]
+  if (index !== undefined) {
+    return index
+  }
+  return date.isBefore(weeksAvailable.value[0])
+    ? 0
+    : weeksAvailable.value.length - 1
 }
 
 const resetDroppableTargets = () => {
@@ -1600,6 +1612,7 @@ const changeStartDate = event => {
     : displayedDays.value[currentIndex]
 
   if (
+    newStartDate &&
     !newStartDate.isSame(currentElement.value.startDate) &&
     isValidItemDates(newStartDate, currentElement.value.endDate)
   ) {
@@ -1641,12 +1654,12 @@ const changeEndDate = event => {
   currentIndex += dayChange - 1
   if (currentIndex < startDateIndex) currentIndex = startDateIndex
   if (isWeekMode.value) {
-    if (currentIndex > displayedWeeksIndex.value.length) {
-      currentIndex = displayedWeeksIndex.value.length - 1
+    if (currentIndex > weeksAvailable.value.length - 1) {
+      currentIndex = weeksAvailable.value.length - 1
     }
   } else {
-    if (currentIndex > displayedDaysIndex.value.length) {
-      currentIndex = displayedDaysIndex.value.length - 1
+    if (currentIndex > displayedDays.value.length - 1) {
+      currentIndex = displayedDays.value.length - 1
     }
   }
 

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1156,25 +1156,12 @@ const weeksAvailable = computed(() => {
   if (daysAvailable.value.length < 1) return []
   const startDate = daysAvailable.value[0]
   const endDate = daysAvailable.value[daysAvailable.value.length - 1]
-  const day = startDate.clone().add(-1, 'days')
-  let dayDate = day.toDate()
+  let dayDate = startDate.clone().add(-1, 'days').toDate()
   const endDayDate = endDate.clone().add(7, 'days').toDate()
-  dayDate.weekday = day.isoWeekday()
-  dayDate.monthday = day.month()
-  dayDate.week = day.week()
 
   while (dayDate < endDayDate) {
     const nextDay = new Date(Number(dayDate))
     nextDay.setDate(dayDate.getDate() + 1) // Add 1 day
-    if (nextDay.isoweekday > 7) {
-      nextDay.isoweekday = 1
-      nextDay.newWeek = true
-    }
-    nextDay.monthday = dayDate.monthday + 1
-    if (nextDay.getMonth() !== dayDate.getMonth()) {
-      nextDay.newMonth = true
-      nextDay.monthday = 1
-    }
     const momentDay = parseDate(moment(nextDay).format('YYYY-MM-DD'))
     if (momentDay.isoWeekday() === 1) {
       momentDay.weekText = momentDay.format('YYYY-MM-DD')
@@ -1286,14 +1273,6 @@ const unitOfTime = computed(() => {
 })
 
 // Methods
-
-const getNbSubChildren = children => {
-  if (!children) return 0
-
-  return Object.values(children).reduce((acc, subChildren) => {
-    return acc + subChildren.length
-  }, 0)
-}
 
 const getNbLines = (items = []) => {
   const values = items.map(item => item.line || 0)
@@ -2490,7 +2469,6 @@ onBeforeUnmount(() => {
 
 defineExpose({
   exportData,
-  getNbSubChildren,
   refreshAllItemPositions,
   refreshItemPositions,
   refreshManDays,

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1086,6 +1086,9 @@ let initialClientX = null
 let initialClientY = null
 let lastStartDate = null
 let lastEndDate = null
+// person row the drag started on: a multi-assignee task renders one bar per
+// assignee, so assignees[0] is not necessarily the person being reassigned
+let dragSourcePersonId = null
 
 let domEvents = []
 
@@ -1472,13 +1475,13 @@ const changeDates = event => {
       target.classList.add('droppable')
 
       selection.value.forEach(item => {
-        // update item assignation in element hierarchy
-        const previousAssigneeId = item.assignees[0]
+        // the handlers own the assignees and person-line updates: mutating
+        // them here too duplicated the new assignee id
+        const previousAssigneeId =
+          dragSourcePersonId && item.assignees.includes(dragSourcePersonId)
+            ? dragSourcePersonId
+            : item.assignees[0]
         const newAssigneeId = target.dataset.personId
-        item.assignees = item.assignees.filter(
-          assigneeId => assigneeId !== previousAssigneeId
-        )
-        item.assignees.push(newAssigneeId)
 
         emit('item-unassign', item, previousAssigneeId)
         emit('item-assign', item, newAssigneeId)
@@ -1781,6 +1784,8 @@ const moveTimebar = (timeElement, event) => {
     lastStartDate = timeElement.startDate.clone()
     lastEndDate = timeElement.endDate.clone()
     initialClientX = getClientX(event)
+    dragSourcePersonId =
+      event.target.closest?.('[data-person-id]')?.dataset.personId ?? null
     document.body.style.cursor = props.reassignable ? 'all-scroll' : 'ew-resize'
 
     stampDragOrigin(timeElement)
@@ -1955,6 +1960,7 @@ const stopBrowsing = event => {
   isBrowsingY.value = false
   initialClientX = null
   initialClientY = null
+  dragSourcePersonId = null
   currentElement.value = null
 }
 

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -2419,7 +2419,13 @@ watch(
   () => {
     resetScheduleSize()
     refreshAllItemPositions()
-    onTimelineScroll(null, { scrollTop: 0, scrollLeft: 0 })
+    setScrollPosition(0)
+    if (timelineContentWrapperRef.value) {
+      timelineContentWrapperRef.value.scrollLeft = 0
+    }
+    if (timelineHeaderRef.value) {
+      timelineHeaderRef.value.scrollLeft = 0
+    }
   }
 )
 


### PR DESCRIPTION
**Problem**
- A daily quota of 0 (or an emptied field) froze the tab in an infinite task-distribution loop
- Switching to the real mode or a locked version kept root bars draggable, and the drags were persisted
- Reassigning a task by drag removed `assignees[0]` instead of the person dragged from, and duplicated the new assignee locally
- Tasks outside the production date range could not be dragged and threw on resize; week-zoom computations also mutated item dates in place
- Selecting an entity type in the assign panel permanently dropped its already-assigned entities
- Schedule loading and version edit/delete failures were invisible: no catch, error flags never raised, modals closed before the API call
- The scroll reset on zoom change was a no-op and the Excel export passed 6-digit hex where ExcelJS expects 8-digit ARGB

**Solution**
- Guard the distribution loop against a non-positive quota
- Recompute the root editable flags on mode/version change and after URL query params are applied
- Track the person row a drag starts on and let the page handlers own the assignee updates
- Resolve out-of-range dates to the nearest displayed boundary and clone moments in the week-index computations
- Copy the entity-type entry instead of filtering its children in place
- Wrap loading and version edition in try/catch, surface the errors in the modals
- Reset the scroll directly on zoom change, prefix export colors with the FF alpha byte, drop dead code