### PR TITLE
[schedule] Reduce render, drag and network overhead

### DIFF
--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -2047,6 +2047,13 @@ export default {
       const tasks = await this.loadTasks(
         this.buildTaskFilters(this.selectedTaskType)
       )
+      // first task per entity, preserving the find() first-match behavior
+      const taskByEntityId = new Map()
+      tasks.forEach(task => {
+        if (!taskByEntityId.has(task.entity_id)) {
+          taskByEntityId.set(task.entity_id, task)
+        }
+      })
 
       // a zero or empty quota would make taskEstimation infinite and hang
       // the distribution loop in addBusinessDays
@@ -2092,7 +2099,7 @@ export default {
 
         // distribute the task assignments according to the daily quotas, the task type duration and people's availability.
         for (const entity of taskType.children) {
-          const task = tasks.find(task => task.entity_id === entity.id)
+          const task = taskByEntityId.get(entity.id)
           if (!task) {
             continue // no task found for this entity
           }

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -1177,6 +1177,8 @@ export default {
       taskTypeElement.expanded = expanded || !taskTypeElement.expanded
 
       if (taskTypeElement.expanded) {
+        // unversioned task list shared with the side panel to avoid a reload
+        let rawTasks = null
         try {
           taskTypeElement.loading = true
 
@@ -1231,6 +1233,7 @@ export default {
           let tasks = await this.loadTasks(
             this.buildTaskFilters(taskTypeElement)
           )
+          rawTasks = tasks
 
           // Update tasks for versioned schedules
           if (this.isVersioned) {
@@ -1496,7 +1499,12 @@ export default {
           refreshScheduleCallBack(taskTypeElement)
         }
 
-        this.selectTaskTypeElement(taskTypeElement, null, resetAssignments)
+        this.selectTaskTypeElement(
+          taskTypeElement,
+          null,
+          resetAssignments,
+          rawTasks
+        )
       }
     },
 
@@ -1745,7 +1753,8 @@ export default {
     async selectTaskTypeElement(
       taskType,
       selectedEntityType = undefined,
-      resetAssignments = true
+      resetAssignments = true,
+      preloadedTasks = null
     ) {
       // No assignment panel on the production-wide planning.
       if (this.isAllEpisodes) {
@@ -1760,14 +1769,17 @@ export default {
 
       this.assignments.loading = true
 
-      // load tasks
-      const tasks = await this.loadTasks(
-        this.buildTaskFilters(this.selectedTaskType)
-      )
+      // when called from expandTaskTypeElement, the tasks and entities were
+      // just loaded: reuse them instead of refetching everything
+      const tasks =
+        preloadedTasks ??
+        (await this.loadTasks(this.buildTaskFilters(this.selectedTaskType)))
 
       // load entity types
       if (taskType.for_entity === 'Asset') {
-        await this.loadScopedAssets()
+        if (!preloadedTasks) {
+          await this.loadScopedAssets()
+        }
 
         this.assignments.entityTypes = this.productionAssetTypes
           .filter(assetType => {
@@ -1802,7 +1814,9 @@ export default {
             }
           })
       } else if (taskType.for_entity === 'Shot') {
-        await this.loadShots()
+        if (!preloadedTasks) {
+          await this.loadShots()
+        }
 
         const shotsBySequence = shotStore.cache.shots
           .filter(shot => tasks.some(task => task.entity_id === shot.id))
@@ -1830,7 +1844,9 @@ export default {
           }
         )
       } else if (taskType.for_entity === 'Sequence') {
-        await this.loadSequences()
+        if (!preloadedTasks) {
+          await this.loadSequences()
+        }
 
         // sequences are the assignable entities, grouped by episode
         const sequencesByEpisode = [...sequenceStore.cache.sequenceMap.values()]
@@ -1866,7 +1882,9 @@ export default {
           }
         )
       } else if (taskType.for_entity === 'Episode') {
-        await this.loadEpisodes()
+        if (!preloadedTasks) {
+          await this.loadEpisodes()
+        }
 
         // episodes are the assignable entities, under a single production group
         const episodes = [...episodeStore.cache.episodeMap.values()]
@@ -1895,7 +1913,9 @@ export default {
           }
         ]
       } else if (taskType.for_entity === 'Edit') {
-        await this.loadEdits()
+        if (!preloadedTasks) {
+          await this.loadEdits()
+        }
 
         // edits are the assignable entities, grouped by episode
         const editsByEpisode = [...editStore.cache.editMap.values()]

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -2084,6 +2084,7 @@ export default {
         // clear-assignation request plus one assign request per assignee
         const taskIdsToUnassign = []
         const taskIdsByAssignee = new Map()
+        const taskUpdates = []
 
         let cumulatedTasks = 0
         let nextAssigneeIndex = 0
@@ -2164,8 +2165,8 @@ export default {
                   taskIdsByAssignee.set(taskAssignee.id, [])
                 }
                 taskIdsByAssignee.get(taskAssignee.id).push(task.id)
-                // save task dates & estimation
-                await this.updateTask({
+                // task dates & estimation are flushed in batches after the loop
+                taskUpdates.push({
                   taskId: task.id,
                   data: {
                     estimation: daysToMinutes(
@@ -2186,6 +2187,14 @@ export default {
               break // jump to next task
             }
           }
+        }
+
+        // ponytail: chunks of 5 keep the server load reasonable, a bulk
+        // endpoint in zou would replace this
+        for (let i = 0; i < taskUpdates.length; i += 5) {
+          await Promise.all(
+            taskUpdates.slice(i, i + 5).map(update => this.updateTask(update))
+          )
         }
 
         // unassign first so batched assignations are not cleared right after

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -2059,6 +2059,22 @@ export default {
       }
       const taskEstimation = 1 / dailyQuota
 
+      // versioned tasks all belong to the selected task type: load them once
+      // instead of once per entity
+      let versionedTaskByTaskId = null
+      if (this.isVersioned) {
+        const versionedTasks = await this.loadTasksFromScheduleVersion({
+          version: { id: this.version },
+          taskType: { id: this.selectedTaskType.task_type_id }
+        })
+        versionedTaskByTaskId = new Map(
+          versionedTasks.map(versionedTask => [
+            versionedTask.task_id,
+            versionedTask
+          ])
+        )
+      }
+
       // assign each selected entity to each selected assignee
       for (const taskType of this.draggedEntities) {
         const startDate = parseDate(this.assignments.startDate)
@@ -2082,11 +2098,7 @@ export default {
 
           let versionedTask
           if (this.isVersioned) {
-            const versionedTasks = await this.loadTasksFromScheduleVersion({
-              version: { id: this.version },
-              taskType: { id: task.task_type_id }
-            })
-            versionedTask = versionedTasks.find(t => t.task_id === task.id) ?? {
+            versionedTask = versionedTaskByTaskId.get(task.id) ?? {
               taskId: task.id,
               version: this.version,
               assignees: []

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -635,6 +635,7 @@ export default {
       },
       availableTaskTypes: [],
       daysOffByPerson: {},
+      daysOffRangeKey: null,
       draggedEntities: [],
       endDate: moment().add(6, 'months').endOf('day'),
       entityType: null,
@@ -1266,12 +1267,18 @@ export default {
               .filter(Boolean)
           }
 
-          this.daysOffByPerson = await this.loadProductionDaysOff({
-            startDate: this.startDate.format('YYYY-MM-DD'),
-            endDate: this.endDate.format('YYYY-MM-DD')
-          }).catch(
-            () => ({}) // fallback if not allowed to fetch days off
-          )
+          // days off only depend on the production and the date range:
+          // reuse them across expands
+          const daysOffKey = `${this.currentProduction.id}_${this.startDate.format('YYYY-MM-DD')}_${this.endDate.format('YYYY-MM-DD')}`
+          if (this.daysOffRangeKey !== daysOffKey) {
+            this.daysOffByPerson = await this.loadProductionDaysOff({
+              startDate: this.startDate.format('YYYY-MM-DD'),
+              endDate: this.endDate.format('YYYY-MM-DD')
+            }).catch(
+              () => ({}) // fallback if not allowed to fetch days off
+            )
+            this.daysOffRangeKey = daysOffKey
+          }
 
           // Read the entity maps fresh from the store cache. They are plain,
           // non-reactive Maps replaced on each episode-scoped load, so a cached

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -1774,6 +1774,7 @@ export default {
       const tasks =
         preloadedTasks ??
         (await this.loadTasks(this.buildTaskFilters(this.selectedTaskType)))
+      const taskEntityIds = new Set(tasks.map(task => task.entity_id))
 
       // load entity types
       if (taskType.for_entity === 'Asset') {
@@ -1803,7 +1804,7 @@ export default {
                     !asset.canceled &&
                     !asset.shared &&
                     this.assetInScope(asset) &&
-                    tasks.some(task => task.entity_id === asset.id)
+                    taskEntityIds.has(asset.id)
                 )
                 .map(asset => ({
                   ...asset,
@@ -1819,7 +1820,7 @@ export default {
         }
 
         const shotsBySequence = shotStore.cache.shots
-          .filter(shot => tasks.some(task => task.entity_id === shot.id))
+          .filter(shot => taskEntityIds.has(shot.id))
           .reduce((acc, shot) => {
             if (!acc[shot.parent_id]) {
               acc[shot.parent_id] = []
@@ -1855,7 +1856,7 @@ export default {
               !sequence.canceled &&
               (!this.currentEpisodeId ||
                 sequence.episode_id === this.currentEpisodeId) &&
-              tasks.some(task => task.entity_id === sequence.id)
+              taskEntityIds.has(sequence.id)
           )
           .reduce((acc, sequence) => {
             const groupId = sequence.episode_id || taskType.for_entity
@@ -1894,7 +1895,7 @@ export default {
               !['all', 'main'].includes(episode.id) &&
               (!this.currentEpisodeId ||
                 episode.id === this.currentEpisodeId) &&
-              tasks.some(task => task.entity_id === episode.id)
+              taskEntityIds.has(episode.id)
           )
           .map(episode => ({
             ...episode,
@@ -1924,7 +1925,7 @@ export default {
               !edit.canceled &&
               (!this.currentEpisodeId ||
                 edit.episode_id === this.currentEpisodeId) &&
-              tasks.some(task => task.entity_id === edit.id)
+              taskEntityIds.has(edit.id)
           )
           .reduce((acc, edit) => {
             const groupId = edit.episode_id || taskType.for_entity

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -440,7 +440,9 @@
                 :key="`dayoff-${dayOff.id}-${index}`"
                 :style="dayOffStyle(dayOff)"
                 :title="dayOff.description"
-                v-for="(dayOff, index) in getDayOffRange(rootElement.daysOff)"
+                v-for="(dayOff, index) in cachedDayOffRange(
+                  rootElement.daysOff
+                )"
               >
                 <briefcase-icon class="day-off-icon" :size="14" />
               </div>
@@ -713,7 +715,7 @@
                         :key="`dayoff-${dayOff.id}-${index}`"
                         :style="dayOffStyle(dayOff)"
                         :title="dayOff.description"
-                        v-for="(dayOff, index) in getDayOffRange(
+                        v-for="(dayOff, index) in cachedDayOffRange(
                           rootElement.people[personId].daysOff
                         )"
                       >
@@ -2009,6 +2011,19 @@ const stopBrowsing = event => {
 }
 
 // Helpers
+
+// the template iterates day-off ranges for each root and person row on every
+// render: expand each daysOff array once and reuse it
+const dayOffRangeCache = new WeakMap()
+const cachedDayOffRange = daysOff => {
+  if (!daysOff?.length) return []
+  let range = dayOffRangeCache.get(daysOff)
+  if (!range) {
+    range = getDayOffRange(daysOff)
+    dayOffRangeCache.set(daysOff, range)
+  }
+  return range
+}
 
 const dateDiff = (startDate, endDate, unit = 'days') => {
   if (startDate.isSame(endDate) || !startDate.isValid() || !endDate.isValid()) {

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1770,9 +1770,10 @@ const isOverlapping = item => {
   )
 }
 
-const isSelected = item => {
-  return selection.value.some(({ id }) => id === item.id)
-}
+// isSelected runs for every bar on every render: keep it O(1)
+const selectedIds = computed(() => new Set(selection.value.map(({ id }) => id)))
+
+const isSelected = item => selectedIds.value.has(item.id)
 
 const addToSelection = itemToAdd => {
   selection.value.push(itemToAdd)

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -381,6 +381,7 @@
         <div
           ref="timelineContentWrapperRef"
           class="timeline-content-wrapper"
+          @mousemove.passive="onPositionBarMove"
           @scroll.passive="onTimelineScroll"
         >
           <div
@@ -1090,7 +1091,13 @@ let lastEndDate = null
 // assignee, so assignees[0] is not necessarily the person being reassigned
 let dragSourcePersonId = null
 
+// cached wrapper rect: getBoundingClientRect on every mousemove forces a
+// layout; invalidated on resize and zoom via resetScheduleSize
+let wrapperRect = null
+let positionBarFrame = null
+
 let domEvents = []
+let moveEvents = []
 
 // Computed
 
@@ -1327,6 +1334,7 @@ const isVisible = timeElement => {
 }
 
 const resetScheduleSize = () => {
+  wrapperRect = null
   if (timelineContentRef.value) {
     if (props.zoomLevel > 0) {
       timelineContentRef.value.style.width = `${displayedDays.value.length * cellWidth.value}px`
@@ -1347,8 +1355,12 @@ const onMouseMove = event => {
     if (isBrowsingX.value) scrollScheduleLeft(event)
     if (isBrowsingY.value) scrollScheduleTop(event)
   }
+}
 
-  updatePositionBarPosition(event)
+// document-level move listeners are attached only for the duration of a drag
+// or browse: a permanent listener ran on every mousemove of the whole page
+const startMoveTracking = () => {
+  addEvents(moveEvents)
 }
 
 const onChildEstimationChanged = (event, childElement, rootElement) => {
@@ -1377,18 +1389,26 @@ const onChildEstimationChanged = (event, childElement, rootElement) => {
 const updatePositionBarPosition = event => {
   if (!timelineContentWrapperRef.value || !timelinePositionRef.value) return
 
-  const cursorX =
-    getClientX(event) -
-    timelineContentWrapperRef.value.getBoundingClientRect().left
+  if (!wrapperRect) {
+    wrapperRect = timelineContentWrapperRef.value.getBoundingClientRect()
+  }
+  const cursorX = getClientX(event) - wrapperRect.left
 
-  if (cursorX <= 0 || cursorX >= timelineContentWrapperRef.value.offsetWidth)
-    return
+  if (cursorX <= 0 || cursorX >= wrapperRect.width) return
 
   const left =
     Math.floor(
       (timelineContentWrapperRef.value.scrollLeft + cursorX) / cellWidth.value
     ) * cellWidth.value
   timelinePositionRef.value.style.left = `${left}px`
+}
+
+const onPositionBarMove = event => {
+  if (positionBarFrame) return
+  positionBarFrame = requestAnimationFrame(() => {
+    positionBarFrame = null
+    updatePositionBarPosition(event)
+  })
 }
 
 const isValidItemDates = (startDate, endDate) => {
@@ -1784,6 +1804,7 @@ const moveTimebar = (timeElement, event) => {
       event.target.closest?.('[data-person-id]')?.dataset.personId ?? null
     document.body.style.cursor = props.reassignable ? 'all-scroll' : 'ew-resize'
 
+    startMoveTracking()
     stampDragOrigin(timeElement)
     updateSelection(timeElement, event)
   }
@@ -1804,6 +1825,7 @@ const moveTimebarLeftSide = (timeElement, event) => {
     initialClientX = getClientX(event)
     document.body.style.cursor = 'w-resize'
 
+    startMoveTracking()
     stampDragOrigin(timeElement)
     updateSelection(timeElement, event)
   }
@@ -1828,6 +1850,7 @@ const moveTimebarRightSide = (timeElement, event) => {
     initialClientX = getClientX(event)
     document.body.style.cursor = 'e-resize'
 
+    startMoveTracking()
     stampDragOrigin(timeElement)
     updateSelection(timeElement, event)
   }
@@ -1901,6 +1924,7 @@ const startBrowsing = event => {
     isBrowsingY.value = true
     initialClientX = getClientX(event)
     initialClientY = getClientY(event)
+    startMoveTracking()
   }
 }
 
@@ -1908,16 +1932,19 @@ const startBrowsingX = event => {
   document.body.style.cursor = 'grabbing'
   isBrowsingX.value = true
   initialClientX = getClientX(event)
+  startMoveTracking()
 }
 
 const startBrowsingY = event => {
   document.body.style.cursor = 'grabbing'
   isBrowsingY.value = true
   initialClientY = getClientY(event)
+  startMoveTracking()
 }
 
 const stopBrowsing = event => {
   document.body.style.cursor = 'default'
+  removeEvents(moveEvents)
   if (currentElement.value) {
     if (initialClientX !== getClientX(event)) {
       // on moving or resizing selected items
@@ -2447,9 +2474,11 @@ watch(
 // Lifecycle
 
 onMounted(() => {
-  domEvents = [
+  moveEvents = [
     ['mousemove', onMouseMove],
-    ['touchmove', onMouseMove],
+    ['touchmove', onMouseMove]
+  ]
+  domEvents = [
     ['mouseup', stopBrowsing],
     ['mouseleave', stopBrowsing],
     ['touchend', stopBrowsing],
@@ -2463,6 +2492,8 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   removeEvents(domEvents)
+  removeEvents(moveEvents)
+  if (positionBarFrame) cancelAnimationFrame(positionBarFrame)
   window.removeEventListener('resize', resetScheduleSize)
   document.body.style.cursor = 'default'
 })

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -2537,54 +2537,34 @@ defineExpose({
  *
  * @param {Array<Object>} items - The list of items to position.
  * @param {Moment.unitOfTime} unitOfTime - A unit of time (eg. 'days', 'weeks', 'months', ...).
- * @returns {Array<Object>} The list of items with updated positions.
  */
 const setItemPositions = (items, unitOfTime = 'days') => {
   if (!items?.length) {
     return
   }
-  const attributeName = 'line'
-  const matrix = []
   const minDate = moment
     .min(items.map(item => item.startDate))
     .clone()
     .startOf(unitOfTime)
-  const maxDate = moment
-    .max(items.map(item => item.endDate))
-    .clone()
-    .endOf(unitOfTime)
-  const nbColumns = maxDate.diff(minDate, unitOfTime) + 1
 
+  // one entry per line: the [start, end] ranges already placed on it
+  const lines = []
   items.forEach(item => {
     const start = item.startDate
       .clone()
       .startOf(unitOfTime)
       .diff(minDate, unitOfTime)
     const end = item.endDate.clone().endOf(unitOfTime).diff(minDate, unitOfTime)
-    const line = getFreeLinePosition(item.id, start, end, matrix)
-    item[attributeName] = line
-  })
-
-  function getFreeLinePosition(value, start, end, matrix, line = 0) {
-    for (let index = start; index <= end; index++) {
-      // if empty line
-      if (!matrix[line]) {
-        matrix.push(Array(nbColumns).fill(0))
-        index = end
-      }
-      // if collision on line
-      else if (matrix[line][index]) {
-        // go to next line
-        return getFreeLinePosition(value, start, end, matrix, line + 1)
-      }
-      // if no collision for the whole item
-      if (index === end) {
-        // save item in matrix
-        matrix[line].fill(value, start, end + 1)
-        return line
-      }
+    let line = 0
+    while (lines[line]?.some(([s, e]) => start <= e && end >= s)) {
+      line++
     }
-  }
+    if (!lines[line]) {
+      lines[line] = []
+    }
+    lines[line].push([start, end])
+    item.line = line
+  })
 }
 </script>
 

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1095,6 +1095,8 @@ let dragSourcePersonId = null
 // layout; invalidated on resize and zoom via resetScheduleSize
 let wrapperRect = null
 let positionBarFrame = null
+let moveFrame = null
+let lastMoveEvent = null
 
 let domEvents = []
 let moveEvents = []
@@ -1344,7 +1346,7 @@ const resetScheduleSize = () => {
   }
 }
 
-const onMouseMove = event => {
+const processMouseMove = event => {
   if (isChangeStartDate.value) {
     changeStartDate(event)
   } else if (isChangeEndDate.value) {
@@ -1355,6 +1357,17 @@ const onMouseMove = event => {
     if (isBrowsingX.value) scrollScheduleLeft(event)
     if (isBrowsingY.value) scrollScheduleTop(event)
   }
+}
+
+// high-frequency mice fire several mousemove events per frame: process only
+// the latest one per animation frame
+const onMouseMove = event => {
+  lastMoveEvent = event
+  if (moveFrame) return
+  moveFrame = requestAnimationFrame(() => {
+    moveFrame = null
+    processMouseMove(lastMoveEvent)
+  })
 }
 
 // document-level move listeners are attached only for the duration of a drag
@@ -1876,7 +1889,9 @@ const setScrollPosition = top => {
 const scrollScheduleLeft = event => {
   if (!timelineContentWrapperRef.value) return
   const previousLeft = timelineContentWrapperRef.value.scrollLeft
-  const movementX = event.movementX || getClientX(event) - initialClientX
+  // cumulative delta from the last processed event: movementX would lose the
+  // moves skipped by the frame throttle
+  const movementX = getClientX(event) - initialClientX
   const newLeft = previousLeft - movementX
   initialClientX = getClientX(event)
   timelineContentWrapperRef.value.scrollLeft = newLeft
@@ -1886,7 +1901,7 @@ const scrollScheduleLeft = event => {
 const scrollScheduleTop = event => {
   if (!timelineContentWrapperRef.value) return
   const previousTop = timelineContentWrapperRef.value.scrollTop
-  const movementY = event.movementY || getClientY(event) - initialClientY
+  const movementY = getClientY(event) - initialClientY
   const newTop = previousTop - movementY
   initialClientY = getClientY(event)
   setScrollPosition(newTop)
@@ -1946,6 +1961,11 @@ const startBrowsingY = event => {
 const stopBrowsing = event => {
   document.body.style.cursor = 'default'
   removeEvents(moveEvents)
+  // a pending frame would move the item again after the drop is saved
+  if (moveFrame) {
+    cancelAnimationFrame(moveFrame)
+    moveFrame = null
+  }
   if (currentElement.value) {
     if (initialClientX !== getClientX(event)) {
       // on moving or resizing selected items
@@ -2495,6 +2515,7 @@ onBeforeUnmount(() => {
   removeEvents(domEvents)
   removeEvents(moveEvents)
   if (positionBarFrame) cancelAnimationFrame(positionBarFrame)
+  if (moveFrame) cancelAnimationFrame(moveFrame)
   window.removeEventListener('resize', resetScheduleSize)
   document.body.style.cursor = 'default'
 })

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1166,31 +1166,27 @@ const daysAvailable = computed(() => {
 })
 
 const weeksAvailable = computed(() => {
-  const weeks = []
   if (daysAvailable.value.length < 1) return []
   const startDate = daysAvailable.value[0]
   const endDate = daysAvailable.value[daysAvailable.value.length - 1]
-  let dayDate = startDate.clone().add(-1, 'days').toDate()
-  const endDayDate = endDate.clone().add(7, 'days').toDate()
+  const lastDay = endDate.clone().add(7, 'days')
 
-  while (dayDate < endDayDate) {
-    const nextDay = new Date(Number(dayDate))
-    nextDay.setDate(dayDate.getDate() + 1) // Add 1 day
-    const momentDay = parseDate(moment(nextDay).format('YYYY-MM-DD'))
-    if (momentDay.isoWeekday() === 1) {
-      momentDay.weekText = momentDay.format('YYYY-MM-DD')
-      momentDay.label = `${momentDay.weekText} to ${momentDay
-        .clone()
-        .add(6, 'days')
-        .format('YYYY-MM-DD')}`
-      momentDay.weekNumber = momentDay.week()
-      momentDay.newMonth =
-        weeks.length === 0 ||
-        momentDay.month() !== weeks[weeks.length - 1].month()
-      momentDay.monthText = momentDay.format('MMMM YY')
-      weeks.push(momentDay)
-    }
-    dayDate = nextDay
+  const weeks = []
+  // first Monday on or after the schedule start
+  const monday = startDate.clone().add((8 - startDate.isoWeekday()) % 7, 'days')
+  while (monday.isSameOrBefore(lastDay)) {
+    const week = monday.clone()
+    week.weekText = week.format('YYYY-MM-DD')
+    week.label = `${week.weekText} to ${week
+      .clone()
+      .add(6, 'days')
+      .format('YYYY-MM-DD')}`
+    week.weekNumber = week.week()
+    week.newMonth =
+      weeks.length === 0 || week.month() !== weeks[weeks.length - 1].month()
+    week.monthText = week.format('MMMM YY')
+    weeks.push(week)
+    monday.add(7, 'days')
   }
   return weeks
 })

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -585,8 +585,9 @@
                       "
                       :title="`${formatDuration(timesheet.duration)} ${isDurationInHours ? $t('main.hours_spent', formatDuration(timesheet.duration, false)) : $t('main.days_spent', formatDuration(timesheet.duration, false))}`"
                       :key="timesheet.id"
-                      v-for="timesheet in rootElement.timesheet.filter(
-                        ({ task_id }) => task_id === childElement.id
+                      v-for="timesheet in taskTimesheets(
+                        rootElement,
+                        childElement.id
                       )"
                     ></div>
                   </template>
@@ -2023,6 +2024,24 @@ const cachedDayOffRange = daysOff => {
     dayOffRangeCache.set(daysOff, range)
   }
   return range
+}
+
+// same render-time concern for timesheets: group them by task once per array
+const timesheetsByTaskCache = new WeakMap()
+const taskTimesheets = (rootElement, taskId) => {
+  if (!rootElement.timesheet) return []
+  let byTask = timesheetsByTaskCache.get(rootElement.timesheet)
+  if (!byTask) {
+    byTask = new Map()
+    rootElement.timesheet.forEach(timesheet => {
+      if (!byTask.has(timesheet.task_id)) {
+        byTask.set(timesheet.task_id, [])
+      }
+      byTask.get(timesheet.task_id).push(timesheet)
+    })
+    timesheetsByTaskCache.set(rootElement.timesheet, byTask)
+  }
+  return byTask.get(taskId) ?? []
 }
 
 const dateDiff = (startDate, endDate, unit = 'days') => {

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1133,10 +1133,12 @@ const daysAvailable = computed(() => {
   const days = []
   let day = props.startDate.clone().utc().startOf('day')
   const endDate = props.endDate.clone().utc().startOf('day')
-  const daysOff = getDayOffRange(props.daysOff).map(dayOff => dayOff.date)
+  const daysOff = new Set(
+    getDayOffRange(props.daysOff).map(dayOff => dayOff.date)
+  )
 
   while (day.isSameOrBefore(endDate)) {
-    day.off = daysOff.includes(day.toISOString().slice(0, 10))
+    day.off = daysOff.has(day.toISOString().slice(0, 10))
     day.newWeek = day.isoWeekday() === 1
     day.newMonth = day.date() === 1
     day.weekend = [6, 7].includes(day.isoWeekday())


### PR DESCRIPTION
**Problem**
- Document-level mousemove listeners forced a layout on every mouse move anywhere on the page, and drag processing ran once per event instead of once per frame
- Each task-type expand fetched the tasks and entities twice, refetched the days off every time, and filtered entities with O(entities x tasks) scans
- Applying assignments issued one sequential request per entity for versioned tasks and for task updates
- Render-time helpers reallocated day-off ranges, timesheet filters and selection scans for every bar on every render
- setItemPositions allocated a cell per day of the range on every drag tick and weeksAvailable reparsed a moment per day just to keep the Mondays

**Solution**
- Attach move listeners only during drags, cache the wrapper rect and throttle drag work with requestAnimationFrame
- Reuse the expand loads for the side panel, replace the linear scans with Sets/Maps and cache the days off per date range
- Load versioned tasks once per assignment run and flush task updates in small parallel batches
- Memoize the day-off ranges and timesheet groups, make isSelected a Set lookup
- Pack timebar lines with per-line interval lists and iterate the week headers Monday to Monday

Note: stacked on #2141, only the 14 `perf` commits are new here.