### PR TITLE
[players] Cut network and render churn in the players

### DIFF
--- a/src/components/players/annotations/SharedAnnotationOverlay.vue
+++ b/src/components/players/annotations/SharedAnnotationOverlay.vue
@@ -139,33 +139,20 @@ const videoBounds = computed(() => {
 
   // Pictures: mirror the studio player's sizing — the image is centered and
   // never upscaled beyond its natural size, so the overlay box matches the
-  // actually displayed <img>. A plain contain-fit (used for movies) would
-  // upscale small images and misalign the annotations on top of them.
+  // actually displayed <img>. One uniform scale: independent width/height
+  // clamps produced a wrong-aspect box when the container was narrower but
+  // taller than the image, and strokes then SAVED with those dimensions
+  // misalign everywhere else.
   if (props.isPicture) {
-    const ratio = mw / mh
-    let width = ratio ? ch * ratio : cw
-    let height = ratio ? Math.round(cw / ratio) : ch
-    let left = 0
-    let top = 0
-    if (cw > mw) {
-      left = Math.round((cw - mw) / 2)
-      width = mw
-    } else if (cw > width) {
-      left = Math.round((cw - width) / 2)
-    } else {
-      width = cw
+    const scale = Math.min(cw / mw, ch / mh, 1)
+    const width = Math.round(mw * scale)
+    const height = Math.round(mh * scale)
+    return {
+      width,
+      height,
+      left: Math.round((cw - width) / 2),
+      top: Math.round((ch - height) / 2)
     }
-    if (ch > mh) {
-      top = Math.round((ch - mh) / 2)
-      height = mh
-    } else if (ch > height) {
-      top = Math.round((ch - height) / 2)
-    } else {
-      height = ch
-      width = Math.round(height * ratio)
-      left = Math.round((cw - width) / 2)
-    }
-    return { width, height, left, top }
   }
 
   // Movies: contain-fit — matches the canvas, which fills the container.

--- a/src/components/players/annotations/SharedAnnotationOverlay.vue
+++ b/src/components/players/annotations/SharedAnnotationOverlay.vue
@@ -213,9 +213,22 @@ const render = async () => {
   const fabricCanvas = annotation.getCanvas()
   if (!fabricCanvas) return
   const token = ++renderToken
+  // Unsaved guest strokes must survive re-renders (resize, comments-panel
+  // toggle, frame stepping): capture the pending diff before the reset
+  // wipes it. This is an explicit-save UX, a silent wipe loses work.
+  const pendingAdditions = annotation.hasChanges()
+    ? annotation.getDiff().additions
+    : []
   fabricCanvas.clear()
   annotation.reset()
-  if (props.isPlaying) return
+  if (props.isPlaying) {
+    // Keep the pending data armed (save button, reappearance on pause)
+    // even though nothing is painted during playback.
+    if (pendingAdditions.length) {
+      annotation.restoreUnsaved(pendingAdditions, [])
+    }
+    return
+  }
   const current = findAnnotationAtTime(
     props.annotations,
     currentTime.value,
@@ -226,8 +239,7 @@ const render = async () => {
     current?.width || props.movieDimensions?.width || fabricCanvas.width,
     current?.height || props.movieDimensions?.height || fabricCanvas.height
   )
-  if (!current) return
-  const objects = current.drawing?.objects || []
+  const objects = current ? current.drawing?.objects || [] : []
   const shapes = await Promise.all(
     objects.map(obj => buildReadOnlyShape(current, obj, fabricCanvas))
   )
@@ -235,6 +247,24 @@ const render = async () => {
   shapes.forEach(shape => {
     if (shape) fabricCanvas.add(shape)
   })
+  if (pendingAdditions.length) {
+    // Repaint the unsaved strokes of the displayed frame; entries drawn
+    // on other frames stay data-only until their frame shows again.
+    const rebuilt = []
+    for (const entry of pendingAdditions) {
+      if (entry.time === currentTime.value) {
+        for (const obj of entry.drawing.objects) {
+          const shape = await buildReadOnlyShape(entry, obj, fabricCanvas)
+          if (token !== renderToken) return
+          if (shape) {
+            fabricCanvas.add(shape)
+            rebuilt.push(shape)
+          }
+        }
+      }
+    }
+    annotation.restoreUnsaved(pendingAdditions, rebuilt)
+  }
   fabricCanvas.requestRenderAll()
 }
 
@@ -299,6 +329,10 @@ const save = async () => {
         deletions: diff.deletions
       }
     })
+    // Drop the local copies now that they are persisted: render() keeps
+    // unsaved work across resets, so a stale diff would repaint the just
+    // saved strokes as pending duplicates.
+    annotation.clearLocal()
     emit('saved', updated.annotations || [])
   } catch (error) {
     // Keep the toolbar so the user can retry; surface the failure for logs.

--- a/src/components/players/bars/PreviewsPerTaskType.vue
+++ b/src/components/players/bars/PreviewsPerTaskType.vue
@@ -62,9 +62,14 @@ const previewFileId = ref(props.entity.preview_file_id)
 
 const taskTypeOptions = computed(() => {
   const entity = editStore.cache.editMap.get(props.entity.id)
+  // A concurrently deleted task leaves a stale id here (the edits store
+  // only prunes displayed edits): filter instead of crashing the header.
+  if (!entity) return []
   return entity.tasks
     .map(taskId => taskMap.value.get(taskId))
+    .filter(Boolean)
     .map(task => taskTypeMap.value.get(task.task_type_id))
+    .filter(Boolean)
     .sort(firstBy('priority', 1).thenBy('name'))
     .map(taskType => ({
       label: taskType.name,

--- a/src/components/players/headers/RevisionPreview.vue
+++ b/src/components/players/headers/RevisionPreview.vue
@@ -82,10 +82,16 @@ const onDragover = event => {
 }
 
 const onDropped = event => {
+  // Cancel the drop (onDragover made us a valid target for ANY drag,
+  // including OS files, whose default action replaces the page) and
+  // ignore payloads that don't come from the reorder strip.
+  event.preventDefault()
   dropArea.value.style.background = 'transparent'
   dropArea.value.style.width = '15px'
+  const previousIndex = event.dataTransfer.getData('previewIndex')
+  if (previousIndex === '') return
   emit('preview-dropped', {
-    previousIndex: event.dataTransfer.getData('previewIndex'),
+    previousIndex,
     newIndex: props.index
   })
 }

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -3203,7 +3203,8 @@ const onFocusToggle = event => {
 }
 
 const onTimeCodeClicked = ({ versionRevision, frame }) => {
-  const previews = currentEntity.value?.preview_files[task.value?.task_type_id]
+  const previews =
+    currentEntity.value?.preview_files?.[task.value?.task_type_id]
   if (!previews) return
   const previewFile = previews.find(
     p => p.revision === parseInt(versionRevision)

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -1110,6 +1110,7 @@ let wavesurfer = null
 // Annotation painted by the show-annotations-while-playing path; reset
 // wherever the canvas is cleared outside that path.
 let lastShownWhilePlaying = null
+let lastWaveformSeek = 0
 
 // — Reactive
 const annotations = ref([])
@@ -2731,7 +2732,13 @@ const onFrameUpdate = frame => {
     // Guard the divisor: while a playlist reset is in flight the next
     // media's duration isn't known yet (maxDurationRaw is 0), and seeking
     // to a non-finite position throws in WaveSurfer's currentTime setter.
-    wavesurfer.seekTo(currentTimeRaw.value / maxDurationRaw.value)
+    // Throttled: seekTo repaints wavesurfer internals, and a per-frame
+    // call is invisible on a 60px strip.
+    const now = performance.now()
+    if (now - lastWaveformSeek > 200) {
+      lastWaveformSeek = now
+      wavesurfer.seekTo(currentTimeRaw.value / maxDurationRaw.value)
+    }
   }
   nextTick(() => {
     const actions = onNextTimeUpdateActions.value

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -3825,7 +3825,7 @@ const configureFullPlayer = () => {
   if (!fullPlaylistPlayer.value) return
   fullPlaylistPlayer.value.addEventListener('loadedmetadata', () => {
     playlistDuration.value = entityList.value.reduce(
-      (acc, e) => acc + e.preview_file_duration,
+      (acc, e) => acc + (e.preview_file_duration || 0),
       0
     )
   })

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -2887,7 +2887,13 @@ const loadComparisonAnnotation = time => {
   if (!isMovieComparison.value) return
   const compared = currentRevisionToCompare.value
   const anns = compared?.annotations || []
-  const annotation = anns.find(a => a.time === time)
+  // Tolerant match like getAnnotation: `time` can be a raw rVFC media
+  // time while stored times are rounded (legacy ones not even that), so
+  // strict float equality mostly missed and the overlay stayed empty.
+  const target = roundToFrame(time, fps.value)
+  const annotation = anns.find(
+    a => Math.abs(roundToFrame(a.time, fps.value) - target) < 0.0001
+  )
   if (annotation) loadSingleAnnotationComparison(annotation)
 }
 

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -2008,7 +2008,13 @@ const scheduleRenderStep = step => {
 const startProgressiveRender = () => {
   cancelProgressiveRender()
   const total = entityList.value.length
-  renderedEntityCount.value = Math.min(RENDER_BATCH_SIZE, total)
+  // Keep whatever is already mounted: a same-content list replacement
+  // (reorder) must not unmount the strip beyond the first batch. Fresh
+  // playlists reset the count through resetPlaylist.
+  renderedEntityCount.value = Math.min(
+    Math.max(RENDER_BATCH_SIZE, renderedEntityCount.value),
+    total
+  )
   const step = () => {
     renderHandle = null
     const total = entityList.value.length
@@ -3682,16 +3688,16 @@ const moveSelectedEntity = (entityToMove, toMoveIndex, targetIndex) => {
   if (!currentEntity.value) return
   if (playingEntityIndex.value >= 0) {
     if (toMoveIndex >= 0 && targetIndex >= 0) {
+      // Single replacement: the transient empty list unmounted every
+      // PlaylistedEntity and remounted the whole strip on each reorder
+      // (the keyed v-for just moves nodes on a same-content swap).
       const tmp = [...entityList.value]
       tmp.splice(toMoveIndex, 1)
       tmp.splice(targetIndex, 0, entityToMove)
-      entityList.value = []
+      entityList.value = tmp
       nextTick(() => {
-        entityList.value = tmp
-        nextTick(() => {
-          playingEntityIndex.value = targetIndex
-          scrollToEntity(playingEntityIndex.value)
-        })
+        playingEntityIndex.value = targetIndex
+        scrollToEntity(playingEntityIndex.value)
       })
     }
   }
@@ -4137,6 +4143,7 @@ const onComparisonPanZoomChanged = ({ x, y, scale }) => {
 const resetPlaylist = () => {
   currentPreviewIndex.value = 0
   currentComparisonPreviewIndex.value = 0
+  renderedEntityCount.value = 0
   entityList.value = props.entities
   resetPlaylistFrameData()
 

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -926,10 +926,12 @@ import {
   computed,
   defineAsyncComponent,
   getCurrentInstance,
+  markRaw,
   nextTick,
   onBeforeUnmount,
   onMounted,
   ref,
+  shallowRef,
   useTemplateRef,
   watch
 } from 'vue'
@@ -1153,7 +1155,10 @@ const pictureDefaultHeight = ref(0)
 const playingEntityIndex = ref(0)
 const playlistDuration = ref(0)
 const playlistProgress = ref(0)
-const playlistShotPosition = ref({})
+// Frame -> entity lookup for the strip. Non-reactive on purpose: one
+// entry per frame of the whole playlist made Vue proxy tens of
+// thousands of objects; consumers re-render on the shallowRef swap.
+const playlistShotPosition = shallowRef({})
 const room = ref({
   people: [],
   newComer: true
@@ -3999,6 +4004,7 @@ const resetHandles = entity => {
 const resetPlaylistFrameData = () => {
   let playlistDur = 0
   let curFrame = 0
+  const positions = {}
   entityList.value.forEach((entity, index) => {
     // An entity without preview still spans its edit length (like a slug
     // in a conform): playback holds the slot, the strip shows it in grey.
@@ -4020,16 +4026,21 @@ const resetPlaylistFrameData = () => {
     // the *current* entity's rate, durations refresh after this pass).
     entity.playlist_start_frame = curFrame
     entity.playlist_nb_frames = n
+    // One shared entry per entity (the fields are identical for all its
+    // frames), written into a fresh map: per-frame objects multiplied
+    // memory by the frame count, and stale frames from a longer previous
+    // playlist were never purged.
+    const entry = {
+      index,
+      name: entity.name,
+      extension: entity.preview_file_extension,
+      start: entity.start_duration,
+      width: entity.preview_file_width,
+      height: entity.preview_file_height,
+      id: entity.preview_file_id
+    }
     for (let i = 0; i < n; i++) {
-      playlistShotPosition.value[curFrame + i] = {
-        index,
-        name: entity.name,
-        extension: entity.preview_file_extension,
-        start: entity.start_duration,
-        width: entity.preview_file_width,
-        height: entity.preview_file_height,
-        id: entity.preview_file_id
-      }
+      positions[curFrame + i] = entry
     }
     curFrame += n
     playlistDur += n / fps.value
@@ -4041,6 +4052,7 @@ const resetPlaylistFrameData = () => {
       entity.task_status_color = taskStatus?.color
     }
   })
+  playlistShotPosition.value = markRaw(positions)
   playlistDuration.value = playlistDur
   return playlistDur
 }

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -2244,7 +2244,7 @@ const syncComparisonPlayer = () => {
     isComparing.value &&
     rawPlayerComparison.value.currentPlayer
   ) {
-    const t = Number(rawPlayer.value.getCurrentTimeRaw().toPrecision(4))
+    const t = rawPlayer.value.getCurrentTimeRaw()
     rawPlayerComparison.value.setCurrentTimeRaw(t)
   }
 }
@@ -2560,8 +2560,9 @@ const getCurrentTime = () => {
   // scrub position leaks into the annotation key and strokes drawn
   // mid-shot disappear when the user comes back to the start.
   if (!isCurrentPreviewMovie.value) return 0
-  const time = roundToFrame(currentTimeRaw.value, fps.value) || 0
-  return Number(time.toPrecision(4))
+  // 4-decimal rounding only: toPrecision(4) keeps 4 significant digits and
+  // quantized times past 100s, landing annotations on neighbouring frames.
+  return roundToFrame(currentTimeRaw.value, fps.value) || 0
 }
 
 const getCurrentFrame = () => {
@@ -2581,7 +2582,7 @@ const setCurrentTimeRaw = time => {
     syncComparisonPlayer()
     const isChromium = !!window.chrome
     const change = isChromium ? 0.0001 : 0
-    currentTimeRaw.value = Number((roundedTime + change).toPrecision(4))
+    currentTimeRaw.value = roundedTime + change
     updateProgressBar()
   }
   return roundedTime
@@ -2650,9 +2651,7 @@ const setPlayerSpeed = rate => {
 const onFrameUpdate = frame => {
   const isChromium = !!window.chrome
   const change = isChromium ? 0.0001 : 0
-  currentTimeRaw.value = Number(
-    (frame * frameDuration.value + change).toPrecision(4)
-  )
+  currentTimeRaw.value = frame * frameDuration.value + change
   currentTime.value = formatTime(currentTimeRaw.value, fps.value)
   updateProgressBar()
   if (isShowAnnotationsWhilePlaying.value) {

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -415,7 +415,7 @@
       <task-info
         ref="task-info"
         class="flexrow-item task-info-column"
-        :current-frame="parseInt(currentFrame) - 1"
+        :current-frame="taskInfoFrame"
         :current-parent-preview="currentPreview"
         :fps="fps"
         :extendable="false"
@@ -1409,6 +1409,21 @@ const currentFrameMovieOrPicture = computed(() => {
   if (isCurrentPreviewPicture.value) return framesSeenOfPicture.value
   return 0
 })
+
+// TaskInfo renders the frame chip in its template: feeding it the live
+// frame re-rendered the whole comments panel dozens of times a second
+// during playback, even while hidden (v-show). Freeze the prop while
+// playing or hidden; it refreshes on pause and when the panel opens.
+const taskInfoFrame = ref(-1)
+watch(
+  [currentFrame, isPlaying, isCommentsHidden],
+  () => {
+    if (!isPlaying.value && !isCommentsHidden.value) {
+      taskInfoFrame.value = parseInt(currentFrame.value) - 1
+    }
+  },
+  { immediate: true }
+)
 
 // Computed — comparison
 

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -1107,6 +1107,9 @@ let lastResizeCall = 0
 let playingPictureTimeout = null
 let autoHideTimer = null
 let wavesurfer = null
+// Annotation painted by the show-annotations-while-playing path; reset
+// wherever the canvas is cleared outside that path.
+let lastShownWhilePlaying = null
 
 // — Reactive
 const annotations = ref([])
@@ -2116,6 +2119,7 @@ const play = () => {
     if (isComparing.value) rawPlayerComparison.value?.play()
     isPlaying.value = rawPlayer.value.isPlaying
   }
+  lastShownWhilePlaying = null
   clearCanvas()
 }
 
@@ -2187,6 +2191,7 @@ const playEntity = (entityIndex, updateFullPlaylist = true, frame = -1) => {
   ensureEntityRendered(entityIndex)
   const entity = entityList.value[entityIndex]
   const wasDrawing = isDrawing.value === true
+  lastShownWhilePlaying = null
   clearCanvas()
   framesSeenOfPicture.value = 1
   playingEntityIndex.value = entityIndex
@@ -2676,10 +2681,16 @@ const onFrameUpdate = frame => {
   updateProgressBar()
   if (isShowAnnotationsWhilePlaying.value) {
     const ann = getAnnotation(currentTimeRaw.value)
-    clearCanvas()
-    if (ann) loadSingleAnnotation(ann)
-    if (isComparing.value && !isComparisonOverlay.value) {
-      loadComparisonAnnotation(currentTimeRaw.value)
+    // Repaint only when the displayed annotation changes: clearing and
+    // rebuilding fabric objects (async PSStroke deserialization) on
+    // EVERY frame tick churned constantly with the option enabled.
+    if (ann !== lastShownWhilePlaying) {
+      lastShownWhilePlaying = ann || null
+      clearCanvas()
+      if (ann) loadSingleAnnotation(ann)
+      if (isComparing.value && !isComparisonOverlay.value) {
+        loadComparisonAnnotation(currentTimeRaw.value)
+      }
     }
   }
   if (props.playlist && isPlaying.value) {
@@ -2868,6 +2879,7 @@ const onMainCanvasResized = () => {
   // objects that already have a fabric instance, so without this
   // the wrongly-scaled strokes drawn at mount-time (when the anchor
   // had no size yet) would stay on screen forever.
+  lastShownWhilePlaying = null
   clearCanvas()
   reloadAnnotations(false)
   const ann = getAnnotation(currentTimeRaw.value)
@@ -4403,6 +4415,10 @@ watch(
     }
   }
 )
+
+watch(isShowAnnotationsWhilePlaying, () => {
+  lastShownWhilePlaying = null
+})
 
 watch(framesSeenOfPicture, () => {
   if (isCurrentPreviewPicture.value) {

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -4424,6 +4424,9 @@ watch(playingEntityIndex, () => {
     })
   } else if (wavesurfer && isWaveformDisplayed.value) {
     wavesurfer.destroy()
+    // Null it like loadWaveForm does, or the next load double-destroys
+    // the dead instance inside its try and skips rebuilding the waveform.
+    wavesurfer = null
   }
   if (currentEntity.value) {
     annotations.value = currentEntity.value.preview_file_annotations || []

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -2439,7 +2439,6 @@ const onScrubEnd = () => {
 
 const onProgressChanged = (frame, updatePlaylistProgress = true) => {
   clearCanvas()
-  reloadAnnotations(false)
   if (isCurrentPreviewPicture.value) {
     framesSeenOfPicture.value = frame + 1
   } else {

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -3809,7 +3809,7 @@ const setPlaylistProgress = time => {
   const pos = playlistShotPosition.value[frame]
   if (pos) {
     const entityIndex = pos.index
-    if (entityIndex !== playingEntityIndex.value && entityIndex) {
+    if (entityIndex !== playingEntityIndex.value) {
       playEntity(entityIndex)
     }
   }

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -3981,7 +3981,7 @@ const resetPlaylistFrameData = () => {
     // An entity without preview still spans its edit length (like a slug
     // in a conform): playback holds the slot, the strip shows it in grey.
     const defaultNbFrames =
-      entity.preview_nb_frames || 2 * fps.value * frameDuration.value
+      entity.preview_nb_frames || Math.round(2 * fps.value)
     framesPerImage.value[index] = defaultNbFrames
     // Duration only counts for movie mains: a picture revision holding a
     // video sub-preview carries that video's duration, and using it here

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -2806,10 +2806,9 @@ const updateMainAnchor = () => {
           height: currentPreview.value.height
         }
       : picturePlayer.value?.getNaturalDimensions?.()
-    if (!naturalDimensions) return
+    if (!naturalDimensions?.width || !naturalDimensions?.height) return
     const naturalWidth = naturalDimensions.width
     const naturalHeight = naturalDimensions.height
-    const ratio = naturalWidth / naturalHeight
 
     let fullWidth = videoContainer.value.offsetWidth
     const fullHeight = videoContainer.value.offsetHeight
@@ -2817,33 +2816,21 @@ const updateMainAnchor = () => {
       fullWidth = Math.round(fullWidth / 2)
     }
 
-    let width = ratio ? fullHeight * ratio : fullWidth
-    let height = ratio ? Math.round(fullWidth / ratio) : fullHeight
-    let left = 0
-    let top = 0
+    // Contain fit, never upscaled: one uniform scale keeps the anchor at
+    // the image's aspect ratio in every container shape. The previous
+    // independent width/height clamps produced a wrong-aspect box when
+    // the container was narrower but taller than the image, misaligning
+    // the annotation canvas.
+    const scale = Math.min(
+      fullWidth / naturalWidth,
+      fullHeight / naturalHeight,
+      1
+    )
+    const width = Math.round(naturalWidth * scale)
+    const height = Math.round(naturalHeight * scale)
 
-    if (fullWidth > naturalWidth) {
-      left = Math.round((fullWidth - naturalWidth) / 2)
-      width = naturalWidth
-    } else if (fullWidth > width) {
-      left = Math.round((fullWidth - width) / 2)
-    } else {
-      width = fullWidth
-    }
-
-    if (fullHeight > naturalHeight) {
-      top = Math.round((fullHeight - naturalHeight) / 2)
-      height = naturalHeight
-    } else if (fullHeight > height) {
-      top = Math.round((fullHeight - height) / 2)
-    } else {
-      height = fullHeight
-      width = Math.round(height * ratio)
-      left = Math.round((fullWidth - width) / 2)
-    }
-
-    anchor.style.left = `${left}px`
-    anchor.style.top = `${top}px`
+    anchor.style.left = `${Math.round((fullWidth - width) / 2)}px`
+    anchor.style.top = `${Math.round((fullHeight - height) / 2)}px`
     anchor.style.width = `${width}px`
     anchor.style.height = `${height}px`
   }

--- a/src/components/players/players/PlaylistPlayer.vue
+++ b/src/components/players/players/PlaylistPlayer.vue
@@ -3611,11 +3611,14 @@ const onEntityDropped = info => {
   }
 }
 
+// Read the reorder payload BEFORE moving: moveSelectedEntity empties
+// entityList synchronously (restored on nextTick), so any index read
+// after the call lands on an empty array.
 const moveSelectedEntityToLeft = () => {
+  if (entityList.value.length < 2) return
   const toMoveIndex = playingEntityIndex.value
   const targetIndex = previousEntityIndex.value
   const entityToMove = currentEntity.value
-  moveSelectedEntity(entityToMove, toMoveIndex, targetIndex)
   const info = {
     before: {
       entity_id: entityList.value[targetIndex].id,
@@ -3626,14 +3629,15 @@ const moveSelectedEntityToLeft = () => {
       preview_file_id: entityList.value[toMoveIndex].preview_file_id
     }
   }
+  moveSelectedEntity(entityToMove, toMoveIndex, targetIndex)
   emit('order-change', info)
 }
 
 const moveSelectedEntityToRight = () => {
+  if (entityList.value.length < 2) return
   const toMoveIndex = playingEntityIndex.value
   const targetIndex = nextEntityIndex.value
   const entityToMove = currentEntity.value
-  moveSelectedEntity(entityToMove, toMoveIndex, targetIndex)
   const info = {
     before: {
       entity_id: entityList.value[toMoveIndex].id,
@@ -3644,6 +3648,7 @@ const moveSelectedEntityToRight = () => {
       preview_file_id: entityList.value[targetIndex].preview_file_id
     }
   }
+  moveSelectedEntity(entityToMove, toMoveIndex, targetIndex)
   emit('order-change', info)
 }
 

--- a/src/components/players/players/PlaylistedEntity.vue
+++ b/src/components/players/players/PlaylistedEntity.vue
@@ -258,6 +258,9 @@ const onDragover = event => {
 }
 
 const onDropped = event => {
+  // Cancel the drop so a foreign drag (OS file) can't trigger the
+  // browser's default open-file action over the app.
+  event.preventDefault()
   dropAreaRef.value.style.width = '15px'
   emit('entity-dropped', {
     before: {

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -1414,7 +1414,6 @@ const onRepeatClicked = () => {
 const onToggleSoundClicked = () => {
   clearFocus()
   isMuted.value = !isMuted.value
-  localPreferences.setPreference('player:muted', isMuted.value)
 }
 
 // Screen
@@ -2392,6 +2391,13 @@ watch(speed, () => {
 watch(volume, () => {
   previewViewer.value.setVolume(volume.value)
   localPreferences.setPreference('player:volume', volume.value)
+})
+
+// Persist through a watcher: ButtonSound drives isMuted via v-model and
+// never emits change-sound, so a click handler on the toggle chain never
+// runs and the preference was never written.
+watch(isMuted, () => {
+  localPreferences.setPreference('player:muted', isMuted.value)
 })
 
 // Lifecycle

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -146,7 +146,7 @@
         <task-info
           ref="task-info-player"
           class="flexrow-item task-info-column"
-          :current-frame="currentFrame"
+          :current-frame="taskInfoFrame"
           :current-parent-preview="currentPreview"
           :entity-type="entityType"
           :extendable="false"
@@ -770,6 +770,21 @@ const currentFrameLabel = computed(() => {
   const frame = Math.min(nbFrames.value, currentFrame.value)
   return formatFrame(frame + 1)
 })
+
+// TaskInfo renders the frame chip in its template: feeding it the live
+// frame re-rendered the whole comments panel dozens of times a second
+// during playback, even while hidden (v-show). Freeze the prop while
+// playing or hidden; it refreshes on pause and when the panel opens.
+const taskInfoFrame = ref(0)
+watch(
+  [currentFrame, isPlaying, isCommentsHidden],
+  () => {
+    if (!isPlaying.value && !isCommentsHidden.value) {
+      taskInfoFrame.value = currentFrame.value
+    }
+  },
+  { immediate: true }
+)
 
 const currentPreview = computed(() => {
   if (

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -470,6 +470,7 @@ import { useComparison } from '@/composables/players/comparison'
 import { useOnionSkin } from '@/composables/players/onionSkin'
 import { usePreviewShortcuts } from '@/composables/players/previewShortcuts'
 import { usePlayerTransport } from '@/composables/players/transport'
+import func from '@/lib/func'
 import { getEntityPath } from '@/lib/path'
 import { mergeAnnotationsByFrame } from '@/lib/players/annotation'
 import localPreferences from '@/lib/preferences'
@@ -2463,10 +2464,14 @@ onMounted(() => {
   // viewer's transform through the panzoom-changed sync.
   previewViewer.value?.resumeZoom()
 
-  containerResizeObserver = new ResizeObserver(() => {
+  // Debounced: a live window resize (or the fullscreen transition) fires
+  // this continuously, and each tick cleared and rebuilt the annotation
+  // objects (async PSStroke deserialization).
+  const onContainerResized = func.debounce(() => {
     resetPlayerPositions()
     if (isPicture.value || isMovie.value) loadAnnotation()
-  })
+  }, 200)
+  containerResizeObserver = new ResizeObserver(onContainerResized)
   containerResizeObserver.observe(container.value)
 
   window.addEventListener('resize', onWindowResize)

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -1131,8 +1131,9 @@ const changeMaxDuration = duration => {
 
 const getCurrentTime = () => {
   if (!isMovie.value) return 0
-  const time = roundToFrame(currentTimeRaw.value, fps.value)
-  return Number(time.toPrecision(4))
+  // 4-decimal rounding only: toPrecision(4) keeps 4 significant digits and
+  // quantized times past 100s, landing annotations on neighbouring frames.
+  return roundToFrame(currentTimeRaw.value, fps.value)
 }
 
 const getCurrentFrame = () => {
@@ -1621,9 +1622,10 @@ const onAnnotationDisplayedClicked = () => {
 const saveAnnotations = () => {
   let currentTimeVal = 0
   if (isMovie.value) {
-    currentTimeVal = currentFrame.value * frameDuration.value
-    currentTimeVal = roundToFrame(currentTimeVal, fps.value)
-    currentTimeVal = Number(currentTimeVal.toPrecision(4))
+    currentTimeVal = roundToFrame(
+      currentFrame.value * frameDuration.value,
+      fps.value
+    )
   }
   const annotation = getAnnotation(currentTimeVal)
   const newAnnotations = getNewAnnotations(

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -2285,6 +2285,20 @@ watch(taskTypeId, () => {
   setDefaultComparisonPreview()
 })
 
+// The comparison lookup map is non-reactive and was only rebuilt on
+// task-type changes: switching tasks in TaskInfo (same task type id) or
+// receiving a new revision left it resolving stale preview files, which
+// blanked the comparison viewer. Rebuild it whenever the payload changes.
+watch(
+  () => props.entityPreviewFiles,
+  () => {
+    resetPreviewFileMap()
+    if (previewToCompareId.value) {
+      previewToCompare.value = resolvePreviewToCompare(previewToCompareId.value)
+    }
+  }
+)
+
 watch(isComparing, () => {
   endAnnotationSaving()
   if (!isComparing.value) {

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -1845,20 +1845,24 @@ const getLinkedEntities = concept => {
 
 // Events
 
+// The playlist modal mounts a PlaylistPlayer above this (still mounted)
+// player: while it is open, its instance owns every shortcut.
+const isPlayerActive = () => {
+  const playlistModal = document.getElementById('temp-playlist-modal')
+  const styles = playlistModal && window.getComputedStyle(playlistModal)
+  return !styles || styles.display === 'none'
+}
+
 const { isAltHeld } = usePreviewShortcuts({
   // Escape is not wired — the browser exits fullscreen on it and the
   // useFullScreen listener picks up the resulting fullscreenchange.
+  isActive: isPlayerActive,
   onDelete: () => deleteSelection(),
   onPrevFrame: () => goPreviousFrame(),
   onNextFrame: () => goNextFrame(),
   onFirstFrame: () => goToFirstFrame(),
   onLastFrame: () => goToLastFrame(),
-  onPlayPause: () => {
-    // Don't toggle play/pause while a shared playlist modal is open.
-    const playlistModal = document.getElementById('temp-playlist-modal')
-    const styles = playlistModal && window.getComputedStyle(playlistModal)
-    if (!styles || styles.display === 'none') togglePlayPause()
-  },
+  onPlayPause: () => togglePlayPause(),
   onPrevAnnotation: () => goPreviousDrawing(),
   onNextAnnotation: () => goNextDrawing(),
   onAnnotate: () => {

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -2353,8 +2353,9 @@ watch(isTyping, () => {
     isAnnotationsDisplayed.value = true
   }
   const clickarea =
-    canvasWrapper.value.getElementsByClassName('upper-canvas')[0]
-  if (isTyping.value && clickarea) {
+    canvasWrapper.value?.getElementsByClassName('upper-canvas')[0]
+  if (!clickarea) return
+  if (isTyping.value) {
     clickarea.addEventListener('dblclick', addText)
   } else {
     clickarea.removeEventListener('dblclick', addText)

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -1771,7 +1771,9 @@ const extractVideoAnnotationSnapshots = async ({ withLabel = false } = {}) => {
       await getFileFromCanvas(canvas, snapshotFilename({ revision, frame }))
     )
   }
-  previewViewer.value.setCurrentFrame(currentFrame.value - 1)
+  // currentFrame is 0-based here (unlike PlaylistPlayer's 1-based label
+  // this restore was copied from): no -1, or the playhead steps back.
+  previewViewer.value.setCurrentFrame(currentFrame.value)
   nextTick(() => {
     clearCanvas()
   })

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -1676,7 +1676,14 @@ const loadComparisonAnnotation = time => {
   }
   let annotation = null
   if (isMovie.value) {
-    annotation = anns.find(a => a.time === time)
+    // Tolerant match like getAnnotation: callers derive `time` from raw
+    // frame math while stored times are rounded (legacy ones not even
+    // that), so strict float equality mostly missed and the comparison
+    // overlay stayed empty.
+    const target = roundToFrame(time, fps.value)
+    annotation = anns.find(
+      a => Math.abs(roundToFrame(a.time, fps.value) - target) < 0.0001
+    )
   } else if (isPicture.value) {
     annotation = anns.find(a => a.time === 0)
   }

--- a/src/components/players/players/SharedPlaylistPlayer.vue
+++ b/src/components/players/players/SharedPlaylistPlayer.vue
@@ -738,7 +738,10 @@ const onProgressPlaylistChanged = frameNumber => {
   const position = playlistShotPosition.value[frameNumber]
   if (!position) return
   const { index, start } = position
-  const localFrame = Math.round(frameNumber - start * fps.value)
+  // start carries the strip's +1 slot convention ((firstGlobalFrame + 1)
+  // / fps): compensate like the studio player, or every strip click
+  // seeks one frame early.
+  const localFrame = Math.round(frameNumber - start * fps.value) + 1
   if (index !== playingEntityIndex.value) {
     selectEntity(index)
     nextTick(() => rawPlayer.value?.setCurrentFrame(Math.max(localFrame, 0)))

--- a/src/components/players/players/SharedPlaylistPlayer.vue
+++ b/src/components/players/players/SharedPlaylistPlayer.vue
@@ -749,6 +749,12 @@ const onProgressPlaylistChanged = frameNumber => {
 
 const onPlayNext = () => {
   if (!isPlaying.value) return
+  // Repeat loops the current movie like the studio player; without this
+  // the toggle did nothing (the viewer's own trim loop is inactive here).
+  if (isRepeating.value && isMovie.value) {
+    rawPlayer.value?.playNext()
+    return
+  }
   // Step through sub-previews first, then the next entity (handles images
   // too, which MultiVideoViewer's own playNext would skip).
   advancePlaylist()

--- a/src/components/players/sides/SharedCommentsPanel.vue
+++ b/src/components/players/sides/SharedCommentsPanel.vue
@@ -131,6 +131,7 @@
           :is-replyable="false"
           :task-types="[]"
           :team="[]"
+          :url-prefix="'/api/shared/playlists/' + token"
           :revision="comment.revision || 1"
           :style="{ animationDelay: Math.min(index, 8) * 60 + 'ms' }"
           @edit-comment="onEditComment"

--- a/src/components/players/viewers/AttachmentVideoPlayer.vue
+++ b/src/components/players/viewers/AttachmentVideoPlayer.vue
@@ -127,7 +127,10 @@ const onSeek = event => {
 const toggleFullscreen = () => {
   const el = wrapperEl.value
   if (!el) return
-  if (document.fullscreenElement) {
+  // Compare against OUR element: with the player itself in fullscreen
+  // (the comments column lives inside it), a truthy-only check exited
+  // the app fullscreen instead of fullscreening the attachment.
+  if (document.fullscreenElement === el) {
     document.exitFullscreen?.()
   } else {
     el.requestFullscreen?.()

--- a/src/components/players/viewers/MultiPictureViewer.vue
+++ b/src/components/players/viewers/MultiPictureViewer.vue
@@ -16,7 +16,7 @@
       @panzoom-changed="$event => $emit('panzoom-changed', $event)"
       @panzoom-ready="() => $emit('panzoom-ready')"
       @size-changed="() => $emit('size-changed')"
-      v-for="preview in validPreviews"
+      v-for="preview in mountedPreviews"
       v-show="
         preview.id === currentPreview.id &&
         preview.position === currentPreview.position
@@ -82,6 +82,21 @@ const pictureRefs = reactive({})
 // Computed
 
 const validPreviews = computed(() => props.previews.filter(p => p?.id))
+
+// Only mount the displayed picture and its immediate neighbours: the
+// strip used to mount (and download) every picture of the playlist up
+// front, saturating the network the moment a playlist opened. The +/-1
+// window keeps prev/next navigation and continuous playback preloaded.
+const mountedPreviews = computed(() => {
+  const list = validPreviews.value
+  const index = list.findIndex(
+    p =>
+      p.id === props.currentPreview?.id &&
+      p.position === props.currentPreview?.position
+  )
+  if (index === -1) return list.slice(0, 2)
+  return list.filter((p, i) => Math.abs(i - index) <= 1)
+})
 
 const setPictureRef = (preview, el) => {
   const key = `${preview.id}-${preview.position}`

--- a/src/components/players/viewers/MultiPictureViewer.vue
+++ b/src/components/players/viewers/MultiPictureViewer.vue
@@ -12,7 +12,7 @@
       :margin-bottom="marginBottom"
       :panzoom="panzoom"
       :preview="preview"
-      @loaded="() => $emit('loaded')"
+      @loaded="onViewerLoaded(preview)"
       @panzoom-changed="$event => $emit('panzoom-changed', $event)"
       @panzoom-ready="() => $emit('panzoom-ready')"
       @size-changed="() => $emit('size-changed')"
@@ -69,7 +69,12 @@ const props = defineProps({
   }
 })
 
-defineEmits(['loaded', 'panzoom-changed', 'panzoom-ready', 'size-changed'])
+const emit = defineEmits([
+  'loaded',
+  'panzoom-changed',
+  'panzoom-ready',
+  'size-changed'
+])
 
 const container = ref(null)
 const pictureRefs = reactive({})
@@ -84,6 +89,19 @@ const setPictureRef = (preview, el) => {
     pictureRefs[key] = el
   } else {
     delete pictureRefs[key]
+  }
+}
+
+// Every PictureViewer in the strip loads eagerly (v-show): only the
+// displayed one may notify the parent, or each background image finishing
+// its download resets the live annotation canvas (wiping in-progress
+// strokes) for seconds after opening a picture-heavy playlist.
+const onViewerLoaded = preview => {
+  if (
+    preview.id === props.currentPreview?.id &&
+    preview.position === props.currentPreview?.position
+  ) {
+    emit('loaded')
   }
 }
 

--- a/src/components/players/viewers/PictureViewer.vue
+++ b/src/components/players/viewers/PictureViewer.vue
@@ -13,13 +13,19 @@
         <div v-show="isGif">
           <img ref="pictureGif" :src="pictureGifPath" />
         </div>
+        <!-- Bind only the displayed variant's src: with both bound, every
+             viewer downloaded the preview AND the original at once. -->
         <div v-show="!isGif">
           <img
             ref="pictureBig"
-            :src="pictureDlPath"
+            :src="fullScreen || big ? pictureDlPath : null"
             v-show="fullScreen || big"
           />
-          <img ref="picture" :src="picturePath" v-show="!fullScreen && !big" />
+          <img
+            ref="picture"
+            :src="!fullScreen && !big ? picturePath : null"
+            v-show="!fullScreen && !big"
+          />
         </div>
       </div>
       <spinner v-if="isLoading" />

--- a/src/components/players/viewers/PictureViewer.vue
+++ b/src/components/players/viewers/PictureViewer.vue
@@ -134,18 +134,12 @@ const isVisibleImageReady = () => {
 }
 
 const getNaturalDimensions = () => {
-  let pic = { naturalWidth: 0, naturalHeight: 0 }
-  if (!props.fullScreen && picture.value.naturalWidth && !isGif.value) {
-    pic = picture.value
-  } else if (
-    props.fullScreen &&
-    pictureBig.value.naturalWidth &&
-    !isGif.value
-  ) {
-    pic = pictureBig.value
-  } else if (pictureGif.value.naturalWidth && isGif.value) {
-    pic = pictureGif.value
-  }
+  // Measure the variant actually displayed: `big` consumers show the
+  // original through pictureBig, and measuring the hidden preview-sized
+  // sibling returned downscaled dimensions (low-resolution annotation
+  // snapshots, display capped at the small variant's width).
+  const pic = visibleImage.value
+  if (!pic?.naturalWidth) return { height: 0, width: 0 }
   return { height: pic.naturalHeight, width: pic.naturalWidth }
 }
 
@@ -193,11 +187,8 @@ const resetPicture = () => {
   }
 
   if (isPicture.value) {
-    const pictureElement = isGif.value
-      ? pictureGif.value
-      : props.fullScreen
-        ? pictureBig.value
-        : picture.value
+    const pictureElement = visibleImage.value
+    if (!pictureElement) return
     const picturePosition = pictureElement.getBoundingClientRect()
     const containerPosition = container.value.getBoundingClientRect()
     const top = picturePosition.top - containerPosition.top
@@ -264,15 +255,13 @@ const setPicturePath = () => {
 
 const endLoading = () => {
   // Refs can be null while the component is being torn down / rebuilt
-  // by a parent v-for (previews change). The optional chain keeps the
-  // listener safe in that window instead of throwing and aborting the
-  // post-mount setup (which is what was leaving panzoom paused).
-  if (
-    props.fullScreen &&
-    (pictureBig.value?.complete || pictureGif.value?.complete)
-  ) {
-    isLoading.value = false
-  } else if (!props.fullScreen && picture.value?.complete) {
+  // by a parent v-for (previews change) — isVisibleImageReady tolerates
+  // that window. Clearing the spinner keys off the image actually
+  // displayed: the fullScreen-only branches used to clear it when the
+  // hidden sibling finished (blank viewer in big mode on slow links),
+  // and pictureGif.complete is true for every non-gif preview (an <img>
+  // without src reports complete).
+  if (isVisibleImageReady()) {
     isLoading.value = false
   }
   emit('loaded')

--- a/src/components/players/viewers/PreviewViewer.vue
+++ b/src/components/players/viewers/PreviewViewer.vue
@@ -305,7 +305,10 @@ const play = () => {
 const pause = () => {
   isPlaying = false
   if (isMovie.value) videoViewer.value.pause()
-  if (isSound.value) soundViewer.value.pause()
+  // Not gated on isSound: when a preview switch triggers this pause, the
+  // computeds already describe the NEW preview, and a still-playing sound
+  // (kept mounted by v-show) would otherwise never be stopped.
+  soundViewer.value?.pause()
 }
 
 const playModelAnimation = animationName => {

--- a/src/components/players/viewers/PreviewViewer.vue
+++ b/src/components/players/viewers/PreviewViewer.vue
@@ -311,12 +311,15 @@ const pause = () => {
   soundViewer.value?.pause()
 }
 
+// The object viewer is only mounted for ready previews: play/pause can
+// arrive while a glb is still processing (or broken), where the parent's
+// extension-based is3DModel is true but the ref is null.
 const playModelAnimation = animationName => {
-  objectViewer.value.play(animationName)
+  objectViewer.value?.play(animationName)
 }
 
 const pauseModelAnimation = () => {
-  objectViewer.value.pause()
+  objectViewer.value?.pause()
 }
 
 const goPreviousFrame = () => {
@@ -336,7 +339,7 @@ const onPlayPauseClicked = () => {
 }
 
 const get3DAnimations = () => {
-  return objectViewer.value.getAnimations()
+  return objectViewer.value?.getAnimations() || []
 }
 
 const getNaturalDimensions = () => {

--- a/src/components/players/viewers/SoundViewer.vue
+++ b/src/components/players/viewers/SoundViewer.vue
@@ -90,6 +90,10 @@ watch(
     if (props.previewUrl && props.previewUrl.length > 0) {
       isLoading.value = true
       wavesurfer.load(props.previewUrl).catch(onLoadError)
+    } else {
+      // The parent blanks the URL when another preview kind takes over:
+      // stop playback instead of letting the loaded audio run on.
+      wavesurfer.pause()
     }
   }
 )

--- a/src/components/players/viewers/VideoViewer.vue
+++ b/src/components/players/viewers/VideoViewer.vue
@@ -354,7 +354,6 @@ const getFrameFromPlayer = () => {
         : 0
   if (raw === 0) return 0
   let frame = Math.ceil(raw / frameDuration.value) + 1
-  frame = Number(frame.toPrecision(4))
   frame = Math.min(frame, props.nbFrames)
   return frame
 }

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -142,25 +142,25 @@
               <attachment-image
                 v-for="attachment in pictureAttachments"
                 :key="attachment.id"
-                :src="getDownloadAttachmentPath(attachment)"
+                :src="attachmentPath(attachment)"
                 :name="attachment.name"
               />
               <attachment-audio-player
                 v-for="attachment in audioAttachments"
                 :key="attachment.id"
-                :src="getDownloadAttachmentPath(attachment)"
+                :src="attachmentPath(attachment)"
                 :name="attachment.name"
-                :download-href="getDownloadAttachmentPath(attachment)"
+                :download-href="attachmentPath(attachment)"
               />
               <attachment-video-player
                 v-for="attachment in videoAttachments"
                 :key="attachment.id"
-                :src="getDownloadAttachmentPath(attachment)"
+                :src="attachmentPath(attachment)"
                 :name="attachment.name"
-                :download-href="getDownloadAttachmentPath(attachment)"
+                :download-href="attachmentPath(attachment)"
               />
               <a
-                :href="getDownloadAttachmentPath(attachment)"
+                :href="attachmentPath(attachment)"
                 :key="attachment.id"
                 :title="attachment.name"
                 class="attachment-file-link"
@@ -234,27 +234,27 @@
                     v-for="attachment in replyAttachmentMap.get(replyComment.id)
                       ?.pictures"
                     :key="attachment.id"
-                    :src="getDownloadAttachmentPath(attachment)"
+                    :src="attachmentPath(attachment)"
                     :name="attachment.name"
                   />
                   <attachment-audio-player
                     v-for="attachment in replyAttachmentMap.get(replyComment.id)
                       ?.audio"
                     :key="attachment.id"
-                    :src="getDownloadAttachmentPath(attachment)"
+                    :src="attachmentPath(attachment)"
                     :name="attachment.name"
-                    :download-href="getDownloadAttachmentPath(attachment)"
+                    :download-href="attachmentPath(attachment)"
                   />
                   <attachment-video-player
                     v-for="attachment in replyAttachmentMap.get(replyComment.id)
                       ?.video"
                     :key="attachment.id"
-                    :src="getDownloadAttachmentPath(attachment)"
+                    :src="attachmentPath(attachment)"
                     :name="attachment.name"
-                    :download-href="getDownloadAttachmentPath(attachment)"
+                    :download-href="attachmentPath(attachment)"
                   />
                   <a
-                    :href="getDownloadAttachmentPath(attachment)"
+                    :href="attachmentPath(attachment)"
                     :key="attachment.id"
                     :title="attachment.name"
                     class="attachment-file-link"
@@ -608,6 +608,10 @@ const props = defineProps({
     type: Object,
     default: () => {}
   },
+  urlPrefix: {
+    type: String,
+    default: ''
+  },
   frame: {
     type: Number,
     default: 0
@@ -766,6 +770,13 @@ const commentAttachments = computed(() => {
     attachment => !attachment.reply_id
   )
 })
+
+// Shared playlist guests have no JWT: the regular attachment route 401s
+// for them. When a urlPrefix is set, use its anonymous token route.
+const attachmentPath = attachment =>
+  props.urlPrefix
+    ? `${props.urlPrefix}/attachment-files/${attachment.id}/file/${attachment.name}`
+    : getDownloadAttachmentPath(attachment)
 
 const pictureAttachments = computed(() => {
   return commentAttachments.value

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -762,9 +762,10 @@ export const useAnnotation = ({
     }
     if (isLaserModeOn.value) {
       // Laser strokes fade out locally and are broadcast as ephemeral
-      // events; they are intentionally not added to the additions stack.
+      // events (flagged so receivers fade them too); they are
+      // intentionally not added to the additions stack.
       fadeObject(o)
-      postAnnotationAddition(getCurrentTime(), o.serialize())
+      postAnnotationAddition(getCurrentTime(), o.serialize(), { laser: true })
     } else {
       addToAdditions(o)
       stackAddAction(obj)

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -32,6 +32,7 @@ import {
   reviveObjectEraser
 } from '@/lib/players/eraserbrush'
 import clipboard from '@/lib/clipboard'
+import func from '@/lib/func'
 import { formatFullDate } from '@/lib/time'
 import localPreferences from '@/lib/preferences'
 
@@ -860,6 +861,16 @@ export const useAnnotation = ({
     }
   }
 
+  // text:changed fires per keystroke and onObjectModified serializes the
+  // whole canvas and dispatches the store each time (plus one socket emit
+  // per keystroke in review rooms): batch it trailing-edge. The final
+  // state is never lost — exiting text editing fires object:modified
+  // directly. The canvas guard drops a pending call whose object was
+  // cleared away (preview or frame switch) while the debounce ran.
+  const onTextChangedDebounced = func.debounce(event => {
+    if (event.target?.canvas === fabricCanvas.value) onObjectModified(event)
+  }, 400)
+
   const onWindowsClosed = event => {
     if (notSaved.value) {
       const confirmationMessage = 'Your annotations are not saved yet.'
@@ -1081,7 +1092,7 @@ export const useAnnotation = ({
     fabricCanvas.value.off('mouse:up', onCanvasReleasedCb)
     fabricCanvas.value.on('object:moved', onObjectModified)
     fabricCanvas.value.on('object:modified', onObjectModified)
-    fabricCanvas.value.on('text:changed', onObjectModified)
+    fabricCanvas.value.on('text:changed', onTextChangedDebounced)
     fabricCanvas.value.on('object:added', onObjectAdded)
     fabricCanvas.value.on('erasing:end', onErasingEnd)
     fabricCanvas.value.on('mouse:down', initializeMouseDrawing)

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -465,6 +465,40 @@ export const useAnnotation = ({
 
   // Annotations
 
+  // Serialize a selection child with its ABSOLUTE transform: serialize()
+  // reads the group-relative state, and the previous manual compensations
+  // wrote live-canvas pixels over the normalized result (wrong reference
+  // frame whenever the canvas differs from the authored size) while
+  // ignoring the group's scale and rotation entirely.
+  const GROUP_TRANSFORM_KEYS = [
+    'left',
+    'top',
+    'angle',
+    'scaleX',
+    'scaleY',
+    'skewX',
+    'skewY',
+    'flipX',
+    'flipY'
+  ]
+
+  const serializeAbsolute = obj => {
+    const group = obj.group
+    if (!group) return obj.serialize()
+    const saved = {}
+    GROUP_TRANSFORM_KEYS.forEach(key => {
+      saved[key] = obj[key]
+    })
+    const matrix = obj.calcTransformMatrix()
+    obj.group = undefined
+    util.applyTransformToObject(obj, matrix)
+    const result = obj.serialize()
+    obj.group = group
+    obj.set(saved)
+    obj.setCoords()
+    return result
+  }
+
   const getNewAnnotations = (currentTime, currentFrame, annotation) => {
     fabricCanvas.value.getObjects().forEach(obj => {
       setObjectData(obj)
@@ -487,13 +521,8 @@ export const useAnnotation = ({
 
     if (annotation) {
       const canvasObjects = fabricCanvas.value._objects.map(obj => {
-        const result = obj.serialize()
-        if (obj.group) {
-          const group = obj.group
-          result.left = group.left + Math.round(group.width / 2) + obj.left
-          result.top = group.top + Math.round(group.height / 2) + obj.top
-          result.group = null
-        }
+        const result = serializeAbsolute(obj)
+        if (obj.group) result.group = null
         return result
       })
       // Fast navigation can run a save while this frame's previously-saved
@@ -815,20 +844,9 @@ export const useAnnotation = ({
     } else {
       const group = movedObject
       group._objects.forEach(groupObj => {
-        const canvasObj = getObjectById(groupObj.id)
+        const canvasObj = getObjectById(groupObj.id) ?? groupObj
         setObjectData(canvasObj)
-        const targetObj = canvasObj.serialize()
-        const point = new Point(groupObj.left, groupObj.top)
-        const transformedPoint = util.transformPoint(
-          point,
-          group.calcTransformMatrix()
-        )
-        targetObj.left = transformedPoint.x
-        targetObj.top = transformedPoint.y
-        targetObj.angle += group.angle
-        targetObj.scaleX *= group.scaleX
-        targetObj.scaleY *= group.scaleY
-        addToUpdatesSerializedObject(targetObj)
+        addToUpdatesSerializedObject(serializeAbsolute(canvasObj))
       })
       saveAnnotationsCb()
     }

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -335,6 +335,7 @@ export const useAnnotation = ({
         time: getCurrentTime()
       })
     }
+    if (activeObject) clearUndoneOnUserAction()
     saveAnnotationsCb()
   }
 
@@ -798,6 +799,7 @@ export const useAnnotation = ({
     } else {
       addToAdditions(o)
       stackAddAction(obj)
+      clearUndoneOnUserAction()
     }
   }
 
@@ -873,6 +875,14 @@ export const useAnnotation = ({
   const isStaleAction = action =>
     action?.time !== undefined && action.time !== getCurrentTime()
 
+  // Any NEW user action invalidates the redo stack (a kept one would
+  // replay stale history on top of the new state) — but not the re-adds
+  // and re-deletes performed by undo/redo themselves.
+  let replayingHistory = false
+  const clearUndoneOnUserAction = () => {
+    if (!replayingHistory) clearUndoneStack()
+  }
+
   // After a canvas reload (e.g. Esc-exit fullscreen) the stack entry
   // holds a stale fabric.Object that's no longer on the live canvas;
   // look it up by id. Groups (_objects) aren't on the canvas as a
@@ -945,31 +955,36 @@ export const useAnnotation = ({
       resetUndoStacks()
       return
     }
-    if (lastAction.type === 'erase') {
+    replayingHistory = true
+    try {
+      if (lastAction.type === 'erase') {
+        const action = doneActionStack.pop()
+        undoEraseAction(action)
+        undoneActionStack.push(action)
+        return
+      }
       const action = doneActionStack.pop()
-      undoEraseAction(action)
+      if (!action?.obj) return
+      const obj = resolveActionObject(action)
+      // Snapshot length so the side-effect pushes addObject / deleteObject
+      // make (object:added → stackAddAction for re-adds, per-child remove
+      // for groups) are dropped before we move the action to the undone
+      // stack — otherwise undo grows the done stack instead of shrinking it.
+      const stackLengthBefore = doneActionStack.length
+      if (action.type === 'add') {
+        deleteObject(obj)
+        removeFromAdditions(obj)
+      } else if (action.type === 'remove') {
+        // addObject's 'object:added' already fires addToAdditions; no
+        // explicit call needed (it would double-record the addition).
+        addObject(obj)
+        removeFromDeletions(obj)
+      }
+      doneActionStack.length = stackLengthBefore
       undoneActionStack.push(action)
-      return
+    } finally {
+      replayingHistory = false
     }
-    const action = doneActionStack.pop()
-    if (!action?.obj) return
-    const obj = resolveActionObject(action)
-    // Snapshot length so the side-effect pushes addObject / deleteObject
-    // make (object:added → stackAddAction for re-adds, per-child remove
-    // for groups) are dropped before we move the action to the undone
-    // stack — otherwise undo grows the done stack instead of shrinking it.
-    const stackLengthBefore = doneActionStack.length
-    if (action.type === 'add') {
-      deleteObject(obj)
-      removeFromAdditions(obj)
-    } else if (action.type === 'remove') {
-      // addObject's 'object:added' already fires addToAdditions; no
-      // explicit call needed (it would double-record the addition).
-      addObject(obj)
-      removeFromDeletions(obj)
-    }
-    doneActionStack.length = stackLengthBefore
-    undoneActionStack.push(action)
   }
 
   const redoLastAction = () => {
@@ -979,23 +994,28 @@ export const useAnnotation = ({
       resetUndoStacks()
       return
     }
-    if (lastUndone.type === 'erase') {
+    replayingHistory = true
+    try {
+      if (lastUndone.type === 'erase') {
+        const action = undoneActionStack.pop()
+        redoEraseAction(action)
+        doneActionStack.push(action)
+        return
+      }
       const action = undoneActionStack.pop()
-      redoEraseAction(action)
+      if (!action?.obj) return
+      const obj = resolveActionObject(action)
+      const stackLengthBefore = doneActionStack.length
+      if (action.type === 'add') {
+        addObject(obj)
+      } else if (action.type === 'remove') {
+        deleteObject(obj)
+      }
+      doneActionStack.length = stackLengthBefore
       doneActionStack.push(action)
-      return
+    } finally {
+      replayingHistory = false
     }
-    const action = undoneActionStack.pop()
-    if (!action?.obj) return
-    const obj = resolveActionObject(action)
-    const stackLengthBefore = doneActionStack.length
-    if (action.type === 'add') {
-      addObject(obj)
-    } else if (action.type === 'remove') {
-      deleteObject(obj)
-    }
-    doneActionStack.length = stackLengthBefore
-    doneActionStack.push(action)
   }
 
   const clearUndoneStack = () => {
@@ -1101,6 +1121,7 @@ export const useAnnotation = ({
         })
         addToAdditions(shape)
         stackAddAction({ target: shape })
+        clearUndoneOnUserAction()
         // Push the shape into annotations.value (and trigger the
         // backend save). The pencil flow gets this from `endDrawing`
         // via the canvas's mouse:up handler, but `endDrawing` only

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -245,7 +245,11 @@ export const useAnnotation = ({
       popOwnAddEntry(activeObject)
     }
     if (persist) {
-      doneActionStack.push({ type: 'add', obj: activeObject })
+      doneActionStack.push({
+        type: 'add',
+        obj: activeObject,
+        time: getCurrentTime()
+      })
       saveAnnotationsCb()
     }
   }
@@ -320,12 +324,16 @@ export const useAnnotation = ({
       children.forEach(obj => {
         fabricCanvas.value.remove(obj)
         addToDeletions(obj)
-        doneActionStack.push({ type: 'remove', obj })
+        doneActionStack.push({ type: 'remove', obj, time: getCurrentTime() })
       })
     } else if (activeObject) {
       fabricCanvas.value.remove(activeObject)
       addToDeletions(activeObject)
-      doneActionStack.push({ type: 'remove', obj: activeObject })
+      doneActionStack.push({
+        type: 'remove',
+        obj: activeObject,
+        time: getCurrentTime()
+      })
     }
     saveAnnotationsCb()
   }
@@ -790,7 +798,8 @@ export const useAnnotation = ({
       type: 'erase',
       targets: affected,
       removedTargets,
-      path
+      path,
+      time: getCurrentTime()
     })
     clearUndoneStack()
     saveAnnotationsCb()
@@ -835,8 +844,15 @@ export const useAnnotation = ({
   // Undo / Redo
 
   const stackAddAction = ({ target }) => {
-    doneActionStack.push({ type: 'add', obj: target })
+    doneActionStack.push({ type: 'add', obj: target, time: getCurrentTime() })
   }
+
+  // History entries belong to the frame they were made on: replayed after
+  // a seek, they would graft objects onto the wrong frame's annotation
+  // entry (deltas are keyed on the CURRENT time). Stale history is
+  // dropped instead of replayed.
+  const isStaleAction = action =>
+    action?.time !== undefined && action.time !== getCurrentTime()
 
   // After a canvas reload (e.g. Esc-exit fullscreen) the stack entry
   // holds a stale fabric.Object that's no longer on the live canvas;
@@ -904,7 +920,13 @@ export const useAnnotation = ({
   }
 
   const undoLastAction = () => {
-    if (doneActionStack[doneActionStack.length - 1]?.type === 'erase') {
+    const lastAction = doneActionStack[doneActionStack.length - 1]
+    if (!lastAction) return
+    if (isStaleAction(lastAction)) {
+      resetUndoStacks()
+      return
+    }
+    if (lastAction.type === 'erase') {
       const action = doneActionStack.pop()
       undoEraseAction(action)
       undoneActionStack.push(action)
@@ -932,7 +954,13 @@ export const useAnnotation = ({
   }
 
   const redoLastAction = () => {
-    if (undoneActionStack[undoneActionStack.length - 1]?.type === 'erase') {
+    const lastUndone = undoneActionStack[undoneActionStack.length - 1]
+    if (!lastUndone) return
+    if (isStaleAction(lastUndone)) {
+      resetUndoStacks()
+      return
+    }
+    if (lastUndone.type === 'erase') {
       const action = undoneActionStack.pop()
       redoEraseAction(action)
       doneActionStack.push(action)

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -226,14 +226,23 @@ export const useAnnotation = ({
     return object
   }
 
+  // add() fires object:added whose handler stacks the action already;
+  // drop that entry (and only that one — the laser branch stacks
+  // nothing) so addObject's explicit push stays the single one.
+  const popOwnAddEntry = obj => {
+    const top = doneActionStack[doneActionStack.length - 1]
+    if (top?.type === 'add' && top.obj === obj) doneActionStack.pop()
+  }
+
   const addObject = (activeObject, persist = true) => {
     if (activeObject._objects) {
       activeObject._objects.forEach(obj => {
         fabricCanvas.value.add(obj)
-        doneActionStack.pop()
+        popOwnAddEntry(obj)
       })
     } else {
       fabricCanvas.value.add(activeObject)
+      popOwnAddEntry(activeObject)
     }
     if (persist) {
       doneActionStack.push({ type: 'add', obj: activeObject })
@@ -1264,29 +1273,40 @@ export const useAnnotation = ({
       })
     } else {
       clipboard.copyAnnotations({
-        mainObject: Object.create(activeObject),
+        mainObject: activeObject,
         subObjects: []
       })
     }
     return activeObject
   }
 
-  const pasteAnnotations = () => {
+  // Pasting must produce REAL copies. Re-adding the source instances (or
+  // an Object.create wrapper inheriting the original's id) made every
+  // later move post an update under the ORIGINAL's id (server and remote
+  // viewers moved the original, the local duplicate vanished on reload)
+  // and stacked duplicate entries of one instance in fabric's _objects.
+  const PASTE_OFFSET = 10
+
+  const pasteAnnotations = async () => {
     if (!fabricCanvas.value) return
+    // Restores absolute coordinates on selection children before cloning.
     fabricCanvas.value.discardActiveObject()
     const { mainObject, subObjects } = clipboard.pasteAnnotations()
-    if (subObjects?.length > 0) {
-      subObjects.forEach(obj => {
-        obj = applyGroupChanges(mainObject, obj)
-        obj.group = null
-        addObject(obj)
-      })
-      fabricCanvas.value.requestRenderAll()
-    } else if (mainObject) {
-      addObject(mainObject)
-      fabricCanvas.value.setActiveObject(mainObject)
-      fabricCanvas.value.requestRenderAll()
+    const sources =
+      subObjects?.length > 0 ? subObjects : mainObject ? [mainObject] : []
+    let lastClone = null
+    for (const source of sources) {
+      const clone = await source.clone()
+      clone.set('id', uuidv4())
+      clone.set('left', clone.left + PASTE_OFFSET)
+      clone.set('top', clone.top + PASTE_OFFSET)
+      addObject(clone)
+      lastClone = clone
     }
+    if (lastClone && sources.length === 1) {
+      fabricCanvas.value.setActiveObject(lastClone)
+    }
+    fabricCanvas.value.requestRenderAll()
   }
 
   const applyGroupChanges = (group, obj) => {

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -602,10 +602,16 @@ export const useAnnotation = ({
     // Adding PSStrokes / shapes is async, so load sequentially and bail if a
     // clear (or newer load) superseded us — otherwise late adds repopulate a
     // canvas that was just cleared, leaving an incomplete/garbled overlay.
+    // Like the main-canvas path, an object whose async build was already in
+    // flight when the clear hit is removed right after it lands.
     const token = comparisonLoadToken
     for (const obj of annotation.drawing.objects) {
       if (token !== comparisonLoadToken) return
-      await addObjectToCanvas(annotation, obj, canvas)
+      const built = await addObjectToCanvas(annotation, obj, canvas)
+      if (token !== comparisonLoadToken) {
+        if (built) canvas.remove(built)
+        return
+      }
     }
   }
 
@@ -1301,10 +1307,17 @@ export const useAnnotation = ({
 
   // Add one ghost annotation's objects at the given opacity. Sequential
   // because object creation is async and addObjectToCanvas mutates shared
-  // state (so it can't run in parallel).
-  const renderOnionGhost = async (canvas, { annotation, opacity }) => {
+  // state (so it can't run in parallel). Token-checked around every await
+  // so a clear or a fresher load mid-ghost can't leave a partial ghost
+  // painted on the cleared canvas.
+  const renderOnionGhost = async (canvas, { annotation, opacity }, token) => {
     for (const obj of annotation.drawing.objects) {
+      if (token !== onionLoadToken) return
       const built = await addObjectToCanvas(annotation, obj, canvas)
+      if (token !== onionLoadToken) {
+        if (built) canvas.remove(built)
+        return
+      }
       built?.set('opacity', opacity)
     }
   }
@@ -1321,7 +1334,7 @@ export const useAnnotation = ({
     canvas.clear()
     for (const ghost of ghosts) {
       if (token !== onionLoadToken) return
-      await renderOnionGhost(canvas, ghost)
+      await renderOnionGhost(canvas, ghost, token)
     }
     if (token === onionLoadToken && isFabricReady(canvas)) {
       canvas.requestRenderAll()

--- a/src/composables/players/annotationBroadcast.js
+++ b/src/composables/players/annotationBroadcast.js
@@ -29,7 +29,7 @@ import { isValidRoomId, PREVIEW_ROOM_EVENTS } from '@/lib/players/events'
  * @param {Object} options.socket - the socket.io client instance.
  */
 export const useAnnotationBroadcast = ({ room, userId, socket }) => {
-  const emitAnnotationEvent = (eventName, time, serializedObj) => {
+  const emitAnnotationEvent = (eventName, time, serializedObj, extra = {}) => {
     const currentRoom = unref(room)
     if (!isValidRoomId(currentRoom)) return
     socket.emit(eventName, {
@@ -38,14 +38,15 @@ export const useAnnotationBroadcast = ({ room, userId, socket }) => {
         local_id: currentRoom.localId,
         user_id: unref(userId),
         time,
-        obj: serializedObj
+        obj: serializedObj,
+        ...extra
       }
     })
   }
 
   return {
-    postAnnotationAddition: (time, obj) =>
-      emitAnnotationEvent(PREVIEW_ROOM_EVENTS.addAnnotation, time, obj),
+    postAnnotationAddition: (time, obj, extra) =>
+      emitAnnotationEvent(PREVIEW_ROOM_EVENTS.addAnnotation, time, obj, extra),
     postAnnotationDeletion: (time, obj) =>
       emitAnnotationEvent(PREVIEW_ROOM_EVENTS.removeAnnotation, time, obj),
     postAnnotationUpdate: (time, obj) =>

--- a/src/composables/players/annotationBroadcast.js
+++ b/src/composables/players/annotationBroadcast.js
@@ -49,6 +49,6 @@ export const useAnnotationBroadcast = ({ room, userId, socket }) => {
     postAnnotationDeletion: (time, obj) =>
       emitAnnotationEvent(PREVIEW_ROOM_EVENTS.removeAnnotation, time, obj),
     postAnnotationUpdate: (time, obj) =>
-      emitAnnotationEvent('preview-update-annotation', time, obj)
+      emitAnnotationEvent(PREVIEW_ROOM_EVENTS.updateAnnotation, time, obj)
   }
 }

--- a/src/composables/players/comparison.js
+++ b/src/composables/players/comparison.js
@@ -180,6 +180,12 @@ export const useComparison = ({
   // comparison viewer mount and lay out before opacity kicks in.
   const toggleFullOverlay = async () => {
     if (!isComparing.value) {
+      // Alt+O can fire before any comparison target was picked: default
+      // the task type and revision like the compare button does, or the
+      // overlay activates with nothing to show (the playlist player then
+      // fades its main viewer over an empty pane).
+      if (!taskTypeId.value) setDefaultComparisonTaskType()
+      else if (!previewToCompareId.value) setDefaultComparisonPreview()
       isComparing.value = true
       await nextTick()
       await nextTick()

--- a/src/composables/players/playlistComparison.js
+++ b/src/composables/players/playlistComparison.js
@@ -182,21 +182,22 @@ export const usePlaylistComparison = ({
     revisionToCompare.value = null
   }
 
-  // Playlist's overlayOpacity is inverted at the extremes vs. the generic
-  // one in useComparison: in PlaylistPlayer the value is applied to the
-  // main player (0% overlay = main fully visible, 100% = main hidden),
-  // whereas useComparison's table is sized for the comparison overlay.
+  // Playlist's overlayOpacity is inverted vs. the generic one in
+  // useComparison: in PlaylistPlayer the value is applied to the MAIN
+  // player (painted on top), so compared-clip visibility is 1 - opacity.
+  // Every step must be inverted, not only the extremes, or "Overlay 25%"
+  // shows more of the compared clip than "Overlay 75%".
   const overlayOpacity = computed(() => {
     if (!base.isComparing.value || !base.isComparisonOverlay.value) return 1
     switch (base.comparisonMode.value) {
       case 'overlay0':
         return 1
       case 'overlay25':
-        return 0.25
+        return 0.75
       case 'overlay50':
         return 0.5
       case 'overlay75':
-        return 0.75
+        return 0.25
       case 'overlay100':
         return 0
       default:

--- a/src/composables/players/previewShortcuts.js
+++ b/src/composables/players/previewShortcuts.js
@@ -196,14 +196,22 @@ export const usePreviewShortcuts = handlers => {
     }
   }
 
+  // Alt+Tab away swallows the keyup: without this reset the overlay
+  // stays pointer-transparent after coming back until Alt is tapped.
+  const onWindowBlur = () => {
+    isAltHeld.value = false
+  }
+
   onMounted(() => {
     window.addEventListener('keydown', onKeyDown, false)
     window.addEventListener('keyup', onKeyUp, false)
+    window.addEventListener('blur', onWindowBlur)
   })
 
   onBeforeUnmount(() => {
     window.removeEventListener('keydown', onKeyDown)
     window.removeEventListener('keyup', onKeyUp)
+    window.removeEventListener('blur', onWindowBlur)
   })
 
   return { isAltHeld }

--- a/src/composables/players/previewShortcuts.js
+++ b/src/composables/players/previewShortcuts.js
@@ -57,6 +57,9 @@ export const isAltLetter = (event, code, key) => {
 
 /**
  * @param {Object} handlers
+ * @param {Function} [handlers.isActive] - return false to ignore shortcuts
+ *   while another player owns them (two players can be mounted at once:
+ *   the playlist modal above a task page's preview player)
  * @param {Function} [handlers.onDelete]
  * @param {Function} [handlers.onPrevFrame]
  * @param {Function} [handlers.onNextFrame]
@@ -85,6 +88,9 @@ export const usePreviewShortcuts = handlers => {
   const isAltHeld = ref(false)
 
   const onKeyDown = event => {
+    // Both players register on window; without this, Ctrl+Z or d/e on
+    // the visible player also mutated the hidden one's canvas.
+    if (handlers.isActive && !handlers.isActive()) return
     if (event.repeat && !REPEATABLE_KEYS.includes(event.key)) return
     // Alt+P plays/pauses even when an <input> / <textarea> has focus, so
     // users can pause / resume while typing a comment without leaving the

--- a/src/composables/players/previewShortcuts.js
+++ b/src/composables/players/previewShortcuts.js
@@ -164,12 +164,18 @@ export const usePreviewShortcuts = handlers => {
         handlers.onNextAnnotation?.()
         break
       case 'd':
-        pauseEvent(event)
-        handlers.onAnnotate?.()
+        // Bare-key tool toggles: leave Ctrl+D (bookmark) / Ctrl+E and
+        // the Alt combos to the browser and other handlers.
+        if (!alt && !mod) {
+          pauseEvent(event)
+          handlers.onAnnotate?.()
+        }
         break
       case 'e':
-        pauseEvent(event)
-        handlers.onErase?.()
+        if (!alt && !mod) {
+          pauseEvent(event)
+          handlers.onErase?.()
+        }
         break
       case 'z':
         if (mod) handlers.onUndo?.()

--- a/src/composables/players/sharedAnnotation.js
+++ b/src/composables/players/sharedAnnotation.js
@@ -184,6 +184,14 @@ export const useSharedAnnotationCanvas = () => {
     additionsRef.value = []
   }
 
+  // Re-adopt unsaved additions captured before a reset (resize, frame
+  // step): the serialized entries are canvas-size independent, only the
+  // live object list needs the rebuilt instances so undo keeps working.
+  const restoreUnsaved = (entries, objects) => {
+    additionsRef.value = entries
+    localStack.value = objects
+  }
+
   const dispose = () => {
     if (fabricCanvas && onPathCreated) {
       fabricCanvas.off('path:created', onPathCreated)
@@ -213,6 +221,7 @@ export const useSharedAnnotationCanvas = () => {
     pencilColor,
     pencilWidth,
     reset,
+    restoreUnsaved,
     setAnnotationDimensions,
     setCanvasSize,
     setColor,

--- a/src/composables/previewRoom.js
+++ b/src/composables/previewRoom.js
@@ -607,7 +607,7 @@ export const usePreviewRoom = options => {
     const r = unref(room)
     if (!isValidRoomId(r) || !joinedRoom.value) return
     if (r.localId === eventData.data?.local_id) return
-    const annotation = getAnnotation(eventData.time)
+    const annotation = getAnnotation(eventData.data.time)
     const obj = eventData.data.obj
     if (getObjectById(obj.id)) return
     if (unref(isLaserModeOn)) {
@@ -633,7 +633,7 @@ export const usePreviewRoom = options => {
     const r = unref(room)
     if (!isValidRoomId(r) || !joinedRoom.value) return
     if (r.localId === eventData.data?.local_id) return
-    const annotation = getAnnotation(eventData.time)
+    const annotation = getAnnotation(eventData.data.time)
     const obj = eventData.data.obj
     updateObjectInCanvas(annotation, obj)
   }
@@ -647,7 +647,7 @@ export const usePreviewRoom = options => {
     [PREVIEW_ROOM_EVENTS.comparisonPanzoomChanged, onComparisonPanzoomChanged],
     [PREVIEW_ROOM_EVENTS.addAnnotation, onAddAnnotation],
     [PREVIEW_ROOM_EVENTS.removeAnnotation, onRemoveAnnotation],
-    ['preview-update-annotation', onUpdateAnnotation]
+    [PREVIEW_ROOM_EVENTS.updateAnnotation, onUpdateAnnotation]
   ]
 
   onMounted(() => {

--- a/src/composables/previewRoom.js
+++ b/src/composables/previewRoom.js
@@ -610,7 +610,10 @@ export const usePreviewRoom = options => {
     const annotation = getAnnotation(eventData.data.time)
     const obj = eventData.data.obj
     if (getObjectById(obj.id)) return
-    if (unref(isLaserModeOn)) {
+    // Fade on the SENDER's laser flag: keying off the receiver's own
+    // toggle made presenter laser gestures permanent on every other
+    // screen, and faded real notes for a laser-holding viewer.
+    if (eventData.data.laser) {
       const result = addObjectToCanvas(annotation, obj)
       if (result && typeof result.then === 'function') {
         result.then(o => fadeObject(o))

--- a/src/lib/players/events.js
+++ b/src/lib/players/events.js
@@ -9,6 +9,7 @@ export const PREVIEW_ROOM_EVENTS = {
   roomUpdated: 'preview-room:room-updated',
   roomPeopleUpdated: 'preview-room:room-people-updated',
   addAnnotation: 'preview-room:add-annotation',
+  updateAnnotation: 'preview-room:update-annotation',
   removeAnnotation: 'preview-room:remove-annotation',
   panzoomChanged: 'preview-room:panzoom-changed',
   comparisonPanzoomChanged: 'preview-room:comparison-panzoom-changed'

--- a/tests/unit/composables/annotationBroadcast.spec.js
+++ b/tests/unit/composables/annotationBroadcast.spec.js
@@ -54,7 +54,7 @@ describe('composables/annotationBroadcast', () => {
   })
 
   describe('postAnnotationUpdate', () => {
-    it("emits 'preview-update-annotation'", () => {
+    it("emits 'preview-room:update-annotation'", () => {
       const socket = makeSocket()
       const { postAnnotationUpdate } = useAnnotationBroadcast({
         room: makeRoom(),
@@ -63,7 +63,7 @@ describe('composables/annotationBroadcast', () => {
       })
       postAnnotationUpdate(0, fakeAnnotation)
       expect(socket.emit).toHaveBeenCalledWith(
-        'preview-update-annotation',
+        'preview-room:update-annotation',
         expect.objectContaining({ playlist_id: 'playlist-1' })
       )
     })

--- a/tests/unit/composables/playlistComparison.spec.js
+++ b/tests/unit/composables/playlistComparison.spec.js
@@ -516,10 +516,10 @@ describe('composables/playlistComparison', () => {
       expect(c.overlayOpacity.value).toBe(1)
     })
 
-    it('returns 0.25 for overlay25', () => {
+    it('returns 0.75 for overlay25 (main mostly visible)', () => {
       const c = setup()
       c.comparisonMode.value = 'overlay25'
-      expect(c.overlayOpacity.value).toBe(0.25)
+      expect(c.overlayOpacity.value).toBe(0.75)
     })
 
     it('returns 0.5 for overlay50', () => {
@@ -528,10 +528,10 @@ describe('composables/playlistComparison', () => {
       expect(c.overlayOpacity.value).toBe(0.5)
     })
 
-    it('returns 0.75 for overlay75', () => {
+    it('returns 0.25 for overlay75 (main mostly hidden)', () => {
       const c = setup()
       c.comparisonMode.value = 'overlay75'
-      expect(c.overlayOpacity.value).toBe(0.75)
+      expect(c.overlayOpacity.value).toBe(0.25)
     })
 
     it('returns 0 for overlay100 (main fully hidden)', () => {

--- a/tests/unit/composables/previewRoom.spec.js
+++ b/tests/unit/composables/previewRoom.spec.js
@@ -10,7 +10,7 @@ const SOCKET_EVENTS = [
   'preview-room:comparison-panzoom-changed',
   'preview-room:add-annotation',
   'preview-room:remove-annotation',
-  'preview-update-annotation'
+  'preview-room:update-annotation'
 ]
 
 const makeSocket = () => ({
@@ -591,7 +591,7 @@ describe('composables/previewRoom', () => {
       wrapper.unmount()
     })
 
-    it("'preview-update-annotation' calls updateObjectInCanvas for remote events", () => {
+    it("'preview-room:update-annotation' calls updateObjectInCanvas for remote events", () => {
       const socket = makeSocket()
       const updateObjectInCanvas = vi.fn()
       const getAnnotation = vi.fn(() => ({ id: 'a' }))
@@ -602,11 +602,11 @@ describe('composables/previewRoom', () => {
         updateObjectInCanvas,
         getAnnotation
       })
-      const handler = handlerFor(socket, 'preview-update-annotation')
+      const handler = handlerFor(socket, 'preview-room:update-annotation')
       handler({
-        time: 1,
-        data: { local_id: 'other', obj: { id: 'x' } }
+        data: { local_id: 'other', obj: { id: 'x' }, time: 1 }
       })
+      expect(getAnnotation).toHaveBeenCalledWith(1)
       expect(updateObjectInCanvas).toHaveBeenCalledWith(
         { id: 'a' },
         { id: 'x' }


### PR DESCRIPTION
**Problem**

- Opening a picture playlist downloaded every image twice (preview variant plus original) for all entities up front, saturating the network before anything was watchable
- Playback re-rendered the whole TaskInfo comments panel on every frame (even hidden behind v-show), rebuilt the playing annotation's fabric objects on every tick and repainted the waveform per frame
- The playlist frame lookup proxied one reactive object per frame (tens of thousands of entries, never purged between playlists), reorders remounted the whole entity strip, every seek copied the annotations list, IText typing serialized the canvas per keystroke and live window resizes rebuilt annotations continuously

**Solution**

- Bind only the displayed picture variant's src and mount only the current playlist picture with its immediate neighbours (prev/next stay preloaded)
- Freeze TaskInfo's frame prop outside pause-with-panel-open, repaint the playing annotation only when it changes, throttle the waveform sync to 5Hz
- Rebuild the frame lookup as one non-reactive map with a shared entry per entity, reorder with a single keyed replacement, drop the per-seek copy, debounce text updates (400ms) and container resizes (200ms)

Note: stacked on #2147, only the 9 perf commits are new here.