### PR TITLE
[productions] Add an option to enable frame_in numbering in players

### DIFF
--- a/src/components/pages/ProjectTemplateSettings.vue
+++ b/src/components/pages/ProjectTemplateSettings.vue
@@ -176,6 +176,10 @@
                 :label="$t('productions.fields.is_publish_default')"
                 v-model="params.is_publish_default_for_artists"
               />
+              <combobox-boolean
+                :label="$t('productions.fields.is_frame_in_numbering')"
+                v-model="params.is_frame_in_numbering"
+              />
               <text-field
                 type="number"
                 :step="1"
@@ -465,6 +469,7 @@ const params = ref({
   is_set_preview_automated: 'false',
   is_single_preview_per_revision: 'false',
   is_publish_default_for_artists: 'false',
+  is_frame_in_numbering: 'false',
   max_retakes: 0
 })
 
@@ -531,6 +536,7 @@ const loadTemplateData = async () => {
     is_publish_default_for_artists: tmpl.is_publish_default_for_artists
       ? 'true'
       : 'false',
+    is_frame_in_numbering: tmpl.is_frame_in_numbering ? 'true' : 'false',
     max_retakes: tmpl.max_retakes || 0
   }
   // Build roles map from task status link data (if available from API)
@@ -579,7 +585,8 @@ const saveParameters = async () => {
       is_single_preview_per_revision:
         params.value.is_single_preview_per_revision === 'true',
       is_publish_default_for_artists:
-        params.value.is_publish_default_for_artists === 'true'
+        params.value.is_publish_default_for_artists === 'true',
+      is_frame_in_numbering: params.value.is_frame_in_numbering === 'true'
     })
   } catch {
     errors.parameters = true

--- a/src/components/pages/production/ProductionParameters.vue
+++ b/src/components/pages/production/ProductionParameters.vue
@@ -134,6 +134,12 @@
           v-if="currentProduction && currentProduction.id"
         />
         <combobox-boolean
+          :label="$t('productions.fields.is_frame_in_numbering')"
+          @enter="runConfirmation"
+          v-model="form.is_frame_in_numbering"
+          v-if="currentProduction && currentProduction.id"
+        />
+        <combobox-boolean
           :label="$t('productions.fields.is_publish_default')"
           @enter="runConfirmation"
           v-model="form.is_publish_default_for_artists"
@@ -227,6 +233,7 @@ const emptyForm = () => ({
   max_retakes: 0,
   revision_padding: 0,
   is_clients_isolated: 'false',
+  is_frame_in_numbering: 'false',
   is_preview_download_allowed: 'false',
   is_set_preview_automated: 'false',
   is_single_preview_per_revision: 'false',
@@ -283,6 +290,9 @@ const resetForm = () => {
       revision_padding: production.revision_padding,
       nb_episodes: production.nb_episodes,
       is_clients_isolated: production.is_clients_isolated ? 'true' : 'false',
+      is_frame_in_numbering: production.is_frame_in_numbering
+        ? 'true'
+        : 'false',
       is_preview_download_allowed: production.is_preview_download_allowed
         ? 'true'
         : 'false',

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -1395,8 +1395,11 @@ const frameNumber = computed(() => {
 // Production start frame of the playing shot (data.frame_in, e.g. 1001).
 // Forwarded to the playback bar / progress bar as a display-only offset —
 // currentFrame stays 1-based since annotation seeks round-trip on it.
+// Opt-in through the production option; a missing field means disabled.
 const frameStart = computed(() =>
-  getEntityFrameStart(shotMap.value.get(currentEntity.value?.id))
+  currentProduction.value?.is_frame_in_numbering
+    ? getEntityFrameStart(shotMap.value.get(currentEntity.value?.id))
+    : undefined
 )
 
 const currentFrame = computed(() => formatFrame(frameNumber.value + 2))

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -878,8 +878,11 @@ const frameDuration = computed(
 
 // Production start frame of the displayed shot (data.frame_in, e.g. 1001).
 // Forwarded to the playback bar / progress bar as a display-only offset.
+// Opt-in through the production option; a missing field means disabled.
 const frameStart = computed(() =>
-  getEntityFrameStart(shotMap.value.get(props.task?.entity_id))
+  currentProduction.value?.is_frame_in_numbering
+    ? getEntityFrameStart(shotMap.value.get(props.task?.entity_id))
+    : undefined
 )
 
 const extension = computed(() =>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1436,6 +1436,7 @@ export default {
       episode_span: 'Episode spacing',
       fps: 'FPS',
       is_clients_isolated: 'Isolate client comments (not visible to each others)',
+      is_frame_in_numbering: 'Start the player frame counter at the frame in',
       is_preview_download_allowed: 'Allow artists to download previews',
       is_publish_default: 'Set comment widget for artists on publish mode by default',
       is_set_preview_automated: 'Set new preview as entity thumbnail automatically',

--- a/src/store/api/productions.js
+++ b/src/store/api/productions.js
@@ -33,6 +33,7 @@ export default {
   updateProduction(production) {
     const BOOLEAN_FIELDS = [
       'is_clients_isolated',
+      'is_frame_in_numbering',
       'is_preview_download_allowed',
       'is_set_preview_automated',
       'is_publish_default_for_artists',

--- a/tests/unit/pages/productionparameters.spec.js
+++ b/tests/unit/pages/productionparameters.spec.js
@@ -1,0 +1,60 @@
+import { shallowMount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: key => key }) }))
+
+import ProductionParameters from '@/components/pages/production/ProductionParameters.vue'
+
+const mountWithProduction = production => {
+  const store = createStore({
+    getters: {
+      currentProduction: () => production,
+      productionAvatarFormData: () => null,
+      isTVShow: () => false
+    }
+  })
+  store.dispatch = vi.fn()
+  return shallowMount(ProductionParameters, {
+    global: {
+      plugins: [store],
+      mocks: { $t: key => key },
+      directives: { focus: () => {} },
+      stubs: {
+        // resetForm calls the upload widget's reset() through a template ref.
+        FileUpload: { template: '<div />', methods: { reset() {} } }
+      }
+    }
+  })
+}
+
+const baseProduction = {
+  id: 'prod-1',
+  name: 'Test',
+  start_date: '2026-01-01',
+  end_date: '2026-12-31'
+}
+
+describe('ProductionParameters — is_frame_in_numbering', () => {
+  it('maps an explicit false to a disabled toggle', () => {
+    const wrapper = mountWithProduction({
+      ...baseProduction,
+      is_frame_in_numbering: false
+    })
+    expect(wrapper.vm.form.is_frame_in_numbering).toBe('false')
+  })
+
+  it('maps an explicit true to an enabled toggle', () => {
+    const wrapper = mountWithProduction({
+      ...baseProduction,
+      is_frame_in_numbering: true
+    })
+    expect(wrapper.vm.form.is_frame_in_numbering).toBe('true')
+  })
+
+  // The option is an opt-in; old zou versions without the column stay off.
+  it('defaults to disabled when the field is missing', () => {
+    const wrapper = mountWithProduction(baseProduction)
+    expect(wrapper.vm.form.is_frame_in_numbering).toBe('false')
+  })
+})


### PR DESCRIPTION
**Problem**
- The frame counter switched to shot frame_in numbering unconditionally; productions that fill frame_in but want the classic counter had no way around it

**Solution**
- Gate the players' frameStart on a new `is_frame_in_numbering` production option (kitsu side of cgwire/zou#1168), exposed in production settings and project templates, disabled by default; a missing field (older zou) keeps it disabled
- Add unit tests on the option's form mapping