### PR TITLE
[players] Render annotation snapshots at native resolution

### DIFF
--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -1401,17 +1401,16 @@ export const useAnnotation = ({
   }
 
   // Render whatever is currently on the live fabric canvas onto the
-  // target canvas. Non-destructive: it draws the live canvas's pixels
-  // straight onto the target (scaled to fit), so objects stay on the
-  // live canvas — no per-object moves and no fabric "object belongs to
-  // a different canvas" warnings.
+  // target canvas. toCanvasElement re-renders the scene vectorially on
+  // an offscreen canvas at the target resolution, so strokes stay sharp
+  // (copying the display-sized live pixels would upscale and pixelate
+  // them) while the live objects are never moved: no fabric "object
+  // belongs to a different canvas" warnings.
   const compositeLiveAnnotationsOntoCanvas = canvas => {
     return new Promise(resolve => {
       const live = fabricCanvas.value
       if (!live) return resolve()
-      live.renderAll()
-      const source = live.lowerCanvasEl
-      if (!source) return resolve()
+      const source = live.toCanvasElement(canvas.width / live.getWidth())
       const context = canvas.getContext('2d')
       context.drawImage(source, 0, 0, canvas.width, canvas.height)
       resolve()

--- a/tests/unit/composables/annotation.spec.js
+++ b/tests/unit/composables/annotation.spec.js
@@ -1317,6 +1317,38 @@ describe('composables/annotation', () => {
     })
   })
 
+  describe('compositeLiveAnnotationsOntoCanvas', () => {
+    // Regression (#pixelated snapshots): the composite must re-render the
+    // scene at the target resolution through toCanvasElement, not upscale
+    // the display-sized live canvas pixels.
+    it('re-renders the scene at the target resolution', async () => {
+      const exportedCanvas = {}
+      const toCanvasElement = vi.fn(() => exportedCanvas)
+      const canvas = createFakeCanvas({ toCanvasElement })
+      const { api, wrapper } = mountAnnotation({ canvas })
+      const drawImage = vi.fn()
+      const target = {
+        width: 1920,
+        height: 1080,
+        getContext: () => ({ drawImage })
+      }
+
+      await api.compositeLiveAnnotationsOntoCanvas(target)
+
+      expect(toCanvasElement).toHaveBeenCalledWith(1920 / 800)
+      expect(drawImage).toHaveBeenCalledWith(exportedCanvas, 0, 0, 1920, 1080)
+      wrapper.unmount()
+    })
+
+    it('resolves without drawing when there is no live canvas', async () => {
+      const { api, wrapper } = mountAnnotation({ skipCanvas: true })
+      await expect(
+        api.compositeLiveAnnotationsOntoCanvas({ width: 100, height: 100 })
+      ).resolves.toBeUndefined()
+      wrapper.unmount()
+    })
+  })
+
   describe('Fabric v6 regressions', () => {
     it('patches the text-dimension override onto Text.prototype, not every object', () => {
       // Regression: the v6 port put _getNonTransformedDimensions /


### PR DESCRIPTION
**Problem**
- Since the composite switched to copying the live fabric canvas pixels, attached snapshots upscaled the display-sized canvas to the media's native resolution: annotation strokes came out heavily pixelated

**Solution**
- Re-render the scene through fabric's toCanvasElement at the target resolution: strokes stay sharp, live objects are never moved, and the cross-canvas warnings that motivated the pixel copy do not come back
- Add a regression test on the composite multiplier plus a no-canvas guard test