### PR TITLE
[schedule] Fix bugs in the schedule consumer pages

### DIFF
--- a/src/components/mixins/entity.js
+++ b/src/components/mixins/entity.js
@@ -44,7 +44,12 @@ export const entityMixin = {
   },
 
   computed: {
-    ...mapGetters(['organisation']),
+    ...mapGetters([
+      'isCurrentUserManager',
+      'isCurrentUserSupervisor',
+      'organisation',
+      'user'
+    ]),
 
     assetList() {
       return assetsStore.cache.assets
@@ -262,7 +267,7 @@ export const entityMixin = {
             expanded: false,
             loading: false,
             man_days: estimation,
-            editable: true,
+            editable: this.canEditTaskDates(taskType),
             unresizable: false,
             parentElement: rootElement,
             color: taskType.color,
@@ -283,6 +288,15 @@ export const entityMixin = {
         man_days: manDays
       })
       this.scheduleItems = [rootElement]
+    },
+
+    canEditTaskDates(taskType) {
+      const departments = this.user.departments || []
+      return (
+        this.isCurrentUserManager ||
+        (this.isCurrentUserSupervisor &&
+          (!departments.length || departments.includes(taskType.department_id)))
+      )
     },
 
     saveTaskScheduleItem(item) {

--- a/src/components/mixins/entity.js
+++ b/src/components/mixins/entity.js
@@ -256,8 +256,9 @@ export const entityMixin = {
           if (!endDate || endDate.isBefore(startDate)) {
             endDate = startDate.clone().add(1, 'days')
           }
-          if (estimation) manDays += task.estimation
           const taskType = this.taskTypeMap.get(task.task_type_id)
+          if (!taskType) return null
+          if (estimation) manDays += task.estimation
 
           return {
             ...task,

--- a/src/components/mixins/entity.js
+++ b/src/components/mixins/entity.js
@@ -303,7 +303,7 @@ export const entityMixin = {
             start_date: item.startDate.format('YYYY-MM-DD'),
             due_date: item.endDate.format('YYYY-MM-DD')
           }
-        })
+        }).catch(console.error)
       }
     }
   },

