### PR TITLE
[schedule] Cut network and render churn in schedule pages

### DIFF
--- a/src/components/mixins/entity.js
+++ b/src/components/mixins/entity.js
@@ -276,6 +276,19 @@ export const entityMixin = {
           }
         })
         .filter(c => c !== null)
+
+      // any task mutation in the store retriggers this build: skip the
+      // replacement (and the widget re-render) when nothing visible changed
+      const signature = children
+        .map(
+          child =>
+            `${child.id}:${child.startDate.valueOf()}:` +
+            `${child.endDate.valueOf()}:${child.man_days || 0}`
+        )
+        .join('|')
+      if (signature === this.scheduleItemsSignature) return
+      this.scheduleItemsSignature = signature
+
       let rootStartDate = moment()
       let rootEndDate = moment().add(1, 'days')
       if (children.length > 0) {

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -340,14 +340,9 @@ export default {
     },
 
     sortedAllTasks() {
-      let tasks = this.sortTasks([
-        ...this.displayedPersonTasks,
-        ...this.displayedPersonDoneTasks
-      ])
-      if (this.productionId) {
-        tasks = tasks.filter(task => task.project_id === this.productionId)
-      }
-      return tasks
+      // reuse the two cached computeds: they already carry the production
+      // filter, only the merged sort remains to do
+      return this.sortTasks([...this.sortedTasks, ...this.sortedDoneTasks])
     },
 
     tasksStartDate() {

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -540,8 +540,10 @@ const activeTab = ref('tasks')
 const currentScheduleItem = ref(null)
 const currentSort = ref('entity_name')
 const daysOffByPerson = ref({})
-// not a ref: only read inside prepareScheduleData, never rendered
+// not refs: only read inside the schedule data loads, never rendered
 let daysOffRangeKey = null
+let timeSpentsRangeKey = null
+let timeSpentsCache = {}
 const timesheetByPerson = ref({})
 const displaySettings = ref({
   contactSheetMode: false,
@@ -1461,16 +1463,27 @@ const buildAssignationMap = () => {
   return taskAssignationMap
 }
 
+// same trade-off as the days off cache: one fetch per range, so the
+// debounced socket rebuilds stop refetching all time spents
+const loadTimeSpentsForRange = async (startDate, endDate) => {
+  const key = `${currentTaskType.value.id}_${startDate}_${endDate}`
+  if (key !== timeSpentsRangeKey) {
+    timeSpentsCache = await store
+      .dispatch('loadProductionTimeSpents', {
+        taskType: currentTaskType.value,
+        startDate,
+        endDate
+      })
+      .catch(
+        () => ({}) // fallback if not allowed to fetch timesheets
+      )
+    timeSpentsRangeKey = key
+  }
+  return timeSpentsCache
+}
+
 const loadTimesheets = async (personIds, startDate, endDate) => {
-  const timesheets = await store
-    .dispatch('loadProductionTimeSpents', {
-      taskType: currentTaskType.value,
-      startDate,
-      endDate
-    })
-    .catch(
-      () => ({}) // fallback if not allowed to fetch timesheets
-    )
+  const timesheets = await loadTimeSpentsForRange(startDate, endDate)
 
   const taskById = new Map(tasks.value.map(task => [task.id, task]))
   const timesheetByPersonResult = {}

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -432,6 +432,7 @@ import { useStore } from 'vuex'
 import { getEntityMap } from '@/composables/entity'
 import csv from '@/lib/csv'
 import { isSupervisorInDepartments } from '@/lib/descriptors'
+import func from '@/lib/func'
 import {
   applyFilters,
   getDescFilters,
@@ -1918,8 +1919,12 @@ const resetScheduleScroll = () => {
   }
 }
 
+// socket events arrive in bursts (imports, bulk assignments): rebuild the
+// schedule once per burst instead of once per event
+const resetScheduleItemsDebounced = func.debounce(resetScheduleItems, 400)
+
 const onRemoteTaskUpdate = eventData => {
-  resetScheduleItems()
+  resetScheduleItemsDebounced()
   if (
     !isActiveTab('schedule') &&
     taskMap.value.get(eventData.task_id) &&

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1223,11 +1223,14 @@ const getTasks = entities => {
     entity.tasks.forEach(taskId => {
       const task = taskMap.value.get(taskId.id || taskId)
       if (task) {
-        // Hack to allow filtering on linked entity metadata.
-        store.commit('SET_TASK_EXTRA_DATA', {
-          task,
-          data: entity.data
-        })
+        // Hack to allow filtering on linked entity metadata. Guarded so
+        // the repeated resets do not commit the same reference again.
+        if (task.data !== entity.data) {
+          store.commit('SET_TASK_EXTRA_DATA', {
+            task,
+            data: entity.data
+          })
+        }
         if (task.task_type_id === currentTaskType.value.id) {
           result.push(task)
         }

--- a/src/components/pages/TeamSchedule.vue
+++ b/src/components/pages/TeamSchedule.vue
@@ -334,6 +334,12 @@ export default {
     }
   },
 
+  created() {
+    // non-reactive: person id -> raw tasks, so re-expanding a row is instant.
+    // Entries are dropped whenever the row's assignments or dates change.
+    this.personTasksCache = new Map()
+  },
+
   mounted() {
     this.selectedDepartment = this.$route.query.department || undefined
     this.selectedStudio = this.$route.query.studio || undefined
@@ -649,6 +655,7 @@ export default {
         if (!task) {
           return
         }
+        this.personTasksCache.delete(person.id)
         person.children.push(task)
         person.children.sort(
           firstBy('startDate').thenBy('project_name').thenBy('name')
@@ -690,6 +697,7 @@ export default {
         try {
           await this.saveTaskScheduleItem(item)
           this.refreshPersonRootDates(item.parentElement)
+          this.personTasksCache.delete(item.parentElement.id)
         } catch (err) {
           console.error(err)
         }
@@ -698,6 +706,7 @@ export default {
 
     onScheduleItemAssigned(item, person) {
       if (item.type === 'Task') {
+        this.personTasksCache.delete(person.id)
         person.children.sort(
           firstBy('startDate').thenBy('project_name').thenBy('name')
         )
@@ -710,6 +719,7 @@ export default {
 
     onScheduleItemUnassigned(item, person) {
       if (item.type === 'Task') {
+        this.personTasksCache.delete(person.id)
         this.unassignPersonFromTask({
           person,
           task: item
@@ -727,7 +737,11 @@ export default {
       element.loading = true
       element.children = []
       try {
-        const tasks = await this.fetchPersonTasks(element.id)
+        let tasks = this.personTasksCache.get(element.id)
+        if (!tasks) {
+          tasks = await this.fetchPersonTasks(element.id)
+          this.personTasksCache.set(element.id, tasks)
+        }
         element.children = tasks
           .map(task => this.buildTaskScheduleItem(element, task))
           .filter(Boolean)

--- a/src/components/pages/TeamSchedule.vue
+++ b/src/components/pages/TeamSchedule.vue
@@ -239,7 +239,13 @@ import { mapGetters, mapActions } from 'vuex'
 
 import colors from '@/lib/colors'
 import { getPersonPath } from '@/lib/path'
-import { addBusinessDays, minutesToDays, parseSimpleDate } from '@/lib/time'
+import {
+  addBusinessDays,
+  getFirstStartDate,
+  getLastEndDate,
+  minutesToDays,
+  parseSimpleDate
+} from '@/lib/time'
 
 import { formatListMixin } from '@/components/mixins/format'
 
@@ -507,7 +513,7 @@ export default {
       this.loading.unassignedTasks = false
     },
 
-    async loadPersonDates(syncSchedule = false) {
+    async loadPersonDates() {
       const personDatesList = await this.getPersonsTasksDates()
       this.personDates = {}
       personDatesList.forEach(p => {
@@ -516,15 +522,17 @@ export default {
           startDate: parseSimpleDate(p.min_date)
         }
       })
+    },
 
-      if (syncSchedule) {
-        this.scheduleItems.forEach(scheduleItem => {
-          const personDates = this.personDates[scheduleItem.id]
-          if (personDates) {
-            scheduleItem.startDate = personDates.startDate
-            scheduleItem.endDate = personDates.endDate
-          }
-        })
+    // recompute the root bar locally after a drag: the person is expanded so
+    // its children are loaded, no need to refetch every person's dates
+    refreshPersonRootDates(person) {
+      if (!person?.children?.length) return
+      person.startDate = getFirstStartDate(person.children).clone()
+      person.endDate = getLastEndDate(person.children).clone()
+      this.personDates[person.id] = {
+        startDate: person.startDate.clone(),
+        endDate: person.endDate.clone()
       }
     },
 
@@ -681,7 +689,7 @@ export default {
         }
         try {
           await this.saveTaskScheduleItem(item)
-          await this.loadPersonDates(true)
+          this.refreshPersonRootDates(item.parentElement)
         } catch (err) {
           console.error(err)
         }

--- a/src/composables/entity.js
+++ b/src/composables/entity.js
@@ -85,6 +85,7 @@ export const useEntity = ({ type, currentEntity, entityList, init }) => {
   const currentSection = ref('infos')
   const zoomLevel = ref(1)
   const scheduleItems = ref([])
+  let scheduleItemsSignature = null
   const zoomOptions = [
     { label: '1', value: 1 },
     { label: '2', value: 2 },
@@ -239,6 +240,19 @@ export const useEntity = ({ type, currentEntity, entityList, init }) => {
         }
       })
       .filter(c => c !== null)
+
+    // any task mutation in the store retriggers this build: skip the
+    // replacement (and the widget re-render) when nothing visible changed
+    const signature = children
+      .map(
+        child =>
+          `${child.id}:${child.startDate.valueOf()}:` +
+          `${child.endDate.valueOf()}:${child.man_days || 0}`
+      )
+      .join('|')
+    if (signature === scheduleItemsSignature) return
+    scheduleItemsSignature = signature
+
     let rootStartDate = moment()
     let rootEndDate = moment().add(1, 'days')
     if (children.length > 0) {


### PR DESCRIPTION
**Problem**
- Each bar drag on the team schedule refetched every person's task dates, and re-expanding a row refetched its tasks (2 requests each time)
- On the task type page every `task:update` socket event rebuilt the whole schedule, refetched all time spents when timesheets are shown, and re-committed the same task extra data
- Entity pages rebuilt their mini schedule (and re-rendered the widget) on any task mutation in the store, even unrelated ones
- The person page filtered and sorted the same task lists three times

**Solution**
- Recompute the dragged person's root bar locally and cache person tasks per row, invalidated on assign, unassign, drop and date change
- Debounce the socket-driven rebuild (400 ms) and cache the time spents fetch per date range, like the days off
- Commit task extra data only when the reference changed and skip the `scheduleItems` replacement when the visible signature is unchanged
- Build the merged person task list from the two cached sorted lists

Note: stacked on #2144, only the 7 `perf` commits are new here.