### PR TITLE
[tasks] Migrate the task type page family to the composition API

### DIFF
--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -1024,6 +1024,12 @@ td.retake-count {
   min-height: calc(100% - 50px);
   transition: margin-top 0.3s ease;
 
+  // Without the schedule beside it, the wrapper is the only child of
+  // the flex row and must claim the remaining page width itself.
+  &:not(.with-schedule) {
+    flex: 1;
+  }
+
   &.with-schedule {
     margin-top: 54px;
     margin-bottom: 0;

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -1056,6 +1056,9 @@ td.retake-count {
 }
 
 .list-wrapper {
+  // Same flex-row constraint as the datatable wrapper: without a flex
+  // basis the auto-fill grid shrinks to a single column.
+  flex: 1;
   overflow-x: auto;
   overflow-y: auto;
 }

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -288,6 +288,7 @@
               :empty-width="200"
               :empty-height="133"
               :show-movie="false"
+              is-rounded-top-border
               no-preview
               v-if="task.entity"
             />
@@ -332,6 +333,7 @@
           :empty-width="200"
           :empty-height="133"
           :show-movie="false"
+          is-rounded-top-border
           no-preview
           v-if="task.entity"
         />
@@ -1064,21 +1066,29 @@ td.retake-count {
 
 .task-grid {
   display: grid;
-  gap: 10px;
-  grid-template-columns: 204px 204px 204px 204px 204px 204px;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fill, 204px);
 
   .task-card {
     border: 2px solid transparent;
-    border-radius: 5px;
-    box-shadow: 0 0 2px var(--box-shadow);
+    border-radius: 10px;
+    box-shadow: 0 1px 3px var(--box-shadow);
     background: var(--background-alt);
     cursor: pointer;
     display: flex;
     font-weight: bold;
     flex-direction: column;
     padding: 0;
-    padding-bottom: 0.2em;
-    transition: border 0.3s ease;
+    padding-bottom: 0.4em;
+    transition:
+      border 0.3s ease,
+      box-shadow 0.2s ease,
+      transform 0.2s ease;
+
+    &:hover {
+      box-shadow: 0 3px 8px var(--box-shadow);
+      transform: translateY(-2px);
+    }
 
     &.selected {
       border: 2px solid $dark-purple;
@@ -1087,12 +1097,12 @@ td.retake-count {
     .task-name {
       font-size: 0.9em;
       margin-bottom: 0.5em;
-      margin-top: 0.3em;
-      padding: 0 0.5em;
+      margin-top: 0.4em;
+      padding: 0 0.6em;
       word-break: break-word;
     }
     .task-data {
-      padding: 0 0.1em 0 0.3em;
+      padding: 0 0.3em 0 0.5em;
 
       .avatar-wrapper:last-child {
         margin-right: 0;

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -167,7 +167,6 @@
                 class="difficulty-combobox"
                 :options="difficultyOptions"
                 :with-margin="false"
-                :value="task.difficulty"
                 @update:model-value="updateDifficulty($event)"
                 v-if="isInDepartment(task) && selectionGrid[task.id]"
                 v-model="task.difficulty"
@@ -259,12 +258,9 @@
         :with-actions="false"
       />
     </div>
-    <div
-      class="list-wrapper"
-      v-else-if="tasksByParent && tasksByParent.length > 0 && isGrouped"
-    >
-      <div :key="`task-section-${i}`" v-for="(taskGroup, i) in tasksByParent">
-        <h2>
+    <div class="list-wrapper" v-else>
+      <div :key="`task-section-${i}`" v-for="(taskGroup, i) in cardGroups">
+        <h2 v-if="taskGroup.name">
           {{ taskGroup.name }}
         </h2>
         <div class="task-grid">
@@ -312,49 +308,6 @@
         </div>
       </div>
     </div>
-    <div class="task-grid list-wrapper" v-else>
-      <div
-        :class="{
-          'task-card': true,
-          selected: selectionGrid[task.id]
-        }"
-        :key="task.id"
-        role="button"
-        tabindex="0"
-        @click="selectTaskFromCard($event, index, task)"
-        @keydown.enter.prevent="selectTaskFromCard($event, index, task)"
-        v-for="(task, index) in displayedTasks"
-      >
-        <entity-preview
-          class="flexrow-item"
-          :entity="getEntity(task.entity.id)"
-          :height="133"
-          :width="200"
-          :empty-width="200"
-          :empty-height="133"
-          :show-movie="false"
-          is-rounded-top-border
-          no-preview
-          v-if="task.entity"
-        />
-        <span class="task-name">
-          {{ getTaskName(task) }}
-        </span>
-        <div class="flexrow task-data">
-          <validation-tag class="flexrow-item" :task="task" thin />
-          <div class="filler"></div>
-          <people-avatar-with-menu
-            class="flexrow-item"
-            :key="`${task.id}-${personId}`"
-            :person="personMap.get(personId)"
-            :size="20"
-            :font-size="10"
-            @unassign="person => onUnassign(task, person)"
-            v-for="personId in task.assignees"
-          />
-        </div>
-      </div>
-    </div>
     <slot></slot>
   </div>
   <task-list-numbers :is-shots="isShots" :tasks="tasks" v-if="!isLoading" />
@@ -375,8 +328,10 @@ import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 
 import { pauseEvent } from '@/composables/dom'
+import { getEntityMap } from '@/composables/entity'
 import { useFormat } from '@/composables/format'
 import { useGrabList } from '@/composables/grabList'
+import { isSupervisorInDepartments } from '@/lib/descriptors'
 import {
   daysToMinutes,
   formatSimpleDate,
@@ -386,11 +341,6 @@ import {
   minutesToDays,
   range
 } from '@/lib/time'
-import assetStore from '@/store/modules/assets'
-import editStore from '@/store/modules/edits'
-import episodeStore from '@/store/modules/episodes'
-import sequenceStore from '@/store/modules/sequences'
-import shotStore from '@/store/modules/shots'
 
 import ValidationCell from '@/components/cells/ValidationCell.vue'
 import Combobox from '@/components/widgets/Combobox.vue'
@@ -405,7 +355,8 @@ import ValidationTag from '@/components/widgets/ValidationTag.vue'
 // Composables
 const { t } = useI18n()
 const store = useStore()
-const { formatDuration, formatDisplayDate, organisation } = useFormat()
+const { formatDuration, formatDisplayDate, isDurationInHours, organisation } =
+  useFormat()
 
 // Props / Emits
 const props = defineProps({
@@ -483,32 +434,24 @@ const isEpisodes = computed(() => props.entityType === 'Episode')
 const isSequences = computed(() => props.entityType === 'Sequence')
 const isShots = computed(() => props.entityType === 'Shot')
 
-const entityMap = computed(() => {
-  const caches = {
-    asset: assetStore.cache.assetMap,
-    edit: editStore.cache.editMap,
-    episode: episodeStore.cache.episodeMap,
-    sequence: sequenceStore.cache.sequenceMap,
-    shot: shotStore.cache.shotMap
-  }
-  return caches[props.entityType.toLowerCase()]
-})
+const entityMap = computed(() => getEntityMap(props.entityType))
 
-const displayedTasks = computed(() => {
-  if (props.tasks && props.tasks.length > 0) {
-    return props.tasks.slice(0, 60 * page.value)
-  }
-  return []
-})
+const displayedTasks = computed(() => props.tasks.slice(0, 60 * page.value))
+
+const cardGroups = computed(() =>
+  props.isGrouped && tasksByParent.value.length > 0
+    ? tasksByParent.value
+    : [{ name: null, tasks: displayedTasks.value }]
+)
 
 const tasksByParent = computed(() => {
   if (props.tasks.length === 0) return []
   if (isShots.value) {
-    return groupTasks(shotStore.cache.shotMap, 'sequence_id', 'sequence_name')
+    return groupTasks(getEntityMap('Shot'), 'sequence_id', 'sequence_name')
   }
   if (isAssets.value) {
     return groupTasks(
-      assetStore.cache.assetMap,
+      getEntityMap('Asset'),
       'asset_type_id',
       'entity_type_name'
     )
@@ -574,8 +517,19 @@ const isTaskChanged = (task, data) => {
 
 const getDate = date => (date ? moment(date, 'YYYY-MM-DD').toDate() : null)
 
+// Dispatch an update built per selected task; a null build skips the task.
+const applyToSelection = buildData => {
+  Object.keys(selectionGrid.value).forEach(taskId => {
+    const task = taskMap.value.get(taskId)
+    const data = buildData(task)
+    if (data && isTaskChanged(task, data)) {
+      store.dispatch('updateTask', { taskId, data }).catch(console.error)
+    }
+  })
+}
+
 const updateEstimation = duration => {
-  const estimation = organisation.value.format_duration_in_hours
+  const estimation = isDurationInHours.value
     ? duration * 60
     : daysToMinutes(organisation.value, duration)
 
@@ -591,86 +545,66 @@ const onUnassign = (task, person) => {
 }
 
 const updateStartDate = date => {
-  Object.keys(selectionGrid.value).forEach(taskId => {
-    const task = taskMap.value.get(taskId)
+  applyToSelection(task => {
+    if (!date) {
+      const data = { start_date: null, due_date: task.due_date }
+      if (task.difficulty) data.difficulty = task.difficulty
+      return data
+    }
+    const startDate = moment(date)
+    if (
+      task.start_date &&
+      task.start_date.substring(0, 10) === formatSimpleDate(startDate)
+    ) {
+      return null
+    }
     const dueDate = task.due_date ? parseSimpleDate(task.due_date) : null
-    let data
-    if (date) {
-      const startDate = moment(date)
-      if (
-        task.start_date &&
-        task.start_date.substring(0, 10) === formatSimpleDate(startDate)
-      )
-        return
-      data = getDatesFromStartDate(
-        organisation.value,
-        startDate,
-        dueDate,
-        minutesToDays(organisation.value, task.estimation)
-      )
-    } else {
-      data = {
-        start_date: null,
-        due_date: task.due_date
-      }
-    }
-    if (task.difficulty) {
-      data.difficulty = task.difficulty
-    }
-    if (isTaskChanged(task, data)) {
-      store.dispatch('updateTask', { taskId, data }).catch(console.error)
-    }
+    const data = getDatesFromStartDate(
+      organisation.value,
+      startDate,
+      dueDate,
+      minutesToDays(organisation.value, task.estimation)
+    )
+    if (task.difficulty) data.difficulty = task.difficulty
+    return data
   })
 }
 
 const updateDueDate = date => {
-  Object.keys(selectionGrid.value).forEach(taskId => {
-    const task = taskMap.value.get(taskId)
+  applyToSelection(task => {
+    if (!date) {
+      return { start_date: task.start_date, due_date: null }
+    }
+    const dueDate = moment(date)
+    if (
+      task.due_date &&
+      task.due_date.substring(0, 10) === formatSimpleDate(dueDate)
+    ) {
+      return null
+    }
     const startDate = task.start_date ? parseSimpleDate(task.start_date) : null
-    let data
-    if (date) {
-      const dueDate = moment(date)
-      if (
-        task.due_date &&
-        task.due_date.substring(0, 10) === formatSimpleDate(dueDate)
-      )
-        return
-      data = getDatesFromEndDate(
-        organisation.value,
-        startDate,
-        dueDate,
-        minutesToDays(organisation.value, task.estimation)
-      )
-    } else {
-      data = {
-        start_date: task.start_date,
-        due_date: null
-      }
-    }
-    if (isTaskChanged(task, data)) {
-      store.dispatch('updateTask', { taskId, data }).catch(console.error)
-    }
+    return getDatesFromEndDate(
+      organisation.value,
+      startDate,
+      dueDate,
+      minutesToDays(organisation.value, task.estimation)
+    )
   })
 }
 
 const updateTasksEstimation = ({ estimation }) => {
-  Object.keys(selectionGrid.value).forEach(taskId => {
-    const task = taskMap.value.get(taskId)
-    let data = { estimation }
-    if (task.start_date) {
-      const startDate = moment(task.start_date)
-      const dueDate = task.due_date ? moment(task.due_date) : null
-      data = getDatesFromStartDate(
-        organisation.value,
-        startDate,
-        dueDate,
-        minutesToDays(organisation.value, estimation)
-      )
-      data.estimation = estimation
-    }
-    if (isTaskChanged(task, data)) {
-      store.dispatch('updateTask', { taskId, data }).catch(console.error)
-    }
+  applyToSelection(task => {
+    if (!task.start_date) return { estimation }
+    const startDate = moment(task.start_date)
+    const dueDate = task.due_date ? moment(task.due_date) : null
+    const data = getDatesFromStartDate(
+      organisation.value,
+      startDate,
+      dueDate,
+      minutesToDays(organisation.value, estimation)
+    )
+    data.estimation = estimation
+    return data
   })
 }
 
@@ -683,15 +617,8 @@ const updateNbDrawings = nbDrawings => {
 }
 
 const updateTasksData = data => {
-  Object.keys(selectionGrid.value).forEach(taskId => {
-    const task = taskMap.value.get(taskId)
-    if (isTaskChanged(task, data)) {
-      store.dispatch('updateTask', { taskId, data }).catch(console.error)
-    }
-  })
+  applyToSelection(() => data)
 }
-
-const formatDate = date => (date ? moment(date).format('YYYY-MM-DD') : '')
 
 const isEstimationBurned = task =>
   task.estimation && task.estimation > 0 && task.duration > task.estimation
@@ -709,7 +636,7 @@ const onBodyScroll = event => {
 
 const onKeyDown = event => {
   if (props.tasks.length > 0 && event.altKey) {
-    let index = lastSelection.value ? lastSelection.value : 0
+    let index = lastSelection.value || 0
     if ([37, 38].includes(event.keyCode)) {
       index = index - 1 < 0 ? props.tasks.length - 1 : index - 1
       selectTask({}, index, props.tasks[index])
@@ -756,7 +683,6 @@ const selectTaskFromCard = (event, index, task) => {
 
 const applySelection = (event, index, task) => {
   const isSelected = selectionGrid.value[task.id]
-  const isManySelection = Object.keys(selectionGrid.value).length > 1
   if (!(event.ctrlKey || event.metaKey) && !event.shiftKey) {
     store.dispatch('clearSelectedTasks')
     resetSelection()
@@ -766,7 +692,7 @@ const applySelection = (event, index, task) => {
     if (isSelected) {
       store.dispatch('removeSelectedTask', { task })
       selectionGrid.value[task.id] = undefined
-    } else if (!isSelected || isManySelection) {
+    } else {
       store.dispatch('addSelectedTask', { task })
       emit('task-selected', task)
       selectionGrid.value[task.id] = true
@@ -812,21 +738,13 @@ const scrollToLine = taskId => {
   }
 }
 
-const isInDepartment = task => {
-  if (isCurrentUserManager.value) {
-    return true
-  } else if (isCurrentUserSupervisor.value) {
-    if (user.value.departments.length === 0) {
-      return true
-    }
-    const taskType = taskTypeMap.value.get(task.task_type_id)
-    return (
-      taskType.department_id &&
-      user.value.departments.includes(taskType.department_id)
-    )
-  }
-  return false
-}
+const isInDepartment = task =>
+  isCurrentUserManager.value ||
+  isSupervisorInDepartments(
+    user.value,
+    isCurrentUserSupervisor.value,
+    taskTypeMap.value.get(task.task_type_id)?.department_id
+  )
 
 const resetSelection = () => {
   selectionGrid.value = {}
@@ -859,31 +777,30 @@ const getTableData = () => {
   const taskLines = [headers]
   props.tasks.forEach(task => {
     if (!task) return
+    const entity = getEntity(task.entity.id)
     const assignees = task.assignees
       .map(personId => personMap.value.get(personId)?.name || '')
       .join(', ')
 
     const line = [
-      isAssets.value
-        ? getEntity(task.entity.id).asset_type_name
-        : getEntity(task.entity.id).sequence_name,
-      getEntity(task.entity.id).name,
+      isAssets.value ? entity.asset_type_name : entity.sequence_name,
+      entity.name,
       task.task_status_short_name,
       assignees,
       task.difficulty,
       formatDuration(task.estimation, false),
       formatDuration(task.duration, false),
       task.retake_count,
-      formatDate(task.start_date),
-      formatDate(task.due_date),
-      formatDate(task.real_start_date),
-      formatDate(task.end_date),
-      formatDate(task.done_date),
-      formatDate(task.last_comment_date)
+      formatSimpleDate(task.start_date),
+      formatSimpleDate(task.due_date),
+      formatSimpleDate(task.real_start_date),
+      formatSimpleDate(task.end_date),
+      formatSimpleDate(task.done_date),
+      formatSimpleDate(task.last_comment_date)
     ]
     if (isShots.value) {
       const value = !isPaperProduction.value
-        ? getEntity(task.entity.id).nb_frames
+        ? entity.nb_frames
         : task.nb_drawings || 0
       line.splice(4, 0, value)
     }

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -74,7 +74,11 @@
           </tr>
         </thead>
 
-        <tbody class="datatable-body">
+        <tbody
+          class="datatable-body"
+          @mousedown="startBrowsing"
+          @touchstart="startBrowsing"
+        >
           <tr
             :ref="el => setTaskRow(task.id, el)"
             :key="task.id"
@@ -370,6 +374,7 @@ import { useStore } from 'vuex'
 
 import { pauseEvent } from '@/composables/dom'
 import { useFormat } from '@/composables/format'
+import { useGrabList } from '@/composables/grabList'
 import {
   daysToMinutes,
   formatSimpleDate,
@@ -454,6 +459,8 @@ const selectionGrid = ref({})
 const bodyRef = useTemplateRef('body')
 // Row elements for scrollToLine, no reactivity needed
 const taskRows = new Map()
+
+const { startBrowsing } = useGrabList(bodyRef)
 
 // Computed
 const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -276,8 +276,8 @@
             :key="task.id"
             role="button"
             tabindex="0"
-            @click="selectTask($event, index, task)"
-            @keydown.enter.prevent="selectTask($event, index, task)"
+            @click="selectTaskFromCard($event, index, task)"
+            @keydown.enter.prevent="selectTaskFromCard($event, index, task)"
             v-for="(task, index) in taskGroup.tasks"
           >
             <entity-preview
@@ -321,8 +321,8 @@
         :key="task.id"
         role="button"
         tabindex="0"
-        @click="selectTask($event, index, task)"
-        @keydown.enter.prevent="selectTask($event, index, task)"
+        @click="selectTaskFromCard($event, index, task)"
+        @keydown.enter.prevent="selectTaskFromCard($event, index, task)"
         v-for="(task, index) in displayedTasks"
       >
         <entity-preview
@@ -743,6 +743,18 @@ const selectTask = (event, index, task) => {
       ['cell day selected'].includes(event.target.className))
   )
     return
+  applySelection(event, index, task)
+}
+
+// Card clicks skip the table-oriented guard above (it swallows most of
+// the card surface); only the avatar and its unassign menu must not
+// select.
+const selectTaskFromCard = (event, index, task) => {
+  if (event.target?.closest?.('.avatar-wrapper')) return
+  applySelection(event, index, task)
+}
+
+const applySelection = (event, index, task) => {
   const isSelected = selectionGrid.value[task.id]
   const isManySelection = Object.keys(selectionGrid.value).length > 1
   if (!(event.ctrlKey || event.metaKey) && !event.shiftKey) {

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -10,74 +10,64 @@
       v-if="!isContactSheet"
     >
       <table class="datatable">
-        <thead ref="thead" class="datatable-head">
+        <thead class="datatable-head">
           <tr class="row-header">
-            <th class="thumbnail" ref="th-thumbnail"></th>
-            <th class="asset-type" ref="th-type" v-if="isAssets">
+            <th class="thumbnail"></th>
+            <th class="asset-type" v-if="isAssets">
               {{ $t('tasks.fields.asset_type') }}
             </th>
             <th
               class="sequence"
-              ref="th-type"
               v-else-if="!isEpisodes && !isSequences && !isEdits"
             >
               {{ $t('tasks.fields.sequence') }}
             </th>
-            <th class="name" ref="th-name">
+            <th class="name">
               {{ $t('tasks.fields.entity_name') }}
             </th>
-            <th class="status" ref="th-status">
+            <th class="status">
               {{ $t('tasks.fields.task_status') }}
             </th>
-            <th class="assignees" ref="th-assignees">
+            <th class="assignees">
               {{ $t('tasks.fields.assignees') }}
             </th>
-            <th
-              ref="th-frames"
-              class="frames number-cell"
-              v-if="isShots && !isPaperProduction"
-            >
+            <th class="frames number-cell" v-if="isShots && !isPaperProduction">
               {{ $t('tasks.fields.frames') }}
             </th>
             <th
-              ref="th-drawings"
               class="drawings number-cell"
               v-if="isShots && isPaperProduction"
             >
               {{ $t('tasks.fields.drawings') }}
             </th>
-            <th class="difficulty number-cell" ref="th-difficulty">
+            <th class="difficulty number-cell">
               {{ $t('tasks.fields.difficulty') }}
             </th>
-            <th
-              ref="th-estimation"
-              class="estimation number-cell"
-              :title="$t('main.estimation')"
-            >
+            <th class="estimation number-cell" :title="$t('main.estimation')">
               {{ $t('tasks.fields.estimation').substring(0, 3) }}.
             </th>
-            <th class="duration number-cell" ref="th-duration">
+            <th class="duration number-cell">
               {{ $t('tasks.fields.duration').substring(0, 3) }}.
             </th>
-            <th class="retake-count number-cell" ref="th-retake-count">
+            <th class="retake-count number-cell">
               {{ $t('tasks.fields.retake_count') }}
             </th>
-            <th class="start-date" ref="th-estimation" v-if="!withSchedule">
+            <th class="start-date" v-if="!withSchedule">
               {{ $t('tasks.fields.start_date') }}
             </th>
-            <th class="due-date" ref="th-estimation" v-if="!withSchedule">
+            <th class="due-date" v-if="!withSchedule">
               {{ $t('tasks.fields.due_date') }}
             </th>
-            <th class="real-start-date" ref="th-status" v-if="!withSchedule">
+            <th class="real-start-date" v-if="!withSchedule">
               {{ $t('tasks.fields.real_start_date') }}
             </th>
-            <th class="real-end-date" ref="th-status" v-if="!withSchedule">
+            <th class="real-end-date" v-if="!withSchedule">
               {{ $t('tasks.fields.real_end_date') }}
             </th>
-            <th class="done-date" ref="th-status" v-if="!withSchedule">
+            <th class="done-date" v-if="!withSchedule">
               {{ $t('tasks.fields.done_date') }}
             </th>
-            <th class="last-comment-date" ref="th-status" v-if="!withSchedule">
+            <th class="last-comment-date" v-if="!withSchedule">
               {{ $t('tasks.fields.last_comment_date') }}
             </th>
             <th class="empty" v-if="!withSchedule">&nbsp;</th>
@@ -86,7 +76,7 @@
 
         <tbody class="datatable-body">
           <tr
-            :ref="`task-${task.id}`"
+            :ref="el => setTaskRow(task.id, el)"
             :key="task.id"
             :class="{
               'task-line': true,
@@ -160,7 +150,6 @@
                 min="0"
                 step="1"
                 type="number"
-                :ref="`${task.id}-drawings`"
                 :value="task.nb_drawings"
                 @change="updateNbDrawings($event.target.value)"
                 v-if="isInDepartment(task) && selectionGrid[task.id]"
@@ -195,7 +184,6 @@
                 min="0"
                 step="any"
                 type="number"
-                :ref="`${task.id}-estimation`"
                 :value="formatDuration(task.estimation, false)"
                 @change="updateEstimation($event.target.value)"
                 v-if="isInDepartment(task) && selectionGrid[task.id]"
@@ -366,9 +354,22 @@
   <task-list-numbers :is-shots="isShots" :tasks="tasks" v-if="!isLoading" />
 </template>
 
-<script>
-import { mapGetters, mapActions } from 'vuex'
+<script setup>
+// Imports
 import moment from 'moment-timezone'
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useTemplateRef,
+  watch
+} from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useStore } from 'vuex'
+
+import { pauseEvent } from '@/composables/dom'
+import { useFormat } from '@/composables/format'
 import {
   daysToMinutes,
   formatSimpleDate,
@@ -378,9 +379,13 @@ import {
   minutesToDays,
   range
 } from '@/lib/time'
-import { formatListMixin } from '@/components/mixins/format'
-import { domMixin } from '@/components/mixins/dom'
+import assetStore from '@/store/modules/assets'
+import editStore from '@/store/modules/edits'
+import episodeStore from '@/store/modules/episodes'
+import sequenceStore from '@/store/modules/sequences'
+import shotStore from '@/store/modules/shots'
 
+import ValidationCell from '@/components/cells/ValidationCell.vue'
 import Combobox from '@/components/widgets/Combobox.vue'
 import DateField from '@/components/widgets/DateField.vue'
 import EntityPreview from '@/components/widgets/EntityPreview.vue'
@@ -388,581 +393,512 @@ import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
 import PeopleAvatarWithMenu from '@/components/widgets/PeopleAvatarWithMenu.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
 import TaskListNumbers from '@/components/widgets/TaskListNumbers.vue'
-import ValidationCell from '@/components/cells/ValidationCell.vue'
 import ValidationTag from '@/components/widgets/ValidationTag.vue'
 
-import assetStore from '@/store/modules/assets'
-import editStore from '@/store/modules/edits'
-import episodeStore from '@/store/modules/episodes'
-import sequenceStore from '@/store/modules/sequences'
-import shotStore from '@/store/modules/shots'
+// Composables
+const { t } = useI18n()
+const store = useStore()
+const { formatDuration, formatDisplayDate, organisation } = useFormat()
 
-export default {
-  name: 'task-list',
-
-  mixins: [domMixin, formatListMixin],
-
-  components: {
-    Combobox,
-    DateField,
-    EntityPreview,
-    EntityThumbnail,
-    PeopleAvatarWithMenu,
-    TableInfo,
-    TaskListNumbers,
-    ValidationCell,
-    ValidationTag
+// Props / Emits
+const props = defineProps({
+  disabledDates: {
+    type: Object,
+    default: () => {}
   },
+  entityType: {
+    type: String,
+    default: 'Asset'
+  },
+  isContactSheet: {
+    type: Boolean,
+    default: false
+  },
+  isError: {
+    type: Boolean,
+    default: false
+  },
+  isGrouped: {
+    type: Boolean,
+    default: false
+  },
+  isLoading: {
+    type: Boolean,
+    default: false
+  },
+  tasks: {
+    type: Array,
+    default: () => []
+  },
+  withSchedule: {
+    type: Boolean,
+    default: false
+  }
+})
 
-  emits: ['scroll', 'task-selected'],
+const emit = defineEmits(['scroll', 'task-selected'])
 
-  data() {
-    return {
-      difficultyOptions: [
-        { label: '•', value: 1 },
-        { label: '••', value: 2 },
-        { label: '•••', value: 3 },
-        { label: '••••', value: 4 },
-        { label: '•••••', value: 5 }
-      ],
-      lastSelection: null,
-      page: 1,
-      selectionGrid: {},
-      selectedDate: moment().toDate() // By default current day.
+// State
+const difficultyOptions = [
+  { label: '•', value: 1 },
+  { label: '••', value: 2 },
+  { label: '•••', value: 3 },
+  { label: '••••', value: 4 },
+  { label: '•••••', value: 5 }
+]
+
+const lastSelection = ref(null)
+const page = ref(1)
+const selectionGrid = ref({})
+
+const bodyRef = useTemplateRef('body')
+// Row elements for scrollToLine, no reactivity needed
+const taskRows = new Map()
+
+// Computed
+const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
+const isCurrentUserSupervisor = computed(
+  () => store.getters.isCurrentUserSupervisor
+)
+const isPaperProduction = computed(() => store.getters.isPaperProduction)
+const nbSelectedTasks = computed(() => store.getters.nbSelectedTasks)
+const personMap = computed(() => store.getters.personMap)
+const selectedTasks = computed(() => store.getters.selectedTasks)
+const taskMap = computed(() => store.getters.taskMap)
+const taskTypeMap = computed(() => store.getters.taskTypeMap)
+const user = computed(() => store.getters.user)
+
+const isAssets = computed(() => props.entityType === 'Asset')
+const isEdits = computed(() => props.entityType === 'Edit')
+const isEpisodes = computed(() => props.entityType === 'Episode')
+const isSequences = computed(() => props.entityType === 'Sequence')
+const isShots = computed(() => props.entityType === 'Shot')
+
+const entityMap = computed(() => {
+  const caches = {
+    asset: assetStore.cache.assetMap,
+    edit: editStore.cache.editMap,
+    episode: episodeStore.cache.episodeMap,
+    sequence: sequenceStore.cache.sequenceMap,
+    shot: shotStore.cache.shotMap
+  }
+  return caches[props.entityType.toLowerCase()]
+})
+
+const displayedTasks = computed(() => {
+  if (props.tasks && props.tasks.length > 0) {
+    return props.tasks.slice(0, 60 * page.value)
+  }
+  return []
+})
+
+const tasksByParent = computed(() => {
+  if (props.tasks.length === 0) return []
+  if (isShots.value) {
+    return groupTasks(shotStore.cache.shotMap, 'sequence_id', 'sequence_name')
+  }
+  if (isAssets.value) {
+    return groupTasks(
+      assetStore.cache.assetMap,
+      'asset_type_id',
+      'entity_type_name'
+    )
+  }
+  return []
+})
+
+// Functions
+const groupTasks = (entityMap, groupKey, nameField) => {
+  const result = []
+  let currentGroup = {
+    name: props.tasks[0][nameField],
+    tasks: []
+  }
+  let previousTask = null
+  props.tasks.forEach(task => {
+    const entity = entityMap.get(task.entity.id)
+    if (previousTask) {
+      const previousEntity = entityMap.get(previousTask.entity.id)
+      if (previousEntity?.[groupKey] !== entity?.[groupKey]) {
+        result.push(currentGroup)
+        currentGroup = {
+          name: task[nameField],
+          tasks: []
+        }
+      }
     }
-  },
+    currentGroup.tasks.push(task)
+    previousTask = task
+  })
+  result.push(currentGroup)
+  return result
+}
 
-  props: {
-    disabledDates: {
-      type: Object,
-      default: () => {}
-    },
-    entityType: {
-      type: String,
-      default: 'Asset'
-    },
-    isContactSheet: {
-      type: Boolean,
-      default: false
-    },
-    isError: {
-      type: Boolean,
-      default: false
-    },
-    isGrouped: {
-      type: Boolean,
-      default: false
-    },
-    isLoading: {
-      type: Boolean,
-      default: false
-    },
-    tasks: {
-      type: Array,
-      default: () => []
-    },
-    withSchedule: {
-      type: Boolean,
-      default: false
-    }
-  },
+const getEntity = entityId => entityMap.value.get(entityId) || {}
 
-  mounted() {
-    window.addEventListener('keydown', this.onKeyDown, false)
-  },
+const setTaskRow = (taskId, el) => {
+  if (el) {
+    taskRows.set(taskId, el)
+  } else {
+    taskRows.delete(taskId)
+  }
+}
 
-  beforeUnmount() {
-    window.removeEventListener('keydown', this.onKeyDown)
-  },
+const getTaskName = task => {
+  if (props.entityType === 'Shot') {
+    return `${task.sequence_name} / ${getEntity(task.entity.id).name}`
+  }
+  return task.entity_name
+}
 
-  computed: {
-    ...mapGetters([
-      'isCurrentUserManager',
-      'isCurrentUserSupervisor',
-      'isPaperProduction',
-      'nbSelectedTasks',
-      'personMap',
-      'user',
-      'selectedTasks',
-      'taskMap',
-      'taskTypeMap'
-    ]),
+const isTaskChanged = (task, data) => {
+  const taskStart = task.start_date ? task.start_date.substring(0, 10) : ''
+  const taskDue = task.due_date ? task.due_date.substring(0, 10) : ''
+  return (
+    (data.start_date !== undefined && taskStart !== data.start_date) ||
+    (data.due_date !== undefined && taskDue !== data.due_date) ||
+    (data.estimation !== undefined && task.estimation !== data.estimation) ||
+    (data.difficulty !== undefined && task.difficulty !== data.difficulty) ||
+    (data.nb_drawings !== undefined && task.nb_drawings !== data.nb_drawings)
+  )
+}
 
-    assetMap() {
-      return assetStore.cache.assetMap
-    },
+const getDate = date => (date ? moment(date, 'YYYY-MM-DD').toDate() : null)
 
-    editMap() {
-      return editStore.cache.editMap
-    },
+const updateEstimation = duration => {
+  const estimation = organisation.value.format_duration_in_hours
+    ? duration * 60
+    : daysToMinutes(organisation.value, duration)
 
-    episodeMap() {
-      return episodeStore.cache.episodeMap
-    },
+  updateTasksEstimation({ estimation })
+}
 
-    sequenceMap() {
-      return sequenceStore.cache.sequenceMap
-    },
+const onUnassign = (task, person) => {
+  const tasks = Array.from(selectedTasks.value.values())
+  if (!selectedTasks.value.has(task.id)) {
+    tasks.push(task)
+  }
+  store.dispatch('unassignPersonFromTasks', { tasks, person })
+}
 
-    shotMap() {
-      return shotStore.cache.shotMap
-    },
-
-    isAssets() {
-      return this.entityType === 'Asset'
-    },
-
-    isEdits() {
-      return this.entityType === 'Edit'
-    },
-
-    isEpisodes() {
-      return this.entityType === 'Episode'
-    },
-
-    isSequences() {
-      return this.entityType === 'Sequence'
-    },
-
-    isShots() {
-      return this.entityType === 'Shot'
-    },
-
-    displayedTasks() {
-      if (this.tasks && this.tasks.length > 0) {
-        return this.tasks.slice(0, 60 * this.page)
-      }
-      return []
-    },
-
-    tasksByParent() {
-      const result = []
-      if (this.tasks.length > 0) {
-        if (this.isShots) {
-          let currentTasks = {
-            name: this.tasks[0].sequence_name,
-            tasks: []
-          }
-          let previousTask = null
-          this.tasks.forEach(task => {
-            const entity = this.shotMap.get(task.entity.id)
-            if (previousTask) {
-              const previousEntity = this.shotMap.get(previousTask.entity.id)
-              if (previousEntity?.sequence_id !== entity?.sequence_id) {
-                result.push(currentTasks)
-                currentTasks = {
-                  name: task.sequence_name,
-                  tasks: []
-                }
-              }
-            }
-            currentTasks.tasks.push(task)
-            previousTask = task
-          })
-          result.push(currentTasks)
-        } else if (this.isAssets) {
-          let currentTasks = {
-            name: this.tasks[0].entity_type_name,
-            tasks: []
-          }
-          let previousTask = null
-          this.tasks.forEach(task => {
-            const entity = this.assetMap.get(task.entity.id)
-            if (previousTask) {
-              const previousEntity = this.assetMap.get(previousTask.entity.id)
-              if (previousEntity?.asset_type_id !== entity?.asset_type_id) {
-                result.push(currentTasks)
-                currentTasks = {
-                  name: task.entity_type_name,
-                  tasks: []
-                }
-              }
-            }
-            currentTasks.tasks.push(task)
-            previousTask = task
-          })
-          result.push(currentTasks)
-        }
-      }
-      return result
-    }
-  },
-
-  methods: {
-    ...mapActions([
-      'addSelectedTask',
-      'addSelectedTasks',
-      'clearSelectedTasks',
-      'updateTask',
-      'unassignPersonFromTasks',
-      'removeSelectedTask'
-    ]),
-
-    getTaskName(task) {
-      if (this.entityType === 'Shot') {
-        return `${task.sequence_name} / ${this.getEntity(task.entity.id).name}`
-      }
-      return task.entity_name
-    },
-
-    isTaskChanged(task, data) {
-      const taskStart = task.start_date ? task.start_date.substring(0, 10) : ''
-      const taskDue = task.due_date ? task.due_date.substring(0, 10) : ''
-      return (
-        (data.start_date !== undefined && taskStart !== data.start_date) ||
-        (data.due_date !== undefined && taskDue !== data.due_date) ||
-        (data.estimation !== undefined &&
-          task.estimation !== data.estimation) ||
-        (data.difficulty !== undefined &&
-          task.difficulty !== data.difficulty) ||
-        (data.nb_drawings !== undefined &&
-          task.nb_drawings !== data.nb_drawings)
-      )
-    },
-
-    getDate(date) {
-      return date ? moment(date, 'YYYY-MM-DD').toDate() : null
-    },
-
-    updateEstimation(duration) {
-      const estimation = this.organisation.format_duration_in_hours
-        ? duration * 60
-        : daysToMinutes(this.organisation, duration)
-
-      this.updateTasksEstimation({ estimation })
-    },
-
-    onUnassign(task, person) {
-      const tasks = Array.from(this.selectedTasks.values())
-      if (!this.selectedTasks.has(task.id)) {
-        tasks.push(task)
-      }
-      this.unassignPersonFromTasks({ tasks, person })
-    },
-
-    updateStartDate(date) {
-      Object.keys(this.selectionGrid).forEach(taskId => {
-        const task = this.taskMap.get(taskId)
-        const dueDate = task.due_date ? parseSimpleDate(task.due_date) : null
-        let data
-        if (date) {
-          const startDate = moment(date)
-          if (
-            task.start_date &&
-            task.start_date.substring(0, 10) === formatSimpleDate(startDate)
-          )
-            return
-          data = getDatesFromStartDate(
-            this.organisation,
-            startDate,
-            dueDate,
-            minutesToDays(this.organisation, task.estimation)
-          )
-        } else {
-          data = {
-            start_date: null,
-            due_date: task.due_date
-          }
-        }
-        if (task.difficulty) {
-          data.difficulty = task.difficulty
-        }
-        if (this.isTaskChanged(task, data)) {
-          this.updateTask({ taskId, data }).catch(console.error)
-        }
-      })
-    },
-
-    updateDueDate(date) {
-      Object.keys(this.selectionGrid).forEach(taskId => {
-        const task = this.taskMap.get(taskId)
-        const startDate = task.start_date
-          ? parseSimpleDate(task.start_date)
-          : null
-        let data
-        if (date) {
-          const dueDate = moment(date)
-          if (
-            task.due_date &&
-            task.due_date.substring(0, 10) === formatSimpleDate(dueDate)
-          )
-            return
-          data = getDatesFromEndDate(
-            this.organisation,
-            startDate,
-            dueDate,
-            minutesToDays(this.organisation, task.estimation)
-          )
-        } else {
-          data = {
-            start_date: task.start_date,
-            due_date: null
-          }
-        }
-        if (this.isTaskChanged(task, data)) {
-          this.updateTask({ taskId, data }).catch(console.error)
-        }
-      })
-    },
-
-    updateTasksEstimation({ estimation }) {
-      Object.keys(this.selectionGrid).forEach(taskId => {
-        const task = this.taskMap.get(taskId)
-        let data = { estimation }
-        if (task.start_date) {
-          const startDate = moment(task.start_date)
-          const dueDate = task.due_date ? moment(task.due_date) : null
-          data = getDatesFromStartDate(
-            this.organisation,
-            startDate,
-            dueDate,
-            minutesToDays(this.organisation, estimation)
-          )
-          data.estimation = estimation
-        }
-        if (this.isTaskChanged(task, data)) {
-          this.updateTask({ taskId, data }).catch(console.error)
-        }
-      })
-    },
-
-    updateDifficulty(difficulty) {
-      this.updateTasksData({ difficulty })
-    },
-
-    updateNbDrawings(nbDrawings) {
-      this.updateTasksData({ nb_drawings: nbDrawings })
-    },
-
-    updateTasksData(data) {
-      Object.keys(this.selectionGrid).forEach(taskId => {
-        const task = this.taskMap.get(taskId)
-        if (this.isTaskChanged(task, data)) {
-          this.updateTask({ taskId, data }).catch(console.error)
-        }
-      })
-    },
-
-    formatDate(date) {
-      if (date) return moment(date).format('YYYY-MM-DD')
-      return ''
-    },
-
-    isEstimationBurned(task) {
-      return (
-        task.estimation &&
-        task.estimation > 0 &&
-        task.duration > task.estimation
-      )
-    },
-
-    onBodyScroll(event) {
-      if (!this.$refs.body) return
-      const position = event.target
-      const maxHeight =
-        this.$refs.body.scrollHeight - this.$refs.body.offsetHeight
-      if (maxHeight < position.scrollTop + 100) {
-        this.page++
-      }
-
-      this.$emit('scroll', { top: position.scrollTop })
-    },
-
-    getEntity(entityId) {
-      return this[`${this.entityType.toLowerCase()}Map`].get(entityId) || {}
-    },
-
-    onKeyDown(event) {
-      if (this.tasks.length > 0 && event.altKey) {
-        let index = this.lastSelection ? this.lastSelection : 0
-        if ([37, 38].includes(event.keyCode)) {
-          index = index - 1 < 0 ? this.tasks.length - 1 : index - 1
-          this.selectTask({}, index, this.tasks[index])
-          this.pauseEvent(event)
-        } else if ([39, 40].includes(event.keyCode)) {
-          index = index + 1 >= this.tasks.length ? 0 : index + 1
-          this.selectTask({}, index, this.tasks[index])
-          this.pauseEvent(event)
-        }
-      }
-    },
-
-    selectTask(event, index, task) {
+const updateStartDate = date => {
+  Object.keys(selectionGrid.value).forEach(taskId => {
+    const task = taskMap.value.get(taskId)
+    const dueDate = task.due_date ? parseSimpleDate(task.due_date) : null
+    let data
+    if (date) {
+      const startDate = moment(date)
       if (
-        event &&
-        event.target &&
-        // Dirty hack needed to make date picker and inputs work properly
-        (['INPUT'].includes(event.target.nodeName) ||
-          // Combo box should not trigger selection
-          event.target.className.indexOf('selected-line') >= 0 ||
-          event.target.className.indexOf('down-icon') >= 0 ||
-          event.target.className.indexOf('flexrow') >= 0 ||
-          event.target.className.indexOf('c-mask') >= 0 ||
-          event.target.className.indexOf('option-line') >= 0 ||
-          event.target.className.indexOf('combobox') >= 0 ||
-          event.target.className === '' ||
-          (event.target.parentNode &&
-            ['difficulty'].includes(event.target.className)) ||
-          (event.target.parentNode &&
-            ['HEADER'].includes(event.target.parentNode.nodeName)) ||
-          ['cell day selected'].includes(event.target.className))
+        task.start_date &&
+        task.start_date.substring(0, 10) === formatSimpleDate(startDate)
       )
         return
-      const isSelected = this.selectionGrid[task.id]
-      const isManySelection = Object.keys(this.selectionGrid).length > 1
-      if (!(event.ctrlKey || event.metaKey) && !event.shiftKey) {
-        this.clearSelectedTasks()
-        this.resetSelection()
+      data = getDatesFromStartDate(
+        organisation.value,
+        startDate,
+        dueDate,
+        minutesToDays(organisation.value, task.estimation)
+      )
+    } else {
+      data = {
+        start_date: null,
+        due_date: task.due_date
       }
-
-      if (!event.shiftKey) {
-        if (isSelected) {
-          this.removeSelectedTask({ task })
-          this.selectionGrid[task.id] = undefined
-        } else if (!isSelected || isManySelection) {
-          this.addSelectedTask({ task })
-          this.$emit('task-selected', task)
-          this.selectionGrid[task.id] = true
-          this.lastSelection = index
-        }
-      } else {
-        this.selectionGrid = {}
-        const taskIndices =
-          this.lastSelection > index
-            ? range(index, this.lastSelection)
-            : range(this.lastSelection, index)
-        const selection = taskIndices.map(i => ({ task: this.tasks[i] }))
-        selection.forEach(task => {
-          this.selectionGrid[task.task.id] = true
-        })
-        this.addSelectedTasks(selection)
-      }
-      this.scrollToLine(task.id)
-    },
-
-    setScrollPosition(top) {
-      if (this.$refs.body) {
-        this.$refs.body.scrollTop = top
-      }
-    },
-
-    scrollToLine(taskId) {
-      const taskLine = this.$refs[`task-${taskId}`]
-      if (taskLine && this.$refs.body) {
-        const margin = 30
-        const rect = taskLine[0].getBoundingClientRect()
-        const listRect = this.$refs.body.getBoundingClientRect()
-        const isBelow = rect.bottom > listRect.bottom - margin
-        const isAbove = rect.top < listRect.top + margin
-
-        if (isBelow) {
-          const scrollingRequired = rect.bottom - listRect.bottom + margin
-          this.setScrollPosition(this.$refs.body.scrollTop + scrollingRequired)
-        } else if (isAbove) {
-          const scrollingRequired = listRect.top - rect.top + margin
-          this.setScrollPosition(this.$refs.body.scrollTop - scrollingRequired)
-        }
-      }
-    },
-
-    isInDepartment(task) {
-      if (this.isCurrentUserManager) {
-        return true
-      } else if (this.isCurrentUserSupervisor) {
-        if (this.user.departments.length === 0) {
-          return true
-        }
-        const taskType = this.taskTypeMap.get(task.task_type_id)
-        return (
-          taskType.department_id &&
-          this.user.departments.includes(taskType.department_id)
-        )
-      }
-      return false
-    },
-
-    resetSelection() {
-      this.selectionGrid = {}
-      this.lastSelection = null
-    },
-
-    getTableData() {
-      const headers = [
-        this.isAssets
-          ? this.$t('tasks.fields.asset_type')
-          : this.$t('tasks.fields.sequence'),
-        this.$t('tasks.fields.entity_name'),
-        this.$t('tasks.fields.task_status'),
-        this.$t('tasks.fields.assignees'),
-        this.$t('tasks.fields.difficulty'),
-        this.$t('tasks.fields.estimation'),
-        this.$t('tasks.fields.duration'),
-        this.$t('tasks.fields.retake_count'),
-        this.$t('tasks.fields.start_date'),
-        this.$t('tasks.fields.due_date'),
-        this.$t('tasks.fields.real_start_date'),
-        this.$t('tasks.fields.real_end_date'),
-        this.$t('tasks.fields.done_date'),
-        this.$t('tasks.fields.last_comment_date')
-      ]
-      if (this.isShots) {
-        const value = !this.isPaperProduction
-          ? this.$t('tasks.fields.frames')
-          : this.$t('tasks.fields.drawings')
-        headers.splice(4, 0, value)
-      }
-      const taskLines = [headers]
-      this.tasks.forEach(task => {
-        if (!task) return
-        const assignees = task.assignees
-          .map(personId => {
-            const person = this.personMap.get(personId)
-            if (person) return person.name
-            return ''
-          })
-          .join(', ')
-
-        const line = [
-          this.isAssets
-            ? this.getEntity(task.entity.id).asset_type_name
-            : this.getEntity(task.entity.id).sequence_name,
-          this.getEntity(task.entity.id).name,
-          task.task_status_short_name,
-          assignees,
-          task.difficulty,
-          this.formatDuration(task.estimation, false),
-          this.formatDuration(task.duration, false),
-          task.retake_count,
-          this.formatDate(task.start_date),
-          this.formatDate(task.due_date),
-          this.formatDate(task.real_start_date),
-          this.formatDate(task.end_date),
-          this.formatDate(task.done_date),
-          this.formatDate(task.last_comment_date)
-        ]
-        if (this.isShots) {
-          const value = !this.isPaperProduction
-            ? this.getEntity(task.entity.id).nb_frames
-            : task.nb_drawings || 0
-          line.splice(4, 0, value)
-        }
-        taskLines.push(line)
-      })
-      return taskLines
     }
-  },
+    if (task.difficulty) {
+      data.difficulty = task.difficulty
+    }
+    if (isTaskChanged(task, data)) {
+      store.dispatch('updateTask', { taskId, data }).catch(console.error)
+    }
+  })
+}
 
-  watch: {
-    tasks() {
-      this.page = 1
-      this.resetSelection()
-    },
+const updateDueDate = date => {
+  Object.keys(selectionGrid.value).forEach(taskId => {
+    const task = taskMap.value.get(taskId)
+    const startDate = task.start_date ? parseSimpleDate(task.start_date) : null
+    let data
+    if (date) {
+      const dueDate = moment(date)
+      if (
+        task.due_date &&
+        task.due_date.substring(0, 10) === formatSimpleDate(dueDate)
+      )
+        return
+      data = getDatesFromEndDate(
+        organisation.value,
+        startDate,
+        dueDate,
+        minutesToDays(organisation.value, task.estimation)
+      )
+    } else {
+      data = {
+        start_date: task.start_date,
+        due_date: null
+      }
+    }
+    if (isTaskChanged(task, data)) {
+      store.dispatch('updateTask', { taskId, data }).catch(console.error)
+    }
+  })
+}
 
-    nbSelectedTasks() {
-      if (this.nbSelectedTasks === 0) this.resetSelection()
+const updateTasksEstimation = ({ estimation }) => {
+  Object.keys(selectionGrid.value).forEach(taskId => {
+    const task = taskMap.value.get(taskId)
+    let data = { estimation }
+    if (task.start_date) {
+      const startDate = moment(task.start_date)
+      const dueDate = task.due_date ? moment(task.due_date) : null
+      data = getDatesFromStartDate(
+        organisation.value,
+        startDate,
+        dueDate,
+        minutesToDays(organisation.value, estimation)
+      )
+      data.estimation = estimation
+    }
+    if (isTaskChanged(task, data)) {
+      store.dispatch('updateTask', { taskId, data }).catch(console.error)
+    }
+  })
+}
+
+const updateDifficulty = difficulty => {
+  updateTasksData({ difficulty })
+}
+
+const updateNbDrawings = nbDrawings => {
+  updateTasksData({ nb_drawings: nbDrawings })
+}
+
+const updateTasksData = data => {
+  Object.keys(selectionGrid.value).forEach(taskId => {
+    const task = taskMap.value.get(taskId)
+    if (isTaskChanged(task, data)) {
+      store.dispatch('updateTask', { taskId, data }).catch(console.error)
+    }
+  })
+}
+
+const formatDate = date => (date ? moment(date).format('YYYY-MM-DD') : '')
+
+const isEstimationBurned = task =>
+  task.estimation && task.estimation > 0 && task.duration > task.estimation
+
+const onBodyScroll = event => {
+  if (!bodyRef.value) return
+  const position = event.target
+  const maxHeight = bodyRef.value.scrollHeight - bodyRef.value.offsetHeight
+  if (maxHeight < position.scrollTop + 100) {
+    page.value++
+  }
+
+  emit('scroll', { top: position.scrollTop })
+}
+
+const onKeyDown = event => {
+  if (props.tasks.length > 0 && event.altKey) {
+    let index = lastSelection.value ? lastSelection.value : 0
+    if ([37, 38].includes(event.keyCode)) {
+      index = index - 1 < 0 ? props.tasks.length - 1 : index - 1
+      selectTask({}, index, props.tasks[index])
+      pauseEvent(event)
+    } else if ([39, 40].includes(event.keyCode)) {
+      index = index + 1 >= props.tasks.length ? 0 : index + 1
+      selectTask({}, index, props.tasks[index])
+      pauseEvent(event)
     }
   }
 }
+
+const selectTask = (event, index, task) => {
+  if (
+    event &&
+    event.target &&
+    // Dirty hack needed to make date picker and inputs work properly
+    (['INPUT'].includes(event.target.nodeName) ||
+      // Combo box should not trigger selection
+      event.target.className.indexOf('selected-line') >= 0 ||
+      event.target.className.indexOf('down-icon') >= 0 ||
+      event.target.className.indexOf('flexrow') >= 0 ||
+      event.target.className.indexOf('c-mask') >= 0 ||
+      event.target.className.indexOf('option-line') >= 0 ||
+      event.target.className.indexOf('combobox') >= 0 ||
+      event.target.className === '' ||
+      (event.target.parentNode &&
+        ['difficulty'].includes(event.target.className)) ||
+      (event.target.parentNode &&
+        ['HEADER'].includes(event.target.parentNode.nodeName)) ||
+      ['cell day selected'].includes(event.target.className))
+  )
+    return
+  const isSelected = selectionGrid.value[task.id]
+  const isManySelection = Object.keys(selectionGrid.value).length > 1
+  if (!(event.ctrlKey || event.metaKey) && !event.shiftKey) {
+    store.dispatch('clearSelectedTasks')
+    resetSelection()
+  }
+
+  if (!event.shiftKey) {
+    if (isSelected) {
+      store.dispatch('removeSelectedTask', { task })
+      selectionGrid.value[task.id] = undefined
+    } else if (!isSelected || isManySelection) {
+      store.dispatch('addSelectedTask', { task })
+      emit('task-selected', task)
+      selectionGrid.value[task.id] = true
+      lastSelection.value = index
+    }
+  } else {
+    selectionGrid.value = {}
+    const taskIndices =
+      lastSelection.value > index
+        ? range(index, lastSelection.value)
+        : range(lastSelection.value, index)
+    const selection = taskIndices.map(i => ({ task: props.tasks[i] }))
+    selection.forEach(task => {
+      selectionGrid.value[task.task.id] = true
+    })
+    store.dispatch('addSelectedTasks', selection)
+  }
+  scrollToLine(task.id)
+}
+
+const setScrollPosition = top => {
+  if (bodyRef.value) {
+    bodyRef.value.scrollTop = top
+  }
+}
+
+const scrollToLine = taskId => {
+  const taskLine = taskRows.get(taskId)
+  if (taskLine && bodyRef.value) {
+    const margin = 30
+    const rect = taskLine.getBoundingClientRect()
+    const listRect = bodyRef.value.getBoundingClientRect()
+    const isBelow = rect.bottom > listRect.bottom - margin
+    const isAbove = rect.top < listRect.top + margin
+
+    if (isBelow) {
+      const scrollingRequired = rect.bottom - listRect.bottom + margin
+      setScrollPosition(bodyRef.value.scrollTop + scrollingRequired)
+    } else if (isAbove) {
+      const scrollingRequired = listRect.top - rect.top + margin
+      setScrollPosition(bodyRef.value.scrollTop - scrollingRequired)
+    }
+  }
+}
+
+const isInDepartment = task => {
+  if (isCurrentUserManager.value) {
+    return true
+  } else if (isCurrentUserSupervisor.value) {
+    if (user.value.departments.length === 0) {
+      return true
+    }
+    const taskType = taskTypeMap.value.get(task.task_type_id)
+    return (
+      taskType.department_id &&
+      user.value.departments.includes(taskType.department_id)
+    )
+  }
+  return false
+}
+
+const resetSelection = () => {
+  selectionGrid.value = {}
+  lastSelection.value = null
+}
+
+const getTableData = () => {
+  const headers = [
+    isAssets.value ? t('tasks.fields.asset_type') : t('tasks.fields.sequence'),
+    t('tasks.fields.entity_name'),
+    t('tasks.fields.task_status'),
+    t('tasks.fields.assignees'),
+    t('tasks.fields.difficulty'),
+    t('tasks.fields.estimation'),
+    t('tasks.fields.duration'),
+    t('tasks.fields.retake_count'),
+    t('tasks.fields.start_date'),
+    t('tasks.fields.due_date'),
+    t('tasks.fields.real_start_date'),
+    t('tasks.fields.real_end_date'),
+    t('tasks.fields.done_date'),
+    t('tasks.fields.last_comment_date')
+  ]
+  if (isShots.value) {
+    const value = !isPaperProduction.value
+      ? t('tasks.fields.frames')
+      : t('tasks.fields.drawings')
+    headers.splice(4, 0, value)
+  }
+  const taskLines = [headers]
+  props.tasks.forEach(task => {
+    if (!task) return
+    const assignees = task.assignees
+      .map(personId => personMap.value.get(personId)?.name || '')
+      .join(', ')
+
+    const line = [
+      isAssets.value
+        ? getEntity(task.entity.id).asset_type_name
+        : getEntity(task.entity.id).sequence_name,
+      getEntity(task.entity.id).name,
+      task.task_status_short_name,
+      assignees,
+      task.difficulty,
+      formatDuration(task.estimation, false),
+      formatDuration(task.duration, false),
+      task.retake_count,
+      formatDate(task.start_date),
+      formatDate(task.due_date),
+      formatDate(task.real_start_date),
+      formatDate(task.end_date),
+      formatDate(task.done_date),
+      formatDate(task.last_comment_date)
+    ]
+    if (isShots.value) {
+      const value = !isPaperProduction.value
+        ? getEntity(task.entity.id).nb_frames
+        : task.nb_drawings || 0
+      line.splice(4, 0, value)
+    }
+    taskLines.push(line)
+  })
+  return taskLines
+}
+
+// Watchers
+watch(
+  () => props.tasks,
+  () => {
+    page.value = 1
+    resetSelection()
+  }
+)
+
+watch(nbSelectedTasks, () => {
+  if (nbSelectedTasks.value === 0) resetSelection()
+})
+
+// Lifecycle
+onMounted(() => {
+  window.addEventListener('keydown', onKeyDown, false)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown)
+})
+
+defineExpose({
+  getTableData,
+  resetSelection,
+  selectTask,
+  setScrollPosition
+})
 </script>
 
 <style lang="scss" scoped>
@@ -1057,18 +993,6 @@ td.retake-count {
   padding: 0.5em;
 }
 
-.table-header th {
-  padding: 0.5em 0;
-
-  &.retake-count {
-    padding-right: 1em;
-  }
-
-  &.status {
-    padding-left: 1em;
-  }
-}
-
 .datatable-head {
   th {
     padding-left: 5px;
@@ -1128,7 +1052,6 @@ td.retake-count {
 .task-grid {
   display: grid;
   gap: 10px;
-  // grid-template-columns: repeat(auto-fill, 202px);
   grid-template-columns: 204px 204px 204px 204px 204px 204px;
 
   .task-card {

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1218,6 +1218,9 @@ const getTasks = entities => {
   entities.forEach(entity => {
     if (
       entity.canceled ||
+      // Episodes carry their cancellation in status, not in the
+      // entity-level canceled boolean.
+      entity.status === 'canceled' ||
       !entity.tasks?.length ||
       (isTVShow.value &&
         !displaySettings.value.showLinkedAssets &&

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -266,7 +266,7 @@
           :is-loading="loading.entities"
           :tasks="tasks"
           :with-schedule="isScheduleVisible"
-          @task-selected="onTaskSelected"
+          @task-selected="updateTaskInQuery"
           @scroll="onTaskListScroll"
           v-if="isActiveTab('tasks')"
         >
@@ -394,7 +394,9 @@ import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 
+import { getEntityMap } from '@/composables/entity'
 import csv from '@/lib/csv'
+import { isSupervisorInDepartments } from '@/lib/descriptors'
 import {
   applyFilters,
   getDescFilters,
@@ -415,11 +417,6 @@ import {
   minutesToDays,
   parseDate
 } from '@/lib/time'
-import assetsStore from '@/store/modules/assets.js'
-import editsStore from '@/store/modules/edits.js'
-import episodesStore from '@/store/modules/episodes.js'
-import sequencesStore from '@/store/modules/sequences.js'
-import shotsStore from '@/store/modules/shots.js'
 import taskStatusStore from '@/store/modules/taskstatus.js'
 import taskTypeStore from '@/store/modules/tasktypes.js'
 
@@ -443,103 +440,51 @@ import SearchQueryList from '@/components/widgets/SearchQueryList.vue'
 import TaskListNumbers from '@/components/widgets/TaskListNumbers.vue'
 import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
 
+const dueIn = (offset, unit, period) => tasks => {
+  const target = moment().add(offset, unit)[period]()
+  return tasks.filter(t => parseDate(t.due_date)[period]() === target)
+}
+
 const filters = {
-  all(tasks) {
-    return tasks
+  all: tasks => tasks,
+  dueweek: dueIn(0, 'days', 'isoWeek'),
+  duepreviousweek: dueIn(-7, 'days', 'isoWeek'),
+  duenextweek: dueIn(7, 'days', 'isoWeek'),
+  duemonth: dueIn(0, 'months', 'month'),
+  duepreviousmonth: dueIn(-1, 'months', 'month'),
+  duenextmonth: dueIn(1, 'months', 'month'),
+
+  duebeforetoday: tasks => {
+    const today = moment()
+    return tasks.filter(t => parseDate(t.due_date).isBefore(today))
   },
 
-  dueweek(tasks) {
-    const todayWeek = moment().isoWeek()
-    return tasks.filter(t => {
-      const dueDate = parseDate(t.due_date)
-      return dueDate.isoWeek() === todayWeek
-    })
+  dueaftertoday: tasks => {
+    const today = moment()
+    return tasks.filter(t => parseDate(t.due_date).isAfter(today))
   },
 
-  duepreviousweek(tasks) {
-    const previousWeek = moment().add(-7, 'days').isoWeek()
-    return tasks.filter(t => {
-      const dueDate = parseDate(t.due_date)
-      return dueDate.isoWeek() === previousWeek
-    })
-  },
+  overestimation: tasks =>
+    tasks.filter(t => t.estimation && t.duration > t.estimation),
 
-  duenextweek(tasks) {
-    const nextWeek = moment().add(7, 'days').isoWeek()
-    return tasks.filter(t => {
-      const dueDate = parseDate(t.due_date)
-      return dueDate.isoWeek() === nextWeek
-    })
-  },
-
-  duebeforetoday(tasks) {
+  approvallate: (tasks, taskStatusMap) => {
     const today = moment()
     return tasks.filter(t => {
-      const dueDate = parseDate(t.due_date)
-      return dueDate.isBefore(today)
-    })
-  },
-
-  duemonth(tasks) {
-    const todayMonth = moment().month()
-    return tasks.filter(t => {
-      const dueDate = parseDate(t.due_date)
-      return dueDate.month() === todayMonth
-    })
-  },
-
-  duepreviousmonth(tasks) {
-    const previousMonth = moment().add(-1, 'months').month()
-    return tasks.filter(t => {
-      const dueDate = parseDate(t.due_date)
-      return dueDate.month() === previousMonth
-    })
-  },
-
-  duenextmonth(tasks) {
-    const nextMonth = moment().add(1, 'months').month()
-    return tasks.filter(t => {
-      const dueDate = parseDate(t.due_date)
-      return dueDate.month() === nextMonth
-    })
-  },
-
-  dueaftertoday(tasks) {
-    const today = moment()
-    return tasks.filter(t => {
-      const dueDate = parseDate(t.due_date)
-      return dueDate.isAfter(today)
-    })
-  },
-
-  overestimation(tasks) {
-    return tasks.filter(t => {
-      return t.estimation && t.duration > t.estimation
-    })
-  },
-
-  approvallate(tasks, taskStatusMap) {
-    const today = moment()
-    return tasks.filter(t => {
-      const dueDate = parseDate(t.due_date)
+      const status = taskStatusMap.get(t.task_status_id)
       return (
-        dueDate.isBefore(today) &&
-        !(
-          taskStatusMap.get(t.task_status_id).is_feedback_request ||
-          taskStatusMap.get(t.task_status_id).is_done
-        )
+        parseDate(t.due_date).isBefore(today) &&
+        !(status.is_feedback_request || status.is_done)
       )
     })
   },
 
-  donelate(tasks, taskStatusMap) {
+  donelate: (tasks, taskStatusMap) => {
     const today = moment()
-    return tasks.filter(t => {
-      const dueDate = parseDate(t.due_date)
-      return (
-        dueDate.isBefore(today) && !taskStatusMap.get(t.task_status_id).is_done
-      )
-    })
+    return tasks.filter(
+      t =>
+        parseDate(t.due_date).isBefore(today) &&
+        !taskStatusMap.get(t.task_status_id).is_done
+    )
   }
 }
 
@@ -574,12 +519,6 @@ const entityType = ref('Asset')
 const estimationFilter = ref('all')
 const importCsvFormData = ref({})
 const isScheduleVisible = ref(false)
-const optionalColumns = ref([
-  'Estimation',
-  'Start date',
-  'Due date',
-  'Difficulty'
-])
 const parsedCSV = ref([])
 const priorityFilter = ref('-1')
 const retakeCountFilter = ref('all')
@@ -662,8 +601,6 @@ const modals = reactive({
 
 const schedule = reactive({
   currentColor: 'status',
-  startDate: null,
-  endDate: null,
   scheduleItems: [],
   taskTypeAfter: null,
   taskTypeBefore: null,
@@ -706,16 +643,7 @@ const user = computed(() => store.getters.user)
 const taskStatusMap = computed(() => taskStatusStore.cache.taskStatusMap)
 const taskTypeMap = computed(() => taskTypeStore.cache.taskTypeMap)
 
-const entityMap = computed(() => {
-  const caches = {
-    asset: assetsStore.cache.assetMap,
-    edit: editsStore.cache.editMap,
-    episode: episodesStore.cache.episodeMap,
-    sequence: sequencesStore.cache.sequenceMap,
-    shot: shotsStore.cache.shotMap
-  }
-  return caches[entityType.value.toLowerCase()]
-})
+const entityMap = computed(() => getEntityMap(entityType.value))
 
 const isEpisodesSection = computed(() => route.meta.section === 'episodes')
 
@@ -774,15 +702,21 @@ const taskTypeStartDate = computed(() =>
 
 const taskTypeEndDate = computed(() => moment(schedule.taskTypeEndDate).utc())
 
-const isSupervisorInDepartment = computed(() => {
-  const departments = user.value.departments || []
-  return (
+const isSupervisorInDepartment = computed(
+  () =>
     isCurrentUserManager.value ||
-    (isCurrentUserSupervisor.value &&
-      (!departments.length ||
-        departments.includes((currentTaskType.value || {}).department_id)))
-  )
-})
+    isSupervisorInDepartments(
+      user.value,
+      isCurrentUserSupervisor.value,
+      currentTaskType.value?.department_id
+    )
+)
+
+const optionalColumns = computed(() =>
+  isPaperProduction.value
+    ? ['Drawings', 'Estimation', 'Start date', 'Due date', 'Difficulty']
+    : ['Estimation', 'Start date', 'Due date', 'Difficulty']
+)
 
 const productionStartDate = computed(() =>
   parseDate(currentProduction.value.start_date)
@@ -887,14 +821,6 @@ const zoomOptions = computed(() => [
 ])
 
 // Functions
-const setOptionalImportColumns = () => {
-  const columns = ['Estimation', 'Start date', 'Due date', 'Difficulty']
-  if (isPaperProduction.value) {
-    columns.unshift('Drawings')
-  }
-  optionalColumns.value = columns
-}
-
 const initData = force => {
   resetTasks()
   focusSearchField({ preventScroll: true })
@@ -908,19 +834,11 @@ const initData = force => {
         loading.entities = false
         resetTasks()
         focusSearchField({ preventScroll: true })
-        let searchQuery = route.query.search
-        if (!searchQuery && searchFieldRef.value) {
-          searchQuery = searchFieldRef.value.getValue()
-        }
-        if (searchQuery) onSearchChange(searchQuery)
+        applySearchAndScheduleState()
         setTimeout(() => {
           setSearchFromUrl()
           resetTaskTypeDates()
         }, 200)
-        if (dataDisplay.value.beforeAfterTasks) {
-          setDefaultBeforeAfterTaskTypes()
-        }
-        resetScheduleItems(true)
 
         dueDateFilter.value = route.query.duedate || 'all'
         estimationFilter.value = route.query.late || 'all'
@@ -948,17 +866,18 @@ const initData = force => {
     setCurrentScheduleItem().then(() => {
       resetTaskTypeDates()
       loading.entities = false
-      let searchQuery = route.query.search
-      if (!searchQuery && searchFieldRef.value) {
-        searchQuery = searchFieldRef.value.getValue()
-      }
-      if (searchQuery) onSearchChange(searchQuery)
-      if (dataDisplay.value.beforeAfterTasks) {
-        setDefaultBeforeAfterTaskTypes()
-      }
-      resetScheduleItems(true)
+      applySearchAndScheduleState()
     })
   }
+}
+
+const applySearchAndScheduleState = () => {
+  const searchQuery = route.query.search || searchFieldRef.value?.getValue()
+  if (searchQuery) onSearchChange(searchQuery)
+  if (dataDisplay.value.beforeAfterTasks) {
+    setDefaultBeforeAfterTaskTypes()
+  }
+  resetScheduleItems(true)
 }
 
 const setCurrentScheduleItem = () => {
@@ -1150,16 +1069,12 @@ const updateUrlParams = () => {
 
 // Tasks
 
+// onSearchChange leaves tasks sorted on every path, no extra sort needed.
 const applyTaskFilters = () => {
   onSearchChange(searchFieldRef.value.getValue())
-  sortTasks()
   taskListRef.value?.resetSelection()
   updateUrlParams()
   store.dispatch('clearSelectedTasks')
-}
-
-const onTaskSelected = () => {
-  updateTaskInQuery()
 }
 
 const onTaskListScroll = ({ top }) => {
@@ -1201,13 +1116,14 @@ const updateTaskInQuery = () => {
 const getEntityTasks = () => getTasks(Array.from(entityMap.value.values()))
 
 const resetTasks = () => {
-  tasks.value = sortTasks(getEntityTasks())
-  resetTaskIndex()
+  const entityTasks = getEntityTasks()
+  tasks.value = sortTasks(entityTasks)
+  resetTaskIndex(entityTasks)
 }
 
-const resetTaskIndex = () => {
+const resetTaskIndex = (entityTasks = getEntityTasks()) => {
   taskIndex = buildSupervisorTaskIndex(
-    getEntityTasks(),
+    entityTasks,
     personMap.value,
     taskStatusMap.value
   )
@@ -1249,23 +1165,20 @@ const getTasks = entities => {
   return result
 }
 
-const sortTasks = list => {
-  if (!list) list = tasks.value
-  const isDesc = ['task_status_short_name', 'entity_name', 'due_date'].includes(
-    currentSort.value
-  )
+const sortTasks = (list = tasks.value) => {
   if (currentSort.value === 'nb_frames') {
-    tasks.value = list.sort((ta, tb) => {
+    return list.sort((ta, tb) => {
       const nbFramesA = getEntity(ta.entity.id)?.nb_frames || 0
       const nbFramesB = getEntity(tb.entity.id)?.nb_frames || 0
       return nbFramesB - nbFramesA
     })
-  } else {
-    tasks.value = list.sort(
-      firstBy(currentSort.value, isDesc ? 1 : -1).thenBy('entity_name')
-    )
   }
-  return list
+  const isDesc = ['task_status_short_name', 'entity_name', 'due_date'].includes(
+    currentSort.value
+  )
+  return list.sort(
+    firstBy(currentSort.value, isDesc ? 1 : -1).thenBy('entity_name')
+  )
 }
 
 const getEntity = entityId => entityMap.value.get(entityId) || {}
@@ -1349,14 +1262,14 @@ const resetScheduleItems = async (resetScroll = false) => {
   }
 }
 
-const resetScheduleItemsForScheduleTab = async () => {
-  if (!currentScheduleItem.value) return
-
+// Shared prelude of the two schedule rebuilds: assignation map plus the
+// days-off and timesheet loads (independent requests, run in parallel).
+const prepareScheduleData = async () => {
   const taskAssignationMap = buildAssignationMap()
   const startDate = currentScheduleItem.value.start_date
   const endDate = currentScheduleItem.value.end_date
 
-  daysOffByPerson.value = await store
+  const daysOffPromise = store
     .dispatch('loadProductionDaysOff', { startDate, endDate })
     .catch(
       () => ({}) // fallback if not allowed to fetch days off
@@ -1366,12 +1279,23 @@ const resetScheduleItemsForScheduleTab = async () => {
     const assignees = Object.keys(taskAssignationMap).filter(
       id => id !== 'unassigned' && taskAssignationMap[id].length > 0
     )
-    timesheetByPerson.value = await loadTimesheets(
-      assignees,
-      startDate,
-      endDate
-    )
+    const [daysOff, timesheets] = await Promise.all([
+      daysOffPromise,
+      loadTimesheets(assignees, startDate, endDate)
+    ])
+    daysOffByPerson.value = daysOff
+    timesheetByPerson.value = timesheets
+  } else {
+    daysOffByPerson.value = await daysOffPromise
   }
+
+  return taskAssignationMap
+}
+
+const resetScheduleItemsForScheduleTab = async () => {
+  if (!currentScheduleItem.value) return
+
+  const taskAssignationMap = await prepareScheduleData()
 
   const scheduleItems = team.value
     .map(person =>
@@ -1398,26 +1322,7 @@ const resetScheduleItemsForScheduleTab = async () => {
 const resetScheduleItemsForTasksTab = async () => {
   if (!currentScheduleItem.value) return
 
-  const taskAssignationMap = buildAssignationMap()
-  const startDate = currentScheduleItem.value.start_date
-  const endDate = currentScheduleItem.value.end_date
-
-  daysOffByPerson.value = await store
-    .dispatch('loadProductionDaysOff', { startDate, endDate })
-    .catch(
-      () => ({}) // fallback if not allowed to fetch days off
-    )
-
-  if (dataDisplay.value.timesheets) {
-    const assignees = Object.keys(taskAssignationMap).filter(
-      id => id !== 'unassigned' && taskAssignationMap[id].length > 0
-    )
-    timesheetByPerson.value = await loadTimesheets(
-      assignees,
-      startDate,
-      endDate
-    )
-  }
+  await prepareScheduleData()
 
   const scheduleItems = [
     {
@@ -1478,12 +1383,13 @@ const loadTimesheets = async (personIds, startDate, endDate) => {
       () => ({}) // fallback if not allowed to fetch timesheets
     )
 
+  const taskById = new Map(tasks.value.map(task => [task.id, task]))
   const timesheetByPersonResult = {}
   for (const personId of personIds) {
     const timesheet =
       timesheets[personId]?.sort(firstBy('date').thenBy('task_id')) || []
     timesheet.forEach(entry => {
-      entry.task = tasks.value.find(task => task.id === entry.task_id)
+      entry.task = taskById.get(entry.task_id)
       entry.startDate = parseDate(entry.date)
       entry.endDate = parseDate(entry.date)
     })
@@ -1516,6 +1422,43 @@ const loadTimesheets = async (personIds, startDate, endDate) => {
     timesheetByPersonResult[personId] = mergedTimesheet
   }
   return timesheetByPersonResult
+}
+
+// Resolve a task's schedule dates: explicit dates first, then the real
+// start, then an estimation-based end. Without a default start a task
+// with no dates yields undefined dates (callers drop those elements).
+const getTaskDates = (task, daysOff, defaultStartDate = undefined) => {
+  let startDate = defaultStartDate
+  if (task.start_date) {
+    startDate = parseDate(task.start_date)
+  } else if (task.real_start_date) {
+    startDate = parseDate(task.real_start_date)
+  }
+
+  let endDate
+  if (task.due_date) {
+    endDate = parseDate(task.due_date)
+  } else if (task.end_date) {
+    endDate = parseDate(task.end_date)
+  } else {
+    endDate = addBusinessDays(
+      startDate,
+      Math.ceil(minutesToDays(organisation.value, task.estimation)) - 1,
+      daysOff
+    )
+  }
+  return { startDate, endDate }
+}
+
+const enrichSiblingElement = (element, taskType, daysOff) => {
+  if (!element) return null
+  const { startDate, endDate } = getTaskDates(element, daysOff)
+  if (!startDate || !endDate) return null
+  element.name = `[${taskType.name}] ${element.entity_name}`
+  element.startDate = startDate
+  element.endDate = endDate
+  element.color = getTaskElementColor(element, endDate)
+  return element
 }
 
 const buildPersonElement = (
@@ -1566,43 +1509,15 @@ const buildPersonElement = (
 
   const children = personTasks.map(task => {
     const estimation = task.estimation
-    let endDate
-
-    let startDate = moment(schedule.taskTypeStartDate)
-    if (task.start_date) {
-      startDate = parseDate(task.start_date)
-    } else if (task.real_start_date) {
-      startDate = parseDate(task.real_start_date)
-    }
-
-    if (startDate.isAfter(schedule.endDate)) {
-      startDate = schedule.endDate.clone().add(-1, 'days')
-    }
-    if (startDate.isBefore(schedule.startDate)) {
-      startDate = schedule.startDate.clone()
-    }
-
-    if (task.due_date) {
-      endDate = parseDate(task.due_date)
-    } else if (task.end_date) {
-      endDate = parseDate(task.end_date)
-    } else {
-      endDate = addBusinessDays(
-        startDate,
-        Math.ceil(minutesToDays(organisation.value, task.estimation)) - 1,
-        personElement.daysOff
-      )
-    }
+    let { startDate, endDate } = getTaskDates(
+      task,
+      personElement.daysOff,
+      moment(schedule.taskTypeStartDate)
+    )
 
     if (!endDate || endDate.isBefore(startDate)) {
       const nbDays = startDate.isoWeekday() === 5 ? 3 : 1
       endDate = startDate.clone().add(nbDays, 'days')
-    }
-    if (endDate.isAfter(schedule.endDate)) {
-      endDate = schedule.endDate.clone().add(-1, 'days')
-      if (startDate.isAfter(endDate)) {
-        startDate = endDate.clone().add(-1, 'days')
-      }
     }
 
     if (estimation) manDays += estimation
@@ -1646,67 +1561,16 @@ const buildPersonElement = (
       }
     }
 
-    if (data.previousElement) {
-      const task = data.previousElement
-      let startDate
-      if (task.start_date) {
-        startDate = parseDate(task.start_date)
-      } else if (task.real_start_date) {
-        startDate = parseDate(task.real_start_date)
-      }
-      let endDate
-      if (task.due_date) {
-        endDate = parseDate(task.due_date)
-      } else if (task.end_date) {
-        endDate = parseDate(task.end_date)
-      } else {
-        endDate = addBusinessDays(
-          startDate,
-          Math.ceil(minutesToDays(organisation.value, task.estimation)) - 1,
-          personElement.daysOff
-        )
-      }
-
-      if (startDate && endDate) {
-        data.previousElement.name = `[${currentTaskTypeBefore.value.name}] ${task.entity_name}`
-        data.previousElement.startDate = startDate
-        data.previousElement.endDate = endDate
-        data.previousElement.color = getTaskElementColor(task, endDate)
-      } else {
-        data.previousElement = null
-      }
-    }
-
-    if (data.nextElement) {
-      const task = data.nextElement
-      let startDate
-      if (task.start_date) {
-        startDate = parseDate(task.start_date)
-      } else if (task.real_start_date) {
-        startDate = parseDate(task.real_start_date)
-      }
-      let endDate
-      if (task.due_date) {
-        endDate = parseDate(task.due_date)
-      } else if (task.end_date) {
-        endDate = parseDate(task.end_date)
-      } else {
-        endDate = addBusinessDays(
-          startDate,
-          Math.ceil(minutesToDays(organisation.value, task.estimation)) - 1,
-          personElement.daysOff
-        )
-      }
-
-      if (startDate && endDate) {
-        data.nextElement.name = `[${currentTaskTypeAfter.value.name}] ${task.entity_name}`
-        data.nextElement.startDate = startDate
-        data.nextElement.endDate = endDate
-        data.nextElement.color = getTaskElementColor(task, endDate)
-      } else {
-        data.nextElement = null
-      }
-    }
+    data.previousElement = enrichSiblingElement(
+      data.previousElement,
+      currentTaskTypeBefore.value,
+      personElement.daysOff
+    )
+    data.nextElement = enrichSiblingElement(
+      data.nextElement,
+      currentTaskTypeAfter.value,
+      personElement.daysOff
+    )
 
     return data
   })
@@ -1963,7 +1827,6 @@ watch(
 )
 
 watch(currentProduction, () => {
-  setOptionalImportColumns()
   initData(true)
 })
 
@@ -2022,35 +1885,17 @@ watch(currentScheduleItem, () => {
 })
 
 watch(
-  () => schedule.taskTypeStartDate,
+  [() => schedule.taskTypeStartDate, () => schedule.taskTypeEndDate],
   () => {
-    const newDate = moment(schedule.taskTypeStartDate)
-      .utc()
-      .format('YYYY-MM-DD')
-    if (newDate !== currentScheduleItem.value.start_date) {
+    const startDate = moment(schedule.taskTypeStartDate).utc()
+    const endDate = moment(schedule.taskTypeEndDate).utc()
+    if (
+      startDate.format('YYYY-MM-DD') !== currentScheduleItem.value.start_date ||
+      endDate.format('YYYY-MM-DD') !== currentScheduleItem.value.end_date
+    ) {
       store.commit('SET_SCHEDULE_ITEM_DATES', {
         scheduleItem: currentScheduleItem.value,
-        dates: {
-          startDate: moment(schedule.taskTypeStartDate).utc(),
-          endDate: moment(schedule.taskTypeEndDate).utc()
-        }
-      })
-      store.dispatch('saveScheduleItem', currentScheduleItem.value)
-    }
-  }
-)
-
-watch(
-  () => schedule.taskTypeEndDate,
-  () => {
-    const newDate = moment(schedule.taskTypeEndDate).utc().format('YYYY-MM-DD')
-    if (newDate !== currentScheduleItem.value.end_date) {
-      store.commit('SET_SCHEDULE_ITEM_DATES', {
-        scheduleItem: currentScheduleItem.value,
-        dates: {
-          startDate: moment(schedule.taskTypeStartDate).utc(),
-          endDate: moment(schedule.taskTypeEndDate).utc()
-        }
+        dates: { startDate, endDate }
       })
       store.dispatch('saveScheduleItem', currentScheduleItem.value)
     }
@@ -2072,7 +1917,6 @@ onMounted(() => {
     ...dataDisplay.value,
     ...preferences.getObjectPreference('tasktype:data_display')
   }
-  setOptionalImportColumns()
   searchFieldRef.value?.setValue(route.query.search || '')
   store.dispatch('clearSelectedTasks')
   const isAssets = route.path.includes('assets')

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1891,7 +1891,7 @@ const onRemoteTaskUpdate = eventData => {
   if (
     !isActiveTab('schedule') &&
     taskMap.value.get(eventData.task_id) &&
-    selectedTasks.value === 0 &&
+    nbSelectedTasks.value === 0 &&
     searchFieldRef.value &&
     searchFieldRef.value.getValue() === ''
   ) {

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="task-type columns fixed-page">
     <div class="column main-column">
-      <div class="task-type page" ref="page">
-        <div class="task-type-header page-header flexrow-item" ref="header">
+      <div class="task-type page">
+        <div class="task-type-header page-header flexrow-item">
           <div class="flexcolumn-item flexrow">
             <router-link class="back-link flexrow-item" :to="backPath">
               <corner-left-up-icon />
@@ -194,8 +194,8 @@
               <date-field
                 class="flexrow-item"
                 :can-delete="false"
-                :min-date="startDisabledDates.to"
-                :max-date="startDisabledDates.from"
+                :min-date="disabledDates.to"
+                :max-date="disabledDates.from"
                 :label="$t('main.start_date')"
                 utc
                 week-days-disabled
@@ -210,8 +210,8 @@
               <date-field
                 class="flexrow-item"
                 :can-delete="false"
-                :min-date="endDisabledDates.to"
-                :max-date="endDisabledDates.from"
+                :min-date="disabledDates.to"
+                :max-date="disabledDates.from"
                 :label="$t('main.end_date')"
                 utc
                 week-days-disabled
@@ -237,7 +237,7 @@
               <combobox-number
                 class="mt0 nowrap"
                 :label="$t('schedule.zoom_level')"
-                :options="schedule.zoomOptions"
+                :options="zoomOptions"
                 no-field
                 v-model="schedule.zoomLevel"
                 v-if="isActiveTab('schedule')"
@@ -331,7 +331,6 @@
           v-if="isActiveTab('estimation')"
         >
           <estimation-helper
-            ref="estimation-widget"
             :entity-type="entityType"
             :tasks="tasks"
             @estimation-changed="updateEstimation"
@@ -374,21 +373,35 @@
   </div>
 </template>
 
-<script>
-import assetsStore from '@/store/modules/assets.js'
-import editsStore from '@/store/modules/edits.js'
-import episodesStore from '@/store/modules/episodes.js'
-import sequencesStore from '@/store/modules/sequences.js'
-import shotsStore from '@/store/modules/shots.js'
-import taskStatusStore from '@/store/modules/taskstatus.js'
-import taskTypeStore from '@/store/modules/tasktypes.js'
-
+<script setup>
+// Imports
+import { useHead } from '@unhead/vue'
 import { CornerLeftUpIcon } from 'lucide-vue-next'
 import moment from 'moment'
 import { firstBy } from 'thenby'
-import { mapGetters, mapActions } from 'vuex'
+import {
+  computed,
+  getCurrentInstance,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  reactive,
+  ref,
+  useTemplateRef,
+  watch
+} from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
+import { useStore } from 'vuex'
 
 import csv from '@/lib/csv'
+import {
+  applyFilters,
+  getDescFilters,
+  getExcludingKeyWords,
+  getKeyWords,
+  getTaskFilters
+} from '@/lib/filtering'
 import { buildSupervisorTaskIndex, indexSearch } from '@/lib/indexing'
 import { getPersonPath } from '@/lib/path'
 import preferences from '@/lib/preferences'
@@ -402,33 +415,31 @@ import {
   minutesToDays,
   parseDate
 } from '@/lib/time'
-import {
-  applyFilters,
-  getDescFilters,
-  getExcludingKeyWords,
-  getKeyWords,
-  getTaskFilters
-} from '@/lib/filtering'
+import assetsStore from '@/store/modules/assets.js'
+import editsStore from '@/store/modules/edits.js'
+import episodesStore from '@/store/modules/episodes.js'
+import sequencesStore from '@/store/modules/sequences.js'
+import shotsStore from '@/store/modules/shots.js'
+import taskStatusStore from '@/store/modules/taskstatus.js'
+import taskTypeStore from '@/store/modules/tasktypes.js'
 
-import { formatListMixin } from '@/components/mixins/format'
-import { searchMixin } from '@/components/mixins/search'
-
+import TaskList from '@/components/lists/TaskList.vue'
+import ImportModal from '@/components/modals/ImportModal.vue'
+import ImportRenderModal from '@/components/modals/ImportRenderModal.vue'
+import EstimationHelper from '@/components/pages/tasktype/EstimationHelper.vue'
+import TaskInfo from '@/components/sides/TaskInfo.vue'
 import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
+import ComboboxDisplayOptions from '@/components/widgets/ComboboxDisplayOptions.vue'
 import ComboboxNumber from '@/components/widgets/ComboboxNumber.vue'
 import ComboboxOptions from '@/components/widgets/ComboboxOptions.vue'
 import ComboboxStatus from '@/components/widgets/ComboboxStatus.vue'
-import ComboboxDisplayOptions from '@/components/widgets/ComboboxDisplayOptions.vue'
 import ComboboxStyled from '@/components/widgets/ComboboxStyled.vue'
 import ComboboxTaskType from '@/components/widgets/ComboboxTaskType.vue'
 import DateField from '@/components/widgets/DateField.vue'
-import EstimationHelper from '@/components/pages/tasktype/EstimationHelper.vue'
-import ImportModal from '@/components/modals/ImportModal.vue'
-import ImportRenderModal from '@/components/modals/ImportRenderModal.vue'
+// eslint-disable-next-line no-unused-vars
 import Schedule from '@/components/widgets/Schedule.vue'
 import SearchField from '@/components/widgets/SearchField.vue'
 import SearchQueryList from '@/components/widgets/SearchQueryList.vue'
-import TaskInfo from '@/components/sides/TaskInfo.vue'
-import TaskList from '@/components/lists/TaskList.vue'
 import TaskListNumbers from '@/components/widgets/TaskListNumbers.vue'
 import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
 
@@ -532,1670 +543,1563 @@ const filters = {
   }
 }
 
-export default {
-  name: 'task-type',
+// Composables
+const { t } = useI18n()
+const route = useRoute()
+const router = useRouter()
+const store = useStore()
 
-  mixins: [formatListMixin, searchMixin],
+const instance = getCurrentInstance()
+const socket = instance.appContext.config.globalProperties.$socket
 
-  components: {
-    ButtonSimple,
-    ComboboxDisplayOptions,
-    CornerLeftUpIcon,
-    ComboboxNumber,
-    ComboboxOptions,
-    ComboboxStatus,
-    ComboboxStyled,
-    ComboboxTaskType,
-    DateField,
-    EstimationHelper,
-    ImportModal,
-    ImportRenderModal,
-    Schedule,
-    SearchField,
-    SearchQueryList,
-    TaskList,
-    TaskInfo,
-    TaskListNumbers,
-    TaskTypeName
+// State
+const activeTab = ref('tasks')
+const currentScheduleItem = ref(null)
+const currentSort = ref('entity_name')
+const daysOffByPerson = ref({})
+const timesheetByPerson = ref({})
+const displaySettings = ref({
+  contactSheetMode: false,
+  showLinkedAssets: true
+})
+const dataDisplay = ref({
+  estimations: true,
+  statuses: true,
+  timesheets: false,
+  beforeAfterTasks: false
+})
+const difficultyFilter = ref('-1')
+const dueDateFilter = ref('all')
+const entityType = ref('Asset')
+const estimationFilter = ref('all')
+const importCsvFormData = ref({})
+const isScheduleVisible = ref(false)
+const optionalColumns = ref([
+  'Estimation',
+  'Start date',
+  'Due date',
+  'Difficulty'
+])
+const parsedCSV = ref([])
+const priorityFilter = ref('-1')
+const retakeCountFilter = ref('all')
+const tasks = ref([])
+const taskStatusIdFilter = ref(null)
+
+// Search index for the supervisor filters, non-reactive by design
+let taskIndex = null
+
+const dataMatchers = ['Parent', 'Entity']
+const difficultyOptions = [
+  { label: 'all_tasks', value: '-1' },
+  { label: 'difficulty.very_easy', value: '1' },
+  { label: 'difficulty.easy', value: '2' },
+  { label: 'difficulty.medium', value: '3' },
+  { label: 'difficulty.hard', value: '4' },
+  { label: 'difficulty.very_hard', value: '5' }
+]
+const dueDateOptions = [
+  { label: 'all_tasks', value: 'all' },
+  { label: 'due_this_week', value: 'dueweek' },
+  { label: 'due_previous_week', value: 'duepreviousweek' },
+  { label: 'due_next_week', value: 'duenextweek' },
+  { label: 'due_this_month', value: 'duemonth' },
+  { label: 'due_previous_month', value: 'duepreviousmonth' },
+  { label: 'due_next_month', value: 'duenextmonth' },
+  { label: 'due_before_today', value: 'duebeforetoday' },
+  { label: 'due_after_today', value: 'dueaftertoday' }
+]
+const estimationOptions = [
+  { label: 'all_tasks', value: 'all' },
+  { label: 'estimation_over', value: 'overestimation' },
+  { label: 'estimation_approval_late', value: 'approvallate' },
+  { label: 'estimation_done_late', value: 'donelate' }
+]
+const priorityOptions = [
+  { label: 'all_tasks', value: '-1' },
+  { label: 'priority.normal', value: '0' },
+  { label: 'priority.high', value: '1' },
+  { label: 'priority.very_high', value: '2' },
+  { label: 'priority.emergency', value: '3' }
+]
+const retakeCountOptions = [
+  { label: 'all_tasks', value: 'all' },
+  { label: 'retake_filter_none', value: 'none' },
+  { label: 'retake_filter_with_retakes', value: 'with_retakes' }
+]
+const sortOptions = [
+  'entity_name',
+  'task_status_short_name',
+  'priority',
+  'nb_frames',
+  'difficulty',
+  'estimation',
+  'duration',
+  'retake_count',
+  'start_date',
+  'due_date',
+  'real_start_date',
+  'end_date',
+  'last_comment_date'
+].map(name => ({ label: name, value: name }))
+
+const errors = reactive({
+  entities: false,
+  importing: false,
+  importingError: null
+})
+
+const loading = reactive({
+  entities: false,
+  importing: false,
+  savingSearch: false
+})
+
+const modals = reactive({
+  isImportRenderDisplayed: false,
+  importing: false
+})
+
+const schedule = reactive({
+  currentColor: 'status',
+  startDate: null,
+  endDate: null,
+  scheduleItems: [],
+  taskTypeAfter: null,
+  taskTypeBefore: null,
+  taskTypeEndDate: null,
+  taskTypeStartDate: null,
+  zoomLevel: 1,
+  colorOptions: [
+    { label: 'Neutral', value: 'neutral' },
+    { label: 'Status', value: 'status' },
+    { label: 'Late', value: 'late' }
+  ]
+})
+
+const importModalRef = useTemplateRef('import-modal')
+const scheduleWidgetRef = useTemplateRef('schedule-widget')
+const searchFieldRef = useTemplateRef('task-search-field')
+const taskListRef = useTemplateRef('task-list')
+
+// Computed
+const currentEpisode = computed(() => store.getters.currentEpisode)
+const currentProduction = computed(() => store.getters.currentProduction)
+const currentTaskType = computed(() => store.getters.currentTaskType)
+const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
+const isCurrentUserSupervisor = computed(
+  () => store.getters.isCurrentUserSupervisor
+)
+const isPaperProduction = computed(() => store.getters.isPaperProduction)
+const isTVShow = computed(() => store.getters.isTVShow)
+const nbSelectedTasks = computed(() => store.getters.nbSelectedTasks)
+const organisation = computed(() => store.getters.organisation)
+const personMap = computed(() => store.getters.personMap)
+const productionTaskStatuses = computed(
+  () => store.getters.productionTaskStatuses
+)
+const selectedTasks = computed(() => store.getters.selectedTasks)
+const taskMap = computed(() => store.getters.taskMap)
+const taskSearchQueries = computed(() => store.getters.taskSearchQueries)
+const user = computed(() => store.getters.user)
+
+const taskStatusMap = computed(() => taskStatusStore.cache.taskStatusMap)
+const taskTypeMap = computed(() => taskTypeStore.cache.taskTypeMap)
+
+const entityMap = computed(() => {
+  const caches = {
+    asset: assetsStore.cache.assetMap,
+    edit: editsStore.cache.editMap,
+    episode: episodesStore.cache.episodeMap,
+    sequence: sequencesStore.cache.sequenceMap,
+    shot: shotsStore.cache.shotMap
+  }
+  return caches[entityType.value.toLowerCase()]
+})
+
+const isEpisodesSection = computed(() => route.meta.section === 'episodes')
+
+const taskStatusList = computed(() => [
+  {
+    id: '',
+    color: '#999',
+    short_name: t('news.all')
   },
+  ...sortByName([...productionTaskStatuses.value])
+])
 
-  data() {
-    return {
-      activeTab: 'tasks',
-      daysOffByPerson: {},
-      timesheetByPerson: {},
-      currentSort: 'entity_name',
-      currentScheduleItem: null,
-      currentTask: null,
-      displaySettings: {
-        contactSheetMode: false,
-        showLinkedAssets: true
-      },
-      dataDisplay: {
-        estimations: true,
-        statuses: true,
-        timesheets: false,
-        beforeAfterTasks: false
-      },
-      dataDisplayOptions: [
-        {
-          label: this.$t('tasks.fields.estimation'),
-          value: 'estimations'
-        },
-        {
-          label: this.$t('tasks.fields.task_status'),
-          value: 'statuses'
-        },
-        {
-          label: this.$t('tasks.fields.timesheets'),
-          value: 'timesheets'
-        },
-        {
-          label: this.$t('tasks.fields.before_after_tasks'),
-          value: 'beforeAfterTasks'
-        }
-      ],
-      dataMatchers: ['Parent', 'Entity'],
-      difficultyFilter: '-1',
-      dueDateFilter: 'all',
-      entityType: 'Asset',
-      estimationFilter: 'all',
-      importCsvFormData: {},
-      isScheduleVisible: false,
-      optionalColumns: ['Estimation', 'Start date', 'Due date', 'Difficulty'],
-      parsedCSV: [],
-      priorityFilter: '-1',
-      retakeCountFilter: 'all',
-      retakeCountOptions: [
-        { label: 'all_tasks', value: 'all' },
-        { label: 'retake_filter_none', value: 'none' },
-        { label: 'retake_filter_with_retakes', value: 'with_retakes' }
-      ],
-      selection: {},
-      tasks: [],
-      taskStatusIdFilter: null,
-      difficultyOptions: [
-        { label: 'all_tasks', value: '-1' },
-        { label: 'difficulty.very_easy', value: '1' },
-        { label: 'difficulty.easy', value: '2' },
-        { label: 'difficulty.medium', value: '3' },
-        { label: 'difficulty.hard', value: '4' },
-        { label: 'difficulty.very_hard', value: '5' }
-      ],
-      dueDateOptions: [
-        { label: 'all_tasks', value: 'all' },
-        { label: 'due_this_week', value: 'dueweek' },
-        { label: 'due_previous_week', value: 'duepreviousweek' },
-        { label: 'due_next_week', value: 'duenextweek' },
-        { label: 'due_this_month', value: 'duemonth' },
-        { label: 'due_previous_month', value: 'duepreviousmonth' },
-        { label: 'due_next_month', value: 'duenextmonth' },
-        { label: 'due_before_today', value: 'duebeforetoday' },
-        { label: 'due_after_today', value: 'dueaftertoday' }
-      ],
-      estimationOptions: [
-        { label: 'all_tasks', value: 'all' },
-        { label: 'estimation_over', value: 'overestimation' },
-        { label: 'estimation_approval_late', value: 'approvallate' },
-        { label: 'estimation_done_late', value: 'donelate' }
-      ],
-      errors: {
-        entities: false,
-        importing: false,
-        importingError: null
-      },
-      loading: {
-        entities: false,
-        importing: false,
-        savingSearch: false
-      },
-      modals: {
-        isImportRenderDisplayed: false,
-        importing: false
-      },
-      priorityOptions: [
-        { label: 'all_tasks', value: '-1' },
-        { label: 'priority.normal', value: '0' },
-        { label: 'priority.high', value: '1' },
-        { label: 'priority.very_high', value: '2' },
-        { label: 'priority.emergency', value: '3' }
-      ],
-      schedule: {
-        currentColor: 'status',
-        startDate: null,
-        endDate: null,
-        scheduleItems: [],
-        taskTypeAfter: null,
-        taskTypeBefore: null,
-        taskTypeEndDate: null,
-        taskTypeStartDate: null,
-        zoomLevel: 1,
-        zoomOptions: [
-          { label: this.$t('main.week'), value: 0 },
-          { label: '1', value: 1 },
-          { label: '2', value: 2 },
-          { label: '3', value: 3 }
-        ],
-        colorOptions: [
-          { label: 'Neutral', value: 'neutral' },
-          { label: 'Status', value: 'status' },
-          { label: 'Late', value: 'late' }
-        ]
-      }
-    }
-  },
+const displayTaskType = computed(
+  () => 'tasktype-' + entityType.value.toLowerCase()
+)
 
-  created() {
-    if (!this.currentProduction) {
-      this.setProduction(this.$route.params.production_id)
-    } else {
-      const options = { productionId: this.currentProduction.id }
-      if (this.currentEpisode) options.episodeId = this.currentEpisode.id
-      this.$store.commit('RESET_PRODUCTION_PATH', options)
-    }
-  },
+const taskTypeList = computed(() => {
+  const validationColumns =
+    store.getters[`${entityType.value.toLowerCase()}ValidationColumns`]
+  return validationColumns.map(taskTypeId => taskTypeMap.value.get(taskTypeId))
+})
 
-  mounted() {
-    if (!this.currentTaskType?.id) {
-      this.$router.push({ name: 'not-found' })
-      return
-    }
+const taskTypeListBeforeFilter = computed(() => {
+  const currentIndex = taskTypeList.value.findIndex(
+    taskType => taskType.id === currentTaskType.value.id
+  )
+  const results = [{ id: null, name: t('tasks.fields.no_task_type') }]
+  if (currentIndex !== -1) {
+    results.push(...taskTypeList.value.slice(0, currentIndex).reverse())
+  }
+  return results
+})
 
-    this.displaySettings = {
-      ...this.displaySettings,
-      ...preferences.getObjectPreference('tasktype:display_settings')
-    }
-    this.dataDisplay = {
-      ...this.dataDisplay,
-      ...preferences.getObjectPreference('tasktype:data_display')
-    }
-    this.setOptionalImportColumns()
-    this.searchField?.setValue(this.$route.query.search || '')
-    this.clearSelectedTasks()
-    const isAssets = this.$route.path.includes('assets')
-    const isShots = this.$route.path.includes('shots')
-    const isEdits = this.$route.path.includes('edits')
-    const isSequences = this.$route.path.includes('sequences')
-    this.entityType = isAssets
-      ? 'Asset'
-      : isShots
-        ? 'Shot'
-        : isEdits
-          ? 'Edit'
-          : isSequences
-            ? 'Sequence'
-            : 'Episode'
-    this.updateActiveTab()
-    setTimeout(() => {
-      this.initData(false)
-      this.resetScheduleScroll()
-    }, 100)
-  },
+const taskTypeListAfterFilter = computed(() => {
+  const currentIndex = taskTypeList.value.findIndex(
+    taskType => taskType.id === currentTaskType.value.id
+  )
+  const results = [{ id: null, name: t('tasks.fields.no_task_type') }]
+  if (currentIndex !== -1) {
+    results.push(...taskTypeList.value.slice(currentIndex + 1))
+  }
+  return results
+})
 
-  beforeUnmount() {
-    this.clearSelectedTasks()
-  },
+const currentTaskTypeBefore = computed(() =>
+  taskTypeList.value.find(taskType => taskType.id === schedule.taskTypeBefore)
+)
 
-  computed: {
-    ...mapGetters([
-      'assetsPath',
-      'assetValidationColumns',
-      'currentEpisode',
-      'currentProduction',
-      'currentTaskType',
-      'editsPath',
-      'editValidationColumns',
-      'episodesPath',
-      'episodeValidationColumns',
-      'isCurrentUserManager',
-      'isCurrentUserSupervisor',
-      'isPaperProduction',
-      'isTVShow',
-      'nbSelectedTasks',
-      'organisation',
-      'personMap',
-      'productionTaskStatuses',
-      'selectedTasks',
-      'sequenceSubscriptions',
-      'sequencesPath',
-      'sequenceValidationColumns',
-      'shotsByEpisode',
-      'shotsPath',
-      'shotValidationColumns',
-      'taskMap',
-      'taskSearchQueries',
-      'user'
-    ]),
+const currentTaskTypeAfter = computed(() =>
+  taskTypeList.value.find(taskType => taskType.id === schedule.taskTypeAfter)
+)
 
-    isEpisodesSection() {
-      return this.$route.meta.section === 'episodes'
-    },
+const taskTypeStartDate = computed(() =>
+  moment(schedule.taskTypeStartDate).utc()
+)
 
-    taskStatusList() {
-      return [
-        {
-          id: '',
-          color: '#999',
-          short_name: this.$t('news.all')
-        }
-      ].concat(sortByName([...this.productionTaskStatuses]))
-    },
+const taskTypeEndDate = computed(() => moment(schedule.taskTypeEndDate).utc())
 
-    displayTaskType() {
-      return 'tasktype-' + this.entityType.toLowerCase()
-    },
+const isSupervisorInDepartment = computed(() => {
+  const departments = user.value.departments || []
+  return (
+    isCurrentUserManager.value ||
+    (isCurrentUserSupervisor.value &&
+      (!departments.length ||
+        departments.includes((currentTaskType.value || {}).department_id)))
+  )
+})
 
-    taskTypeList() {
-      const type = this.entityType.toLowerCase()
-      return this[`${type}ValidationColumns`].map(taskTypeId =>
-        this.taskTypeMap.get(taskTypeId)
-      )
-    },
+const productionStartDate = computed(() =>
+  parseDate(currentProduction.value.start_date)
+)
 
-    taskTypeListBeforeFilter() {
-      const currentIndex = this.taskTypeList.findIndex(
-        taskType => taskType.id === this.currentTaskType.id
-      )
-      const results = [{ id: null, name: this.$t('tasks.fields.no_task_type') }]
-      if (currentIndex !== -1) {
-        results.push(...this.taskTypeList.slice(0, currentIndex).reverse())
-      }
-      return results
-    },
+const productionEndDate = computed(() =>
+  parseDate(currentProduction.value.end_date)
+)
 
-    taskTypeListAfterFilter() {
-      const currentIndex = this.taskTypeList.findIndex(
-        taskType => taskType.id === this.currentTaskType.id
-      )
-      const results = [{ id: null, name: this.$t('tasks.fields.no_task_type') }]
-      if (currentIndex !== -1) {
-        results.push(...this.taskTypeList.slice(currentIndex + 1))
-      }
-      return results
-    },
+const disabledDates = computed(() => ({
+  to: parseDate(currentProduction.value.start_date).toDate(),
+  from: parseDate(currentProduction.value.end_date).toDate(),
+  days: [6, 0]
+}))
 
-    currentTaskTypeBefore() {
-      return this.taskTypeList.find(
-        taskType => taskType.id === this.schedule.taskTypeBefore
-      )
-    },
+const entityTasks = computed(() =>
+  getTasks(Array.from(entityMap.value.values()))
+)
 
-    currentTaskTypeAfter() {
-      return this.taskTypeList.find(
-        taskType => taskType.id === this.schedule.taskTypeAfter
-      )
-    },
-
-    taskTypeStartDate() {
-      return moment(this.schedule.taskTypeStartDate).utc()
-    },
-
-    taskTypeEndDate() {
-      return moment(this.schedule.taskTypeEndDate).utc()
-    },
-
-    isSupervisorInDepartment() {
-      const departments = this.user.departments || []
+const title = computed(() => {
+  if (currentProduction.value) {
+    if (isTVShow.value && currentEpisode.value) {
+      const episodeName =
+        currentEpisode.value.id === 'all'
+          ? t('main.all_assets')
+          : currentEpisode.value.name
       return (
-        this.isCurrentUserManager ||
-        (this.isCurrentUserSupervisor &&
-          (!departments.length ||
-            departments.includes((this.currentTaskType || {}).department_id)))
+        `${currentProduction.value.name} / ` +
+        `${episodeName} / ` +
+        `${currentTaskType.value.name}`
       )
-    },
-
-    entityMap() {
-      return this[`${this.entityType.toLowerCase()}Map`]
-    },
-
-    assetMap() {
-      return assetsStore.cache.assetMap
-    },
-
-    editMap() {
-      return editsStore.cache.editMap
-    },
-
-    episodeMap() {
-      return episodesStore.cache.episodeMap
-    },
-
-    sequenceMap() {
-      return sequencesStore.cache.sequenceMap
-    },
-
-    shotMap() {
-      return shotsStore.cache.shotMap
-    },
-
-    taskStatusMap() {
-      return taskStatusStore.cache.taskStatusMap
-    },
-
-    taskTypeMap() {
-      return taskTypeStore.cache.taskTypeMap
-    },
-
-    productionStartDate() {
-      return parseDate(this.currentProduction.start_date)
-    },
-
-    productionEndDate() {
-      return parseDate(this.currentProduction.end_date)
-    },
-
-    disabledDates() {
-      return {
-        to: parseDate(this.currentProduction.start_date).toDate(),
-        from: parseDate(this.currentProduction.end_date).toDate(),
-        days: [6, 0]
-      }
-    },
-
-    startDisabledDates() {
-      return {
-        to: parseDate(this.currentProduction.start_date).toDate(),
-        from: parseDate(this.currentProduction.end_date).toDate(),
-        days: [6, 0]
-      }
-    },
-
-    endDisabledDates() {
-      return {
-        to: parseDate(this.currentProduction.start_date).toDate(),
-        from: parseDate(this.currentProduction.end_date).toDate(),
-        days: [6, 0]
-      }
-    },
-
-    entityTasks() {
-      return this.getTasks(Array.from(this.entityMap.values()))
-    },
-
-    // Meta
-
-    title() {
-      if (this.currentProduction) {
-        if (this.isTVShow && this.currentEpisode) {
-          const episodeName =
-            this.currentEpisode.id === 'all'
-              ? this.$t('main.all_assets')
-              : this.currentEpisode.name
-          return (
-            `${this.currentProduction.name} / ` +
-            `${episodeName} / ` +
-            `${this.currentTaskType.name}`
-          )
-        }
-        return `${this.currentProduction.name} / ${this.currentTaskType.name}`
-      }
-      return this.$t('main.loading')
-    },
-
-    // Paths
-
-    backPath() {
-      let route = {}
-      if (this.isActiveTab('schedule')) {
-        route = {
-          name: 'schedule',
-          params: {
-            production_id: this.currentProduction.id
-          },
-          query: { search: '' }
-        }
-      } else {
-        if (this.currentTaskType.for_entity === 'Shot') {
-          route = this.shotsPath
-        }
-        if (this.currentTaskType.for_entity === 'Asset') {
-          route = this.assetsPath
-        }
-        if (this.currentTaskType.for_entity === 'Edit') {
-          route = this.editsPath
-        }
-        if (this.currentTaskType.for_entity === 'Episode') {
-          route = this.episodesPath
-        }
-        if (this.currentTaskType.for_entity === 'Sequence') {
-          route = this.sequencesPath
-        }
-      }
-      return {
-        ...route,
-        query: { search: '' }
-      }
-    },
-
-    tasksPath() {
-      return this.getRoute('task-type')
-    },
-
-    schedulePath() {
-      return this.getRoute('task-type-schedule')
-    },
-
-    estimationPath() {
-      return this.getRoute('task-type-estimation')
-    },
-
-    // Helpers
-
-    sortOptions() {
-      return [
-        'entity_name',
-        'task_status_short_name',
-        'priority',
-        'nb_frames',
-        'difficulty',
-        'estimation',
-        'duration',
-        'retake_count',
-        'start_date',
-        'due_date',
-        'real_start_date',
-        'end_date',
-        'last_comment_date'
-      ].map(name => ({ label: name, value: name }))
-    },
-
-    searchQueries() {
-      return this.taskSearchQueries.filter(
-        t => t.entity_type === this.entityType
-      )
-    },
-
-    team() {
-      return sortPeople(
-        this.currentProduction?.team
-          .map(personId => this.personMap.get(personId))
-          .filter(person => person && !person.is_bot) ?? []
-      )
-    },
-
-    searchField() {
-      return this.$refs['task-search-field']
     }
-  },
-
-  methods: {
-    ...mapActions([
-      'addSelectedTask',
-      'clearSelectedTasks',
-      'initTaskType',
-      'loadAggregatedPersonDaysOff',
-      'loadEpisodeScheduleItems',
-      'loadProductionDaysOff',
-      'loadProductionTimeSpents',
-      'loadScheduleItems',
-      'removeTaskSearch',
-      'saveScheduleItem',
-      'saveTaskSearch',
-      'setProduction',
-      'subscribeToSequence',
-      'updateTask',
-      'unsubscribeFromSequence',
-      'uploadTaskTypeEstimations'
-    ]),
-
-    setOptionalImportColumns() {
-      this.optionalColumns = [
-        'Estimation',
-        'Start date',
-        'Due date',
-        'Difficulty'
-      ]
-      if (this.isPaperProduction) {
-        this.optionalColumns.unshift('Drawings')
-      }
-    },
-
-    initData(force) {
-      this.resetTasks()
-      this.focusSearchField({ preventScroll: true })
-      if (this.tasks.length < 2) {
-        this.loading.entities = true
-        this.errors.entities = false
-        this.initTaskType(force)
-          .then(this.setCurrentScheduleItem)
-          .then(() => {
-            this.loading.entities = false
-            this.resetTasks()
-            this.focusSearchField({ preventScroll: true })
-            let searchQuery = this.$route.query.search
-            if (!searchQuery && this.searchField) {
-              searchQuery = this.searchField.getValue()
-            }
-            if (searchQuery) this.onSearchChange(searchQuery)
-            setTimeout(() => {
-              this.setSearchFromUrl()
-              this.resetTaskTypeDates()
-            }, 200)
-            if (this.dataDisplay.beforeAfterTasks) {
-              this.setDefaultBeforeAfterTaskTypes()
-            }
-            this.resetScheduleItems(true)
-
-            this.dueDateFilter = this.$route.query.duedate || 'all'
-            this.estimationFilter = this.$route.query.late || 'all'
-            this.priorityFilter = this.$route.query.priority || '-1'
-            this.difficultyFilter = this.$route.query.difficulty || '-1'
-            this.retakeCountFilter = this.$route.query.retake_count || 'all'
-            this.taskStatusIdFilter = this.$route.query.task_status_id || ''
-
-            const taskId = this.$route.query.task_id
-            const task = this.taskMap.get(taskId)
-            if (task) {
-              const index = this.tasks.findIndex(t => t.id === taskId)
-              this.$nextTick(() => {
-                this.$refs['task-list']?.selectTask({}, index, task)
-              })
-            }
-          })
-          .catch(err => {
-            console.error(err)
-            this.loading.entities = false
-            this.errors.entities = true
-          })
-      } else {
-        this.loading.entities = true
-        this.setCurrentScheduleItem().then(() => {
-          this.resetTaskTypeDates()
-          this.loading.entities = false
-          let searchQuery = this.$route.query.search
-          if (!searchQuery && this.searchField) {
-            searchQuery = this.searchField.getValue()
-          }
-          if (searchQuery) this.onSearchChange(searchQuery)
-          if (this.dataDisplay.beforeAfterTasks) {
-            this.setDefaultBeforeAfterTaskTypes()
-          }
-          this.resetScheduleItems(true)
-        })
-      }
-    },
-
-    setCurrentScheduleItem() {
-      const episodeId = this.currentEpisode?.id
-      if (this.isTVShow && episodeId && !['all', 'main'].includes(episodeId)) {
-        return this.loadEpisodeScheduleItems({
-          production: this.currentProduction,
-          taskType: this.currentTaskType
-        }).then(items => {
-          this.currentScheduleItem = items.find(
-            item =>
-              item.task_type_id === this.currentTaskType.id &&
-              item.object_id === episodeId
-          )
-          return this.currentScheduleItem
-        })
-      }
-      return this.loadScheduleItems(this.currentProduction).then(items => {
-        this.currentScheduleItem = items.find(
-          item => item.task_type_id === this.currentTaskType.id
-        )
-        return this.currentScheduleItem
-      })
-    },
-
-    // Tabs
-
-    isActiveTab(tab) {
-      return this.activeTab === tab
-    },
-
-    updateActiveTab() {
-      if (this.$route.path.indexOf('schedule') > 0) {
-        this.activeTab = 'schedule'
-      } else if (this.$route.path.indexOf('estimation') > 0) {
-        this.activeTab = 'estimation'
-      } else {
-        this.activeTab = 'tasks'
-      }
-    },
-
-    getRoute(section) {
-      const routeTaskTypeId = this.$route.params.task_type_id
-      const taskTypeId = this.currentTaskType
-        ? this.currentTaskType.id
-        : routeTaskTypeId
-      const route = {
-        name: section,
-        params: {
-          production_id: this.currentProduction.id,
-          task_type_id: taskTypeId
-        }
-      }
-      if (this.currentTaskType.for_entity === 'Episode') {
-        route.name = `episodes-${route.name}`
-      } else if (this.isTVShow && this.currentEpisode) {
-        route.name = `episode-${route.name}`
-        route.params.episode_id = this.currentEpisode.id
-      }
-
-      return route
-    },
-
-    // Search
-
-    onSearchChange(query) {
-      if (query && query.length !== 1) {
-        query = query.toLowerCase().trim()
-        const descriptors = (this.currentProduction.descriptors || []).filter(
-          d => {
-            return d.entity_type === this.entityType
-          }
-        )
-        const keywords = getKeyWords(query) || []
-        const excludingKeyWords = getExcludingKeyWords(query) || []
-        const descFilters = getDescFilters(descriptors, [], query)
-        const taskFilters = getTaskFilters(this.$options.taskIndex, query)
-        if (
-          keywords.length > 0 ||
-          excludingKeyWords.length > 0 ||
-          descFilters.length > 0 ||
-          taskFilters.length > 0
-        ) {
-          let tasks
-          const filters = taskFilters.concat(descFilters)
-          if (keywords.length > 0) {
-            tasks = indexSearch(this.$options.taskIndex, keywords)
-          } else {
-            this.resetTasks()
-            tasks = this.tasks
-          }
-          tasks = applyFilters(tasks, filters, this.taskMap)
-          this.tasks = this.sortTasks(tasks)
-        } else {
-          this.resetTasks()
-        }
-      } else {
-        this.resetTasks()
-      }
-
-      this.resetScheduleItems()
-      this.setSearchInUrl()
-      this.clearSelectedTasks()
-
-      if (filters[this.dueDateFilter]) {
-        this.tasks = filters[this.dueDateFilter](this.tasks)
-      }
-      if (filters[this.estimationFilter]) {
-        this.tasks = filters[this.estimationFilter](
-          this.tasks,
-          this.taskStatusMap
-        )
-      }
-      if (this.priorityFilter !== '-1') {
-        this.tasks = this.tasks.filter(
-          t => t.priority === parseInt(this.priorityFilter)
-        )
-      }
-      if (this.difficultyFilter !== '-1') {
-        this.tasks = this.tasks.filter(
-          t => t.difficulty === parseInt(this.difficultyFilter)
-        )
-      }
-      if (this.retakeCountFilter === 'none') {
-        this.tasks = this.tasks.filter(t => !(t.retake_count > 0))
-      } else if (this.retakeCountFilter === 'with_retakes') {
-        this.tasks = this.tasks.filter(t => t.retake_count > 0)
-      }
-      if (this.taskStatusIdFilter !== null && this.taskStatusIdFilter !== '') {
-        this.tasks = this.tasks.filter(
-          t => t.task_status_id === this.taskStatusIdFilter
-        )
-      }
-    },
-
-    saveSearchQuery(searchQuery) {
-      if (this.loading.savingSearch) {
-        return
-      }
-      const entityType = this.entityType
-      this.loading.savingSearch = true
-      this.saveTaskSearch({ searchQuery, entityType })
-        .catch(console.error)
-        .finally(() => {
-          this.loading.savingSearch = false
-        })
-    },
-
-    removeSearchQuery(searchQuery) {
-      this.removeTaskSearch(searchQuery).catch(console.error)
-    },
-
-    updateUrlParams() {
-      const search = this.searchField.getValue()
-      const duedate = this.dueDateFilter
-      const late = this.estimationFilter
-      const priority = this.priorityFilter
-      const difficulty = this.difficultyFilter
-      const retakeCount = this.retakeCountFilter
-      const taskStatusId = this.taskStatusIdFilter || null
-      this.$router.push({
-        query: {
-          search,
-          duedate,
-          late,
-          priority,
-          difficulty,
-          retake_count: retakeCount === 'all' ? undefined : retakeCount,
-          task_status_id: taskStatusId
-        }
-      })
-    },
-
-    // Tasks
-
-    applyTaskFilters() {
-      this.onSearchChange(this.searchField.getValue())
-      this.sortTasks()
-      this.$refs['task-list']?.resetSelection()
-      this.updateUrlParams()
-      this.clearSelectedTasks()
-    },
-
-    onTaskSelected(task) {
-      this.currentTask = task
-      this.updateTaskInQuery()
-    },
-
-    onTaskListScroll({ top }) {
-      this.$refs['schedule-widget']?.setScrollPosition(top)
-    },
-
-    onScheduleScroll({ top }) {
-      this.$refs['task-list']?.setScrollPosition(top)
-    },
-
-    toggleSchedule() {
-      this.isScheduleVisible = !this.isScheduleVisible
-      this.resetScheduleItems(true)
-    },
-
-    updateTaskInQuery() {
-      if (this.nbSelectedTasks === 1) {
-        const selectedTaskIds = Array.from(this.selectedTasks.keys())
-        const taskId = selectedTaskIds[0]
-        this.$router.push({
-          query: {
-            ...this.$route.query,
-            task_id: taskId
-          }
-        })
-      } else {
-        this.$router.push({
-          query: {
-            ...this.$route.query,
-            task_id: undefined
-          }
-        })
-      }
-    },
-
-    resetTasks() {
-      let tasks = this.entityTasks
-
-      if (['Episode', 'Sequence'].includes(this.entityTypes)) {
-        tasks = tasks.filter(task => {
-          const entity = this.entityMap.get(task.entity_id)
-          return !entity.canceled
-        })
-      }
-      this.tasks = this.sortTasks(tasks)
-      this.resetTaskIndex()
-    },
-
-    resetTaskIndex() {
-      if (!this.entityTasks) return
-      this.$options.taskIndex = buildSupervisorTaskIndex(
-        this.entityTasks,
-        this.personMap,
-        this.taskStatusMap
-      )
-      this.$options.taskIndex.me = indexSearch(
-        this.$options.taskIndex,
-        this.user.full_name.split(' ')
-      )
-    },
-
-    getTasks(entities) {
-      const tasks = []
-      entities.forEach(entity => {
-        if (
-          entity.canceled ||
-          !entity.tasks?.length ||
-          (this.isTVShow &&
-            !this.displaySettings.showLinkedAssets &&
-            !this.isEpisodesSection &&
-            !['all', entity.episode_id || 'main'].includes(
-              this.currentEpisode?.id
-            ))
-        ) {
-          return
-        }
-        entity.tasks.forEach(taskId => {
-          const task = this.taskMap.get(taskId.id || taskId)
-          if (task) {
-            // Hack to allow filtering on linked entity metadata.
-            this.$store.commit('SET_TASK_EXTRA_DATA', {
-              task,
-              data: entity.data
-            })
-            if (task.task_type_id === this.currentTaskType.id) {
-              tasks.push(task)
-            }
-          }
-        })
-      })
-      return tasks
-    },
-
-    sortTasks(tasks) {
-      if (!tasks) tasks = this.tasks
-      const isDesc = [
-        'task_status_short_name',
-        'entity_name',
-        'due_date'
-      ].includes(this.currentSort)
-      if (this.currentSort === 'nb_frames') {
-        this.tasks = tasks.sort((ta, tb) => {
-          const nbFramesA = this.getEntity(ta.entity.id)?.nb_frames || 0
-          const nbFramesB = this.getEntity(tb.entity.id)?.nb_frames || 0
-          return nbFramesB - nbFramesA
-        })
-      } else if (this.currentSort !== name) {
-        this.tasks = tasks.sort(
-          firstBy(this.currentSort, isDesc ? 1 : -1).thenBy('entity_name')
-        )
-      } else {
-        this.tasks = tasks.sort(firstBy('entity_name'))
-      }
-      return tasks
-    },
-
-    getEntity(entityId) {
-      return this[`${this.entityType.toLowerCase()}Map`].get(entityId) || {}
-    },
-
-    onExportClick() {
-      const taskLines = this.$refs['task-list'].getTableData()
-      const nameData = [
-        formatSimpleDate(moment()),
-        this.currentProduction.name,
-        this.currentTaskType.name,
-        'tasks'
-      ]
-      if (this.currentEpisode) {
-        nameData.splice(1, 0, this.currentEpisode.name)
-      }
-      const name = stringHelpers.slugify(nameData.join('_'))
-      csv.buildCsvFile(name, taskLines)
-    },
-
-    updateEstimation({ taskId, days, item, daysOff }) {
-      const estimation = daysToMinutes(this.organisation, days)
-      const task = this.taskMap.get(taskId)
-      let data = { estimation }
-      if (task.start_date) {
-        const startDate = parseDate(task.start_date)
-        const dueDate = task.due_date ? parseDate(task.due_date) : null
-        data = {
-          ...data,
-          ...getDatesFromStartDate(
-            this.organisation,
-            startDate,
-            dueDate,
-            minutesToDays(this.organisation, estimation),
-            daysOff
-          )
-        }
-        if (item) {
-          item.startDate = parseDate(data.start_date)
-          item.endDate = parseDate(data.due_date)
-
-          if (item.startDate && item.endDate) {
-            item.parentElement.startDate = this.getMinDate(item.parentElement)
-            item.parentElement.endDate = this.getMaxDate(item.parentElement)
-          }
-        }
-      }
-      this.updateTask({ taskId, data }).catch(console.error)
-    },
-
-    // Schedule
-
-    onDataDisplayChange(item) {
-      if (item.key === 'timesheets' && item.value) {
-        this.resetScheduleItems()
-        return
-      }
-
-      if (item.key === 'beforeAfterTasks' && item.value) {
-        this.setDefaultBeforeAfterTaskTypes()
-        this.resetScheduleItems()
-      }
-    },
-
-    setDefaultBeforeAfterTaskTypes() {
-      if (!this.schedule.taskTypeBefore) {
-        this.schedule.taskTypeBefore = this.taskTypeListBeforeFilter[1]?.id
-      }
-      if (!this.schedule.taskTypeAfter) {
-        this.schedule.taskTypeAfter = this.taskTypeListAfterFilter[1]?.id
-      }
-    },
-
-    async resetScheduleItems(resetScroll = false) {
-      if (this.isActiveTab('schedule')) {
-        await this.resetScheduleItemsForScheduleTab()
-      } else if (this.isActiveTab('tasks') && this.isScheduleVisible) {
-        await this.resetScheduleItemsForTasksTab()
-      }
-      if (resetScroll) {
-        this.resetScheduleScroll()
-      }
-    },
-
-    async resetScheduleItemsForScheduleTab() {
-      if (!this.currentScheduleItem) return
-
-      const taskAssignationMap = this.buildAssignationMap()
-      const startDate = this.currentScheduleItem.start_date
-      const endDate = this.currentScheduleItem.end_date
-
-      this.daysOffByPerson = await this.loadProductionDaysOff({
-        startDate,
-        endDate
-      }).catch(
-        () => ({}) // fallback if not allowed to fetch days off
-      )
-
-      if (this.dataDisplay.timesheets) {
-        const assignees = Object.keys(taskAssignationMap).filter(
-          id => id !== 'unassigned' && taskAssignationMap[id].length > 0
-        )
-        this.timesheetByPerson = await this.loadTimesheets(
-          assignees,
-          startDate,
-          endDate
-        )
-      }
-
-      const scheduleItems = this.team
-        .map(person =>
-          this.buildPersonElement(
-            person,
-            taskAssignationMap,
-            this.dataDisplay.beforeAfterTasks
-          )
-        )
-        .filter(item => item?.children.length > 0)
-
-      if (taskAssignationMap.unassigned.length > 0) {
-        scheduleItems.push(
-          this.buildPersonElement(
-            { id: 'unassigned' },
-            taskAssignationMap,
-            this.dataDisplay.beforeAfterTasks
-          )
-        )
-      }
-      this.schedule.scheduleItems = scheduleItems
-    },
-
-    async resetScheduleItemsForTasksTab() {
-      if (!this.currentScheduleItem) return
-
-      const taskAssignationMap = this.buildAssignationMap()
-      const startDate = this.currentScheduleItem.start_date
-      const endDate = this.currentScheduleItem.end_date
-
-      this.daysOffByPerson = await this.loadProductionDaysOff({
-        startDate,
-        endDate
-      }).catch(
-        () => ({}) // fallback if not allowed to fetch days off
-      )
-
-      if (this.dataDisplay.timesheets) {
-        const assignees = Object.keys(taskAssignationMap).filter(
-          id => id !== 'unassigned' && taskAssignationMap[id].length > 0
-        )
-        this.timesheetByPerson = await this.loadTimesheets(
-          assignees,
-          startDate,
-          endDate
-        )
-      }
-
-      const scheduleItems = [
-        {
-          id: '',
-          color: 'transparent',
-          children: [],
-          timesheet: [],
-          expanded: true
-        }
-      ]
-      this.tasks.forEach(task => {
-        const person = this.personMap.get(task.assignees[0]) || {
-          id: 'unassigned'
-        }
-        const taskAssignationMap = { [person.id]: [task] }
-        const scheduleItem = this.buildPersonElement(
-          person,
-          taskAssignationMap,
-          this.dataDisplay.beforeAfterTasks
-        )
-        scheduleItems[0].startDate = scheduleItem.startDate
-        scheduleItems[0].endDate = scheduleItem.endDate
-        scheduleItems[0].children.push(...scheduleItem.children)
-        scheduleItems[0].timesheet.push(...scheduleItem.timesheet)
-      })
-
-      this.schedule.scheduleItems = scheduleItems
-    },
-
-    buildAssignationMap() {
-      const taskAssignationMap = { unassigned: [] }
-      this.team.forEach(person => {
-        if (person) taskAssignationMap[person.id] = []
-      })
-      this.tasks.forEach(task => {
-        if (task.assignees.length > 0) {
-          task.assignees.forEach(personId => {
-            if (!taskAssignationMap[personId]) {
-              taskAssignationMap[personId] = []
-            }
-            taskAssignationMap[personId].push(task)
-          })
-        } else {
-          taskAssignationMap.unassigned.push(task)
-        }
-      })
-      return taskAssignationMap
-    },
-
-    async loadTimesheets(personIds, startDate, endDate) {
-      const timesheets = await this.loadProductionTimeSpents({
-        taskType: this.currentTaskType,
-        startDate,
-        endDate
-      }).catch(
-        () => ({}) // fallback if not allowed to fetch timesheets
-      )
-
-      const timesheetByPerson = {}
-      for (const personId of personIds) {
-        const timesheet =
-          timesheets[personId]?.sort(firstBy('date').thenBy('task_id')) || []
-        timesheet.forEach(entry => {
-          entry.task = this.tasks.find(task => task.id === entry.task_id)
-          entry.startDate = parseDate(entry.date)
-          entry.endDate = parseDate(entry.date)
-        })
-
-        // merge consecutive timesheet entries with duration >= one organisation day
-        const mergedTimesheet = []
-        const oneDay = this.organisation.hours_by_day * 60
-        for (const entry of timesheet) {
-          const previous = mergedTimesheet.length
-            ? mergedTimesheet[mergedTimesheet.length - 1]
-            : null
-          if (
-            previous &&
-            previous.task_id === entry.task_id &&
-            (previous.date === entry.date ||
-              (previous.duration >= oneDay &&
-                entry.startDate.diff(previous.startDate, 'days') === 1))
-          ) {
-            // merge with previous
-            mergedTimesheet[mergedTimesheet.length - 1] = {
-              ...previous,
-              duration: previous.duration + entry.duration,
-              endDate: entry.endDate
-            }
-          } else {
-            mergedTimesheet.push(entry)
-          }
-        }
-
-        timesheetByPerson[personId] = mergedTimesheet
-      }
-      return timesheetByPerson
-    },
-
-    buildPersonElement(person, taskAssignationMap, withBeforeAfter = false) {
-      if (!person) return null
-
-      let manDays = 0
-      let minStartDate
-      let maxEndDate
-      const personTasks = taskAssignationMap[person.id]
-
-      let personElement
-      if (person.id === 'unassigned') {
-        personElement = {
-          avatar: false,
-          id: person.id,
-          name: this.$t('main.unassigned'),
-          color: '#888',
-          priority: 1,
-          expanded: true,
-          loading: false,
-          children: [],
-          editable: false,
-          timesheet: []
-        }
-      } else {
-        personElement = {
-          avatar: true,
-          has_avatar: person.has_avatar,
-          avatarPath: person.avatarPath,
-          initials: person.initials,
-          id: person.id,
-          name: person.full_name,
-          color: person.color,
-          priority: 1,
-          expanded: true,
-          loading: false,
-          children: [],
-          editable: false,
-          daysOff: this.daysOffByPerson[person.id],
-          timesheet: this.timesheetByPerson[person.id] ?? [],
-          route: getPersonPath(person.id, 'schedule')
-        }
-      }
-
-      const children = personTasks.map(task => {
-        const estimation = task.estimation
-        let endDate
-
-        let startDate = moment(this.schedule.taskTypeStartDate)
-        if (task.start_date) {
-          startDate = parseDate(task.start_date)
-        } else if (task.real_start_date) {
-          startDate = parseDate(task.real_start_date)
-        }
-
-        if (startDate.isAfter(this.schedule.endDate)) {
-          startDate = this.schedule.endDate.clone().add(-1, 'days')
-        }
-        if (startDate.isBefore(this.schedule.startDate)) {
-          startDate = this.schedule.startDate.clone()
-        }
-
-        if (task.due_date) {
-          endDate = parseDate(task.due_date)
-        } else if (task.end_date) {
-          endDate = parseDate(task.end_date)
-        } else {
-          endDate = addBusinessDays(
-            startDate,
-            Math.ceil(minutesToDays(this.organisation, task.estimation)) - 1,
-            personElement.daysOff
-          )
-        }
-
-        if (!endDate || endDate.isBefore(startDate)) {
-          const nbDays = startDate.isoWeekday() === 5 ? 3 : 1
-          endDate = startDate.clone().add(nbDays, 'days')
-        }
-        if (endDate.isAfter(this.schedule.endDate)) {
-          endDate = this.schedule.endDate.clone().add(-1, 'days')
-          if (startDate.isAfter(endDate)) {
-            startDate = endDate.clone().add(-1, 'days')
-          }
-        }
-
-        if (estimation) manDays += estimation
-        if (!minStartDate || minStartDate.isAfter(startDate)) {
-          minStartDate = startDate.clone()
-        }
-        if (!maxEndDate || maxEndDate.isBefore(endDate)) {
-          maxEndDate = endDate.clone()
-        }
-
-        const data = {
-          ...task,
-          name: task.entity_name,
-          startDate,
-          endDate,
-          expanded: false,
-          loading: false,
-          man_days: estimation,
-          editable: this.isSupervisorInDepartment,
-          unresizable: false,
-          parentElement: personElement,
-          color: this.getTaskElementColor(task, endDate),
-          children: []
-        }
-
-        if (withBeforeAfter) {
-          const entity = this.entityMap.get(task.entity_id)
-          const siblingElements = entity?.tasks
-            .map(taskId => this.taskMap.get(taskId))
-            .filter(Boolean)
-
-          if (this.schedule.taskTypeBefore) {
-            data.previousElement = siblingElements.find(
-              item => item.task_type_id === this.schedule.taskTypeBefore
-            )
-          }
-          if (this.schedule.taskTypeAfter) {
-            data.nextElement = siblingElements.find(
-              item => item.task_type_id === this.schedule.taskTypeAfter
-            )
-          }
-        }
-
-        if (data.previousElement) {
-          const task = data.previousElement
-          let startDate
-          if (task.start_date) {
-            startDate = parseDate(task.start_date)
-          } else if (task.real_start_date) {
-            startDate = parseDate(task.real_start_date)
-          }
-          let endDate
-          if (task.due_date) {
-            endDate = parseDate(task.due_date)
-          } else if (task.end_date) {
-            endDate = parseDate(task.end_date)
-          } else {
-            endDate = addBusinessDays(
-              startDate,
-              Math.ceil(minutesToDays(this.organisation, task.estimation)) - 1,
-              personElement.daysOff
-            )
-          }
-
-          if (startDate && endDate) {
-            data.previousElement.name = `[${this.currentTaskTypeBefore.name}] ${task.entity_name}`
-            data.previousElement.startDate = startDate
-            data.previousElement.endDate = endDate
-            data.previousElement.color = this.getTaskElementColor(task, endDate)
-          } else {
-            data.previousElement = null
-          }
-        }
-
-        if (data.nextElement) {
-          const task = data.nextElement
-          let startDate
-          if (task.start_date) {
-            startDate = parseDate(task.start_date)
-          } else if (task.real_start_date) {
-            startDate = parseDate(task.real_start_date)
-          }
-          let endDate
-          if (task.due_date) {
-            endDate = parseDate(task.due_date)
-          } else if (task.end_date) {
-            endDate = parseDate(task.end_date)
-          } else {
-            endDate = addBusinessDays(
-              startDate,
-              Math.ceil(minutesToDays(this.organisation, task.estimation)) - 1,
-              personElement.daysOff
-            )
-          }
-
-          if (startDate && endDate) {
-            data.nextElement.name = `[${this.currentTaskTypeAfter.name}] ${task.entity_name}`
-            data.nextElement.startDate = startDate
-            data.nextElement.endDate = endDate
-            data.nextElement.color = this.getTaskElementColor(task, endDate)
-          } else {
-            data.nextElement = null
-          }
-        }
-
-        return data
-      })
-
-      return {
-        ...personElement,
-        children,
-        startDate: minStartDate,
-        endDate: maxEndDate,
-        man_days: manDays
-      }
-    },
-
-    getTaskElementColor(task, endDate) {
-      if (this.schedule.currentColor === 'status') {
-        let color = this.taskStatusMap.get(task.task_status_id).color
-        if (color === '#f5f5f5') color = '#999'
-        return color
-      } else if (this.schedule.currentColor === 'late') {
-        const isLate =
-          !this.taskStatusMap.get(task.task_status_id).is_done &&
-          endDate.isBefore(moment())
-        return isLate ? '#FF3860' : '#999'
-      }
-      return null
-    },
-
-    saveTaskScheduleItem(item) {
-      if (item.estimation) {
-        item.endDate = addBusinessDays(
-          item.startDate,
-          Math.ceil(minutesToDays(this.organisation, item.estimation)) - 1,
-          item.parentElement.daysOff
-        )
-      }
-      item.man_days = item.estimation || 0
-
-      if (item.startDate && item.endDate) {
-        item.parentElement.startDate = this.getMinDate(item.parentElement)
-        item.parentElement.endDate = this.getMaxDate(item.parentElement)
-        this.updateTask({
-          taskId: item.id,
-          data: {
-            estimation: item.estimation,
-            start_date: item.startDate.format('YYYY-MM-DD'),
-            due_date: item.endDate.format('YYYY-MM-DD')
-          }
-        })
-      }
-    },
-
-    getMinDate(personElement) {
-      const endDate = this.productionEndDate
-      let minDate = endDate.clone()
-      personElement.children.forEach(item => {
-        if (item.startDate && item.startDate.isBefore(minDate)) {
-          minDate = item.startDate
-        }
-      })
-      return minDate.clone()
-    },
-
-    getMaxDate(personElement) {
-      const startDate = this.productionStartDate
-      let maxDate = startDate.clone()
-      personElement.children.forEach(item => {
-        if (item.endDate && item.endDate.isAfter(maxDate)) {
-          maxDate = item.endDate
-        }
-      })
-      return maxDate.clone()
-    },
-
-    expandPersonElement(personElement) {
-      personElement.expanded = !personElement.expanded
-    },
-
-    showImportModal() {
-      this.modals.importing = true
-    },
-
-    hideImportModal() {
-      this.modals.importing = false
-    },
-
-    showImportRenderModal() {
-      this.modals.isImportRenderDisplayed = true
-    },
-
-    hideImportRenderModal() {
-      this.modals.isImportRenderDisplayed = false
-    },
-
-    resetImport() {
-      this.errors.importing = false
-      this.errors.importingError = null
-      this.hideImportRenderModal()
-      this.importCsvFormData = undefined
-      this.$refs['import-modal']?.reset()
-      this.showImportModal()
-    },
-
-    uploadImportFile(data) {
-      const formData = new FormData()
-      const filename = 'import.csv'
-      const csvContent = csv.turnEntriesToCsvString(data)
-      const file = new File([csvContent], filename, { type: 'text/csv' })
-
-      formData.append('file', file)
-
-      this.loading.importing = true
-      this.errors.importing = false
-      this.errors.importingError = null
-      this.importCsvFormData = formData
-
-      this.uploadTaskTypeEstimations(this.importCsvFormData) // to change
-        .then(() => {
-          this.hideImportRenderModal()
-        })
-        .catch(err => {
-          this.errors.importingError = err
-          this.errors.importing = true
-        })
-        .finally(() => {
-          this.loading.importing = false
-        })
-    },
-
-    renderImport(data, mode) {
-      this.loading.importing = true
-      this.errors.importing = false
-      if (mode === 'file') {
-        data = data.get('file')
-      }
-      csv
-        .processCSV(data)
-        .then(results => {
-          this.parsedCSV = results
-          this.hideImportModal()
-          this.showImportRenderModal()
-        })
-        .catch(err => {
-          console.error(err)
-          this.errors.importing = true
-        })
-        .finally(() => {
-          this.loading.importing = false
-        })
-    },
-
-    resetTaskTypeDates() {
-      if (this.currentScheduleItem) {
-        this.schedule.taskTypeStartDate = parseDate(
-          this.currentScheduleItem.start_date
-        ).toDate()
-        this.schedule.taskTypeEndDate = parseDate(
-          this.currentScheduleItem.end_date
-        ).toDate()
-      }
-    },
-
-    resetScheduleScroll() {
-      if (!this.$refs['schedule-widget']) return
-
-      const today = moment()
-      if (
-        today.isBefore(moment(this.schedule.taskTypeStartDate)) ||
-        today.isAfter(moment(this.schedule.taskTypeEndDate))
-      ) {
-        const date = moment(this.schedule.taskTypeStartDate).add(
-          this.isScheduleVisible ? 0 : 20,
-          'days'
-        )
-        this.$refs['schedule-widget'].scrollToDate(date)
-      } else {
-        this.$refs['schedule-widget'].scrollToToday()
-      }
+    return `${currentProduction.value.name} / ${currentTaskType.value.name}`
+  }
+  return t('main.loading')
+})
+
+const backPath = computed(() => {
+  let pathRoute
+  if (isActiveTab('schedule')) {
+    pathRoute = {
+      name: 'schedule',
+      params: {
+        production_id: currentProduction.value.id
+      },
+      query: { search: '' }
     }
-  },
-
-  watch: {
-    $route() {
-      this.updateActiveTab()
-    },
-
-    'displaySettings.contactSheetMode'() {
-      this.isScheduleVisible = false
-    },
-
-    'displaySettings.showLinkedAssets'() {
-      this.resetTasks()
-    },
-
-    displaySettings: {
-      deep: true,
-      handler(newSettings) {
-        preferences.setObjectPreference(
-          'tasktype:display_settings',
-          newSettings
-        )
-      }
-    },
-
-    dataDisplay: {
-      deep: true,
-      handler(newSettings) {
-        preferences.setObjectPreference('tasktype:data_display', newSettings)
-      }
-    },
-
-    '$route.query.search'() {
-      const currentSearch = this.searchField.getValue()
-      const routeSearch = this.$route.query.search
-      if (routeSearch && routeSearch !== currentSearch) {
-        this.searchField.setValue(routeSearch)
-        this.onSearchChange(routeSearch)
-      }
-    },
-
-    currentProduction() {
-      this.setOptionalImportColumns()
-      this.initData(true)
-    },
-
-    nbSelectedTasks() {
-      this.updateTaskInQuery()
-    },
-
-    // Quickfix for the edge case where the backPath is not properly set
-    // because it was set when the episode was not fully loaded.
-    currentEpisode() {
-      if (this.currentEpisode && !this.backPath.params?.episode_id) {
-        this.$store.commit('RESET_PRODUCTION_PATH', {
-          productionId: this.currentProduction.id,
-          episodeId: this.currentEpisode.id
-        })
-      }
-    },
-
-    difficultyFilter() {
-      this.applyTaskFilters()
-    },
-
-    dueDateFilter() {
-      this.applyTaskFilters()
-    },
-
-    estimationFilter() {
-      this.applyTaskFilters()
-    },
-
-    priorityFilter() {
-      this.applyTaskFilters()
-    },
-
-    taskStatusIdFilter() {
-      this.applyTaskFilters()
-    },
-
-    retakeCountFilter() {
-      this.applyTaskFilters()
-    },
-
-    currentSort() {
-      this.sortTasks()
-      this.$refs['task-list'].resetSelection()
-      this.resetScheduleItems()
-      this.clearSelectedTasks()
-      this.updateTaskInQuery()
-    },
-
-    'schedule.currentColor'() {
-      this.resetScheduleItems()
-    },
-
-    activeTab() {
-      this.resetScheduleItems(true)
-    },
-
-    currentScheduleItem() {
-      if (this.currentScheduleItem) {
-        this.resetTaskTypeDates()
-      }
-    },
-
-    'schedule.taskTypeStartDate'() {
-      const newDate = moment(this.schedule.taskTypeStartDate)
-        .utc()
-        .format('YYYY-MM-DD')
-      if (newDate !== this.currentScheduleItem.start_date) {
-        this.$store.commit('SET_SCHEDULE_ITEM_DATES', {
-          scheduleItem: this.currentScheduleItem,
-          dates: {
-            startDate: moment(this.schedule.taskTypeStartDate).utc(),
-            endDate: moment(this.schedule.taskTypeEndDate).utc()
-          }
-        })
-        this.saveScheduleItem(this.currentScheduleItem)
-      }
-    },
-
-    'schedule.taskTypeEndDate'() {
-      const newDate = moment(this.schedule.taskTypeEndDate)
-        .utc()
-        .format('YYYY-MM-DD')
-      if (newDate !== this.currentScheduleItem.end_date) {
-        this.$store.commit('SET_SCHEDULE_ITEM_DATES', {
-          scheduleItem: this.currentScheduleItem,
-          dates: {
-            startDate: moment(this.schedule.taskTypeStartDate).utc(),
-            endDate: moment(this.schedule.taskTypeEndDate).utc()
-          }
-        })
-        this.saveScheduleItem(this.currentScheduleItem)
-      }
+  } else {
+    const pathsByEntity = {
+      Shot: store.getters.shotsPath,
+      Asset: store.getters.assetsPath,
+      Edit: store.getters.editsPath,
+      Episode: store.getters.episodesPath,
+      Sequence: store.getters.sequencesPath
     }
-  },
+    pathRoute = pathsByEntity[currentTaskType.value.for_entity] || {}
+  }
+  return {
+    ...pathRoute,
+    query: { search: '' }
+  }
+})
 
-  socket: {
-    events: {
-      'task:update'(eventData) {
-        this.resetScheduleItems()
-        if (
-          !this.isActiveTab('schedule') &&
-          this.taskMap.get(eventData.task_id) &&
-          this.selectedTasks === 0 &&
-          this.searchField &&
-          this.searchField.getValue() === ''
-        ) {
-          this.resetTaskIndex()
-          this.$nextTick(() => {
-            this.onSearchChange(this.searchField.getValue())
+const tasksPath = computed(() => getRoute('task-type'))
+const schedulePath = computed(() => getRoute('task-type-schedule'))
+const estimationPath = computed(() => getRoute('task-type-estimation'))
+
+const searchQueries = computed(() =>
+  taskSearchQueries.value.filter(
+    query => query.entity_type === entityType.value
+  )
+)
+
+const team = computed(() =>
+  sortPeople(
+    currentProduction.value?.team
+      .map(personId => personMap.value.get(personId))
+      .filter(person => person && !person.is_bot) ?? []
+  )
+)
+
+const dataDisplayOptions = computed(() => [
+  {
+    label: t('tasks.fields.estimation'),
+    value: 'estimations'
+  },
+  {
+    label: t('tasks.fields.task_status'),
+    value: 'statuses'
+  },
+  {
+    label: t('tasks.fields.timesheets'),
+    value: 'timesheets'
+  },
+  {
+    label: t('tasks.fields.before_after_tasks'),
+    value: 'beforeAfterTasks'
+  }
+])
+
+const zoomOptions = computed(() => [
+  { label: t('main.week'), value: 0 },
+  { label: '1', value: 1 },
+  { label: '2', value: 2 },
+  { label: '3', value: 3 }
+])
+
+// Functions
+const setOptionalImportColumns = () => {
+  const columns = ['Estimation', 'Start date', 'Due date', 'Difficulty']
+  if (isPaperProduction.value) {
+    columns.unshift('Drawings')
+  }
+  optionalColumns.value = columns
+}
+
+const initData = force => {
+  resetTasks()
+  focusSearchField({ preventScroll: true })
+  if (tasks.value.length < 2) {
+    loading.entities = true
+    errors.entities = false
+    store
+      .dispatch('initTaskType', force)
+      .then(setCurrentScheduleItem)
+      .then(() => {
+        loading.entities = false
+        resetTasks()
+        focusSearchField({ preventScroll: true })
+        let searchQuery = route.query.search
+        if (!searchQuery && searchFieldRef.value) {
+          searchQuery = searchFieldRef.value.getValue()
+        }
+        if (searchQuery) onSearchChange(searchQuery)
+        setTimeout(() => {
+          setSearchFromUrl()
+          resetTaskTypeDates()
+        }, 200)
+        if (dataDisplay.value.beforeAfterTasks) {
+          setDefaultBeforeAfterTaskTypes()
+        }
+        resetScheduleItems(true)
+
+        dueDateFilter.value = route.query.duedate || 'all'
+        estimationFilter.value = route.query.late || 'all'
+        priorityFilter.value = route.query.priority || '-1'
+        difficultyFilter.value = route.query.difficulty || '-1'
+        retakeCountFilter.value = route.query.retake_count || 'all'
+        taskStatusIdFilter.value = route.query.task_status_id || ''
+
+        const taskId = route.query.task_id
+        const task = taskMap.value.get(taskId)
+        if (task) {
+          const index = tasks.value.findIndex(t => t.id === taskId)
+          nextTick(() => {
+            taskListRef.value?.selectTask({}, index, task)
           })
         }
+      })
+      .catch(err => {
+        console.error(err)
+        loading.entities = false
+        errors.entities = true
+      })
+  } else {
+    loading.entities = true
+    setCurrentScheduleItem().then(() => {
+      resetTaskTypeDates()
+      loading.entities = false
+      let searchQuery = route.query.search
+      if (!searchQuery && searchFieldRef.value) {
+        searchQuery = searchFieldRef.value.getValue()
       }
-    }
-  },
-
-  head() {
-    return {
-      title: `${this.title} - Kitsu`
-    }
+      if (searchQuery) onSearchChange(searchQuery)
+      if (dataDisplay.value.beforeAfterTasks) {
+        setDefaultBeforeAfterTaskTypes()
+      }
+      resetScheduleItems(true)
+    })
   }
 }
+
+const setCurrentScheduleItem = () => {
+  const episodeId = currentEpisode.value?.id
+  if (isTVShow.value && episodeId && !['all', 'main'].includes(episodeId)) {
+    return store
+      .dispatch('loadEpisodeScheduleItems', {
+        production: currentProduction.value,
+        taskType: currentTaskType.value
+      })
+      .then(items => {
+        currentScheduleItem.value = items.find(
+          item =>
+            item.task_type_id === currentTaskType.value.id &&
+            item.object_id === episodeId
+        )
+        return currentScheduleItem.value
+      })
+  }
+  return store
+    .dispatch('loadScheduleItems', currentProduction.value)
+    .then(items => {
+      currentScheduleItem.value = items.find(
+        item => item.task_type_id === currentTaskType.value.id
+      )
+      return currentScheduleItem.value
+    })
+}
+
+// Tabs
+
+const isActiveTab = tab => activeTab.value === tab
+
+const updateActiveTab = () => {
+  if (route.path.indexOf('schedule') > 0) {
+    activeTab.value = 'schedule'
+  } else if (route.path.indexOf('estimation') > 0) {
+    activeTab.value = 'estimation'
+  } else {
+    activeTab.value = 'tasks'
+  }
+}
+
+const getRoute = section => {
+  const routeTaskTypeId = route.params.task_type_id
+  const taskTypeId = currentTaskType.value
+    ? currentTaskType.value.id
+    : routeTaskTypeId
+  const sectionRoute = {
+    name: section,
+    params: {
+      production_id: currentProduction.value.id,
+      task_type_id: taskTypeId
+    }
+  }
+  if (currentTaskType.value.for_entity === 'Episode') {
+    sectionRoute.name = `episodes-${sectionRoute.name}`
+  } else if (isTVShow.value && currentEpisode.value) {
+    sectionRoute.name = `episode-${sectionRoute.name}`
+    sectionRoute.params.episode_id = currentEpisode.value.id
+  }
+
+  return sectionRoute
+}
+
+// Search
+
+const focusSearchField = options => {
+  searchFieldRef.value?.focus(options)
+}
+
+const setSearchFromUrl = () => {
+  const searchQuery = searchFieldRef.value?.getValue()
+  const searchFromUrl = route.query.search
+  if (!searchQuery && searchFromUrl) {
+    searchFieldRef.value?.setValue(searchFromUrl)
+  }
+}
+
+const setSearchInUrl = query => {
+  const searchQuery = query || searchFieldRef.value?.getValue()
+  router.push({
+    query: {
+      ...route.query,
+      search: searchQuery || undefined
+    }
+  })
+}
+
+const onSearchChange = query => {
+  if (query && query.length !== 1) {
+    query = query.toLowerCase().trim()
+    const descriptors = (currentProduction.value.descriptors || []).filter(
+      d => d.entity_type === entityType.value
+    )
+    const keywords = getKeyWords(query) || []
+    const excludingKeyWords = getExcludingKeyWords(query) || []
+    const descFilters = getDescFilters(descriptors, [], query)
+    const taskFilters = getTaskFilters(taskIndex, query)
+    if (
+      keywords.length > 0 ||
+      excludingKeyWords.length > 0 ||
+      descFilters.length > 0 ||
+      taskFilters.length > 0
+    ) {
+      let filteredTasks
+      const searchFilters = taskFilters.concat(descFilters)
+      if (keywords.length > 0) {
+        filteredTasks = indexSearch(taskIndex, keywords)
+      } else {
+        resetTasks()
+        filteredTasks = tasks.value
+      }
+      filteredTasks = applyFilters(filteredTasks, searchFilters, taskMap.value)
+      tasks.value = sortTasks(filteredTasks)
+    } else {
+      resetTasks()
+    }
+  } else {
+    resetTasks()
+  }
+
+  resetScheduleItems()
+  setSearchInUrl()
+  store.dispatch('clearSelectedTasks')
+
+  if (filters[dueDateFilter.value]) {
+    tasks.value = filters[dueDateFilter.value](tasks.value)
+  }
+  if (filters[estimationFilter.value]) {
+    tasks.value = filters[estimationFilter.value](
+      tasks.value,
+      taskStatusMap.value
+    )
+  }
+  if (priorityFilter.value !== '-1') {
+    tasks.value = tasks.value.filter(
+      t => t.priority === parseInt(priorityFilter.value)
+    )
+  }
+  if (difficultyFilter.value !== '-1') {
+    tasks.value = tasks.value.filter(
+      t => t.difficulty === parseInt(difficultyFilter.value)
+    )
+  }
+  if (retakeCountFilter.value === 'none') {
+    tasks.value = tasks.value.filter(t => !(t.retake_count > 0))
+  } else if (retakeCountFilter.value === 'with_retakes') {
+    tasks.value = tasks.value.filter(t => t.retake_count > 0)
+  }
+  if (taskStatusIdFilter.value !== null && taskStatusIdFilter.value !== '') {
+    tasks.value = tasks.value.filter(
+      t => t.task_status_id === taskStatusIdFilter.value
+    )
+  }
+}
+
+const saveSearchQuery = searchQuery => {
+  if (loading.savingSearch) {
+    return
+  }
+  loading.savingSearch = true
+  store
+    .dispatch('saveTaskSearch', { searchQuery, entityType: entityType.value })
+    .catch(console.error)
+    .finally(() => {
+      loading.savingSearch = false
+    })
+}
+
+const removeSearchQuery = searchQuery => {
+  store.dispatch('removeTaskSearch', searchQuery).catch(console.error)
+}
+
+const updateUrlParams = () => {
+  const retakeCount = retakeCountFilter.value
+  router.push({
+    query: {
+      search: searchFieldRef.value.getValue(),
+      duedate: dueDateFilter.value,
+      late: estimationFilter.value,
+      priority: priorityFilter.value,
+      difficulty: difficultyFilter.value,
+      retake_count: retakeCount === 'all' ? undefined : retakeCount,
+      task_status_id: taskStatusIdFilter.value || null
+    }
+  })
+}
+
+// Tasks
+
+const applyTaskFilters = () => {
+  onSearchChange(searchFieldRef.value.getValue())
+  sortTasks()
+  taskListRef.value?.resetSelection()
+  updateUrlParams()
+  store.dispatch('clearSelectedTasks')
+}
+
+const onTaskSelected = () => {
+  updateTaskInQuery()
+}
+
+const onTaskListScroll = ({ top }) => {
+  scheduleWidgetRef.value?.setScrollPosition(top)
+}
+
+const onScheduleScroll = ({ top }) => {
+  taskListRef.value?.setScrollPosition(top)
+}
+
+const toggleSchedule = () => {
+  isScheduleVisible.value = !isScheduleVisible.value
+  resetScheduleItems(true)
+}
+
+const updateTaskInQuery = () => {
+  if (nbSelectedTasks.value === 1) {
+    const selectedTaskIds = Array.from(selectedTasks.value.keys())
+    router.push({
+      query: {
+        ...route.query,
+        task_id: selectedTaskIds[0]
+      }
+    })
+  } else {
+    router.push({
+      query: {
+        ...route.query,
+        task_id: undefined
+      }
+    })
+  }
+}
+
+const resetTasks = () => {
+  tasks.value = sortTasks(entityTasks.value)
+  resetTaskIndex()
+}
+
+const resetTaskIndex = () => {
+  if (!entityTasks.value) return
+  taskIndex = buildSupervisorTaskIndex(
+    entityTasks.value,
+    personMap.value,
+    taskStatusMap.value
+  )
+  taskIndex.me = indexSearch(taskIndex, user.value.full_name.split(' '))
+}
+
+const getTasks = entities => {
+  const result = []
+  entities.forEach(entity => {
+    if (
+      entity.canceled ||
+      !entity.tasks?.length ||
+      (isTVShow.value &&
+        !displaySettings.value.showLinkedAssets &&
+        !isEpisodesSection.value &&
+        !['all', entity.episode_id || 'main'].includes(
+          currentEpisode.value?.id
+        ))
+    ) {
+      return
+    }
+    entity.tasks.forEach(taskId => {
+      const task = taskMap.value.get(taskId.id || taskId)
+      if (task) {
+        // Hack to allow filtering on linked entity metadata.
+        store.commit('SET_TASK_EXTRA_DATA', {
+          task,
+          data: entity.data
+        })
+        if (task.task_type_id === currentTaskType.value.id) {
+          result.push(task)
+        }
+      }
+    })
+  })
+  return result
+}
+
+const sortTasks = list => {
+  if (!list) list = tasks.value
+  const isDesc = ['task_status_short_name', 'entity_name', 'due_date'].includes(
+    currentSort.value
+  )
+  if (currentSort.value === 'nb_frames') {
+    tasks.value = list.sort((ta, tb) => {
+      const nbFramesA = getEntity(ta.entity.id)?.nb_frames || 0
+      const nbFramesB = getEntity(tb.entity.id)?.nb_frames || 0
+      return nbFramesB - nbFramesA
+    })
+  } else {
+    tasks.value = list.sort(
+      firstBy(currentSort.value, isDesc ? 1 : -1).thenBy('entity_name')
+    )
+  }
+  return list
+}
+
+const getEntity = entityId => entityMap.value.get(entityId) || {}
+
+const onExportClick = () => {
+  const taskLines = taskListRef.value.getTableData()
+  const nameData = [
+    formatSimpleDate(moment()),
+    currentProduction.value.name,
+    currentTaskType.value.name,
+    'tasks'
+  ]
+  if (currentEpisode.value) {
+    nameData.splice(1, 0, currentEpisode.value.name)
+  }
+  const name = stringHelpers.slugify(nameData.join('_'))
+  csv.buildCsvFile(name, taskLines)
+}
+
+const updateEstimation = ({ taskId, days, item, daysOff }) => {
+  const estimation = daysToMinutes(organisation.value, days)
+  const task = taskMap.value.get(taskId)
+  let data = { estimation }
+  if (task.start_date) {
+    const startDate = parseDate(task.start_date)
+    const dueDate = task.due_date ? parseDate(task.due_date) : null
+    data = {
+      ...data,
+      ...getDatesFromStartDate(
+        organisation.value,
+        startDate,
+        dueDate,
+        minutesToDays(organisation.value, estimation),
+        daysOff
+      )
+    }
+    if (item) {
+      item.startDate = parseDate(data.start_date)
+      item.endDate = parseDate(data.due_date)
+
+      if (item.startDate && item.endDate) {
+        item.parentElement.startDate = getMinDate(item.parentElement)
+        item.parentElement.endDate = getMaxDate(item.parentElement)
+      }
+    }
+  }
+  store.dispatch('updateTask', { taskId, data }).catch(console.error)
+}
+
+// Schedule
+
+const onDataDisplayChange = item => {
+  if (item.key === 'timesheets' && item.value) {
+    resetScheduleItems()
+    return
+  }
+
+  if (item.key === 'beforeAfterTasks' && item.value) {
+    setDefaultBeforeAfterTaskTypes()
+    resetScheduleItems()
+  }
+}
+
+const setDefaultBeforeAfterTaskTypes = () => {
+  if (!schedule.taskTypeBefore) {
+    schedule.taskTypeBefore = taskTypeListBeforeFilter.value[1]?.id
+  }
+  if (!schedule.taskTypeAfter) {
+    schedule.taskTypeAfter = taskTypeListAfterFilter.value[1]?.id
+  }
+}
+
+const resetScheduleItems = async (resetScroll = false) => {
+  if (isActiveTab('schedule')) {
+    await resetScheduleItemsForScheduleTab()
+  } else if (isActiveTab('tasks') && isScheduleVisible.value) {
+    await resetScheduleItemsForTasksTab()
+  }
+  if (resetScroll) {
+    resetScheduleScroll()
+  }
+}
+
+const resetScheduleItemsForScheduleTab = async () => {
+  if (!currentScheduleItem.value) return
+
+  const taskAssignationMap = buildAssignationMap()
+  const startDate = currentScheduleItem.value.start_date
+  const endDate = currentScheduleItem.value.end_date
+
+  daysOffByPerson.value = await store
+    .dispatch('loadProductionDaysOff', { startDate, endDate })
+    .catch(
+      () => ({}) // fallback if not allowed to fetch days off
+    )
+
+  if (dataDisplay.value.timesheets) {
+    const assignees = Object.keys(taskAssignationMap).filter(
+      id => id !== 'unassigned' && taskAssignationMap[id].length > 0
+    )
+    timesheetByPerson.value = await loadTimesheets(
+      assignees,
+      startDate,
+      endDate
+    )
+  }
+
+  const scheduleItems = team.value
+    .map(person =>
+      buildPersonElement(
+        person,
+        taskAssignationMap,
+        dataDisplay.value.beforeAfterTasks
+      )
+    )
+    .filter(item => item?.children.length > 0)
+
+  if (taskAssignationMap.unassigned.length > 0) {
+    scheduleItems.push(
+      buildPersonElement(
+        { id: 'unassigned' },
+        taskAssignationMap,
+        dataDisplay.value.beforeAfterTasks
+      )
+    )
+  }
+  schedule.scheduleItems = scheduleItems
+}
+
+const resetScheduleItemsForTasksTab = async () => {
+  if (!currentScheduleItem.value) return
+
+  const taskAssignationMap = buildAssignationMap()
+  const startDate = currentScheduleItem.value.start_date
+  const endDate = currentScheduleItem.value.end_date
+
+  daysOffByPerson.value = await store
+    .dispatch('loadProductionDaysOff', { startDate, endDate })
+    .catch(
+      () => ({}) // fallback if not allowed to fetch days off
+    )
+
+  if (dataDisplay.value.timesheets) {
+    const assignees = Object.keys(taskAssignationMap).filter(
+      id => id !== 'unassigned' && taskAssignationMap[id].length > 0
+    )
+    timesheetByPerson.value = await loadTimesheets(
+      assignees,
+      startDate,
+      endDate
+    )
+  }
+
+  const scheduleItems = [
+    {
+      id: '',
+      color: 'transparent',
+      children: [],
+      timesheet: [],
+      expanded: true
+    }
+  ]
+  tasks.value.forEach(task => {
+    const person = personMap.value.get(task.assignees[0]) || {
+      id: 'unassigned'
+    }
+    const taskAssignationMap = { [person.id]: [task] }
+    const scheduleItem = buildPersonElement(
+      person,
+      taskAssignationMap,
+      dataDisplay.value.beforeAfterTasks
+    )
+    scheduleItems[0].startDate = scheduleItem.startDate
+    scheduleItems[0].endDate = scheduleItem.endDate
+    scheduleItems[0].children.push(...scheduleItem.children)
+    scheduleItems[0].timesheet.push(...scheduleItem.timesheet)
+  })
+
+  schedule.scheduleItems = scheduleItems
+}
+
+const buildAssignationMap = () => {
+  const taskAssignationMap = { unassigned: [] }
+  team.value.forEach(person => {
+    if (person) taskAssignationMap[person.id] = []
+  })
+  tasks.value.forEach(task => {
+    if (task.assignees.length > 0) {
+      task.assignees.forEach(personId => {
+        if (!taskAssignationMap[personId]) {
+          taskAssignationMap[personId] = []
+        }
+        taskAssignationMap[personId].push(task)
+      })
+    } else {
+      taskAssignationMap.unassigned.push(task)
+    }
+  })
+  return taskAssignationMap
+}
+
+const loadTimesheets = async (personIds, startDate, endDate) => {
+  const timesheets = await store
+    .dispatch('loadProductionTimeSpents', {
+      taskType: currentTaskType.value,
+      startDate,
+      endDate
+    })
+    .catch(
+      () => ({}) // fallback if not allowed to fetch timesheets
+    )
+
+  const timesheetByPersonResult = {}
+  for (const personId of personIds) {
+    const timesheet =
+      timesheets[personId]?.sort(firstBy('date').thenBy('task_id')) || []
+    timesheet.forEach(entry => {
+      entry.task = tasks.value.find(task => task.id === entry.task_id)
+      entry.startDate = parseDate(entry.date)
+      entry.endDate = parseDate(entry.date)
+    })
+
+    // merge consecutive timesheet entries with duration >= one organisation day
+    const mergedTimesheet = []
+    const oneDay = organisation.value.hours_by_day * 60
+    for (const entry of timesheet) {
+      const previous = mergedTimesheet.length
+        ? mergedTimesheet[mergedTimesheet.length - 1]
+        : null
+      if (
+        previous &&
+        previous.task_id === entry.task_id &&
+        (previous.date === entry.date ||
+          (previous.duration >= oneDay &&
+            entry.startDate.diff(previous.startDate, 'days') === 1))
+      ) {
+        // merge with previous
+        mergedTimesheet[mergedTimesheet.length - 1] = {
+          ...previous,
+          duration: previous.duration + entry.duration,
+          endDate: entry.endDate
+        }
+      } else {
+        mergedTimesheet.push(entry)
+      }
+    }
+
+    timesheetByPersonResult[personId] = mergedTimesheet
+  }
+  return timesheetByPersonResult
+}
+
+const buildPersonElement = (
+  person,
+  taskAssignationMap,
+  withBeforeAfter = false
+) => {
+  if (!person) return null
+
+  let manDays = 0
+  let minStartDate
+  let maxEndDate
+  const personTasks = taskAssignationMap[person.id]
+
+  let personElement
+  if (person.id === 'unassigned') {
+    personElement = {
+      avatar: false,
+      id: person.id,
+      name: t('main.unassigned'),
+      color: '#888',
+      priority: 1,
+      expanded: true,
+      loading: false,
+      children: [],
+      editable: false,
+      timesheet: []
+    }
+  } else {
+    personElement = {
+      avatar: true,
+      has_avatar: person.has_avatar,
+      avatarPath: person.avatarPath,
+      initials: person.initials,
+      id: person.id,
+      name: person.full_name,
+      color: person.color,
+      priority: 1,
+      expanded: true,
+      loading: false,
+      children: [],
+      editable: false,
+      daysOff: daysOffByPerson.value[person.id],
+      timesheet: timesheetByPerson.value[person.id] ?? [],
+      route: getPersonPath(person.id, 'schedule')
+    }
+  }
+
+  const children = personTasks.map(task => {
+    const estimation = task.estimation
+    let endDate
+
+    let startDate = moment(schedule.taskTypeStartDate)
+    if (task.start_date) {
+      startDate = parseDate(task.start_date)
+    } else if (task.real_start_date) {
+      startDate = parseDate(task.real_start_date)
+    }
+
+    if (startDate.isAfter(schedule.endDate)) {
+      startDate = schedule.endDate.clone().add(-1, 'days')
+    }
+    if (startDate.isBefore(schedule.startDate)) {
+      startDate = schedule.startDate.clone()
+    }
+
+    if (task.due_date) {
+      endDate = parseDate(task.due_date)
+    } else if (task.end_date) {
+      endDate = parseDate(task.end_date)
+    } else {
+      endDate = addBusinessDays(
+        startDate,
+        Math.ceil(minutesToDays(organisation.value, task.estimation)) - 1,
+        personElement.daysOff
+      )
+    }
+
+    if (!endDate || endDate.isBefore(startDate)) {
+      const nbDays = startDate.isoWeekday() === 5 ? 3 : 1
+      endDate = startDate.clone().add(nbDays, 'days')
+    }
+    if (endDate.isAfter(schedule.endDate)) {
+      endDate = schedule.endDate.clone().add(-1, 'days')
+      if (startDate.isAfter(endDate)) {
+        startDate = endDate.clone().add(-1, 'days')
+      }
+    }
+
+    if (estimation) manDays += estimation
+    if (!minStartDate || minStartDate.isAfter(startDate)) {
+      minStartDate = startDate.clone()
+    }
+    if (!maxEndDate || maxEndDate.isBefore(endDate)) {
+      maxEndDate = endDate.clone()
+    }
+
+    const data = {
+      ...task,
+      name: task.entity_name,
+      startDate,
+      endDate,
+      expanded: false,
+      loading: false,
+      man_days: estimation,
+      editable: isSupervisorInDepartment.value,
+      unresizable: false,
+      parentElement: personElement,
+      color: getTaskElementColor(task, endDate),
+      children: []
+    }
+
+    if (withBeforeAfter) {
+      const entity = entityMap.value.get(task.entity_id)
+      const siblingElements = entity?.tasks
+        .map(taskId => taskMap.value.get(taskId))
+        .filter(Boolean)
+
+      if (schedule.taskTypeBefore) {
+        data.previousElement = siblingElements.find(
+          item => item.task_type_id === schedule.taskTypeBefore
+        )
+      }
+      if (schedule.taskTypeAfter) {
+        data.nextElement = siblingElements.find(
+          item => item.task_type_id === schedule.taskTypeAfter
+        )
+      }
+    }
+
+    if (data.previousElement) {
+      const task = data.previousElement
+      let startDate
+      if (task.start_date) {
+        startDate = parseDate(task.start_date)
+      } else if (task.real_start_date) {
+        startDate = parseDate(task.real_start_date)
+      }
+      let endDate
+      if (task.due_date) {
+        endDate = parseDate(task.due_date)
+      } else if (task.end_date) {
+        endDate = parseDate(task.end_date)
+      } else {
+        endDate = addBusinessDays(
+          startDate,
+          Math.ceil(minutesToDays(organisation.value, task.estimation)) - 1,
+          personElement.daysOff
+        )
+      }
+
+      if (startDate && endDate) {
+        data.previousElement.name = `[${currentTaskTypeBefore.value.name}] ${task.entity_name}`
+        data.previousElement.startDate = startDate
+        data.previousElement.endDate = endDate
+        data.previousElement.color = getTaskElementColor(task, endDate)
+      } else {
+        data.previousElement = null
+      }
+    }
+
+    if (data.nextElement) {
+      const task = data.nextElement
+      let startDate
+      if (task.start_date) {
+        startDate = parseDate(task.start_date)
+      } else if (task.real_start_date) {
+        startDate = parseDate(task.real_start_date)
+      }
+      let endDate
+      if (task.due_date) {
+        endDate = parseDate(task.due_date)
+      } else if (task.end_date) {
+        endDate = parseDate(task.end_date)
+      } else {
+        endDate = addBusinessDays(
+          startDate,
+          Math.ceil(minutesToDays(organisation.value, task.estimation)) - 1,
+          personElement.daysOff
+        )
+      }
+
+      if (startDate && endDate) {
+        data.nextElement.name = `[${currentTaskTypeAfter.value.name}] ${task.entity_name}`
+        data.nextElement.startDate = startDate
+        data.nextElement.endDate = endDate
+        data.nextElement.color = getTaskElementColor(task, endDate)
+      } else {
+        data.nextElement = null
+      }
+    }
+
+    return data
+  })
+
+  return {
+    ...personElement,
+    children,
+    startDate: minStartDate,
+    endDate: maxEndDate,
+    man_days: manDays
+  }
+}
+
+const getTaskElementColor = (task, endDate) => {
+  if (schedule.currentColor === 'status') {
+    let color = taskStatusMap.value.get(task.task_status_id).color
+    if (color === '#f5f5f5') color = '#999'
+    return color
+  } else if (schedule.currentColor === 'late') {
+    const isLate =
+      !taskStatusMap.value.get(task.task_status_id).is_done &&
+      endDate.isBefore(moment())
+    return isLate ? '#FF3860' : '#999'
+  }
+  return null
+}
+
+const saveTaskScheduleItem = item => {
+  if (item.estimation) {
+    item.endDate = addBusinessDays(
+      item.startDate,
+      Math.ceil(minutesToDays(organisation.value, item.estimation)) - 1,
+      item.parentElement.daysOff
+    )
+  }
+  item.man_days = item.estimation || 0
+
+  if (item.startDate && item.endDate) {
+    item.parentElement.startDate = getMinDate(item.parentElement)
+    item.parentElement.endDate = getMaxDate(item.parentElement)
+    store.dispatch('updateTask', {
+      taskId: item.id,
+      data: {
+        estimation: item.estimation,
+        start_date: item.startDate.format('YYYY-MM-DD'),
+        due_date: item.endDate.format('YYYY-MM-DD')
+      }
+    })
+  }
+}
+
+const getMinDate = personElement => {
+  let minDate = productionEndDate.value.clone()
+  personElement.children.forEach(item => {
+    if (item.startDate && item.startDate.isBefore(minDate)) {
+      minDate = item.startDate
+    }
+  })
+  return minDate.clone()
+}
+
+const getMaxDate = personElement => {
+  let maxDate = productionStartDate.value.clone()
+  personElement.children.forEach(item => {
+    if (item.endDate && item.endDate.isAfter(maxDate)) {
+      maxDate = item.endDate
+    }
+  })
+  return maxDate.clone()
+}
+
+const expandPersonElement = personElement => {
+  personElement.expanded = !personElement.expanded
+}
+
+// Import
+
+const showImportModal = () => {
+  modals.importing = true
+}
+
+const hideImportModal = () => {
+  modals.importing = false
+}
+
+const showImportRenderModal = () => {
+  modals.isImportRenderDisplayed = true
+}
+
+const hideImportRenderModal = () => {
+  modals.isImportRenderDisplayed = false
+}
+
+const resetImport = () => {
+  errors.importing = false
+  errors.importingError = null
+  hideImportRenderModal()
+  importCsvFormData.value = undefined
+  importModalRef.value?.reset()
+  showImportModal()
+}
+
+const uploadImportFile = data => {
+  const formData = new FormData()
+  const filename = 'import.csv'
+  const csvContent = csv.turnEntriesToCsvString(data)
+  const file = new File([csvContent], filename, { type: 'text/csv' })
+
+  formData.append('file', file)
+
+  loading.importing = true
+  errors.importing = false
+  errors.importingError = null
+  importCsvFormData.value = formData
+
+  store
+    .dispatch('uploadTaskTypeEstimations', importCsvFormData.value)
+    .then(() => {
+      hideImportRenderModal()
+    })
+    .catch(err => {
+      errors.importingError = err
+      errors.importing = true
+    })
+    .finally(() => {
+      loading.importing = false
+    })
+}
+
+const renderImport = (data, mode) => {
+  loading.importing = true
+  errors.importing = false
+  if (mode === 'file') {
+    data = data.get('file')
+  }
+  csv
+    .processCSV(data)
+    .then(results => {
+      parsedCSV.value = results
+      hideImportModal()
+      showImportRenderModal()
+    })
+    .catch(err => {
+      console.error(err)
+      errors.importing = true
+    })
+    .finally(() => {
+      loading.importing = false
+    })
+}
+
+const resetTaskTypeDates = () => {
+  if (currentScheduleItem.value) {
+    schedule.taskTypeStartDate = parseDate(
+      currentScheduleItem.value.start_date
+    ).toDate()
+    schedule.taskTypeEndDate = parseDate(
+      currentScheduleItem.value.end_date
+    ).toDate()
+  }
+}
+
+const resetScheduleScroll = () => {
+  if (!scheduleWidgetRef.value) return
+
+  const today = moment()
+  if (
+    today.isBefore(moment(schedule.taskTypeStartDate)) ||
+    today.isAfter(moment(schedule.taskTypeEndDate))
+  ) {
+    const date = moment(schedule.taskTypeStartDate).add(
+      isScheduleVisible.value ? 0 : 20,
+      'days'
+    )
+    scheduleWidgetRef.value.scrollToDate(date)
+  } else {
+    scheduleWidgetRef.value.scrollToToday()
+  }
+}
+
+const onRemoteTaskUpdate = eventData => {
+  resetScheduleItems()
+  if (
+    !isActiveTab('schedule') &&
+    taskMap.value.get(eventData.task_id) &&
+    selectedTasks.value === 0 &&
+    searchFieldRef.value &&
+    searchFieldRef.value.getValue() === ''
+  ) {
+    resetTaskIndex()
+    nextTick(() => {
+      onSearchChange(searchFieldRef.value.getValue())
+    })
+  }
+}
+
+// Equivalent of the Options API created() hook: runs during setup.
+if (!currentProduction.value) {
+  store.dispatch('setProduction', route.params.production_id)
+} else {
+  const options = { productionId: currentProduction.value.id }
+  if (currentEpisode.value) options.episodeId = currentEpisode.value.id
+  store.commit('RESET_PRODUCTION_PATH', options)
+}
+
+// Watchers
+watch(
+  () => route.fullPath,
+  () => {
+    updateActiveTab()
+  }
+)
+
+watch(
+  () => displaySettings.value.contactSheetMode,
+  () => {
+    isScheduleVisible.value = false
+  }
+)
+
+watch(
+  () => displaySettings.value.showLinkedAssets,
+  () => {
+    resetTasks()
+  }
+)
+
+watch(
+  displaySettings,
+  newSettings => {
+    preferences.setObjectPreference('tasktype:display_settings', newSettings)
+  },
+  { deep: true }
+)
+
+watch(
+  dataDisplay,
+  newSettings => {
+    preferences.setObjectPreference('tasktype:data_display', newSettings)
+  },
+  { deep: true }
+)
+
+watch(
+  () => route.query.search,
+  () => {
+    const currentSearch = searchFieldRef.value.getValue()
+    const routeSearch = route.query.search
+    if (routeSearch && routeSearch !== currentSearch) {
+      searchFieldRef.value.setValue(routeSearch)
+      onSearchChange(routeSearch)
+    }
+  }
+)
+
+watch(currentProduction, () => {
+  setOptionalImportColumns()
+  initData(true)
+})
+
+watch(nbSelectedTasks, () => {
+  updateTaskInQuery()
+})
+
+// Quickfix for the edge case where the backPath is not properly set
+// because it was set when the episode was not fully loaded.
+watch(currentEpisode, () => {
+  if (currentEpisode.value && !backPath.value.params?.episode_id) {
+    store.commit('RESET_PRODUCTION_PATH', {
+      productionId: currentProduction.value.id,
+      episodeId: currentEpisode.value.id
+    })
+  }
+})
+
+watch(
+  [
+    difficultyFilter,
+    dueDateFilter,
+    estimationFilter,
+    priorityFilter,
+    taskStatusIdFilter,
+    retakeCountFilter
+  ],
+  () => {
+    applyTaskFilters()
+  }
+)
+
+watch(currentSort, () => {
+  sortTasks()
+  taskListRef.value.resetSelection()
+  resetScheduleItems()
+  store.dispatch('clearSelectedTasks')
+  updateTaskInQuery()
+})
+
+watch(
+  () => schedule.currentColor,
+  () => {
+    resetScheduleItems()
+  }
+)
+
+watch(activeTab, () => {
+  resetScheduleItems(true)
+})
+
+watch(currentScheduleItem, () => {
+  if (currentScheduleItem.value) {
+    resetTaskTypeDates()
+  }
+})
+
+watch(
+  () => schedule.taskTypeStartDate,
+  () => {
+    const newDate = moment(schedule.taskTypeStartDate)
+      .utc()
+      .format('YYYY-MM-DD')
+    if (newDate !== currentScheduleItem.value.start_date) {
+      store.commit('SET_SCHEDULE_ITEM_DATES', {
+        scheduleItem: currentScheduleItem.value,
+        dates: {
+          startDate: moment(schedule.taskTypeStartDate).utc(),
+          endDate: moment(schedule.taskTypeEndDate).utc()
+        }
+      })
+      store.dispatch('saveScheduleItem', currentScheduleItem.value)
+    }
+  }
+)
+
+watch(
+  () => schedule.taskTypeEndDate,
+  () => {
+    const newDate = moment(schedule.taskTypeEndDate).utc().format('YYYY-MM-DD')
+    if (newDate !== currentScheduleItem.value.end_date) {
+      store.commit('SET_SCHEDULE_ITEM_DATES', {
+        scheduleItem: currentScheduleItem.value,
+        dates: {
+          startDate: moment(schedule.taskTypeStartDate).utc(),
+          endDate: moment(schedule.taskTypeEndDate).utc()
+        }
+      })
+      store.dispatch('saveScheduleItem', currentScheduleItem.value)
+    }
+  }
+)
+
+// Lifecycle
+onMounted(() => {
+  if (!currentTaskType.value?.id) {
+    router.push({ name: 'not-found' })
+    return
+  }
+
+  displaySettings.value = {
+    ...displaySettings.value,
+    ...preferences.getObjectPreference('tasktype:display_settings')
+  }
+  dataDisplay.value = {
+    ...dataDisplay.value,
+    ...preferences.getObjectPreference('tasktype:data_display')
+  }
+  setOptionalImportColumns()
+  searchFieldRef.value?.setValue(route.query.search || '')
+  store.dispatch('clearSelectedTasks')
+  const isAssets = route.path.includes('assets')
+  const isShots = route.path.includes('shots')
+  const isEdits = route.path.includes('edits')
+  const isSequences = route.path.includes('sequences')
+  entityType.value = isAssets
+    ? 'Asset'
+    : isShots
+      ? 'Shot'
+      : isEdits
+        ? 'Edit'
+        : isSequences
+          ? 'Sequence'
+          : 'Episode'
+  updateActiveTab()
+  setTimeout(() => {
+    initData(false)
+    resetScheduleScroll()
+  }, 100)
+
+  socket.on('task:update', onRemoteTaskUpdate)
+})
+
+onBeforeUnmount(() => {
+  store.dispatch('clearSelectedTasks')
+  socket.off('task:update', onRemoteTaskUpdate)
+})
+
+// Head
+useHead({ title: computed(() => `${title.value} - Kitsu`) })
 </script>
 
 <style lang="scss" scoped>
@@ -2210,10 +2114,6 @@ export default {
 
 .search-options {
   width: 325px;
-}
-
-.ml2 {
-  margin-left: 2em;
 }
 
 .tabs ul {
@@ -2250,10 +2150,6 @@ export default {
   overflow: hidden;
 }
 
-.sorting-combobox {
-  padding-top: 3px;
-}
-
 .field {
   margin-bottom: 0;
 }
@@ -2261,11 +2157,6 @@ export default {
 .query-list {
   margin-bottom: 0;
   margin-top: 0.5em;
-}
-
-.push-right {
-  flex: 1;
-  text-align: right;
 }
 
 .task-type-schedule {

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -798,10 +798,6 @@ const disabledDates = computed(() => ({
   days: [6, 0]
 }))
 
-const entityTasks = computed(() =>
-  getTasks(Array.from(entityMap.value.values()))
-)
-
 const title = computed(() => {
   if (currentProduction.value) {
     if (isTVShow.value && currentEpisode.value) {
@@ -1198,15 +1194,20 @@ const updateTaskInQuery = () => {
   }
 }
 
+// Read at call time, not through a computed: the entity caches are
+// non-reactive Maps that start empty on a hard refresh, so a computed
+// evaluated before they fill never reads an invalidating dependency
+// and latches the empty result forever.
+const getEntityTasks = () => getTasks(Array.from(entityMap.value.values()))
+
 const resetTasks = () => {
-  tasks.value = sortTasks(entityTasks.value)
+  tasks.value = sortTasks(getEntityTasks())
   resetTaskIndex()
 }
 
 const resetTaskIndex = () => {
-  if (!entityTasks.value) return
   taskIndex = buildSupervisorTaskIndex(
-    entityTasks.value,
+    getEntityTasks(),
     personMap.value,
     taskStatusMap.value
   )

--- a/src/components/pages/tasktype/EstimationHelper.vue
+++ b/src/components/pages/tasktype/EstimationHelper.vue
@@ -99,7 +99,7 @@
                   step="any"
                   type="number"
                   @blur="onInputBlur"
-                  @change="estimationUpdated($event, task, index)"
+                  @change="estimationUpdated($event, task)"
                   @keydown="onKeyDown"
                   @mouseout="onInputMouseOut"
                   @mouseover="onInputMouseOver"
@@ -241,14 +241,11 @@ import {
   onInputMouseOver,
   pauseEvent
 } from '@/composables/dom'
+import { getEntityMap } from '@/composables/entity'
 import { useFormat } from '@/composables/format'
+import { isSupervisorInDepartments } from '@/lib/descriptors'
 import { minutesToDays, range } from '@/lib/time'
 import { frameToSeconds } from '@/lib/video'
-import assetsStore from '@/store/modules/assets.js'
-import editsStore from '@/store/modules/edits.js'
-import episodesStore from '@/store/modules/episodes.js'
-import sequencesStore from '@/store/modules/sequences.js'
-import shotsStore from '@/store/modules/shots.js'
 
 import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
 import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
@@ -293,43 +290,24 @@ const user = computed(() => store.getters.user)
 const isAssets = computed(() => props.entityType === 'Asset')
 const isShots = computed(() => props.entityType === 'Shot')
 
-const entityMap = computed(() => {
-  const caches = {
-    asset: assetsStore.cache.assetMap,
-    edit: editsStore.cache.editMap,
-    episode: episodesStore.cache.episodeMap,
-    sequence: sequencesStore.cache.sequenceMap,
-    shot: shotsStore.cache.shotMap
-  }
-  return caches[props.entityType.toLowerCase()]
-})
+const entityMap = computed(() => getEntityMap(props.entityType))
 
 const tasksByPerson = computed(() =>
   [...props.tasks].sort(compareFirstAssignees)
 )
 
 const assignees = computed(() => {
-  const alltasks = {
-    countMap: new Map(),
-    frameMap: new Map(),
-    estimationMap: new Map(),
-    secondMap: new Map()
-  }
-  const remaining = {
-    countMap: new Map(),
-    frameMap: new Map(),
-    estimationMap: new Map(),
-    secondMap: new Map()
-  }
+  const allTasksStats = new Map()
+  const remainingStats = new Map()
   const assigneeSet = new Set()
   props.tasks.forEach(task => {
     const entity = getEntity(task.entity_id)
     task.assignees.forEach(personId => {
       assigneeSet.add(personId)
-      addAssigneeStatsToMaps(alltasks, personId, task, entity)
+      addTaskToStats(allTasksStats, personId, task, entity)
       const status = taskStatusMap.value.get(task.task_status_id)
       if (!status.is_done && !status.is_feedback_request) {
-        addAssigneeStatsToMaps(remaining, personId, task, entity)
+        addTaskToStats(remainingStats, personId, task, entity)
       }
     })
   })
@@ -338,8 +316,8 @@ const assignees = computed(() => {
     .sort(firstBy('name'))
     .map(person => ({
       ...person,
-      alltasks: getAssigneeStats(person, alltasks),
-      remaining: getAssigneeStats(person, remaining)
+      alltasks: formatStats(allTasksStats.get(person.id)),
+      remaining: formatStats(remainingStats.get(person.id))
     }))
 })
 
@@ -359,13 +337,8 @@ const compareFirstAssignees = (a, b) => {
     const personA = personMap.value.get(a.assignees[0])
     const personB = personMap.value.get(b.assignees[0])
     return personA.name.localeCompare(personB.name)
-  } else if (a.assignees.length > 0) {
-    return -1
-  } else if (b.assignees.length > 0) {
-    return 1
-  } else {
-    return -1
   }
+  return a.assignees.length > 0 || b.assignees.length === 0 ? -1 : 1
 }
 
 const getSeconds = task => {
@@ -375,7 +348,7 @@ const getSeconds = task => {
 
 const estimationUpdated = (event, task) => {
   const value = event.target.value
-  if (value && value.length > 0) {
+  if (value) {
     saveEstimations(parseFloat(value), task)
   }
 }
@@ -461,27 +434,30 @@ const selectTaskRange = index => {
   })
 }
 
-const isInDepartment = task => {
-  if (isCurrentUserManager.value) {
-    return true
-  } else if (isCurrentUserSupervisor.value) {
-    if (user.value.departments.length === 0) {
-      return true
-    }
-    const taskType = taskTypeMap.value.get(task.task_type_id)
-    return (
-      taskType.department_id &&
-      user.value.departments.includes(taskType.department_id)
-    )
+const isInDepartment = task =>
+  isCurrentUserManager.value ||
+  isSupervisorInDepartments(
+    user.value,
+    isCurrentUserSupervisor.value,
+    taskTypeMap.value.get(task.task_type_id)?.department_id
+  )
+
+const addTaskToStats = (statsMap, personId, task, entity) => {
+  if (!statsMap.has(personId)) {
+    statsMap.set(personId, { count: 0, estimation: 0, frames: 0, seconds: 0 })
   }
-  return false
+  const stats = statsMap.get(personId)
+  stats.count += 1
+  stats.estimation += task.estimation
+  if (!isAssets.value) {
+    const frames = entity.nb_frames || 0
+    stats.frames += frames
+    stats.seconds += frameToSeconds(frames, currentProduction.value, entity)
+  }
 }
 
-const getAssigneeStats = (person, maps) => {
-  const estimation = maps.estimationMap.get(person.id) || 0
-  const seconds = maps.secondMap.get(person.id) || 0
-  const frames = maps.frameMap.get(person.id) || 0
-  const count = maps.countMap.get(person.id) || 0
+const formatStats = stats => {
+  const { count = 0, estimation = 0, frames = 0, seconds = 0 } = stats || {}
   const estimationDays = minutesToDays(organisation.value, estimation)
   const quota = estimation > 0 ? seconds / estimationDays : 0
   const quotaCount = estimation > 0 ? count / estimationDays : 0
@@ -495,20 +471,6 @@ const getAssigneeStats = (person, maps) => {
     quotaFrames: quotaFrames.toFixed(2),
     quotaCount: quotaCount.toFixed(2),
     seconds: seconds.toFixed(2)
-  }
-}
-
-const addAssigneeStatsToMaps = (maps, personId, task, entity) => {
-  maps.countMap.set(personId, (maps.countMap.get(personId) || 0) + 1)
-  maps.estimationMap.set(
-    personId,
-    (maps.estimationMap.get(personId) || 0) + task.estimation
-  )
-  if (!isAssets.value) {
-    const frames = entity.nb_frames || 0
-    const seconds = frameToSeconds(frames, currentProduction.value, entity)
-    maps.secondMap.set(personId, (maps.secondMap.get(personId) || 0) + seconds)
-    maps.frameMap.set(personId, (maps.frameMap.get(personId) || 0) + frames)
   }
 }
 </script>

--- a/src/components/pages/tasktype/EstimationHelper.vue
+++ b/src/components/pages/tasktype/EstimationHelper.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="estimation-wrapper">
     <div class="estimation-helper columns">
-      <div ref="body" class="task-list column datatable-wrapper">
+      <div class="task-list column datatable-wrapper">
         <table class="datatable">
           <thead class="datatable-head">
             <tr>
@@ -32,7 +32,6 @@
 
           <tbody class="datatable-body">
             <tr
-              :ref="'task-' + task.id"
               :key="task.id"
               :class="{
                 'datatable-row': true,
@@ -94,7 +93,7 @@
                 class="estimation numeric-cell"
               >
                 <input
-                  :ref="task.id + '-estimation'"
+                  :ref="el => setEstimationInput(task.id, el)"
                   class="input stylehidden"
                   min="0"
                   step="any"
@@ -118,7 +117,7 @@
 
       <div class="person-list column datatable-wrapper">
         <table class="datatable">
-          <thead ref="thead" class="datatable-head">
+          <thead class="datatable-head">
             <tr>
               <th class="assignees">
                 {{ $t('tasks.fields.assignees') }}
@@ -228,11 +227,23 @@
   </div>
 </template>
 
-<script>
+<script setup>
+// Imports
 import { CornerDownRightIcon } from 'lucide-vue-next'
 import { firstBy } from 'thenby'
-import { mapGetters, mapActions } from 'vuex'
+import { computed, ref } from 'vue'
+import { useStore } from 'vuex'
 
+import {
+  focusInput,
+  onInputBlur,
+  onInputMouseOut,
+  onInputMouseOver,
+  pauseEvent
+} from '@/composables/dom'
+import { useFormat } from '@/composables/format'
+import { minutesToDays, range } from '@/lib/time'
+import { frameToSeconds } from '@/lib/video'
 import assetsStore from '@/store/modules/assets.js'
 import editsStore from '@/store/modules/edits.js'
 import episodesStore from '@/store/modules/episodes.js'
@@ -243,306 +254,261 @@ import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
 import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
 import PeopleName from '@/components/widgets/PeopleName.vue'
 
-import { domMixin } from '@/components/mixins/dom'
-import { formatListMixin } from '@/components/mixins/format'
-import { minutesToDays, range } from '@/lib/time'
-import { frameToSeconds } from '@/lib/video'
+// Composables
+const store = useStore()
+const { formatDuration, organisation } = useFormat()
 
-export default {
-  name: 'estimation-helper',
-
-  mixins: [domMixin, formatListMixin],
-
-  components: {
-    CornerDownRightIcon,
-    EntityThumbnail,
-    PeopleAvatar,
-    PeopleName
+// Props / Emits
+const props = defineProps({
+  entityType: {
+    type: String,
+    default: 'Asset'
   },
+  tasks: {
+    type: Array,
+    default: () => []
+  }
+})
 
-  props: {
-    entityType: {
-      type: String,
-      default: 'Asset'
-    },
-    tasks: {
-      type: Array,
-      default: () => []
+const emit = defineEmits(['estimation-changed'])
+
+// State
+const lastSelection = ref(0)
+const lastShiftSelection = ref(0)
+const selectionGrid = ref({})
+// Imperative focus targets only, no reactivity needed
+const estimationInputs = new Map()
+
+// Computed
+const currentProduction = computed(() => store.getters.currentProduction)
+const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
+const isCurrentUserSupervisor = computed(
+  () => store.getters.isCurrentUserSupervisor
+)
+const personMap = computed(() => store.getters.personMap)
+const taskStatusMap = computed(() => store.getters.taskStatusMap)
+const taskTypeMap = computed(() => store.getters.taskTypeMap)
+const user = computed(() => store.getters.user)
+
+const isAssets = computed(() => props.entityType === 'Asset')
+const isShots = computed(() => props.entityType === 'Shot')
+
+const entityMap = computed(() => {
+  const caches = {
+    asset: assetsStore.cache.assetMap,
+    edit: editsStore.cache.editMap,
+    episode: episodesStore.cache.episodeMap,
+    sequence: sequencesStore.cache.sequenceMap,
+    shot: shotsStore.cache.shotMap
+  }
+  return caches[props.entityType.toLowerCase()]
+})
+
+const tasksByPerson = computed(() =>
+  [...props.tasks].sort(compareFirstAssignees)
+)
+
+const assignees = computed(() => {
+  const alltasks = {
+    countMap: new Map(),
+    frameMap: new Map(),
+    estimationMap: new Map(),
+    secondMap: new Map()
+  }
+  const remaining = {
+    countMap: new Map(),
+    frameMap: new Map(),
+    estimationMap: new Map(),
+    secondMap: new Map()
+  }
+  const assigneeSet = new Set()
+  props.tasks.forEach(task => {
+    const entity = getEntity(task.entity_id)
+    task.assignees.forEach(personId => {
+      assigneeSet.add(personId)
+      addAssigneeStatsToMaps(alltasks, personId, task, entity)
+      const status = taskStatusMap.value.get(task.task_status_id)
+      if (!status.is_done && !status.is_feedback_request) {
+        addAssigneeStatsToMaps(remaining, personId, task, entity)
+      }
+    })
+  })
+  return [...assigneeSet]
+    .map(personId => personMap.value.get(personId))
+    .sort(firstBy('name'))
+    .map(person => ({
+      ...person,
+      alltasks: getAssigneeStats(person, alltasks),
+      remaining: getAssigneeStats(person, remaining)
+    }))
+})
+
+// Functions
+const getEntity = entityId => entityMap.value.get(entityId)
+
+const setEstimationInput = (taskId, el) => {
+  if (el) {
+    estimationInputs.set(taskId, el)
+  } else {
+    estimationInputs.delete(taskId)
+  }
+}
+
+const compareFirstAssignees = (a, b) => {
+  if (a.assignees.length > 0 && b.assignees.length > 0) {
+    const personA = personMap.value.get(a.assignees[0])
+    const personB = personMap.value.get(b.assignees[0])
+    return personA.name.localeCompare(personB.name)
+  } else if (a.assignees.length > 0) {
+    return -1
+  } else if (b.assignees.length > 0) {
+    return 1
+  } else {
+    return -1
+  }
+}
+
+const getSeconds = task => {
+  const shot = getEntity(task.entity_id)
+  return frameToSeconds(shot.nb_frames, currentProduction.value, shot)
+}
+
+const estimationUpdated = (event, task) => {
+  const value = event.target.value
+  if (value && value.length > 0) {
+    saveEstimations(parseFloat(value), task)
+  }
+}
+
+const saveEstimations = (days, task) => {
+  const selection = Object.keys(selectionGrid.value)
+  if (selection.length > 1) {
+    selection.forEach(taskId => {
+      emit('estimation-changed', { taskId, days })
+    })
+  } else {
+    emit('estimation-changed', { taskId: task.id, days })
+  }
+}
+
+const onKeyDown = event => {
+  if (event.key === 'Tab') {
+    pauseEvent(event)
+    if (event.shiftKey) {
+      selectPrevious()
+    } else {
+      selectNext()
     }
-  },
+  } else if (event.key === 'ArrowDown') {
+    pauseEvent(event)
+    selectNext(event.shiftKey)
+  } else if (event.key === 'ArrowUp') {
+    pauseEvent(event)
+    selectPrevious(event.shiftKey)
+  }
+}
 
-  emits: ['estimation-changed'],
+const clearSelection = () => {
+  selectionGrid.value = {}
+}
 
-  data() {
-    return {
-      lastSelection: 0,
-      lastShiftSelection: 0,
-      selectionGrid: {}
+const addToSelection = taskId => {
+  selectionGrid.value[taskId] = true
+}
+
+const selectTask = (event, task, index) => {
+  if (!(event.ctrlKey || event.metaKey)) clearSelection()
+  if (event.shiftKey) {
+    selectTaskRange(index)
+  } else {
+    selectSingleTask(index)
+  }
+  if (isInDepartment(task)) {
+    focusInput(estimationInputs.get(tasksByPerson.value[index].id))
+  }
+}
+
+const selectPrevious = shiftKey => {
+  const index =
+    lastSelection.value - 1 < 0
+      ? tasksByPerson.value.length - 1
+      : lastSelection.value - 1
+  selectTask({ shiftKey }, tasksByPerson.value[index], index)
+}
+
+const selectNext = shiftKey => {
+  const index =
+    lastSelection.value + 1 >= tasksByPerson.value.length
+      ? 0
+      : lastSelection.value + 1
+  selectTask({ shiftKey }, tasksByPerson.value[index], index)
+}
+
+const selectSingleTask = index => {
+  addToSelection(tasksByPerson.value[index].id)
+  lastSelection.value = index
+  lastShiftSelection.value = index
+}
+
+const selectTaskRange = index => {
+  lastSelection.value = index
+  const taskIndices =
+    lastShiftSelection.value > index
+      ? range(index, lastShiftSelection.value)
+      : range(lastShiftSelection.value, index)
+  taskIndices.forEach(i => {
+    addToSelection(tasksByPerson.value[i].id)
+  })
+}
+
+const isInDepartment = task => {
+  if (isCurrentUserManager.value) {
+    return true
+  } else if (isCurrentUserSupervisor.value) {
+    if (user.value.departments.length === 0) {
+      return true
     }
-  },
+    const taskType = taskTypeMap.value.get(task.task_type_id)
+    return (
+      taskType.department_id &&
+      user.value.departments.includes(taskType.department_id)
+    )
+  }
+  return false
+}
 
-  computed: {
-    ...mapGetters([
-      'currentProduction',
-      'isCurrentUserManager',
-      'isCurrentUserSupervisor',
-      'organisation',
-      'personMap',
-      'taskStatusMap',
-      'taskTypeMap',
-      'user'
-    ]),
+const getAssigneeStats = (person, maps) => {
+  const estimation = maps.estimationMap.get(person.id) || 0
+  const seconds = maps.secondMap.get(person.id) || 0
+  const frames = maps.frameMap.get(person.id) || 0
+  const count = maps.countMap.get(person.id) || 0
+  const estimationDays = minutesToDays(organisation.value, estimation)
+  const quota = estimation > 0 ? seconds / estimationDays : 0
+  const quotaCount = estimation > 0 ? count / estimationDays : 0
+  const quotaFrames = estimation > 0 ? frames / estimationDays : 0
 
-    isAssets() {
-      return this.entityType === 'Asset'
-    },
+  return {
+    count,
+    estimation: formatDuration(estimation),
+    frames,
+    quota: quota.toFixed(2),
+    quotaFrames: quotaFrames.toFixed(2),
+    quotaCount: quotaCount.toFixed(2),
+    seconds: seconds.toFixed(2)
+  }
+}
 
-    isShots() {
-      return this.entityType === 'Shot'
-    },
-
-    tasksByPerson() {
-      return [...this.tasks].sort(this.compareFirstAssignees)
-    },
-
-    assetMap() {
-      return assetsStore.cache.assetMap
-    },
-
-    editMap() {
-      return editsStore.cache.editMap
-    },
-
-    episodeMap() {
-      return episodesStore.cache.episodeMap
-    },
-
-    sequenceMap() {
-      return sequencesStore.cache.sequenceMap
-    },
-
-    shotMap() {
-      return shotsStore.cache.shotMap
-    },
-
-    entityMap() {
-      return this[`${this.entityType.toLowerCase()}Map`]
-    },
-
-    assignees() {
-      const assigneeSet = new Set()
-      const alltasks = {
-        countMap: new Map(),
-        frameMap: new Map(),
-        estimationMap: new Map(),
-        secondMap: new Map()
-      }
-      const remaining = {
-        countMap: new Map(),
-        frameMap: new Map(),
-        estimationMap: new Map(),
-        secondMap: new Map()
-      }
-      const assignees = []
-      this.tasks.forEach(task => {
-        const entity = this.getEntity(task.entity_id)
-        task.assignees.forEach(personId => {
-          assigneeSet.add(personId)
-          this.addAssigneeStatsToMaps(alltasks, personId, task, entity)
-          const status = this.taskStatusMap.get(task.task_status_id)
-          if (!status.is_done && !status.is_feedback_request) {
-            this.addAssigneeStatsToMaps(remaining, personId, task, entity)
-          }
-        })
-      })
-      assigneeSet.forEach((val, personId) =>
-        assignees.push(this.personMap.get(personId))
-      )
-      return assignees.sort(firstBy('name')).map(person => {
-        const allTasksStats = this.getAssigneeStats(person, alltasks)
-        const remainingStats = this.getAssigneeStats(person, remaining)
-        return {
-          ...person,
-          alltasks: allTasksStats,
-          remaining: remainingStats
-        }
-      })
-    }
-  },
-
-  methods: {
-    ...mapActions(['updateTask']),
-
-    frameToSeconds,
-
-    getEntity(entityId) {
-      return this.entityMap.get(entityId)
-    },
-
-    compareFirstAssignees(a, b) {
-      if (a.assignees.length > 0 && b.assignees.length > 0) {
-        const personA = this.personMap.get(a.assignees[0])
-        const personB = this.personMap.get(b.assignees[0])
-        return personA.name.localeCompare(personB.name)
-      } else if (a.assignees.length > 0) {
-        return -1
-      } else if (b.assignees.length > 0) {
-        return 1
-      } else {
-        return -1
-      }
-    },
-
-    getSeconds(task) {
-      const shot = this.getEntity(task.entity_id)
-      return frameToSeconds(shot.nb_frames, this.currentProduction, shot)
-    },
-
-    estimationUpdated(event, task) {
-      const value = event.target.value
-      if (value && value.length > 0) {
-        const estimation = parseFloat(event.target.value)
-        this.saveEstimations(estimation, task)
-      }
-    },
-
-    saveEstimations(days, task) {
-      const selection = Object.keys(this.selectionGrid)
-      if (selection.length > 1) {
-        selection.forEach(taskId => {
-          this.$emit('estimation-changed', { taskId, days })
-        })
-      } else {
-        this.$emit('estimation-changed', { taskId: task.id, days })
-      }
-    },
-
-    onKeyDown(event) {
-      if (event.key === 'Tab') {
-        this.pauseEvent(event)
-        if (event.shiftKey) {
-          this.selectPrevious()
-        } else {
-          this.selectNext()
-        }
-      } else if (event.key === 'ArrowDown') {
-        this.pauseEvent(event)
-        this.selectNext(event.shiftKey)
-      } else if (event.key === 'ArrowUp') {
-        this.pauseEvent(event)
-        this.selectPrevious(event.shiftKey)
-      }
-    },
-
-    clearSelection() {
-      this.selectionGrid = {}
-    },
-
-    addToSelection(taskId) {
-      this.selectionGrid[taskId] = true
-    },
-
-    selectTask(event, task, index) {
-      if (event.shiftKey) {
-        if (!(event.ctrlKey || event.metaKey)) this.clearSelection()
-        this.selectTaskRange(index)
-      } else {
-        if (!(event.ctrlKey || event.metaKey)) this.clearSelection()
-        this.selectSingleTask(index)
-      }
-      if (this.isInDepartment(task)) {
-        this.focusInput(
-          this.$refs[this.tasksByPerson[index].id + '-estimation'][0]
-        )
-      }
-    },
-
-    selectPrevious(shiftKey) {
-      let index = this.lastSelection
-      index = index - 1 < 0 ? this.tasksByPerson.length - 1 : index - 1
-      this.selectTask({ shiftKey }, this.tasksByPerson[index], index)
-    },
-
-    selectNext(shiftKey) {
-      let index = this.lastSelection
-      index = index + 1 >= this.tasksByPerson.length ? 0 : index + 1
-      this.selectTask({ shiftKey }, this.tasksByPerson[index], index)
-    },
-
-    selectSingleTask(index) {
-      const task = this.tasksByPerson[index]
-      this.addToSelection(task.id)
-      this.lastSelection = index
-      this.lastShiftSelection = index
-    },
-
-    selectTaskRange(index) {
-      this.lastSelection = index
-      const taskIndices =
-        this.lastShiftSelection > index
-          ? range(index, this.lastShiftSelection)
-          : range(this.lastShiftSelection, index)
-      const selection = taskIndices.map(i => this.tasksByPerson[i].id)
-      selection.forEach(taskId => {
-        this.addToSelection(taskId)
-      })
-    },
-
-    isInDepartment(task) {
-      if (this.isCurrentUserManager) {
-        return true
-      } else if (this.isCurrentUserSupervisor) {
-        if (this.user.departments.length === 0) {
-          return true
-        } else {
-          const taskType = this.taskTypeMap.get(task.task_type_id)
-          return (
-            taskType.department_id &&
-            this.user.departments.includes(taskType.department_id)
-          )
-        }
-      } else {
-        return false
-      }
-    },
-
-    getAssigneeStats(person, maps) {
-      const estimation = maps.estimationMap.get(person.id) || 0
-      const seconds = maps.secondMap.get(person.id) || 0
-      const frames = maps.frameMap.get(person.id) || 0
-      const count = maps.countMap.get(person.id) || 0
-      const estimationDays = minutesToDays(this.organisation, estimation)
-      const quota = estimation > 0 ? seconds / estimationDays : 0
-      const quotaCount = estimation > 0 ? count / estimationDays : 0
-      const quotaFrames = estimation > 0 ? frames / estimationDays : 0
-
-      return {
-        count: maps.countMap.get(person.id) || 0,
-        estimation: this.formatDuration(estimation),
-        frames,
-        quota: quota.toFixed(2),
-        quotaFrames: quotaFrames.toFixed(2),
-        quotaCount: quotaCount.toFixed(2),
-        seconds: seconds.toFixed(2)
-      }
-    },
-
-    addAssigneeStatsToMaps(maps, personId, task, entity) {
-      maps.countMap.set(personId, (maps.countMap.get(personId) || 0) + 1)
-      maps.estimationMap.set(
-        personId,
-        (maps.estimationMap.get(personId) || 0) + task.estimation
-      )
-      if (!this.isAssets) {
-        const frames = entity.nb_frames || 0
-        const seconds = frameToSeconds(frames, this.currentProduction, entity)
-        maps.secondMap.set(
-          personId,
-          (maps.secondMap.get(personId) || 0) + seconds
-        )
-        maps.frameMap.set(personId, (maps.frameMap.get(personId) || 0) + frames)
-      }
-    }
+const addAssigneeStatsToMaps = (maps, personId, task, entity) => {
+  maps.countMap.set(personId, (maps.countMap.get(personId) || 0) + 1)
+  maps.estimationMap.set(
+    personId,
+    (maps.estimationMap.get(personId) || 0) + task.estimation
+  )
+  if (!isAssets.value) {
+    const frames = entity.nb_frames || 0
+    const seconds = frameToSeconds(frames, currentProduction.value, entity)
+    maps.secondMap.set(personId, (maps.secondMap.get(personId) || 0) + seconds)
+    maps.frameMap.set(personId, (maps.frameMap.get(personId) || 0) + frames)
   }
 }
 </script>
@@ -607,12 +573,6 @@ td {
   width: 60px;
 }
 
-.number {
-  min-width: 80px;
-  width: 80px;
-  text-align: right;
-}
-
 .estimation-helper {
   max-height: 100%;
 }
@@ -627,12 +587,6 @@ td {
 
 .column {
   padding: 0 1em 1em 1em;
-}
-
-.task-list {
-  .empty {
-    border-left: 0 solid transparent;
-  }
 }
 
 .task-list .numeric-cell,

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -193,7 +193,7 @@
                   :revision="currentRevision"
                   :is-movie="isMoviePreview"
                   :is-picture="isPicturePreview"
-                  @add-comment="addComment"
+                  @add-comment="postComment"
                   @add-preview="onAddPreviewClicked"
                   @file-drop="selectFile"
                   @clear-files="clearPreviewFiles"
@@ -877,7 +877,11 @@ const loadTaskData = () => {
   }
 }
 
-const addComment = (
+// Named postComment, not addComment: in script setup a binding whose
+// camelCase matches a component tag shadows the component (camelize
+// wins over capitalize during template resolution), so an addComment
+// function would replace the <add-comment> widget itself.
+const postComment = (
   comment,
   attachment,
   checklist,

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="side-wrapper">
+  <div class="side-wrapper" ref="side-wrapper">
     <div
       class="extend-bar"
       @mousedown.prevent="onExtendDown"
@@ -111,7 +111,7 @@
           />
         </div>
 
-        <div class="task-columns pa1 pt0" ref="task-columns">
+        <div class="task-columns pa1 pt0">
           <div class="task-column preview-column" v-if="isPreview">
             <div class="preview-column-content">
               <div class="flexrow" v-if="!isConceptTask">
@@ -371,13 +371,31 @@
   </div>
 </template>
 
-<script>
+<script setup>
+// Imports
 import { CornerRightUpIcon, XIcon } from 'lucide-vue-next'
 import moment from 'moment'
-import { mapGetters, mapActions } from 'vuex'
+import {
+  computed,
+  getCurrentInstance,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  provide,
+  reactive,
+  ref,
+  useTemplateRef,
+  watch
+} from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute } from 'vue-router'
+import { useStore } from 'vuex'
 
+import { addEvents, getClientX, removeEvents } from '@/composables/dom'
+import { useTime } from '@/composables/time'
 import csv from '@/lib/csv'
 import drafts from '@/lib/drafts'
+import func from '@/lib/func'
 import {
   getDownloadAttachmentPath,
   getTaskEntityPath,
@@ -386,1385 +404,1310 @@ import {
 import preferences from '@/lib/preferences'
 import { formatRevision } from '@/lib/preview'
 import { getTaskTypeWithUrl } from '@/lib/productions'
-import { getTaskTypeStyle } from '@/lib/render'
 import { sortPeople, sortTaskNames } from '@/lib/sorting'
 import stringHelpers from '@/lib/string'
-import { formatFrame } from '@/lib/video'
+import { DEFAULT_FPS, formatFrame } from '@/lib/video'
 
-import { domMixin } from '@/components/mixins/dom'
-import { taskMixin } from '@/components/mixins/task'
-import { timeMixin } from '@/components/mixins/time'
-
-import ActionPanel from '@/components/tops/ActionPanel.vue'
-import AddComment from '@/components/widgets/AddComment.vue'
 import AddPreviewModal from '@/components/modals/AddPreviewModal.vue'
-import Comment from '@/components/widgets/Comment.vue'
-import ComboboxActions from '@/components/widgets/ComboboxActions.vue'
-import ComboboxStyled from '@/components/widgets/ComboboxStyled.vue'
 import DeleteModal from '@/components/modals/DeleteModal.vue'
 import EditCommentModal from '@/components/modals/EditCommentModal.vue'
 import MoveCommentModal from '@/components/modals/MoveCommentModal.vue'
-import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
 import PreviewPlayer from '@/components/players/players/PreviewPlayer.vue'
+import ActionPanel from '@/components/tops/ActionPanel.vue'
+// eslint-disable-next-line no-unused-vars
+import AddComment from '@/components/widgets/AddComment.vue'
+import ComboboxActions from '@/components/widgets/ComboboxActions.vue'
+import ComboboxStyled from '@/components/widgets/ComboboxStyled.vue'
+import Comment from '@/components/widgets/Comment.vue'
+import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
 import Spinner from '@/components/widgets/Spinner.vue'
 import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
 
 const DEFAULT_PANEL_WIDTH = 400
 
-export default {
-  name: 'task-info',
+// Composables
+const { t } = useI18n()
+const route = useRoute()
+const store = useStore()
+const { formatDate } = useTime()
 
-  mixins: [domMixin, taskMixin, timeMixin],
+const instance = getCurrentInstance()
+const socket = instance.appContext.config.globalProperties.$socket
 
-  components: {
-    ActionPanel,
-    AddComment,
-    AddPreviewModal,
-    ComboboxActions,
-    ComboboxStyled,
-    Comment,
-    CornerRightUpIcon,
-    DeleteModal,
-    EditCommentModal,
-    MoveCommentModal,
-    PeopleAvatar,
-    PreviewPlayer,
-    Spinner,
-    TaskTypeName,
-    XIcon
+// Props / Emits
+const props = defineProps({
+  currentFrame: {
+    type: Number,
+    default: 0
   },
+  currentParentPreview: {
+    type: Object,
+    default: null
+  },
+  entityType: {
+    type: String,
+    default: 'Asset'
+  },
+  extendable: {
+    type: Boolean,
+    default: true
+  },
+  inPlaylist: {
+    type: Boolean,
+    default: false
+  },
+  isLoading: {
+    type: Boolean,
+    default: true
+  },
+  isPreview: {
+    type: Boolean,
+    default: true
+  },
+  silent: {
+    type: Boolean,
+    default: false
+  },
+  showAssignees: {
+    type: Boolean,
+    default: false
+  },
+  task: {
+    type: Object,
+    default: () => {}
+  },
+  withActions: {
+    type: Boolean,
+    default: false
+  },
+  player: {
+    type: Object,
+    default: null
+  },
+  root: {
+    type: Boolean,
+    default: true
+  }
+})
 
-  props: {
-    currentFrame: {
-      type: Number,
-      default: 0
-    },
-    currentParentPreview: {
-      type: Object,
-      default: null
-    },
-    entityType: {
-      type: String,
-      default: 'Asset'
-    },
-    extendable: {
-      type: Boolean,
-      default: true
-    },
-    inPlaylist: {
-      type: Boolean,
-      default: false
-    },
-    isLoading: {
-      type: Boolean,
-      default: true
-    },
-    isPreview: {
-      type: Boolean,
-      default: true
-    },
-    silent: {
-      type: Boolean,
-      default: false
-    },
-    showAssignees: {
-      type: Boolean,
-      default: false
-    },
-    task: {
-      type: Object,
-      default: () => {}
-    },
-    withActions: {
-      type: Boolean,
-      default: false
-    },
-    player: {
-      type: Object,
-      default: null
-    },
-    root: {
-      type: Boolean,
-      default: true
+const emit = defineEmits(['comment-added', 'task-removed', 'time-code-clicked'])
+
+// State
+const draftComment = reactive({})
+// Only the root panel provides the draft: nested TaskInfo instances inject
+// it so the comment draft survives switching between panels.
+if (props.root) {
+  provide('draftComment', draftComment)
+}
+
+const addExtraPreviewFormData = ref(null)
+const animOn = ref(false)
+const previewForms = ref([])
+const currentFrameRaw = ref(0)
+const currentPreviewIndex = ref(0)
+const commentToEdit = ref(null)
+const commentToMove = ref(null)
+const isWide = ref(false)
+const isExtraWide = ref(false)
+const taskComments = ref([])
+const taskPreviews = ref([])
+
+// Extend-drag bookkeeping, read only inside event handlers
+let currentExtraPreviewId = null
+let lastWidth = 0
+let lastWidthX = 0
+
+const errors = reactive({
+  addComment: false,
+  addCommentMaxRetakes: false,
+  addPreview: false,
+  addExtraPreview: false,
+  editComment: false,
+  deleteComment: false,
+  moveComment: false,
+  deleteExtraPreview: false,
+  task: false
+})
+
+const loading = reactive({
+  addComment: false,
+  addPreview: false,
+  addExtraPreview: false,
+  editComment: false,
+  deleteComment: false,
+  moveComment: false,
+  deleteExtraPreview: false,
+  task: false,
+  setFrameThumbnail: false
+})
+
+const modals = reactive({
+  addPreview: false,
+  addExtraPreview: false,
+  editComment: false,
+  deleteComment: false,
+  moveComment: false,
+  deleteExtraPreview: false
+})
+
+const addCommentRef = useTemplateRef('add-comment')
+const addExtraPreviewModalRef = useTemplateRef('add-extra-preview-modal')
+const addPreviewModalRef = useTemplateRef('add-preview-modal')
+const previewPlayerRef = useTemplateRef('preview-player')
+const sideWrapperRef = useTemplateRef('side-wrapper')
+
+// Computed
+const currentEpisode = computed(() => store.getters.currentEpisode)
+const currentProduction = computed(() => store.getters.currentProduction)
+const isCurrentUserArtist = computed(() => store.getters.isCurrentUserArtist)
+const isCurrentUserClient = computed(() => store.getters.isCurrentUserClient)
+const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
+const isCurrentUserSupervisor = computed(
+  () => store.getters.isCurrentUserSupervisor
+)
+const isTVShow = computed(() => store.getters.isTVShow)
+const nbSelectedTasks = computed(() => store.getters.nbSelectedTasks)
+const nbSelectedValidations = computed(
+  () => store.getters.nbSelectedValidations
+)
+const personMap = computed(() => store.getters.personMap)
+const productionMap = computed(() => store.getters.productionMap)
+const selectedConcepts = computed(() => store.getters.selectedConcepts)
+const selectedTasks = computed(() => store.getters.selectedTasks)
+const shotMap = computed(() => store.getters.shotMap)
+const taskEntityPreviews = computed(() => store.getters.taskEntityPreviews)
+const taskMap = computed(() => store.getters.taskMap)
+const taskTypeMap = computed(() => store.getters.taskTypeMap)
+const user = computed(() => store.getters.user)
+
+const sideColumnParent = computed(() => {
+  const parent = sideWrapperRef.value?.parentElement
+  return parent?.classList.contains('side-column') ? parent : undefined
+})
+
+const selectedEntities = computed(() => {
+  const byType = {
+    Asset: store.getters.selectedAssets,
+    Concept: store.getters.selectedConcepts,
+    Edit: store.getters.selectedEdits,
+    Shot: store.getters.selectedShots
+  }
+  return byType[props.entityType]
+})
+
+const nbSelectedEntities = computed(() => selectedEntities.value?.size || 0)
+
+const currentProductionId = computed(
+  () => props.task?.project_id || currentProduction.value?.id
+)
+
+const currentTeam = computed(() => {
+  if (!props.task) return []
+  const production = productionMap.value.get(props.task.project_id)
+  if (!production?.team) return []
+  return sortPeople(
+    production.team
+      .map(personId => personMap.value.get(personId))
+      .filter(Boolean)
+  )
+})
+
+// Task types of the same project, filtered by the current task entity type
+// (Shot or Asset), each with a url pointing to the matching task.
+const currentTaskTypes = computed(() => {
+  if (!props.task || !currentProduction.value) return []
+
+  const taskTypeEntity = taskTypeMap.value.get(
+    props.task.task_type_id
+  ).for_entity
+  const taskTypeEntitySlug = taskTypeEntity.toLowerCase() + 's'
+
+  const entityTasks = {}
+  taskMap.value.forEach(task => {
+    if (task.entity_id === props.task.entity_id) {
+      entityTasks[task.task_type_id] = task
     }
-  },
+  })
 
-  emits: ['comment-added', 'task-removed', 'time-code-clicked'],
+  return currentProduction.value.task_types
+    .map(taskTypeId => taskTypeMap.value.get(taskTypeId))
+    .filter(taskType => taskType?.for_entity === taskTypeEntity)
+    .filter(taskType => entityTasks[taskType.id])
+    .map(taskType =>
+      getTaskTypeWithUrl(taskType, entityTasks[taskType.id], taskTypeEntitySlug)
+    )
+})
 
-  provide() {
-    if (this.root) {
-      return {
-        draftComment: this.draftComment
-      }
-    }
-    return {}
-  },
+const title = computed(() => {
+  if (props.task) {
+    return props.task.full_entity_name || props.task.entity_name
+  }
+  return t('main.loading')
+})
 
-  data() {
-    return {
-      draftComment: {},
-      addExtraPreviewFormData: null,
-      animOn: false,
-      previewForms: [],
-      currentFrameRaw: 0,
-      currentPreviewIndex: 0,
-      currentPreviewPath: '',
-      currentPreviewDlPath: '',
-      currentTask: null,
-      commentToEdit: null,
-      commentToMove: null,
-      isWide: false,
-      isExtraWide: false,
-      otherPreviews: [],
-      panelWidth: 800,
-      selectedEpisodes: null,
-      selectedSequences: null,
-      taskComments: [],
-      taskPreviews: [],
-      domEvents: [
-        ['mousemove', this.onExtendMove],
-        ['touchmove', this.onExtendMove],
-        ['mouseup', this.onExtendUp],
-        ['mouseleave', this.onExtendUp],
-        ['touchend', this.onExtendUp],
-        ['touchcancel', this.onExtendUp]
-      ],
-      errors: {
-        addComment: false,
-        addCommentMaxRetakes: false,
-        addPreview: false,
-        addExtraPreview: false,
-        editComment: false,
-        deleteComment: false,
-        moveComment: false,
-        confirmDeleteTaskPreview: false,
-        task: false
-      },
-      loading: {
-        addComment: false,
-        addPreview: false,
-        addExtraPreview: false,
-        editComment: false,
-        deleteComment: false,
-        moveComment: false,
-        confirmDeleteTaskPreview: false,
-        task: false,
-        setFrameThumbnail: false
-      },
-      modals: {
-        addPreview: false,
-        addExtraPreview: false,
-        editComment: false,
-        deleteComment: false,
-        moveComment: false,
-        deleteExtraPreview: false
-      }
-    }
-  },
+const isAssigned = computed(
+  () =>
+    props.task?.assignees.some(personId => personId === user.value.id) ?? false
+)
 
-  mounted() {
-    if (this.sideColumnParent) {
-      const panelWidth = preferences.getIntPreference(
-        'task:panel-width',
-        DEFAULT_PANEL_WIDTH
-      )
-      this.setWidth(panelWidth)
-      this.refreshPreviewPlay()
-    }
-  },
+const isCommentingAllowed = computed(
+  () =>
+    props.task &&
+    (isAssigned.value ||
+      isCurrentUserClient.value ||
+      isDepartmentSupervisor.value ||
+      isCurrentUserManager.value)
+)
 
-  beforeUnmount() {
-    this.removeEvents(this.domEvents)
-  },
+const isConceptTask = computed(() => props.entityType === 'Concept')
 
-  computed: {
-    ...mapGetters([
-      'currentEpisode',
-      'currentProduction',
-      'getTaskComment',
-      'getTaskComments',
-      'getTaskPreviews',
-      'getTaskStatusForCurrentUser',
-      'isCurrentUserArtist',
-      'isCurrentUserClient',
-      'isCurrentUserManager',
-      'isCurrentUserSupervisor',
-      'isSavingCommentPreview',
-      'isSingleEpisode',
-      'isTVShow',
-      'nbSelectedTasks',
-      'personMap',
-      'productionMap',
-      'selectedAssets',
-      'selectedConcepts',
-      'selectedEdits',
-      'selectedShots',
-      'selectedTasks',
-      'shotMap',
-      'nbSelectedValidations',
-      'taskEntityPreviews',
-      'taskMap',
-      'taskTypeMap',
-      'user'
-    ]),
+const isDepartmentSupervisor = computed(() => {
+  if (!isCurrentUserSupervisor.value) {
+    return false
+  }
+  if (user.value.departments.length === 0) {
+    return true
+  }
+  return user.value.departments.includes(currentTaskType.value?.department_id)
+})
 
-    sideColumnParent() {
-      if (this.$el.parentElement.classList.contains('side-column')) {
-        return this.$el.parentElement
-      }
-      return undefined
-    },
-
-    nbSelectedEntities() {
-      return this.selectedEntities?.size || 0
-    },
-
-    selectedEntities() {
-      return this[`selected${this.entityType}s`]
-    },
-
-    currentProductionId() {
-      return this.task?.project_id || this.currentProduction?.id
-    },
-
-    currentTeam() {
-      if (!this.task) return []
-      const production = this.productionMap.get(this.task.project_id)
-      if (!production?.team) return []
-      return sortPeople(
-        production.team
-          .map(personId => this.personMap.get(personId))
-          .filter(Boolean)
-      )
-    },
-
-    // get current task types for this project filtered by current task entity type (Shot or Asset)
-    currentTaskTypes() {
-      if (!this.task || !this.currentProduction) return []
-
-      // task types for this project
-      const task_types = this.currentProduction.task_types
-
-      // get the current task entity type eg. 'Shot' or 'Asset'
-      const current_task_type = this.taskTypeMap.get(this.task.task_type_id)
-      const task_type_entity = current_task_type.for_entity
-      const task_type_entity_slug = task_type_entity.toLowerCase() + 's'
-
-      // lets get a map of all tasks that are the same entity
-      // where the key is the task type id
-      const entity_tasks = {}
-      for (const keyValue of this.taskMap) {
-        const task = keyValue[1]
-        if (task.entity_id === this.task.entity_id)
-          entity_tasks[task.task_type_id] = task
-      }
-
-      const filtered = task_types
-        // get all task type objects
-        .map(taskTypeId => this.taskTypeMap.get(taskTypeId))
-
-        // filter down to just those that match this task entity type Shot, Asset etc.
-        .filter(taskType => taskType?.for_entity === task_type_entity)
-
-        // filter to tasks that exist
-        .filter(taskType => entity_tasks[taskType.id])
-
-        // add a url that points to the task
-        .map(taskType =>
-          getTaskTypeWithUrl(
-            taskType,
-            entity_tasks[taskType.id],
-            task_type_entity_slug
-          )
-        )
-      return filtered
-    },
-
-    title() {
-      if (this.task) {
-        const entityName = this.task.full_entity_name || this.task.entity_name
-        return `${entityName}`
-      } else {
-        return this.$t('main.loading')
-      }
-    },
-
-    isAssigned() {
-      return (
-        this.task?.assignees.some(personId => personId === this.user.id) ??
-        false
-      )
-    },
-
-    isCommentingAllowed() {
-      return (
-        this.task &&
-        (this.isAssigned ||
-          this.isCurrentUserClient ||
-          this.isDepartmentSupervisor ||
-          this.isCurrentUserManager)
-      )
-    },
-
-    isConceptTask() {
-      return this.entityType === 'Concept'
-    },
-
-    isDepartmentSupervisor() {
-      if (!this.isCurrentUserSupervisor) {
+const isPreviewPlayerReadOnly = computed(() => {
+  if (props.task) {
+    if (isCurrentUserManager.value || isCurrentUserClient.value) {
+      return false
+    } else if (isCurrentUserSupervisor.value) {
+      if (user.value.departments.length === 0) {
         return false
-      }
-      if (this.user.departments.length === 0) {
-        return true
-      }
-      return this.user.departments.includes(this.currentTaskType?.department_id)
-    },
-
-    isPreviewPlayerReadOnly() {
-      if (this.task) {
-        if (this.isCurrentUserManager || this.isCurrentUserClient) {
-          return false
-        } else if (this.isCurrentUserSupervisor) {
-          if (this.user.departments.length === 0) {
-            return false
-          } else {
-            return !this.user.departments.includes(
-              this.currentTaskType?.department_id
-            )
-          }
-        }
-      }
-      return true
-    },
-
-    isSetThumbnailAllowed() {
-      return (
-        this.currentPreviewId &&
-        this.task &&
-        this.task.entity &&
-        this.currentPreviewId !== this.task.entity.preview_file_id &&
-        this.extension !== 'gif'
-      )
-    },
-
-    currentTaskType() {
-      return this.taskTypeMap.get(this.task?.task_type_id)
-    },
-
-    currentPreview() {
-      const index = this.currentPreviewIndex
-      return this.taskPreviews && this.taskPreviews.length > 0
-        ? this.taskPreviews[index]
-        : null
-    },
-
-    currentPreviewComment() {
-      return this.taskComments.find(comment =>
-        comment.previews?.some(
-          preview => preview.revision === this.currentRevision
-        )
-      )
-    },
-
-    currentPreviewId() {
-      const index = this.currentPreviewIndex
-      if (
-        this.taskPreviews &&
-        this.taskPreviews.length > 0 &&
-        this.taskPreviews[index]
-      ) {
-        return this.taskPreviews[index].id
       } else {
-        return null
+        return !user.value.departments.includes(
+          currentTaskType.value?.department_id
+        )
       }
-    },
-
-    canDownloadAnnotations() {
-      return (
-        this.isCurrentUserManager &&
-        this.currentPreviewId &&
-        (this.currentPreview?.annotations?.length || 0) > 0
-      )
-    },
-
-    annotationsZipPath() {
-      return this.currentPreviewId
-        ? `/api/actions/preview-files/${this.currentPreviewId}/extract-annotated-frames`
-        : null
-    },
-
-    annotationsPdfPath() {
-      return this.currentPreviewId
-        ? `/api/actions/preview-files/${this.currentPreviewId}/extract-annotated-frames-pdf`
-        : null
-    },
-
-    exportActions() {
-      return [
-        {
-          label: 'annotations.zip',
-          href: this.annotationsZipPath,
-          visible: this.canDownloadAnnotations
-        },
-        {
-          label: 'annotations.pdf',
-          href: this.annotationsPdfPath,
-          visible: this.canDownloadAnnotations
-        },
-        {
-          label: 'comments.csv',
-          handler: () => this.onExportClick(),
-          visible: !this.withActions && !this.isCurrentUserClient
-        }
-      ].filter(action => action.visible !== false)
-    },
-
-    currentRevision() {
-      return this.currentParentPreview && this.currentParentPreview.revision
-        ? this.currentParentPreview.revision
-        : this.currentPreview
-          ? this.currentPreview.revision
-          : 0
-    },
-
-    extension() {
-      const index = this.currentPreviewIndex
-      return this.taskPreviews && this.taskPreviews.length > 0
-        ? this.taskPreviews[index].extension
-        : ''
-    },
-
-    isStandardPreview() {
-      return (
-        this.taskPreviews &&
-        this.taskPreviews.length > 0 &&
-        [
-          'ai',
-          'blend',
-          'ma',
-          'mb',
-          'pdf',
-          'psd',
-          'rar',
-          'ae',
-          'fla',
-          'flv',
-          'swf',
-          'zip'
-        ].includes(this.extension)
-      )
-    },
-
-    isMoviePreview() {
-      return (
-        this.taskPreviews &&
-        this.taskPreviews.length > 0 &&
-        this.extension === 'mp4'
-      )
-    },
-
-    isPicturePreview() {
-      return (
-        this.taskPreviews &&
-        this.taskPreviews.length > 0 &&
-        ['png', 'gif'].includes(this.extension)
-      )
-    },
-
-    is3DModelPreview() {
-      return (
-        this.taskPreviews &&
-        this.taskPreviews.length > 0 &&
-        this.extension === 'obj'
-      )
-    },
-
-    moviePath() {
-      const previewId = this.currentPreview.id
-      return `/api/movies/originals/preview-files/${previewId}.mp4`
-    },
-
-    taskStatuses() {
-      return this.getTaskStatusForCurrentUser(
-        this.task.project_id,
-        this.isConceptTask
-      )
-    },
-
-    taskTypeStyle() {
-      return getTaskTypeStyle(this.task)
-    },
-
-    taskPath() {
-      return getTaskPath(
-        this.task,
-        null,
-        this.isTVShow,
-        this.currentEpisode,
-        this.taskTypeMap
-      )
-    },
-
-    taskEntityPath() {
-      const episodeId = this.$route.params.episode_id
-      return getTaskEntityPath(this.task, episodeId)
-    },
-
-    previewOptions() {
-      if (!this.taskPreviews) return []
-      return [...this.taskPreviews]
-        .sort((a, b) => b.revision - a.revision)
-        .map(preview => ({
-          value: preview.id,
-          label: formatRevision(preview.revision, this.currentProduction),
-          validation_status: preview.validation_status
-        }))
-    },
-
-    selectedTasksToDisplay() {
-      return sortTaskNames(
-        Array.from(this.selectedTasks.values()),
-        this.taskTypeMap
-      )
     }
-  },
+  }
+  return true
+})
 
-  methods: {
-    ...mapActions([
-      'addAttachmentToComment',
-      'ackComment',
-      'addCommentExtraPreview',
-      'commentTask',
-      'commentTaskWithPreview',
-      'deleteAttachment',
-      'deleteTaskComment',
-      'deleteTaskPreview',
-      'editTaskComment',
-      'loadComment',
-      'loadPreviewFileFormData',
-      'loadTask',
-      'loadTaskComments',
-      'loadTaskSubscribed',
-      'refreshPreview',
-      'pinComment',
-      'refreshComment',
-      'removeSelectedTask',
-      'setPreview',
-      'subscribeToTask',
-      'unsubscribeFromTask',
-      'updatePreviewAnnotation'
-    ]),
+const currentTaskType = computed(() =>
+  taskTypeMap.value.get(props.task?.task_type_id)
+)
 
-    loadTaskData() {
-      if (this.task) {
-        this.loading.task = true
-        this.errors.task = false
-        this.loadTaskComments({
-          taskId: this.task.id,
-          entityId: this.task.entity_id
-        })
-          .then(() => {
-            this.loading.task = false
-            this.reset()
-          })
-          .catch(err => {
-            console.error(err)
-            this.errors.task = true
-          })
-      }
+const currentFps = computed(() => {
+  if (!props.task) return 25
+  // An entity can override the production fps via data.fps; use it so
+  // the player builds its frame model on the rate the video was
+  // actually rendered at (otherwise frames get duplicated/dropped).
+  // The entity may be a Shot, Edit, Sequence, Episode or Asset, each
+  // in its own store map — task.entity is only { id } here.
+  const entityFps = parseFloat(getTaskEntity(props.task)?.data?.fps)
+  if (entityFps) return entityFps
+  return (
+    parseInt(productionMap.value.get(props.task.project_id)?.fps) || DEFAULT_FPS
+  )
+})
+
+const entityFrames = computed(() => {
+  if (!props.task?.entity) return 0
+  return shotMap.value.get(props.task.entity.id)?.nb_frames || 0
+})
+
+const currentPreview = computed(() =>
+  taskPreviews.value && taskPreviews.value.length > 0
+    ? taskPreviews.value[currentPreviewIndex.value]
+    : null
+)
+
+const currentPreviewComment = computed(() =>
+  taskComments.value.find(comment =>
+    comment.previews?.some(
+      preview => preview.revision === currentRevision.value
+    )
+  )
+)
+
+const currentPreviewId = computed(() => {
+  const index = currentPreviewIndex.value
+  if (
+    taskPreviews.value &&
+    taskPreviews.value.length > 0 &&
+    taskPreviews.value[index]
+  ) {
+    return taskPreviews.value[index].id
+  }
+  return null
+})
+
+const canDownloadAnnotations = computed(
+  () =>
+    isCurrentUserManager.value &&
+    currentPreviewId.value &&
+    (currentPreview.value?.annotations?.length || 0) > 0
+)
+
+const annotationsZipPath = computed(() =>
+  currentPreviewId.value
+    ? `/api/actions/preview-files/${currentPreviewId.value}/extract-annotated-frames`
+    : null
+)
+
+const annotationsPdfPath = computed(() =>
+  currentPreviewId.value
+    ? `/api/actions/preview-files/${currentPreviewId.value}/extract-annotated-frames-pdf`
+    : null
+)
+
+const exportActions = computed(() =>
+  [
+    {
+      label: 'annotations.zip',
+      href: annotationsZipPath.value,
+      visible: canDownloadAnnotations.value
     },
+    {
+      label: 'annotations.pdf',
+      href: annotationsPdfPath.value,
+      visible: canDownloadAnnotations.value
+    },
+    {
+      label: 'comments.csv',
+      handler: () => onExportClick(),
+      visible: !props.withActions && !isCurrentUserClient.value
+    }
+  ].filter(action => action.visible !== false)
+)
 
-    addComment(
-      comment,
+const currentRevision = computed(() =>
+  props.currentParentPreview && props.currentParentPreview.revision
+    ? props.currentParentPreview.revision
+    : currentPreview.value
+      ? currentPreview.value.revision
+      : 0
+)
+
+const extension = computed(() =>
+  taskPreviews.value && taskPreviews.value.length > 0
+    ? taskPreviews.value[currentPreviewIndex.value].extension
+    : ''
+)
+
+const isMoviePreview = computed(
+  () =>
+    taskPreviews.value &&
+    taskPreviews.value.length > 0 &&
+    extension.value === 'mp4'
+)
+
+const isPicturePreview = computed(
+  () =>
+    taskPreviews.value &&
+    taskPreviews.value.length > 0 &&
+    ['png', 'gif'].includes(extension.value)
+)
+
+const taskStatuses = computed(() =>
+  store.getters.getTaskStatusForCurrentUser(
+    props.task.project_id,
+    isConceptTask.value
+  )
+)
+
+const taskPath = computed(() =>
+  getTaskPath(
+    props.task,
+    null,
+    isTVShow.value,
+    currentEpisode.value,
+    taskTypeMap.value
+  )
+)
+
+const taskEntityPath = computed(() =>
+  getTaskEntityPath(props.task, route.params.episode_id)
+)
+
+const previewOptions = computed(() => {
+  if (!taskPreviews.value) return []
+  return [...taskPreviews.value]
+    .sort((a, b) => b.revision - a.revision)
+    .map(preview => ({
+      value: preview.id,
+      label: formatRevision(preview.revision, currentProduction.value),
+      validation_status: preview.validation_status
+    }))
+})
+
+const selectedTasksToDisplay = computed(() =>
+  sortTaskNames(Array.from(selectedTasks.value.values()), taskTypeMap.value)
+)
+
+// Functions
+const getTaskEntity = task => {
+  const getterByType = {
+    Shot: 'shotMap',
+    Episode: 'episodeMap',
+    Sequence: 'sequenceMap',
+    Edit: 'editMap',
+    Asset: 'assetMap'
+  }
+  const getterName = getterByType[task?.entity_type_name]
+  if (!getterName || !task?.entity?.id) return null
+  return store.getters[getterName]?.get(task.entity.id) || null
+}
+
+const getCurrentTaskComments = () =>
+  store.getters.getTaskComments(props.task.id)
+
+const loadTaskData = () => {
+  if (props.task) {
+    loading.task = true
+    errors.task = false
+    store
+      .dispatch('loadTaskComments', {
+        taskId: props.task.id,
+        entityId: props.task.entity_id
+      })
+      .then(() => {
+        loading.task = false
+        reset()
+      })
+      .catch(err => {
+        console.error(err)
+        errors.task = true
+      })
+  }
+}
+
+const addComment = (
+  comment,
+  attachment,
+  checklist,
+  taskStatusId,
+  revision = undefined,
+  link = undefined,
+  forClient = false
+) => {
+  animOn.value = true
+  nextTick(() => {
+    const params = {
+      taskId: props.task.id,
+      taskStatusId,
       attachment,
       checklist,
-      taskStatusId,
-      revision = undefined,
-      link = undefined,
-      forClient = false
+      comment,
+      links: link ? [link] : null,
+      revision,
+      forClient
+    }
+    const action =
+      previewForms.value.length > 0 ? 'commentTaskWithPreview' : 'commentTask'
+    loading.addComment = true
+    errors.addComment = false
+    errors.addCommentMaxRetakes = false
+    store
+      .dispatch(action, params)
+      .then(() => {
+        drafts.clearTaskDraft(props.task.id)
+        addCommentRef.value?.reset()
+        reset()
+        loading.addComment = false
+        emit('comment-added')
+      })
+      .catch(err => {
+        console.error(err)
+        const isRetakeError = err.body?.message?.includes('retake') ?? false
+        errors.addComment = !isRetakeError
+        errors.addCommentMaxRetakes = isRetakeError
+        loading.addComment = false
+      })
+  })
+}
+
+const resetModals = () => {
+  addPreviewModalRef.value?.reset()
+}
+
+const resetComments = () => {
+  taskComments.value = store.getters.getTaskComments(props.task.id)
+}
+
+const reset = ({ keepPreviewFiles = false } = {}) => {
+  resetModals()
+  if (!keepPreviewFiles) {
+    clearPreviewFiles()
+  }
+  if (props.task) {
+    taskComments.value = store.getters.getTaskComments(props.task.id)
+    taskPreviews.value = store.getters.getTaskPreviews(props.task.id)
+    nextTick(() => {
+      previewPlayerRef.value?.focus()
+    })
+  }
+}
+
+const focusCommentTextarea = () => {
+  addCommentRef.value?.focus()
+}
+
+const selectFile = forms => {
+  previewForms.value = previewForms.value.concat(forms)
+  store.dispatch('loadPreviewFileFormData', previewForms.value)
+}
+
+const onPreviewFormRemoved = previewForm => {
+  previewForms.value = previewForms.value.filter(f => f !== previewForm)
+  store.dispatch('loadPreviewFileFormData', previewForms.value)
+}
+
+const clearPreviewFiles = () => {
+  previewForms.value = []
+  store.dispatch('loadPreviewFileFormData', previewForms.value)
+  store.commit('CLEAR_UPLOAD_PROGRESS')
+}
+
+const createExtraPreview = forms => {
+  selectFile(forms)
+  errors.addExtraPreview = false
+  loading.addExtraPreview = true
+  const comment = taskComments.value.find(comment =>
+    comment.previews.find(preview => preview.id === currentPreviewId.value)
+  )
+  store
+    .dispatch('addCommentExtraPreview', {
+      taskId: props.task.id,
+      commentId: comment?.id,
+      previewId: currentPreviewId.value
+    })
+    .then(() => {
+      loading.addExtraPreview = false
+      addExtraPreviewModalRef.value.reset()
+      reset()
+      setTimeout(() => {
+        previewPlayerRef.value?.displayLast()
+      }, 0)
+      modals.addExtraPreview = false
+    })
+    .catch(err => {
+      console.error(err)
+      loading.addExtraPreview = false
+      errors.addExtraPreview = true
+    })
+}
+
+const onPreviewAdded = eventData => {
+  const taskId = eventData.task_id
+  const commentId = eventData.comment_id
+  const previewId = eventData.preview_file_id
+  const revision = eventData.revision
+  const extension = eventData.extension
+  const comment = store.getters.getTaskComment(taskId, commentId)
+
+  if (props.task) {
+    if (
+      taskId === props.task.id &&
+      comment &&
+      (comment.previews.length === 0 || comment.previews[0].id !== previewId)
     ) {
-      this.animOn = true
-      this.$nextTick(() => {
-        let preview = this.currentParentPreview
-          ? this.currentParentPreview
-          : this.currentPreview
-        // find real preview, which contains the `revision`
-        preview = this.taskPreviews.find(p => p.id === preview.id)
-        const params = {
-          taskId: this.task.id,
-          taskStatusId,
-          attachment,
-          checklist,
-          comment,
-          links: link ? [link] : null,
+      store.commit('ADD_PREVIEW_END', {
+        preview: {
+          id: previewId,
           revision,
-          forClient
-        }
-        const action =
-          this.previewForms.length > 0
-            ? 'commentTaskWithPreview'
-            : 'commentTask'
-        this.loading.addComment = true
-        this.errors.addComment = false
-        this.errors.addCommentMaxRetakes = false
-        this.$store
-          .dispatch(action, params)
-          .then(() => {
-            drafts.clearTaskDraft(this.task.id)
-            this.$refs['add-comment']?.reset()
-            this.reset()
-            this.loading.addComment = false
-            this.$emit('comment-added')
-          })
-          .catch(err => {
-            console.error(err)
-            const isRetakeError = err.body?.message?.includes('retake') ?? false
-            this.errors.addComment = !isRetakeError
-            this.errors.addCommentMaxRetakes = isRetakeError
-            this.loading.addComment = false
-          })
+          extension
+        },
+        taskId,
+        commentId,
+        comment
       })
-    },
+      reset({ keepPreviewFiles: true })
+    }
+  }
+}
 
-    reset({ keepPreviewFiles = false } = {}) {
-      this.resetModals()
-      if (!keepPreviewFiles) {
-        this.clearPreviewFiles()
-      }
-      if (this.task) {
-        this.taskComments = this.getTaskComments(this.task.id)
-        this.taskPreviews = this.getTaskPreviews(this.task.id)
-        this.setOtherPreviews()
-        this.currentPreviewPath = this.getOriginalPath()
-        this.currentPreviewDlPath = this.getOriginalDlPath()
-        this.$nextTick(() => {
-          this.$refs['preview-player']?.focus()
-        })
-      }
-    },
+const onPreviewsOrderChange = () => {
+  taskPreviews.value = store.getters.getTaskPreviews(props.task.id)
+}
 
-    focusCommentTextarea() {
-      this.$refs['add-comment']?.focus()
-    },
+const onAnnotationChanged = async ({
+  preview,
+  additions,
+  deletions,
+  updates
+}) => {
+  const taskId = props.task?.id || preview.task_id
+  if (!taskId) return
+  try {
+    await store.dispatch('updatePreviewAnnotation', {
+      taskId,
+      preview,
+      additions,
+      deletions,
+      updates
+    })
+    previewPlayerRef.value?.confirmAnnotationsSaved()
+  } catch {
+    previewPlayerRef.value?.restoreFailedAnnotations()
+  }
+}
 
-    getOriginalPath() {
-      const previewId = this.currentPreviewId
-      const extension = this.extension ? this.extension : 'png'
-      return `/api/pictures/originals/preview-files/${previewId}.${extension}`
-    },
+const onAddPreviewClicked = () => {
+  modals.addPreview = true
+}
 
-    getOriginalDlPath() {
-      const previewId = this.currentPreviewId
-      return `/api/pictures/originals/preview-files/${previewId}/download`
-    },
+const onAddExtraPreview = () => {
+  clearPreviewFiles()
+  modals.addExtraPreview = true
+}
 
-    setOtherPreviews() {
-      if (this.taskPreviews) {
-        this.otherPreviews = this.taskPreviews.filter(p => {
-          return p.id !== this.currentPreviewId && p.extension === 'mp4'
-        })
-      }
-      return this.otherPreviews
-    },
+const onRemoveExtraPreview = preview => {
+  currentExtraPreviewId = preview.id
+  modals.deleteExtraPreview = true
+}
 
-    selectFile(forms) {
-      this.previewForms = this.previewForms.concat(forms)
-      this.loadPreviewFileFormData(this.previewForms)
-    },
+const onCommentAdded = () => {
+  taskComments.value = store.getters.getTaskComments(props.task.id)
+}
 
-    onPreviewFormRemoved(previewForm) {
-      this.previewForms = this.previewForms.filter(f => f !== previewForm)
-      this.loadPreviewFileFormData(this.previewForms)
-    },
+const onCancelRemoveExtraPreview = () => {
+  modals.deleteExtraPreview = false
+}
 
-    clearPreviewFiles() {
-      this.previewForms = []
-      this.loadPreviewFileFormData(this.previewForms)
-      this.$store.commit('CLEAR_UPLOAD_PROGRESS')
-    },
+const closeAddPreviewModal = () => {
+  modals.addPreview = false
+}
 
-    createExtraPreview(forms) {
-      this.selectFile(forms)
-      this.errors.addExtraPreview = false
-      this.loading.addExtraPreview = true
-      const comment = this.taskComments.find(comment =>
-        comment.previews.find(preview => preview.id === this.currentPreviewId)
-      )
-      this.addCommentExtraPreview({
-        taskId: this.task.id,
-        commentId: comment?.id,
-        previewId: this.currentPreviewId
+const confirmAddPreviewModal = forms => {
+  selectFile(forms)
+  closeAddPreviewModal()
+}
+
+const onCloseExtraPreview = () => {
+  modals.addExtraPreview = false
+}
+
+const onPreviewChanged = previewId => {
+  currentPreviewIndex.value = taskPreviews.value.findIndex(
+    p => p.id === previewId
+  )
+}
+
+const changeCurrentPreview = previewFile => {
+  const index = taskPreviews.value.findIndex(p => p.id === previewFile.id)
+  if (index || index === 0) {
+    currentPreviewIndex.value = index
+  }
+}
+
+const setCurrentPreviewAsEntityThumbnail = frame => {
+  const previewId = previewPlayerRef.value.currentPreview.id
+  store
+    .dispatch('setPreview', {
+      taskId: props.task.id,
+      entityId: props.task.entity_id,
+      previewId,
+      frame
+    })
+    .finally(() => {
+      loading.setFrameThumbnail = false
+    })
+}
+
+const onAckComment = comment => {
+  store.dispatch('ackComment', comment)
+}
+
+const onDuplicateComment = comment => {
+  addCommentRef.value.setValue(comment)
+}
+
+const onPinComment = comment => {
+  store.dispatch('pinComment', comment)
+}
+
+const onToggleForClient = comment => {
+  store.dispatch('toggleCommentForClient', comment)
+}
+
+const onEditComment = comment => {
+  commentToEdit.value = comment
+  modals.editComment = true
+}
+
+const onDeleteComment = comment => {
+  commentToEdit.value = comment
+  modals.deleteComment = true
+}
+
+const onMoveComment = comment => {
+  commentToMove.value = comment
+  errors.moveComment = false
+  modals.moveComment = true
+}
+
+const onCancelEditComment = () => {
+  modals.editComment = false
+}
+
+const onCancelDeleteComment = () => {
+  modals.deleteComment = false
+}
+
+const onCancelMoveComment = () => {
+  modals.moveComment = false
+}
+
+const confirmEditTaskComment = comment => {
+  loading.editComment = true
+  errors.editComment = false
+  const attachmentFilesToDelete = comment.attachmentFilesToDelete || []
+  const newAttachmentFiles = comment.newAttachmentFiles || []
+  delete comment.attachmentFilesToDelete
+  delete comment.newAttachmentFiles
+  func
+    .runPromiseMapAsSeries(attachmentFilesToDelete, attachment =>
+      store.dispatch('deleteAttachment', {
+        attachment,
+        comment: commentToEdit.value
       })
-        .then(() => {
-          this.loading.addExtraPreview = false
-          this.$refs['add-extra-preview-modal'].reset()
-          this.reset()
-          setTimeout(() => {
-            this.$refs['preview-player']?.displayLast()
-          }, 0)
-          this.modals.addExtraPreview = false
-        })
-        .catch(err => {
-          console.error(err)
-          this.loading.addExtraPreview = false
-          this.errors.addExtraPreview = true
-        })
-    },
+    )
+    .then(() =>
+      store.dispatch('addAttachmentToComment', {
+        comment: commentToEdit.value,
+        files: newAttachmentFiles
+      })
+    )
+    .then(() =>
+      store.dispatch('editTaskComment', {
+        taskId: props.task.id,
+        comment
+      })
+    )
+    .then(() => {
+      nextTick(() => {
+        resetComments()
+      })
+      loading.editComment = false
+      modals.editComment = false
+    })
+    .catch(err => {
+      console.error(err)
+      loading.editComment = false
+      errors.editComment = true
+    })
+}
 
-    onPreviewAdded(eventData) {
-      const taskId = eventData.task_id
-      const commentId = eventData.comment_id
-      const previewId = eventData.preview_file_id
-      const revision = eventData.revision
-      const extension = eventData.extension
-      const comment = this.getTaskComment(taskId, commentId)
+const confirmMoveComment = async targetTaskId => {
+  animOn.value = true
+  loading.moveComment = true
+  errors.moveComment = false
+  try {
+    await store.dispatch('moveCommentToTask', {
+      taskId: props.task.id,
+      commentId: commentToMove.value.id,
+      targetTaskId
+    })
+    taskComments.value = store.getters.getTaskComments(props.task.id)
+    modals.moveComment = false
+    commentToMove.value = null
+  } catch (err) {
+    console.error(err)
+    errors.moveComment = true
+  } finally {
+    loading.moveComment = false
+  }
+}
 
-      if (this.task) {
+const isClientFromSameStudio = person =>
+  isCurrentUserClient.value &&
+  user.value.studio_id === person.studio_id &&
+  person.role === 'client'
+
+const saveComment = async comment => {
+  try {
+    await store.dispatch('editTaskComment', {
+      taskId: props.task.id,
+      comment
+    })
+  } catch (err) {
+    console.error(err)
+    await loadTaskData()
+  }
+}
+
+const confirmDeleteTaskComment = () => {
+  animOn.value = true
+  loading.deleteComment = true
+  errors.deleteComment = false
+  const commentId = commentToEdit.value.id
+
+  store
+    .dispatch('deleteTaskComment', {
+      taskId: props.task.id,
+      commentId
+    })
+    .then(() => {
+      reset()
+      loading.deleteComment = false
+      modals.deleteComment = false
+    })
+    .catch(err => {
+      console.error(err)
+      loading.deleteComment = false
+      errors.deleteComment = true
+    })
+    .finally(() => {
+      animOn.value = false
+    })
+}
+
+const confirmDeleteTaskPreview = () => {
+  loading.deleteExtraPreview = true
+  errors.deleteExtraPreview = false
+  const previewId = currentExtraPreviewId
+  const comment = getCurrentTaskComments().find(comment => {
+    return comment.previews.findIndex(p => p.id === previewId) >= 0
+  })
+
+  previewPlayerRef.value.displayFirst()
+  store
+    .dispatch('deleteTaskPreview', {
+      taskId: props.task.id,
+      commentId: comment?.id,
+      previewId
+    })
+    .then(() => {
+      loading.deleteExtraPreview = false
+      modals.deleteExtraPreview = false
+    })
+    .catch(err => {
+      console.error(err)
+      loading.deleteExtraPreview = false
+      errors.deleteExtraPreview = true
+    })
+}
+
+const onRemoteAcknowledge = (eventData, type) => {
+  if (props.task) {
+    const comment = store.getters.getTaskComment(
+      props.task.id,
+      eventData.comment_id
+    )
+    const person = personMap.value.get(eventData.person_id)
+    if (comment && person) {
+      if (user.value.id === person.id) {
         if (
-          taskId === this.task.id &&
-          comment &&
-          (comment.previews.length === 0 ||
-            comment.previews[0].id !== previewId)
+          (type === 'ack' && !comment.acknowledgements.includes(person.id)) ||
+          (type === 'unack' && comment.acknowledgements.includes(person.id))
         ) {
-          this.$store.commit('ADD_PREVIEW_END', {
-            preview: {
-              id: previewId,
-              revision,
-              extension
-            },
-            taskId,
-            commentId,
-            comment
-          })
-          this.reset({ keepPreviewFiles: true })
+          store.commit('ACK_COMMENT', { comment, user: person })
         }
+      } else {
+        store.commit('ACK_COMMENT', { comment, user: person })
       }
-    },
+    }
+  }
+}
 
-    onPreviewsOrderChange() {
-      this.taskPreviews = this.getTaskPreviews(this.task.id)
-      this.setOtherPreviews()
-      this.currentPreviewPath = this.getOriginalPath()
-      this.currentPreviewDlPath = this.getOriginalDlPath()
-    },
+const isStatusChange = index => {
+  const comment = taskComments.value[index]
+  return (
+    index === taskComments.value.length - 1 ||
+    comment.task_status_id !== taskComments.value[index + 1].task_status_id
+  )
+}
 
-    async onAnnotationChanged({ preview, additions, deletions, updates }) {
-      let taskId = this.task ? this.task.id : this.previousTaskId
-      taskId = taskId || preview.task_id
-      if (!taskId) return
-      const previewPlayer = this.$refs['preview-player']
-      try {
-        await this.updatePreviewAnnotation({
-          taskId,
-          preview,
-          additions,
-          deletions,
-          updates
-        })
-        previewPlayer?.confirmAnnotationsSaved()
-      } catch {
-        previewPlayer?.restoreFailedAnnotations()
-      }
-    },
-
-    onAddPreviewClicked() {
-      this.modals.addPreview = true
-    },
-
-    onAddExtraPreview() {
-      this.clearPreviewFiles()
-      this.modals.addExtraPreview = true
-    },
-
-    onRemoveExtraPreview(preview) {
-      this.currentExtraPreviewId = preview.id
-      this.modals.deleteExtraPreview = true
-    },
-
-    onCommentAdded() {
-      this.taskComments = this.getTaskComments(this.task.id)
-    },
-
-    onCancelRemoveExtraPreview() {
-      this.modals.deleteExtraPreview = false
-    },
-
-    closeAddPreviewModal() {
-      this.modals.addPreview = false
-    },
-
-    confirmAddPreviewModal(forms) {
-      this.selectFile(forms)
-      this.closeAddPreviewModal()
-    },
-
-    onCloseExtraPreview() {
-      this.modals.addExtraPreview = false
-    },
-
-    onPreviewChanged(previewId) {
-      this.currentPreviewIndex = this.taskPreviews.findIndex(
-        p => p.id === previewId
-      )
-      this.currentPreviewPath = this.getOriginalPath()
-      this.currentPreviewDlPath = this.getOriginalDlPath()
-    },
-
-    changeCurrentPreview(previewFile) {
-      const index = this.taskPreviews.findIndex(p => p.id === previewFile.id)
-      if (index || index === 0) {
-        this.currentPreviewIndex = index
-        this.currentPreviewPath = this.getOriginalPath()
-        this.currentPreviewDlPath = this.getOriginalDlPath()
-      }
-    },
-
-    setCurrentPreviewAsEntityThumbnail(frame) {
-      const previewPlayer = this.$refs['preview-player']
-      const previewId = previewPlayer.currentPreview.id
-      this.setPreview({
-        taskId: this.task.id,
-        entityId: this.task.entity_id,
-        previewId,
-        frame
-      }).finally(() => {
-        this.loading.setFrameThumbnail = false
-      })
-    },
-
-    onAckComment(comment) {
-      this.ackComment(comment)
-    },
-
-    onDuplicateComment(comment) {
-      this.$refs['add-comment'].setValue(comment)
-    },
-
-    onPinComment(comment) {
-      this.pinComment(comment)
-    },
-
-    onToggleForClient(comment) {
-      this.$store.dispatch('toggleCommentForClient', comment)
-    },
-
-    onEditComment(comment) {
-      this.commentToEdit = comment
-      this.modals.editComment = true
-    },
-
-    onDeleteComment(comment) {
-      this.commentToEdit = comment
-      this.modals.deleteComment = true
-    },
-
-    onMoveComment(comment) {
-      this.commentToMove = comment
-      this.errors.moveComment = false
-      this.modals.moveComment = true
-    },
-
-    onCancelEditComment() {
-      this.modals.editComment = false
-    },
-
-    onCancelDeleteComment() {
-      this.modals.deleteComment = false
-    },
-
-    onCancelMoveComment() {
-      this.modals.moveComment = false
-    },
-
-    async confirmMoveComment(targetTaskId) {
-      this.animOn = true
-      this.loading.moveComment = true
-      this.errors.moveComment = false
-      try {
-        await this.$store.dispatch('moveCommentToTask', {
-          taskId: this.task.id,
-          commentId: this.commentToMove.id,
-          targetTaskId
-        })
-        this.taskComments = this.getTaskComments(this.task.id)
-        this.modals.moveComment = false
-        this.commentToMove = null
-      } catch (err) {
-        console.error(err)
-        this.errors.moveComment = true
-      } finally {
-        this.loading.moveComment = false
-      }
-    },
-
-    isClientFromSameStudio(person) {
-      return (
-        this.isCurrentUserClient &&
-        this.user.studio_id === person.studio_id &&
-        person.role === 'client'
-      )
-    },
-
-    async saveComment(comment) {
-      try {
-        await this.editTaskComment({
-          taskId: this.task.id,
-          comment
-        })
-      } catch (err) {
-        console.error(err)
-        await this.loadTaskData()
-      }
-    },
-
-    confirmDeleteTaskComment() {
-      this.animOn = true
-      this.loading.deleteComment = true
-      this.errors.deleteComment = false
-      const commentId = this.commentToEdit.id
-
-      this.deleteTaskComment({
-        taskId: this.task.id,
-        commentId
-      })
-        .then(() => {
-          this.reset()
-          this.loading.deleteComment = false
-          this.modals.deleteComment = false
-        })
-        .catch(err => {
-          console.error(err)
-          this.loading.deleteComment = false
-          this.errors.deleteComment = true
-        })
-        .finally(() => {
-          this.animOn = false
-        })
-    },
-
-    getCurrentTaskComments() {
-      return this.getTaskComments(this.task.id)
-    },
-
-    confirmDeleteTaskPreview() {
-      this.loading.deleteExtraPreview = true
-      this.errors.deleteExtraPreview = false
-      const previewId = this.currentExtraPreviewId
-      const comment = this.getCurrentTaskComments().find(comment => {
-        return comment.previews.findIndex(p => p.id === previewId) >= 0
-      })
-
-      this.$refs['preview-player'].displayFirst()
-      this.deleteTaskPreview({
-        taskId: this.task.id,
-        commentId: comment?.id,
-        previewId
-      })
-        .then(() => {
-          this.loading.deleteExtraPreview = false
-          this.modals.deleteExtraPreview = false
-        })
-        .catch(err => {
-          console.error(err)
-          this.loading.deleteExtraPreview = false
-          this.errors.deleteExtraPreview = true
-        })
-    },
-
-    onRemoteAcknowledge(eventData, type) {
-      if (this.task) {
-        const comment = this.getTaskComment(this.task.id, eventData.comment_id)
-        const user = this.personMap.get(eventData.person_id)
-        if (comment && user) {
-          if (this.user.id === user.id) {
-            if (
-              (type === 'ack' && !comment.acknowledgements.includes(user.id)) ||
-              (type === 'unack' && comment.acknowledgements.includes(user.id))
-            ) {
-              this.$store.commit('ACK_COMMENT', { comment, user })
-            }
-          } else {
-            this.$store.commit('ACK_COMMENT', { comment, user })
-          }
-        }
-      }
-    },
-
-    isStatusChange(index) {
-      const comment = this.taskComments[index]
-      return (
-        index === this.taskComments.length - 1 ||
-        comment.task_status_id !== this.taskComments[index + 1].task_status_id
-      )
-    },
-
-    timeCodeClicked({
+const timeCodeClicked = ({
+  versionRevision,
+  minutes,
+  seconds,
+  milliseconds,
+  frame
+}) => {
+  if (!props.isPreview) {
+    emit('time-code-clicked', {
       versionRevision,
       minutes,
       seconds,
       milliseconds,
       frame
-    }) {
-      if (!this.isPreview) {
-        this.$emit('time-code-clicked', {
-          versionRevision,
-          minutes,
-          seconds,
-          milliseconds,
-          frame
-        })
-        return
-      }
-      this.changeCurrentPreview(
-        this.taskPreviews.find(p => p.revision === parseInt(versionRevision))
-      )
-      setTimeout(() => {
-        this.$refs['preview-player']?.setCurrentFrame(frame)
-        this.$refs['preview-player']?.focus()
-      }, 20)
-    },
+    })
+    return
+  }
+  changeCurrentPreview(
+    taskPreviews.value.find(p => p.revision === parseInt(versionRevision))
+  )
+  setTimeout(() => {
+    previewPlayerRef.value?.setCurrentFrame(frame)
+    previewPlayerRef.value?.focus()
+  }, 20)
+}
 
-    onFrameUpdated(frame) {
-      this.currentFrameRaw = frame
-    },
+const onFrameUpdated = frame => {
+  currentFrameRaw.value = frame
+}
 
-    async extractAnnotationSnapshots(withLabel = false) {
-      let previewPlayer = this.$refs['preview-player']
-      if (!previewPlayer) previewPlayer = this.player
-      this.$refs['add-comment'].showAnnotationLoading(
-        withLabel ? 'label' : 'standard'
-      )
-      const files = await previewPlayer.extractAnnotationSnapshots({
-        withLabel
-      })
-      this.$refs['add-comment'].hideAnnotationLoading()
-      this.$refs['add-comment'].setAnnotationSnapshots(files)
-      return files
-    },
+const extractAnnotationSnapshots = async (withLabel = false) => {
+  const previewPlayer = previewPlayerRef.value || props.player
+  addCommentRef.value.showAnnotationLoading(withLabel ? 'label' : 'standard')
+  const files = await previewPlayer.extractAnnotationSnapshots({
+    withLabel
+  })
+  addCommentRef.value.hideAnnotationLoading()
+  addCommentRef.value.setAnnotationSnapshots(files)
+  return files
+}
 
-    onExportClick() {
-      const nameData = [
-        moment().format('YYYY-MM-DD'),
-        'kitsu',
-        this.productionMap.get(this.task.project_id)?.name,
-        this.task.entity_name.replaceAll(' / ', '_'),
-        this.taskTypeMap.get(this.task.task_type_id).name,
-        'comments'
-      ]
-      const name = stringHelpers.slugify(nameData.join('_'))
-      const headers = [
-        this.$t('comments.fields.created_at'),
-        this.$t('comments.fields.task_status'),
-        this.$t('comments.fields.person'),
-        this.$t('comments.fields.text'),
-        this.$t('comments.fields.checklist'),
-        this.$t('comments.fields.acknowledgements'),
-        this.$t('comments.fields.revision'),
-        this.$t('comments.fields.attachments')
-      ]
-      const commentLines = []
-      this.getCurrentTaskComments().forEach(comment => {
+const onExportClick = () => {
+  const nameData = [
+    moment().format('YYYY-MM-DD'),
+    'kitsu',
+    productionMap.value.get(props.task.project_id)?.name,
+    props.task.entity_name.replaceAll(' / ', '_'),
+    taskTypeMap.value.get(props.task.task_type_id).name,
+    'comments'
+  ]
+  const name = stringHelpers.slugify(nameData.join('_'))
+  const headers = [
+    t('comments.fields.created_at'),
+    t('comments.fields.task_status'),
+    t('comments.fields.person'),
+    t('comments.fields.text'),
+    t('comments.fields.checklist'),
+    t('comments.fields.acknowledgements'),
+    t('comments.fields.revision'),
+    t('comments.fields.attachments')
+  ]
+  const commentLines = []
+  getCurrentTaskComments().forEach(comment => {
+    commentLines.push([
+      formatDate(comment.created_at),
+      comment.task_status.name,
+      comment.person.name,
+      comment.text,
+      comment.checklist
+        ? comment.checklist
+            .map(item => {
+              const checked = item.checked ? 'x' : ' '
+              const revision =
+                item.revision > -1
+                  ? `(${formatRevision(item.revision, currentProduction.value)} - ${formatFrame(item.frame)}) `
+                  : ''
+              return `[${checked}] ${revision}${item.text}`
+            })
+            .join('\n')
+        : '',
+      comment.acknowledgements
+        ? comment.acknowledgements
+            .map(personId => personMap.value.get(personId).name)
+            .join(',')
+        : '',
+      comment.previews[0]?.revision,
+      comment.attachment_files
+        ? comment.attachment_files
+            .filter(attachment => !attachment.reply_id)
+            .map(attachment => getDownloadAttachmentPath(attachment, true))
+            .join('\n')
+        : ''
+    ])
+    if (comment.replies) {
+      comment.replies.forEach(reply =>
         commentLines.push([
-          this.formatDate(comment.created_at),
-          comment.task_status.name,
-          comment.person.name,
-          comment.text,
-          comment.checklist
-            ? comment.checklist
-                .map(item => {
-                  const checked = item.checked ? 'x' : ' '
-                  const revision =
-                    item.revision > -1
-                      ? `(${formatRevision(item.revision, this.currentProduction)} - ${formatFrame(item.frame)}) `
-                      : ''
-                  return `[${checked}] ${revision}${item.text}`
-                })
-                .join('\n')
-            : '',
-          comment.acknowledgements
-            ? comment.acknowledgements
-                .map(personId => this.personMap.get(personId).name)
-                .join(',')
-            : '',
-          comment.previews[0]?.revision,
+          formatDate(reply.date),
+          t('main.reply'),
+          personMap.value.get(reply.person_id).name,
+          reply.text,
+          null,
+          null,
+          null,
           comment.attachment_files
             ? comment.attachment_files
-                .filter(attachment => !attachment.reply_id)
+                .filter(attachment => attachment.reply_id === reply.id)
                 .map(attachment => getDownloadAttachmentPath(attachment, true))
                 .join('\n')
             : ''
         ])
-        if (comment.replies) {
-          comment.replies.forEach(reply =>
-            commentLines.push([
-              this.formatDate(reply.date),
-              this.$t('main.reply'),
-              this.personMap.get(reply.person_id).name,
-              reply.text,
-              null,
-              null,
-              null,
-              comment.attachment_files
-                ? comment.attachment_files
-                    .filter(attachment => attachment.reply_id === reply.id)
-                    .map(attachment =>
-                      getDownloadAttachmentPath(attachment, true)
-                    )
-                    .join('\n')
-                : ''
-            ])
-          )
-        }
+      )
+    }
+  })
+  csv.buildCsvFile(name, [headers, ...commentLines])
+}
+
+const onExtendDown = event => {
+  if (!sideColumnParent.value) {
+    return
+  }
+  lastWidthX = getClientX(event)
+  lastWidth = sideColumnParent.value.offsetWidth
+  addEvents(domEvents)
+}
+
+const onExtendMove = event => {
+  const diff = lastWidthX - getClientX(event)
+  let panelWidth = Math.max(lastWidth + diff, DEFAULT_PANEL_WIDTH)
+  if (panelWidth > 900) panelWidth = 900
+  setWidth(panelWidth)
+  refreshPreviewPlay()
+}
+
+const onExtendUp = () => {
+  removeEvents(domEvents)
+  refreshPreviewPlay()
+  if (sideColumnParent.value) {
+    preferences.setPreference(
+      'task:panel-width',
+      sideColumnParent.value.offsetWidth
+    )
+  }
+}
+
+const domEvents = [
+  ['mousemove', onExtendMove],
+  ['touchmove', onExtendMove],
+  ['mouseup', onExtendUp],
+  ['mouseleave', onExtendUp],
+  ['touchend', onExtendUp],
+  ['touchcancel', onExtendUp]
+]
+
+const setWidth = width => {
+  if (!sideColumnParent.value) {
+    return
+  }
+  sideColumnParent.value.style['min-width'] = `${width}px`
+  isWide.value = width > 699
+  isExtraWide.value = width >= 900
+}
+
+const onSetCurrentFrameAsThumbnail = isUseCurrentFrame => {
+  if (previewPlayerRef.value) {
+    loading.setFrameThumbnail = true
+    let frame = null
+    if (isUseCurrentFrame) {
+      frame = currentFrameRaw.value + 1
+    }
+    return setCurrentPreviewAsEntityThumbnail(frame)
+  }
+}
+
+const refreshPreviewPlay = () => {
+  previewPlayerRef.value?.resize()
+}
+
+const removeTaskFromSelection = task => {
+  const data = {
+    column: { id: task.task_type_id },
+    entity: { id: task.entity_id },
+    task
+  }
+  store.dispatch('removeSelectedTask', { task: data }) // remove list selection
+  store.dispatch('removeSelectedTask', { task }) // remove
+  emit('task-removed', task)
+}
+
+const onRemotePreviewUpdate = eventData => {
+  const comment = taskComments.value.find(
+    c =>
+      c.previews &&
+      c.previews.length > 0 &&
+      c.previews[0].id === eventData.preview_file_id
+  )
+  if (comment && props.task) {
+    store
+      .dispatch('refreshPreview', {
+        taskId: props.task.id,
+        previewId: eventData.preview_file_id
       })
-      csv.buildCsvFile(name, [headers].concat(commentLines))
-    },
+      .then(preview => {
+        comment.previews[0].validation_status = preview.validation_status
+      })
+  }
+}
 
-    onExtendDown(event) {
-      if (!this.sideColumnParent) {
-        return
+const onRemoteTaskUpdate = eventData => {
+  // Wait for data to be reinitialized by App.vue to update comments.
+  if (props.task && eventData.task_id === props.task.id) {
+    setTimeout(() => {
+      // in case the task changed during the timeout
+      if (props.task && eventData.task_id === props.task.id) {
+        taskComments.value = store.getters.getTaskComments(props.task.id)
       }
-      this.lastWidthX = this.getClientX(event)
-      const panelWidth = this.sideColumnParent.offsetWidth
-      this.lastWidth = panelWidth
-      this.addEvents(this.domEvents)
-    },
+    }, 1000)
+  }
+}
 
-    onExtendMove(event) {
-      const diff = this.lastWidthX - this.getClientX(event)
-      let panelWidth = Math.max(this.lastWidth + diff, DEFAULT_PANEL_WIDTH)
-      if (panelWidth > 900) panelWidth = 900
-      this.setWidth(panelWidth)
-      this.refreshPreviewPlay()
-    },
-
-    onExtendUp() {
-      this.removeEvents(this.domEvents)
-      this.refreshPreviewPlay()
-      if (this.sideColumnParent) {
-        const panelWidth = this.sideColumnParent.offsetWidth
-        preferences.setPreference('task:panel-width', panelWidth)
-      }
-    },
-
-    setWidth(width) {
-      if (!this.sideColumnParent) {
-        return
-      }
-      this.sideColumnParent.style['min-width'] = `${width}px`
-      this.isWide = width > 699
-      this.isExtraWide = width >= 900
-    },
-
-    onSetCurrentFrameAsThumbnail(isUseCurrentFrame) {
-      if (this.$refs['preview-player']) {
-        this.loading.setFrameThumbnail = true
-        let frame = null
-        if (isUseCurrentFrame) {
-          frame = this.currentFrameRaw + 1
-        }
-        return this.setCurrentPreviewAsEntityThumbnail(frame)
-      }
-    },
-
-    refreshPreviewPlay() {
-      this.$refs['preview-player']?.resize()
-    },
-
-    removeTaskFromSelection(task) {
-      const data = {
-        column: { id: task.task_type_id },
-        entity: { id: task.entity_id },
-        task
-      }
-      this.removeSelectedTask({ task: data }) // remove list selection
-      this.removeSelectedTask({ task }) // remove
-      this.$emit('task-removed', task)
+const onRemoteCommentNew = eventData => {
+  setTimeout(() => {
+    animOn.value = true
+    const comments = props.task
+      ? store.getters.getTaskComments(props.task.id)
+      : null
+    if (
+      props.task &&
+      comments &&
+      comments.length !== taskComments.value.length &&
+      eventData.task_id === props.task.id &&
+      !loading.task
+    ) {
+      taskComments.value = comments
+      taskPreviews.value = store.getters.getTaskPreviews(props.task.id)
     }
-  },
+    animOn.value = false
+  }, 1000)
+}
 
-  watch: {
-    task() {
-      this.clearPreviewFiles()
-      this.currentPreviewIndex = 0
-      if (!this.silent) {
-        this.loadTaskData()
-      }
-    },
+const onRemoteCommentUpdate = eventData => {
+  const commentId = eventData.comment_id
+  if (
+    store.getters.isSavingCommentPreview ||
+    (!props.task && !taskComments.value.some(({ id }) => id === commentId))
+  ) {
+    return
+  }
+  store.dispatch('loadComment', { commentId }).catch(console.error)
+}
 
-    silent: {
-      immediate: true,
-      handler() {
-        if (!this.silent) {
-          this.loadTaskData()
-        }
-      }
-    },
+const onRemoteCommentAck = eventData => onRemoteAcknowledge(eventData, 'ack')
 
-    currentFrame() {
-      this.currentFrameRaw = this.currentFrame
-    }
-  },
+const onRemoteCommentUnack = eventData =>
+  onRemoteAcknowledge(eventData, 'unack')
 
-  socket: {
-    events: {
-      'preview-file:add-file'(eventData) {
-        this.onPreviewAdded(eventData)
-      },
-
-      'preview-file:update'(eventData) {
-        const comment = this.taskComments.find(
-          c =>
-            c.previews &&
-            c.previews.length > 0 &&
-            c.previews[0].id === eventData.preview_file_id
-        )
-        if (comment && this.task) {
-          this.refreshPreview({
-            taskId: this.task.id,
-            previewId: eventData.preview_file_id
-          }).then(preview => {
-            comment.previews[0].validation_status = preview.validation_status
+const onRemoteCommentReply = eventData => {
+  if (props.task) {
+    const comment = taskComments.value.find(c => c.id === eventData.comment_id)
+    if (comment) {
+      if (!comment.replies) comment.replies = []
+      const reply = comment.replies.find(r => r.id === eventData.reply_id)
+      if (!reply) {
+        store
+          .dispatch('refreshComment', {
+            commentId: eventData.comment_id
           })
-        }
-      },
-
-      'task:update'(eventData) {
-        const task = this.getTask()
-        // Wait for data to be reinitialized by App.vue to update comments.
-        if (task && eventData.task_id === task.id) {
-          setTimeout(() => {
-            const task = this.getTask()
-            // in case the task changed during the timeout
-            if (task && eventData.task_id === task.id) {
-              this.taskComments = this.getTaskComments(task.id)
-            }
-          }, 1000)
-        }
-      },
-
-      'comment:new'(eventData) {
-        setTimeout(() => {
-          this.animOn = true
-          const comments = this.task ? this.getTaskComments(this.task.id) : null
-          if (
-            this.task &&
-            comments &&
-            comments.length !== this.taskComments.length &&
-            eventData.task_id === this.task.id &&
-            !this.loading.task
-          ) {
-            this.taskComments = comments
-            this.taskPreviews = this.getTaskPreviews(this.task.id)
-          }
-          this.animOn = false
-        }, 1000)
-      },
-
-      'comment:update'(eventData) {
-        const commentId = eventData.comment_id
-        if (
-          this.isSavingCommentPreview ||
-          (!this.task && !this.taskComments.some(({ id }) => id === commentId))
-        ) {
-          return
-        }
-        this.loadComment({ commentId }).catch(console.error)
-      },
-
-      'comment:acknowledge'(eventData) {
-        this.onRemoteAcknowledge(eventData, 'ack')
-      },
-
-      'comment:unacknowledge'(eventData) {
-        this.onRemoteAcknowledge(eventData, 'unack')
-      },
-
-      'comment:reply'(eventData) {
-        if (this.task) {
-          const comment = this.taskComments.find(
-            c => c.id === eventData.comment_id
-          )
-          if (comment) {
-            if (!comment.replies) comment.replies = []
-            const reply = comment.replies.find(r => r.id === eventData.reply_id)
-            if (!reply) {
-              this.refreshComment({
-                commentId: eventData.comment_id
-              })
-                .then(remoteComment => {
-                  comment.replies = remoteComment.replies
-                })
-                .catch(console.error)
-            }
-          }
-        }
-      },
-
-      'comment:delete'(eventData) {
-        const task = this.getTask()
-        this.animOn = true
-        if (task) {
-          const comments = this.getComments()
-          const comment = comments.find(c => c.id === eventData.comment_id)
-          if (comment) {
-            this.$store.commit('REMOVE_TASK_COMMENT', { task, comment })
-            this.taskComments = this.getTaskComments(this.task.id)
-            this.taskPreviews = this.getTaskPreviews(this.task.id)
-          }
-          this.animOn = false
-        }
-      },
-
-      'comment:delete-reply'(eventData) {
-        if (this.task) {
-          const comment = this.taskComments.find(
-            c => c.id === eventData.comment_id
-          )
-          if (comment) {
-            if (!comment.replies) comment.replies = []
-            this.$store.commit('REMOVE_REPLY_FROM_COMMENT', {
-              comment,
-              reply: { id: eventData.reply_id }
-            })
-          }
-        }
-      },
-
-      'preview-file:annotation-update'(eventData) {
-        const previewPlayer = this.$refs['preview-player']
-        if (!previewPlayer) return
-        const isValid = previewPlayer.isValidPreviewModification(
-          eventData.preview_file_id,
-          eventData.updated_at
-        )
-        if (isValid) {
-          this.refreshPreview({
-            previewId: previewPlayer.currentPreview.id,
-            taskId: previewPlayer.currentPreview.task_id
-          }).then(() => {
-            if (!previewPlayer.notSaved) {
-              this.taskPreviews = this.getTaskPreviews(this.task.id)
-              // Wait for the refreshed previews prop to propagate to the
-              // player before reloading — otherwise reloadAnnotations
-              // reads the stale currentPreview and the remote drawing
-              // never shows up outside a review room.
-              this.$nextTick(() => {
-                previewPlayer.reloadAnnotations()
-                previewPlayer.loadAnnotation()
-              })
-            }
+          .then(remoteComment => {
+            comment.replies = remoteComment.replies
           })
-        }
-      }
-    },
-
-    head() {
-      return {
-        title: this.title
+          .catch(console.error)
       }
     }
   }
 }
+
+const onRemoteCommentDelete = eventData => {
+  animOn.value = true
+  if (props.task) {
+    const comment = taskComments.value.find(c => c.id === eventData.comment_id)
+    if (comment) {
+      store.commit('REMOVE_TASK_COMMENT', { task: props.task, comment })
+      taskComments.value = store.getters.getTaskComments(props.task.id)
+      taskPreviews.value = store.getters.getTaskPreviews(props.task.id)
+    }
+    animOn.value = false
+  }
+}
+
+const onRemoteCommentDeleteReply = eventData => {
+  if (props.task) {
+    const comment = taskComments.value.find(c => c.id === eventData.comment_id)
+    if (comment) {
+      if (!comment.replies) comment.replies = []
+      store.commit('REMOVE_REPLY_FROM_COMMENT', {
+        comment,
+        reply: { id: eventData.reply_id }
+      })
+    }
+  }
+}
+
+const onRemoteAnnotationUpdate = eventData => {
+  const previewPlayer = previewPlayerRef.value
+  if (!previewPlayer) return
+  const isValid = previewPlayer.isValidPreviewModification(
+    eventData.preview_file_id,
+    eventData.updated_at
+  )
+  if (isValid) {
+    store
+      .dispatch('refreshPreview', {
+        previewId: previewPlayer.currentPreview.id,
+        taskId: previewPlayer.currentPreview.task_id
+      })
+      .then(() => {
+        if (!previewPlayer.notSaved) {
+          taskPreviews.value = store.getters.getTaskPreviews(props.task.id)
+          // Wait for the refreshed previews prop to propagate to the
+          // player before reloading — otherwise reloadAnnotations
+          // reads the stale currentPreview and the remote drawing
+          // never shows up outside a review room.
+          nextTick(() => {
+            previewPlayer.reloadAnnotations()
+            previewPlayer.loadAnnotation()
+          })
+        }
+      })
+  }
+}
+
+const socketEvents = [
+  ['preview-file:add-file', onPreviewAdded],
+  ['preview-file:update', onRemotePreviewUpdate],
+  ['preview-file:annotation-update', onRemoteAnnotationUpdate],
+  ['task:update', onRemoteTaskUpdate],
+  ['comment:new', onRemoteCommentNew],
+  ['comment:update', onRemoteCommentUpdate],
+  ['comment:acknowledge', onRemoteCommentAck],
+  ['comment:unacknowledge', onRemoteCommentUnack],
+  ['comment:reply', onRemoteCommentReply],
+  ['comment:delete', onRemoteCommentDelete],
+  ['comment:delete-reply', onRemoteCommentDeleteReply]
+]
+
+// Watchers
+watch(
+  () => props.task,
+  () => {
+    clearPreviewFiles()
+    currentPreviewIndex.value = 0
+    if (!props.silent) {
+      loadTaskData()
+    }
+  }
+)
+
+watch(
+  () => props.silent,
+  () => {
+    if (!props.silent) {
+      loadTaskData()
+    }
+  },
+  { immediate: true }
+)
+
+watch(
+  () => props.currentFrame,
+  () => {
+    currentFrameRaw.value = props.currentFrame
+  }
+)
+
+// Lifecycle
+onMounted(() => {
+  if (sideColumnParent.value) {
+    const panelWidth = preferences.getIntPreference(
+      'task:panel-width',
+      DEFAULT_PANEL_WIDTH
+    )
+    setWidth(panelWidth)
+    refreshPreviewPlay()
+  }
+  socketEvents.forEach(([event, handler]) => socket.on(event, handler))
+})
+
+onBeforeUnmount(() => {
+  removeEvents(domEvents)
+  socketEvents.forEach(([event, handler]) => socket.off(event, handler))
+})
+
+defineExpose({
+  focusCommentTextarea
+})
 </script>
 
 <style lang="scss" scoped>
@@ -1796,18 +1739,15 @@ export default {
 
 .side {
   background: #f8f8f8;
+  flex: 1;
   min-height: 100%;
+  overflow: auto;
 }
 
 .add-comment {
   padding: 0.5em;
   margin-bottom: 0.5em;
   box-shadow: 0 0 6px #e0e0e0;
-}
-
-.page-header {
-  padding: 0;
-  margin-top: 0;
 }
 
 .header-title .flexrow-item {
@@ -1853,37 +1793,8 @@ export default {
   box-shadow: 0 0 6px #e0e0e0;
 }
 
-.add-preview-button {
-  margin-top: 0.5em;
-  width: 100%;
-}
-
-.no-comment {
-  background: white;
-  box-shadow: 0 0 6px #e0e0e0;
-}
-
 .comments {
   padding-bottom: 1em;
-}
-
-.preview-colum-content {
-  box-shadow: 0 0 6px #e0e0e0;
-}
-
-.preview-standard-file {
-  text-align: center;
-  padding: 1em;
-}
-
-.model-viewer {
-  padding: 0.3em;
-}
-
-.change-wideness-button,
-.set-thumbnail-button,
-.subscribe-button {
-  margin-right: 0.2em;
 }
 
 .preview {
@@ -1912,50 +1823,11 @@ export default {
   min-height: 100%;
 }
 
-.side {
-  flex: 1;
-  overflow: auto;
-}
-
 .extend-bar {
   width: 3px;
   margin-left: 3px;
   background: #ccc;
   cursor: ew-resize;
-}
-
-.revision-thumbnail {
-  border: 2px solid transparent;
-  border-radius: 3px;
-  height: 33px;
-  margin-bottom: 4px;
-  position: relative;
-
-  &:hover {
-    border: 2px solid $grey;
-  }
-
-  &.selected {
-    border: 2px solid $dark-purple;
-  }
-
-  span {
-    background: $dark-purple;
-    border-radius: 0;
-    border-bottom-right-radius: 4px;
-    color: $white;
-    font-size: 0.8em;
-    height: 14px;
-    line-height: 1.1em;
-    margin: 0;
-    opacity: 0.8;
-    left: 0;
-    padding: 0;
-    position: absolute;
-    text-align: center;
-    top: 0;
-    width: 14px;
-  }
 }
 
 .empty {
@@ -1979,19 +1851,5 @@ export default {
 
 .task-type {
   margin-right: 1em;
-}
-
-.extra-buttons {
-  img {
-    width: 16px;
-  }
-}
-
-.annotation-dl {
-  color: inherit;
-  display: inline-flex;
-  align-items: center;
-  margin-right: 0.5em;
-  text-decoration: none;
 }
 </style>

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -189,7 +189,7 @@
                   :is-error="errors.addComment"
                   :is-max-retakes-error="errors.addCommentMaxRetakes"
                   :fps="currentFps"
-                  :frame="currentFrame || currentFrameRaw"
+                  :frame="displayedFrame"
                   :revision="currentRevision"
                   :is-movie="isMoviePreview"
                   :is-picture="isPicturePreview"
@@ -219,7 +219,7 @@
                       :key="`comment-${comment.id}`"
                       :comment="comment"
                       :fps="currentFps"
-                      :frame="currentFrame || currentFrameRaw"
+                      :frame="displayedFrame"
                       :is-change="isStatusChange(index)"
                       :is-checkable="
                         user.id === comment.person?.id ||
@@ -298,7 +298,7 @@
           :active="modals.editComment"
           :comment-to-edit="commentToEdit"
           :fps="currentFps"
-          :frame="currentFrame || currentFrameRaw"
+          :frame="displayedFrame"
           :is-loading="loading.editComment"
           :is-error="errors.editComment"
           :revision="currentRevision"
@@ -392,8 +392,10 @@ import { useRoute } from 'vue-router'
 import { useStore } from 'vuex'
 
 import { addEvents, getClientX, removeEvents } from '@/composables/dom'
+import { getEntityMap } from '@/composables/entity'
 import { useTime } from '@/composables/time'
 import csv from '@/lib/csv'
+import { isSupervisorInDepartments } from '@/lib/descriptors'
 import drafts from '@/lib/drafts'
 import func from '@/lib/func'
 import {
@@ -406,6 +408,7 @@ import { formatRevision } from '@/lib/preview'
 import { getTaskTypeWithUrl } from '@/lib/productions'
 import { sortPeople, sortTaskNames } from '@/lib/sorting'
 import stringHelpers from '@/lib/string'
+import { formatSimpleDate } from '@/lib/time'
 import { DEFAULT_FPS, formatFrame } from '@/lib/video'
 
 import AddPreviewModal from '@/components/modals/AddPreviewModal.vue'
@@ -646,8 +649,7 @@ const title = computed(() => {
 })
 
 const isAssigned = computed(
-  () =>
-    props.task?.assignees.some(personId => personId === user.value.id) ?? false
+  () => props.task?.assignees.includes(user.value.id) ?? false
 )
 
 const isCommentingAllowed = computed(
@@ -661,32 +663,23 @@ const isCommentingAllowed = computed(
 
 const isConceptTask = computed(() => props.entityType === 'Concept')
 
-const isDepartmentSupervisor = computed(() => {
-  if (!isCurrentUserSupervisor.value) {
-    return false
-  }
-  if (user.value.departments.length === 0) {
-    return true
-  }
-  return user.value.departments.includes(currentTaskType.value?.department_id)
-})
+const isDepartmentSupervisor = computed(() =>
+  isSupervisorInDepartments(
+    user.value,
+    isCurrentUserSupervisor.value,
+    currentTaskType.value?.department_id
+  )
+)
 
-const isPreviewPlayerReadOnly = computed(() => {
-  if (props.task) {
-    if (isCurrentUserManager.value || isCurrentUserClient.value) {
-      return false
-    } else if (isCurrentUserSupervisor.value) {
-      if (user.value.departments.length === 0) {
-        return false
-      } else {
-        return !user.value.departments.includes(
-          currentTaskType.value?.department_id
-        )
-      }
-    }
-  }
-  return true
-})
+const isPreviewPlayerReadOnly = computed(
+  () =>
+    !props.task ||
+    !(
+      isCurrentUserManager.value ||
+      isCurrentUserClient.value ||
+      isDepartmentSupervisor.value
+    )
+)
 
 const currentTaskType = computed(() =>
   taskTypeMap.value.get(props.task?.task_type_id)
@@ -711,10 +704,8 @@ const entityFrames = computed(() => {
   return shotMap.value.get(props.task.entity.id)?.nb_frames || 0
 })
 
-const currentPreview = computed(() =>
-  taskPreviews.value && taskPreviews.value.length > 0
-    ? taskPreviews.value[currentPreviewIndex.value]
-    : null
+const currentPreview = computed(
+  () => taskPreviews.value[currentPreviewIndex.value] ?? null
 )
 
 const currentPreviewComment = computed(() =>
@@ -725,17 +716,7 @@ const currentPreviewComment = computed(() =>
   )
 )
 
-const currentPreviewId = computed(() => {
-  const index = currentPreviewIndex.value
-  if (
-    taskPreviews.value &&
-    taskPreviews.value.length > 0 &&
-    taskPreviews.value[index]
-  ) {
-    return taskPreviews.value[index].id
-  }
-  return null
-})
+const currentPreviewId = computed(() => currentPreview.value?.id ?? null)
 
 const canDownloadAnnotations = computed(
   () =>
@@ -744,28 +725,21 @@ const canDownloadAnnotations = computed(
     (currentPreview.value?.annotations?.length || 0) > 0
 )
 
-const annotationsZipPath = computed(() =>
+const annotationsPath = suffix =>
   currentPreviewId.value
-    ? `/api/actions/preview-files/${currentPreviewId.value}/extract-annotated-frames`
+    ? `/api/actions/preview-files/${currentPreviewId.value}/extract-annotated-frames${suffix}`
     : null
-)
-
-const annotationsPdfPath = computed(() =>
-  currentPreviewId.value
-    ? `/api/actions/preview-files/${currentPreviewId.value}/extract-annotated-frames-pdf`
-    : null
-)
 
 const exportActions = computed(() =>
   [
     {
       label: 'annotations.zip',
-      href: annotationsZipPath.value,
+      href: annotationsPath(''),
       visible: canDownloadAnnotations.value
     },
     {
       label: 'annotations.pdf',
-      href: annotationsPdfPath.value,
+      href: annotationsPath('-pdf'),
       visible: canDownloadAnnotations.value
     },
     {
@@ -776,32 +750,21 @@ const exportActions = computed(() =>
   ].filter(action => action.visible !== false)
 )
 
-const currentRevision = computed(() =>
-  props.currentParentPreview && props.currentParentPreview.revision
-    ? props.currentParentPreview.revision
-    : currentPreview.value
-      ? currentPreview.value.revision
-      : 0
-)
-
-const extension = computed(() =>
-  taskPreviews.value && taskPreviews.value.length > 0
-    ? taskPreviews.value[currentPreviewIndex.value].extension
-    : ''
-)
-
-const isMoviePreview = computed(
+const currentRevision = computed(
   () =>
-    taskPreviews.value &&
-    taskPreviews.value.length > 0 &&
-    extension.value === 'mp4'
+    props.currentParentPreview?.revision || currentPreview.value?.revision || 0
 )
 
-const isPicturePreview = computed(
-  () =>
-    taskPreviews.value &&
-    taskPreviews.value.length > 0 &&
-    ['png', 'gif'].includes(extension.value)
+const displayedFrame = computed(
+  () => props.currentFrame || currentFrameRaw.value
+)
+
+const extension = computed(() => currentPreview.value?.extension ?? '')
+
+const isMoviePreview = computed(() => extension.value === 'mp4')
+
+const isPicturePreview = computed(() =>
+  ['png', 'gif'].includes(extension.value)
 )
 
 const taskStatuses = computed(() =>
@@ -842,16 +805,8 @@ const selectedTasksToDisplay = computed(() =>
 
 // Functions
 const getTaskEntity = task => {
-  const getterByType = {
-    Shot: 'shotMap',
-    Episode: 'episodeMap',
-    Sequence: 'sequenceMap',
-    Edit: 'editMap',
-    Asset: 'assetMap'
-  }
-  const getterName = getterByType[task?.entity_type_name]
-  if (!getterName || !task?.entity?.id) return null
-  return store.getters[getterName]?.get(task.entity.id) || null
+  if (!task?.entity_type_name || !task?.entity?.id) return null
+  return getEntityMap(task.entity_type_name)?.get(task.entity.id) || null
 }
 
 const getCurrentTaskComments = () =>
@@ -931,7 +886,7 @@ const resetModals = () => {
 }
 
 const resetComments = () => {
-  taskComments.value = store.getters.getTaskComments(props.task.id)
+  taskComments.value = getCurrentTaskComments()
 }
 
 const reset = ({ keepPreviewFiles = false } = {}) => {
@@ -940,7 +895,7 @@ const reset = ({ keepPreviewFiles = false } = {}) => {
     clearPreviewFiles()
   }
   if (props.task) {
-    taskComments.value = store.getters.getTaskComments(props.task.id)
+    resetComments()
     taskPreviews.value = store.getters.getTaskPreviews(props.task.id)
     nextTick(() => {
       previewPlayerRef.value?.focus()
@@ -1067,7 +1022,7 @@ const onRemoveExtraPreview = preview => {
 }
 
 const onCommentAdded = () => {
-  taskComments.value = store.getters.getTaskComments(props.task.id)
+  resetComments()
 }
 
 const onCancelRemoveExtraPreview = () => {
@@ -1094,10 +1049,9 @@ const onPreviewChanged = previewId => {
 }
 
 const changeCurrentPreview = previewFile => {
-  const index = taskPreviews.value.findIndex(p => p.id === previewFile.id)
-  if (index || index === 0) {
-    currentPreviewIndex.value = index
-  }
+  currentPreviewIndex.value = taskPreviews.value.findIndex(
+    p => p.id === previewFile.id
+  )
 }
 
 const setCurrentPreviewAsEntityThumbnail = frame => {
@@ -1208,7 +1162,7 @@ const confirmMoveComment = async targetTaskId => {
       commentId: commentToMove.value.id,
       targetTaskId
     })
-    taskComments.value = store.getters.getTaskComments(props.task.id)
+    resetComments()
     modals.moveComment = false
     commentToMove.value = null
   } catch (err) {
@@ -1289,24 +1243,18 @@ const confirmDeleteTaskPreview = () => {
 }
 
 const onRemoteAcknowledge = (eventData, type) => {
-  if (props.task) {
-    const comment = store.getters.getTaskComment(
-      props.task.id,
-      eventData.comment_id
-    )
-    const person = personMap.value.get(eventData.person_id)
-    if (comment && person) {
-      if (user.value.id === person.id) {
-        if (
-          (type === 'ack' && !comment.acknowledgements.includes(person.id)) ||
-          (type === 'unack' && comment.acknowledgements.includes(person.id))
-        ) {
-          store.commit('ACK_COMMENT', { comment, user: person })
-        }
-      } else {
-        store.commit('ACK_COMMENT', { comment, user: person })
-      }
-    }
+  if (!props.task) return
+  const comment = store.getters.getTaskComment(
+    props.task.id,
+    eventData.comment_id
+  )
+  const person = personMap.value.get(eventData.person_id)
+  if (!comment || !person) return
+  const hasAck = comment.acknowledgements.includes(person.id)
+  // For the current user's own events, skip commits that would double
+  // apply an acknowledgement already reflected locally.
+  if (user.value.id !== person.id || (type === 'ack') !== hasAck) {
+    store.commit('ACK_COMMENT', { comment, user: person })
   }
 }
 
@@ -1318,23 +1266,12 @@ const isStatusChange = index => {
   )
 }
 
-const timeCodeClicked = ({
-  versionRevision,
-  minutes,
-  seconds,
-  milliseconds,
-  frame
-}) => {
+const timeCodeClicked = payload => {
   if (!props.isPreview) {
-    emit('time-code-clicked', {
-      versionRevision,
-      minutes,
-      seconds,
-      milliseconds,
-      frame
-    })
+    emit('time-code-clicked', payload)
     return
   }
+  const { versionRevision, frame } = payload
   changeCurrentPreview(
     taskPreviews.value.find(p => p.revision === parseInt(versionRevision))
   )
@@ -1361,7 +1298,7 @@ const extractAnnotationSnapshots = async (withLabel = false) => {
 
 const onExportClick = () => {
   const nameData = [
-    moment().format('YYYY-MM-DD'),
+    formatSimpleDate(moment()),
     'kitsu',
     productionMap.value.get(props.task.project_id)?.name,
     props.task.entity_name.replaceAll(' / ', '_'),
@@ -1483,10 +1420,7 @@ const setWidth = width => {
 const onSetCurrentFrameAsThumbnail = isUseCurrentFrame => {
   if (previewPlayerRef.value) {
     loading.setFrameThumbnail = true
-    let frame = null
-    if (isUseCurrentFrame) {
-      frame = currentFrameRaw.value + 1
-    }
+    const frame = isUseCurrentFrame ? currentFrameRaw.value + 1 : null
     return setCurrentPreviewAsEntityThumbnail(frame)
   }
 }
@@ -1531,7 +1465,7 @@ const onRemoteTaskUpdate = eventData => {
     setTimeout(() => {
       // in case the task changed during the timeout
       if (props.task && eventData.task_id === props.task.id) {
-        taskComments.value = store.getters.getTaskComments(props.task.id)
+        resetComments()
       }
     }, 1000)
   }
@@ -1599,7 +1533,7 @@ const onRemoteCommentDelete = eventData => {
     const comment = taskComments.value.find(c => c.id === eventData.comment_id)
     if (comment) {
       store.commit('REMOVE_TASK_COMMENT', { task: props.task, comment })
-      taskComments.value = store.getters.getTaskComments(props.task.id)
+      resetComments()
       taskPreviews.value = store.getters.getTaskPreviews(props.task.id)
     }
     animOn.value = false

--- a/src/composables/dom.js
+++ b/src/composables/dom.js
@@ -1,0 +1,61 @@
+/*
+ * Composition API counterpart of `src/components/mixins/dom.js`.
+ * Every helper is a pure function, so there is no `useDom()` to
+ * instantiate: import the named exports directly. The legacy mixin
+ * stays in place so existing Options API components keep working.
+ */
+
+export const isFocusTextArea = () =>
+  document.activeElement.nodeName === 'TEXTAREA'
+
+export const clearFocus = () => document.activeElement.blur()
+
+export const focusInput = inputEl => {
+  inputEl.focus()
+  inputEl.select()
+  inputEl.className = 'input'
+}
+
+export const onInputBlur = event => {
+  event.target.className = 'input stylehidden'
+}
+
+export const onInputMouseOut = event => {
+  if (document.activeElement !== event.target) {
+    event.target.className = 'input stylehidden'
+  }
+}
+
+export const onInputMouseOver = event => {
+  event.target.className = 'input'
+}
+
+export const pauseEvent = e => {
+  if (e.stopPropagation) e.stopPropagation()
+  if (e.preventDefault) e.preventDefault()
+  e.cancelBubble = true
+  e.returnValue = false
+  return false
+}
+
+export const addEvents = events => {
+  events.forEach(([type, listener]) => {
+    document.addEventListener(type, listener)
+  })
+}
+
+export const removeEvents = events => {
+  events.forEach(([type, listener]) => {
+    document.removeEventListener(type, listener)
+  })
+}
+
+export const getClientX = event =>
+  event.touches?.[0]?.clientX ??
+  event.changedTouches?.[0]?.clientX ??
+  event.clientX
+
+export const getClientY = event =>
+  event.touches?.[0]?.clientY ??
+  event.changedTouches?.[0]?.clientY ??
+  event.clientY

--- a/src/composables/entity.js
+++ b/src/composables/entity.js
@@ -10,6 +10,28 @@ import {
   parseDate,
   parseSimpleDate
 } from '@/lib/time'
+import assetStore from '@/store/modules/assets'
+import editStore from '@/store/modules/edits'
+import episodeStore from '@/store/modules/episodes'
+import sequenceStore from '@/store/modules/sequences'
+import shotStore from '@/store/modules/shots'
+
+/*
+ * Non-reactive cache Map for a given entity type ('Asset', 'shot', ...).
+ * Plain function on purpose: the caches are module-level Maps mutated in
+ * place, so read them at call time, never iterate them from a computed
+ * (an empty first evaluation would cache [] forever).
+ */
+export const getEntityMap = entityType => {
+  const caches = {
+    asset: assetStore.cache.assetMap,
+    edit: editStore.cache.editMap,
+    episode: episodeStore.cache.episodeMap,
+    sequence: sequenceStore.cache.sequenceMap,
+    shot: shotStore.cache.shotMap
+  }
+  return caches[entityType.toLowerCase()]
+}
 
 /**
  * Composable mirroring src/components/mixins/entity.js for pages that use

--- a/src/composables/grabList.js
+++ b/src/composables/grabList.js
@@ -1,0 +1,72 @@
+/*
+ * Composition API counterpart of `src/components/mixins/grablist.js`:
+ * grab-and-drag scrolling for list wrappers. The legacy mixin stays in
+ * place so existing Options API components keep working.
+ *
+ * Wire `startBrowsing` on the grabbable area (tbody usually); document
+ * level move/stop listeners are managed here.
+ */
+import { onBeforeUnmount, onMounted } from 'vue'
+
+import {
+  addEvents,
+  getClientX,
+  getClientY,
+  removeEvents
+} from '@/composables/dom'
+
+const FORM_TAGS = ['INPUT', 'SELECT', 'TEXTAREA']
+
+export const useGrabList = wrapperRef => {
+  let isBrowsing = false
+  let initialClientX = null
+  let initialClientY = null
+
+  const startBrowsing = event => {
+    if (FORM_TAGS.includes(event.target.tagName)) return
+    document.body.style.cursor = 'grabbing'
+    isBrowsing = true
+    initialClientX = getClientX(event)
+    initialClientY = getClientY(event)
+  }
+
+  const stopBrowsing = () => {
+    if (!isBrowsing) return
+    document.body.style.cursor = 'default'
+    isBrowsing = false
+    initialClientX = null
+    initialClientY = null
+  }
+
+  const onMouseMove = event => {
+    const wrapper = wrapperRef.value
+    if (!isBrowsing || !wrapper) return
+    const movementX = event.movementX || getClientX(event) - initialClientX
+    const movementY = event.movementY || getClientY(event) - initialClientY
+    initialClientX = getClientX(event)
+    initialClientY = getClientY(event)
+    wrapper.scrollLeft -= movementX
+    wrapper.scrollTop -= movementY
+  }
+
+  const documentEvents = [
+    ['mousemove', onMouseMove],
+    ['touchmove', onMouseMove],
+    ['mouseup', stopBrowsing],
+    ['mouseleave', stopBrowsing],
+    ['touchend', stopBrowsing],
+    ['touchcancel', stopBrowsing],
+    ['keyup', stopBrowsing]
+  ]
+
+  onMounted(() => {
+    addEvents(documentEvents)
+  })
+
+  onBeforeUnmount(() => {
+    stopBrowsing()
+    removeEvents(documentEvents)
+  })
+
+  return { startBrowsing }
+}

--- a/src/lib/drafts.js
+++ b/src/lib/drafts.js
@@ -18,7 +18,9 @@ const normalize = draft => {
     return { text: draft, checklist: [] }
   }
   return {
-    text: draft.text || '',
+    // Coerce non-strings to '' so a corrupted stored draft cannot feed
+    // an object back into the comment form after a reload.
+    text: typeof draft.text === 'string' ? draft.text : '',
     checklist: Array.isArray(draft.checklist) ? draft.checklist : []
   }
 }


### PR DESCRIPTION
**Problem**
- The task type page family (TaskType, TaskList, TaskInfo, EstimationHelper) still used the Options API with mixins.
- Cold loads froze on an empty task list (computed iterating non-reactive caches), canceled episodes kept their tasks visible, and the task:update refresh guard could never run.
- Migrating exposed a script setup trap: the addComment handler shadowed the add-comment widget, so Vue mounted the function as a component and posted its vnode props to zou as comments.
- Contact sheet cards ignored most clicks, the table and card grid did not fill the page without the schedule, and the list could not be grabbed to scroll.

**Solution**
- Convert the four components to script setup; add dom and grabList composables, share getEntityMap and reuse isSupervisorInDepartments for permission checks.
- Read entity tasks at call time, filter status-canceled episodes, fix the refresh guard, rename the handler to postComment and coerce non-string draft text.
- Give cards their own click handler, let the table and grid claim the page width, add grab-and-drag scrolling and soften the card styling.
- Deduplicate the migrated code (about 500 lines net removed): shared date, filter and selection helpers, parallel schedule loads, merged watchers.