--- a/src/components/mixins/entity.js
+++ b/src/components/mixins/entity.js
@@ -242,7 +242,10 @@ export const entityMixin = {
           } else if (task.end_date) {
             endDate = parseSimpleDate(task.end_date)
           } else if (task.estimation) {
-            endDate = startDate.clone().add(estimation, 'days')
+            endDate = addBusinessDays(
+              startDate,
+              Math.ceil(minutesToDays(this.organisation, estimation)) - 1
+            )
           }
 
           if (!endDate || endDate.isBefore(startDate)) {

--- a/src/components/pages/Edit.vue
+++ b/src/components/pages/Edit.vue
@@ -158,6 +158,8 @@
                 :is-estimation-linked="true"
                 :hide-root="true"
                 :with-milestones="false"
+                @item-changed="saveTaskScheduleItem"
+                @estimation-changed="event => saveTaskScheduleItem(event.item)"
               />
             </div>
           </div>
@@ -379,7 +381,8 @@ const {
   nextEntityPath,
   currentTasks,
   tasksStartDate,
-  tasksEndDate
+  tasksEndDate,
+  saveTaskScheduleItem
 } = useEntity({
   type: 'edit',
   currentEntity,

--- a/src/components/pages/Episode.vue
+++ b/src/components/pages/Episode.vue
@@ -227,6 +227,8 @@
               :is-estimation-linked="true"
               :hide-root="true"
               :with-milestones="false"
+              @item-changed="saveTaskScheduleItem"
+              @estimation-changed="event => saveTaskScheduleItem(event.item)"
             />
           </div>
         </div>

--- a/src/components/pages/MainSchedule.vue
+++ b/src/components/pages/MainSchedule.vue
@@ -6,13 +6,21 @@
           <label class="label">
             {{ $t('main.start_date') }}
           </label>
-          <date-field week-days-disabled v-model="selectedStartDate" />
+          <date-field
+            week-days-disabled
+            v-model="selectedStartDate"
+            @update:model-value="onUpdateSelectedStartDate"
+          />
         </div>
         <div class="flexrow-item field">
           <label class="label">
             {{ $t('main.end_date') }}
           </label>
-          <date-field week-days-disabled v-model="selectedEndDate" />
+          <date-field
+            week-days-disabled
+            v-model="selectedEndDate"
+            @update:model-value="onUpdateSelectedEndDate"
+          />
         </div>
         <combobox-number
           class="flexrow-item zoom-level"
@@ -51,7 +59,8 @@ import {
   getFirstStartDate,
   getLastEndDate,
   getStartDateFromString,
-  getEndDateFromString
+  getEndDateFromString,
+  parseSimpleDate
 } from '@/lib/time'
 import colors from '@/lib/colors'
 
@@ -168,6 +177,14 @@ export default {
       } else {
         productionElement.expanded = false
       }
+    },
+
+    onUpdateSelectedStartDate(date) {
+      this.startDate = parseSimpleDate(date)
+    },
+
+    onUpdateSelectedEndDate(date) {
+      this.endDate = parseSimpleDate(date)
     },
 
     onScheduleItemChanged(item) {

--- a/src/components/pages/MainSchedule.vue
+++ b/src/components/pages/MainSchedule.vue
@@ -146,23 +146,25 @@ export default {
     },
 
     convertTaskTypeScheduleItems(scheduleItems) {
-      return scheduleItems.map(item => {
-        const startDate = getStartDateFromString(item.start_date)
-        const endDate = getEndDateFromString(startDate, item.end_date)
-        const taskType = this.taskTypeMap.get(item.task_type_id)
+      return scheduleItems
+        .filter(item => this.taskTypeMap.get(item.task_type_id))
+        .map(item => {
+          const startDate = getStartDateFromString(item.start_date)
+          const endDate = getEndDateFromString(startDate, item.end_date)
+          const taskType = this.taskTypeMap.get(item.task_type_id)
 
-        return {
-          ...item,
-          name: taskType.name,
-          color: taskType.color,
-          startDate: startDate,
-          endDate: endDate,
-          expanded: false,
-          loading: false,
-          editable: true,
-          children: []
-        }
-      })
+          return {
+            ...item,
+            name: taskType.name,
+            color: taskType.color,
+            startDate: startDate,
+            endDate: endDate,
+            expanded: false,
+            loading: false,
+            editable: true,
+            children: []
+          }
+        })
     },
 
     expandProductionElement(productionElement) {

--- a/src/components/pages/MainSchedule.vue
+++ b/src/components/pages/MainSchedule.vue
@@ -169,11 +169,18 @@ export default {
       if (!productionElement.expanded) {
         productionElement.loading = true
         productionElement.expanded = true
-        this.loadScheduleItems(productionElement).then(scheduleItems => {
-          scheduleItems = this.convertTaskTypeScheduleItems(scheduleItems)
-          productionElement.children = scheduleItems
-          productionElement.loading = false
-        })
+        this.loadScheduleItems(productionElement)
+          .then(scheduleItems => {
+            scheduleItems = this.convertTaskTypeScheduleItems(scheduleItems)
+            productionElement.children = scheduleItems
+          })
+          .catch(err => {
+            console.error(err)
+            productionElement.expanded = false
+          })
+          .finally(() => {
+            productionElement.loading = false
+          })
       } else {
         productionElement.expanded = false
       }

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -259,7 +259,7 @@ export default {
     this.init = true
   },
 
-  afterDestroy() {
+  unmounted() {
     this.$store.commit('LOAD_PERSON_TASKS_END', {
       tasks: [],
       userFilters: {},

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -630,12 +630,21 @@ export default {
         expanded: false,
         loading: false,
         man_days: estimation,
-        editable: false,
+        editable: this.canEditTaskDates(taskType),
         unresizable: false,
         parentElement,
         color: taskType.color,
         children: []
       }
+    },
+
+    canEditTaskDates(taskType) {
+      const departments = this.user.departments || []
+      return (
+        this.isCurrentUserManager ||
+        (this.isCurrentUserSupervisor &&
+          (!departments.length || departments.includes(taskType.department_id)))
+      )
     },
 
     isActiveTab(tab) {

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -612,7 +612,10 @@ export default {
       } else if (task.end_date) {
         endDate = parseDate(task.end_date)
       } else if (task.estimation) {
-        endDate = startDate.clone().add(estimation, 'days')
+        endDate = addBusinessDays(
+          startDate,
+          Math.ceil(minutesToDays(this.organisation, estimation)) - 1
+        )
       }
       if (!endDate || endDate.isBefore(startDate)) {
         endDate = startDate.clone().add(1, 'days')

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -824,7 +824,7 @@ export default {
             start_date: item.startDate.format('YYYY-MM-DD'),
             due_date: item.endDate.format('YYYY-MM-DD')
           }
-        })
+        }).catch(console.error)
       }
     },
 

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -622,6 +622,9 @@ export default {
       }
 
       const taskType = this.taskTypeMap.get(task.task_type_id)
+      if (!taskType) {
+        return null
+      }
       return {
         ...task,
         name: `${task.full_entity_name} / ${taskType.name}`,

--- a/src/components/pages/Sequence.vue
+++ b/src/components/pages/Sequence.vue
@@ -221,6 +221,8 @@
               :is-estimation-linked="true"
               :hide-root="true"
               :with-milestones="false"
+              @item-changed="saveTaskScheduleItem"
+              @estimation-changed="event => saveTaskScheduleItem(event.item)"
             />
           </div>
         </div>

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1639,19 +1639,23 @@ const buildPersonElement = (
 
     if (withBeforeAfter) {
       const entity = entityMap.value.get(task.entity_id)
+      // copies: the ghost blocks below mutate name, dates and color,
+      // which must not leak into the taskMap objects
       const siblingElements = entity?.tasks
         .map(taskId => taskMap.value.get(taskId))
         .filter(Boolean)
 
       if (schedule.taskTypeBefore) {
-        data.previousElement = siblingElements.find(
+        const previousTask = siblingElements.find(
           item => item.task_type_id === schedule.taskTypeBefore
         )
+        data.previousElement = previousTask ? { ...previousTask } : null
       }
       if (schedule.taskTypeAfter) {
-        data.nextElement = siblingElements.find(
+        const nextTask = siblingElements.find(
           item => item.task_type_id === schedule.taskTypeAfter
         )
+        data.nextElement = nextTask ? { ...nextTask } : null
       }
     }
 

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -539,6 +539,8 @@ const activeTab = ref('tasks')
 const currentScheduleItem = ref(null)
 const currentSort = ref('entity_name')
 const daysOffByPerson = ref({})
+// not a ref: only read inside prepareScheduleData, never rendered
+let daysOffRangeKey = null
 const timesheetByPerson = ref({})
 const displaySettings = ref({
   contactSheetMode: false,
@@ -1350,11 +1352,15 @@ const prepareScheduleData = async () => {
   const startDate = currentScheduleItem.value.start_date
   const endDate = currentScheduleItem.value.end_date
 
-  const daysOffPromise = store
-    .dispatch('loadProductionDaysOff', { startDate, endDate })
-    .catch(
-      () => ({}) // fallback if not allowed to fetch days off
-    )
+  // every task:update socket event rebuilds the schedule, so the days off
+  // fetch is cached per range to avoid one HTTP call per event
+  const daysOffKey = `${currentProduction.value.id}_${startDate}_${endDate}`
+  const daysOffPromise =
+    daysOffKey === daysOffRangeKey
+      ? Promise.resolve(daysOffByPerson.value)
+      : store.dispatch('loadProductionDaysOff', { startDate, endDate }).catch(
+          () => ({}) // fallback if not allowed to fetch days off
+        )
 
   if (dataDisplay.value.timesheets) {
     const assignees = Object.keys(taskAssignationMap).filter(
@@ -1369,6 +1375,7 @@ const prepareScheduleData = async () => {
   } else {
     daysOffByPerson.value = await daysOffPromise
   }
+  daysOffRangeKey = daysOffKey
 
   return taskAssignationMap
 }

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1596,9 +1596,22 @@ const buildPersonElement = (
       moment(schedule.taskTypeStartDate)
     )
 
+    if (startDate.isAfter(productionEndDate.value)) {
+      startDate = productionEndDate.value.clone().add(-1, 'days')
+    }
+    if (startDate.isBefore(productionStartDate.value)) {
+      startDate = productionStartDate.value.clone()
+    }
+
     if (!endDate || endDate.isBefore(startDate)) {
       const nbDays = startDate.isoWeekday() === 5 ? 3 : 1
       endDate = startDate.clone().add(nbDays, 'days')
+    }
+    if (endDate.isAfter(productionEndDate.value)) {
+      endDate = productionEndDate.value.clone().add(-1, 'days')
+      if (startDate.isAfter(endDate)) {
+        startDate = endDate.clone().add(-1, 'days')
+      }
     }
 
     if (estimation) manDays += estimation

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -2047,6 +2047,7 @@ watch(currentScheduleItem, () => {
 watch(
   [() => schedule.taskTypeStartDate, () => schedule.taskTypeEndDate],
   () => {
+    if (!currentScheduleItem.value) return
     const startDate = moment(schedule.taskTypeStartDate).utc()
     const endDate = moment(schedule.taskTypeEndDate).utc()
     if (

--- a/src/components/pages/TeamSchedule.vue
+++ b/src/components/pages/TeamSchedule.vue
@@ -682,7 +682,6 @@ export default {
         try {
           await this.saveTaskScheduleItem(item)
           await this.loadPersonDates(true)
-          await this.loadDaysOff()
         } catch (err) {
           console.error(err)
         }

--- a/src/components/pages/TeamSchedule.vue
+++ b/src/components/pages/TeamSchedule.vue
@@ -425,9 +425,15 @@ export default {
     },
 
     async init() {
-      await this.loadPeople()
-      await this.loadPersonDates()
-      await this.loadDaysOff()
+      try {
+        await this.loadPeople()
+        await this.loadPersonDates()
+        await this.loadDaysOff()
+      } catch (err) {
+        console.error(err)
+        this.errors.schedule = true
+        return
+      }
 
       this.refreshSchedule()
       this.scrollScheduleToToday()
@@ -636,11 +642,19 @@ export default {
         if (refreshScheduleCallBack) {
           refreshScheduleCallBack(person)
         }
-        await this.assignSelectedTasks({
-          personId: person.id,
-          taskIds: [task.id]
-        })
-        await this.saveTaskScheduleItem(task)
+        try {
+          await this.assignSelectedTasks({
+            personId: person.id,
+            taskIds: [task.id]
+          })
+          await this.saveTaskScheduleItem(task)
+        } catch (err) {
+          console.error(err)
+          person.children = person.children.filter(({ id }) => id !== task.id)
+          if (refreshScheduleCallBack) {
+            refreshScheduleCallBack(person)
+          }
+        }
         await this.loadUnassignedTasks()
       }
     },
@@ -659,9 +673,13 @@ export default {
             item.parentElement.daysOff
           )
         }
-        await this.saveTaskScheduleItem(item)
-        await this.loadPersonDates(true)
-        await this.loadDaysOff()
+        try {
+          await this.saveTaskScheduleItem(item)
+          await this.loadPersonDates(true)
+          await this.loadDaysOff()
+        } catch (err) {
+          console.error(err)
+        }
       }
     },
 

--- a/src/components/pages/TeamSchedule.vue
+++ b/src/components/pages/TeamSchedule.vue
@@ -376,11 +376,13 @@ export default {
           person => person.studio_id === this.selectedStudio
         )
       }
-      if (this.selectedProduction) {
-        selectablePeople = selectablePeople.filter(person => {
-          const production = this.productionMap.get(this.selectedProduction)
-          return production.team.includes(person.id)
-        })
+      const production = this.selectedProduction
+        ? this.productionMap.get(this.selectedProduction)
+        : null
+      if (production) {
+        selectablePeople = selectablePeople.filter(person =>
+          production.team.includes(person.id)
+        )
       }
       return selectablePeople
     },

--- a/src/components/pages/TeamSchedule.vue
+++ b/src/components/pages/TeamSchedule.vue
@@ -588,6 +588,9 @@ export default {
         endDate = startDate.clone().add(1, 'days')
       }
       const taskType = this.taskTypeMap.get(task.task_type_id)
+      if (!taskType) {
+        return null
+      }
       return {
         ...task,
         name: `${task.full_entity_name} / ${taskType.name}`,
@@ -635,6 +638,9 @@ export default {
     async onScheduleItemDropped(item, person, refreshScheduleCallBack) {
       if (item.type === 'Task') {
         const task = this.buildTaskScheduleItem(person, item)
+        if (!task) {
+          return
+        }
         person.children.push(task)
         person.children.sort(
           firstBy('startDate').thenBy('project_name').thenBy('name')

--- a/src/composables/entity.js
+++ b/src/composables/entity.js
@@ -219,8 +219,9 @@ export const useEntity = ({ type, currentEntity, entityList, init }) => {
         if (!endDate || endDate.isBefore(startDate)) {
           endDate = startDate.clone().add(1, 'days')
         }
-        if (estimation) manDays += task.estimation
         const taskType = taskTypeMap.value.get(task.task_type_id)
+        if (!taskType) return null
+        if (estimation) manDays += task.estimation
 
         return {
           ...task,

--- a/src/composables/entity.js
+++ b/src/composables/entity.js
@@ -64,6 +64,22 @@ export const useEntity = ({ type, currentEntity, entityList, init }) => {
   const currentEpisode = computed(() => store.getters.currentEpisode)
   const currentProduction = computed(() => store.getters.currentProduction)
   const organisation = computed(() => store.getters.organisation)
+  const isCurrentUserManager = computed(
+    () => store.getters.isCurrentUserManager
+  )
+  const isCurrentUserSupervisor = computed(
+    () => store.getters.isCurrentUserSupervisor
+  )
+  const user = computed(() => store.getters.user)
+
+  const canEditTaskDates = taskType => {
+    const departments = user.value.departments || []
+    return (
+      isCurrentUserManager.value ||
+      (isCurrentUserSupervisor.value &&
+        (!departments.length || departments.includes(taskType.department_id)))
+    )
+  }
 
   // Local state (mirrors the mixin's `data()` fields used by Edit.vue).
   const currentSection = ref('infos')
@@ -214,7 +230,7 @@ export const useEntity = ({ type, currentEntity, entityList, init }) => {
           expanded: false,
           loading: false,
           man_days: estimation,
-          editable: true,
+          editable: canEditTaskDates(taskType),
           unresizable: false,
           parentElement: rootElement,
           color: taskType.color,

--- a/src/composables/entity.js
+++ b/src/composables/entity.js
@@ -237,6 +237,28 @@ export const useEntity = ({ type, currentEntity, entityList, init }) => {
     scheduleItems.value = [rootElement]
   }
 
+  const saveTaskScheduleItem = item => {
+    if (item.estimation) {
+      item.endDate = addBusinessDays(
+        item.startDate,
+        Math.ceil(minutesToDays(organisation.value, item.estimation)) - 1,
+        item.parentElement.daysOff
+      )
+    }
+    item.man_days = item.estimation || 0
+
+    if (item.startDate && item.endDate) {
+      store.dispatch('updateTask', {
+        taskId: item.id,
+        data: {
+          estimation: item.estimation,
+          start_date: item.startDate.format('YYYY-MM-DD'),
+          due_date: item.endDate.format('YYYY-MM-DD')
+        }
+      })
+    }
+  }
+
   // Watch route params and re-init when the entity id in the URL changes.
   // Mirrors the mixin's `$route` watcher.
   watch(
@@ -263,6 +285,7 @@ export const useEntity = ({ type, currentEntity, entityList, init }) => {
     nextEntityPath,
     currentTasks,
     tasksStartDate,
-    tasksEndDate
+    tasksEndDate,
+    saveTaskScheduleItem
   }
 }

--- a/src/composables/entity.js
+++ b/src/composables/entity.js
@@ -248,14 +248,16 @@ export const useEntity = ({ type, currentEntity, entityList, init }) => {
     item.man_days = item.estimation || 0
 
     if (item.startDate && item.endDate) {
-      store.dispatch('updateTask', {
-        taskId: item.id,
-        data: {
-          estimation: item.estimation,
-          start_date: item.startDate.format('YYYY-MM-DD'),
-          due_date: item.endDate.format('YYYY-MM-DD')
-        }
-      })
+      store
+        .dispatch('updateTask', {
+          taskId: item.id,
+          data: {
+            estimation: item.estimation,
+            start_date: item.startDate.format('YYYY-MM-DD'),
+            due_date: item.endDate.format('YYYY-MM-DD')
+          }
+        })
+        .catch(console.error)
     }
   }
 

--- a/src/composables/entity.js
+++ b/src/composables/entity.js
@@ -5,8 +5,10 @@ import { useStore } from 'vuex'
 
 import { getEntityPath } from '@/lib/path'
 import {
+  addBusinessDays,
   getFirstStartDate,
   getLastEndDate,
+  minutesToDays,
   parseDate,
   parseSimpleDate
 } from '@/lib/time'
@@ -61,6 +63,7 @@ export const useEntity = ({ type, currentEntity, entityList, init }) => {
   const getTaskTypePriority = computed(() => store.getters.getTaskTypePriority)
   const currentEpisode = computed(() => store.getters.currentEpisode)
   const currentProduction = computed(() => store.getters.currentProduction)
+  const organisation = computed(() => store.getters.organisation)
 
   // Local state (mirrors the mixin's `data()` fields used by Edit.vue).
   const currentSection = ref('infos')
@@ -191,7 +194,10 @@ export const useEntity = ({ type, currentEntity, entityList, init }) => {
         } else if (task.end_date) {
           endDate = parseSimpleDate(task.end_date)
         } else if (task.estimation) {
-          endDate = startDate.clone().add(estimation, 'days')
+          endDate = addBusinessDays(
+            startDate,
+            Math.ceil(minutesToDays(organisation.value, estimation)) - 1
+          )
         }
 
         if (!endDate || endDate.isBefore(startDate)) {


### PR DESCRIPTION
**Problem**
- Fallback end dates added `estimation` (minutes) as days: bars hundreds of days long on entity and person pages
- Sequence, episode and edit pages let users drag bars but never saved the change; the person page wired save handlers on bars that were never editable; entity pages were editable by everyone, including artists
- The team schedule crashed on an unknown production id in the URL and the main schedule date filters did nothing
- Task type page: the date clamp read never-assigned state, the socket refresh condition could never be true, before/after ghosts mutated tasks in the Vuex store, and the date watchers crashed when no schedule item was found
- Load and save failures were silent (stuck spinners, error flags never raised) and `afterDestroy` is not a Vue hook, so person tasks were never cleaned from the store
- A deleted task type crashed item building; days off and timesheets were refetched on every socket event or bar drag

**Solution**
- Convert estimations with `minutesToDays` before computing fallback end dates (mixin, composable, person page)
- Wire `saveTaskScheduleItem` on sequence/episode/edit and gate `editable` on manager or department supervisor on the person and entity pages
- Guard the team schedule production filter, apply the main schedule date fields to the timeline and clamp task type bars to the production range
- Fix the `nbSelectedTasks` check, copy ghost tasks before mutating them, guard the task type date watchers and skip items whose task type is gone
- Add catches, error flags and spinner cleanup on the load/save paths; rename `afterDestroy` to `unmounted`
- Cache the days off fetch per date range, index tasks by id when attaching timesheets, drop the studio-wide days off refetch after drags