### PR TITLE
[tasks] Task metadata columns in the task list

### DIFF
--- a/src/components/cells/MetadataHeader.vue
+++ b/src/components/cells/MetadataHeader.vue
@@ -2,8 +2,8 @@
   <th
     scope="col"
     class="metadata-descriptor"
-    :class="{ 'datatable-row-header': isStick }"
-    :style="{ left }"
+    :class="{ 'datatable-row-header': isStick, resizable }"
+    :style="thStyle"
   >
     <div class="flexrow metadata-wrapper-header">
       <department-name
@@ -32,6 +32,11 @@
         <chevron-down-icon :size="14" />
       </span>
     </div>
+    <span
+      class="resize-handle"
+      @mousedown.stop.prevent="startResize"
+      v-if="resizable"
+    ></span>
   </th>
 </template>
 
@@ -46,10 +51,12 @@ const props = defineProps({
   descriptor: { type: Object, required: true },
   isStick: { type: Boolean, default: false },
   left: { type: String, default: '0px' },
-  noMenu: { type: Boolean, default: false }
+  noMenu: { type: Boolean, default: false },
+  resizable: { type: Boolean, default: false },
+  width: { type: Number, default: null }
 })
 
-defineEmits(['show-metadata-header-menu'])
+const emit = defineEmits(['resize', 'resize-end', 'show-metadata-header-menu'])
 
 const store = useStore()
 const departmentMap = computed(() => store.getters.departmentMap)
@@ -57,6 +64,39 @@ const departmentMap = computed(() => store.getters.departmentMap)
 const currentDepartments = computed(() =>
   (props.descriptor.departments || []).map(id => departmentMap.value.get(id))
 )
+
+const thStyle = computed(() => {
+  const style = { left: props.left }
+  // min-width is the lever the auto table-layout actually honours; width
+  // overrides the fixed 120px base so the column can shrink too.
+  if (props.width) {
+    style.width = `${props.width}px`
+    style.minWidth = `${props.width}px`
+  }
+  return style
+})
+
+// Column resize: drag the right-edge handle, report the new width upward so
+// the parent owns and persists it (and applies it to the body cells).
+let startX = 0
+let startWidth = 0
+
+const onResizeMove = event => {
+  emit('resize', Math.max(60, startWidth + event.clientX - startX))
+}
+
+const onResizeUp = () => {
+  window.removeEventListener('mousemove', onResizeMove)
+  window.removeEventListener('mouseup', onResizeUp)
+  emit('resize-end')
+}
+
+const startResize = event => {
+  startX = event.clientX
+  startWidth = event.currentTarget.parentElement.offsetWidth
+  window.addEventListener('mousemove', onResizeMove)
+  window.addEventListener('mouseup', onResizeUp)
+}
 </script>
 
 <style lang="scss" scoped>
@@ -70,6 +110,25 @@ th.metadata-descriptor {
   &.datatable-row-header {
     z-index: 1001; // above sticky cells
   }
+
+  &.resizable {
+    min-width: 60px;
+    position: relative;
+  }
+}
+
+.resize-handle {
+  bottom: 0;
+  cursor: col-resize;
+  position: absolute;
+  right: 0;
+  top: 0;
+  user-select: none;
+  width: 6px;
+}
+
+th.metadata-descriptor.resizable:hover .resize-handle {
+  background: var(--border);
 }
 
 .metadata-wrapper-header {

--- a/src/components/cells/MetadataInput.vue
+++ b/src/components/cells/MetadataInput.vue
@@ -1,5 +1,14 @@
 <template>
   <div class="metadata-input" :class="metadataInputClass">
+    <!-- long text: preview + popup editor (teleported, escapes the table). -->
+    <metadata-textarea
+      :model-value="getMetadataFieldValue(descriptor, entity)"
+      :editable="isEditable"
+      @update:model-value="
+        value => onMetadataFieldChanged(entity, descriptor, value)
+      "
+      v-if="descriptor.data_type === 'textarea'"
+    />
     <!-- read-only URL: clickable link until the row is selected -->
     <a
       class="metadata-readonly align-left metadata-link"
@@ -7,7 +16,7 @@
       target="_blank"
       rel="noopener noreferrer"
       @click.stop
-      v-if="
+      v-else-if="
         selected === false && descriptor.data_type === 'url' && displayValue
       "
     >
@@ -165,6 +174,7 @@ import {
 import { sortPeople } from '@/lib/sorting'
 
 import MetadataPerson from '@/components/cells/MetadataPerson.vue'
+import MetadataTextarea from '@/components/cells/MetadataTextarea.vue'
 import ComboboxTag from '@/components/widgets/ComboboxTag.vue'
 import DateField from '@/components/widgets/DateField.vue'
 
@@ -228,7 +238,7 @@ const isReadonly = computed(() => props.selected === false)
 const isTextType = computed(
   () =>
     !props.descriptor.data_type ||
-    ['string', 'url'].includes(props.descriptor.data_type)
+    ['string', 'url', 'textarea'].includes(props.descriptor.data_type)
 )
 
 // The read-only value uses a plain display, so the editor-specific layout

--- a/src/components/cells/MetadataInput.vue
+++ b/src/components/cells/MetadataInput.vue
@@ -13,11 +13,20 @@
     >
       {{ displayValue }}
     </a>
+    <!-- person: avatar + name; click opens a teleported picker popup. -->
+    <metadata-person
+      :person="personValue"
+      :people="team"
+      :editable="isEditable"
+      @select="value => onMetadataFieldChanged(entity, descriptor, value)"
+      v-else-if="descriptor.data_type === 'person'"
+    />
     <!-- read-only value: editors only appear once the row is selected.
          Boolean keeps its checkbox (disabled below), so it is excluded here. -->
     <div
       class="metadata-readonly"
       :class="{ 'align-left': isTextType }"
+      :title="displayValue"
       v-else-if="selected === false && descriptor.data_type !== 'boolean'"
     >
       {{ displayValue }}
@@ -153,7 +162,9 @@ import {
   getMetadataFieldValue,
   isSupervisorInDepartments
 } from '@/lib/descriptors'
+import { sortPeople } from '@/lib/sorting'
 
+import MetadataPerson from '@/components/cells/MetadataPerson.vue'
 import ComboboxTag from '@/components/widgets/ComboboxTag.vue'
 import DateField from '@/components/widgets/DateField.vue'
 
@@ -178,11 +189,29 @@ const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
 const isCurrentUserSupervisor = computed(
   () => store.getters.isCurrentUserSupervisor
 )
+const currentProduction = computed(() => store.getters.currentProduction)
+const personMap = computed(() => store.getters.personMap)
 const selectedAssets = computed(() => store.getters.selectedAssets)
 const selectedEdits = computed(() => store.getters.selectedEdits)
 const selectedShots = computed(() => store.getters.selectedShots)
 const selectedTasks = computed(() => store.getters.selectedTasks)
 const user = computed(() => store.getters.user)
+
+// Project team, for the "person" descriptor picker.
+const team = computed(() =>
+  sortPeople(
+    (currentProduction.value?.team || [])
+      .map(personId => personMap.value.get(personId))
+      .filter(Boolean)
+  )
+)
+
+const personValue = computed(
+  () =>
+    personMap.value.get(
+      getMetadataFieldValue(props.descriptor, props.entity)
+    ) || null
+)
 
 const isEditable = computed(
   () =>
@@ -337,6 +366,11 @@ const onNumberFieldKeyDown = event => {
 .metadata-link {
   color: inherit;
   text-decoration: underline;
+}
+
+/* Raise the cell so an open inline editor is not trapped behind neighbours. */
+.metadata-input:focus-within {
+  z-index: 40;
 }
 
 /* Let the datepicker flow like the schedule/task date cells instead of being

--- a/src/components/cells/MetadataInput.vue
+++ b/src/components/cells/MetadataInput.vue
@@ -1,12 +1,21 @@
 <template>
   <div class="metadata-input" :class="metadataInputClass">
+    <!-- read-only value: editors only appear once the row is selected.
+         Boolean keeps its checkbox (disabled below), so it is excluded here. -->
+    <div
+      class="metadata-readonly"
+      :class="{ 'align-left': isTextType }"
+      v-if="selected === false && descriptor.data_type !== 'boolean'"
+    >
+      {{ displayValue }}
+    </div>
     <!-- text input -->
     <input
       class="input-editor"
       :readonly="!isEditable"
       @input="event => onMetadataFieldChanged(entity, descriptor, event)"
       :value="getMetadataFieldValue(descriptor, entity)"
-      v-if="!descriptor.data_type || descriptor.data_type === 'string'"
+      v-else-if="!descriptor.data_type || descriptor.data_type === 'string'"
     />
     <!-- number input -->
     <input
@@ -19,10 +28,24 @@
       :value="getMetadataFieldValue(descriptor, entity)"
       v-else-if="descriptor.data_type === 'number'"
     />
+    <!-- date input -->
+    <date-field
+      class="date-editor"
+      model-type="yyyy-MM-dd"
+      :disabled="!isEditable"
+      :format="dateInputFormat"
+      :model-value="getMetadataFieldValue(descriptor, entity) || null"
+      :placeholder="''"
+      :with-margin="false"
+      @update:model-value="
+        value => onMetadataFieldChanged(entity, descriptor, value ?? '')
+      "
+      v-else-if="descriptor.data_type === 'date'"
+    />
     <!-- boolean input -->
     <input
       class="input-editor"
-      :disabled="!isEditable"
+      :disabled="!isEditable || selected === false"
       @input="event => onMetadataFieldChanged(entity, descriptor, event)"
       type="checkbox"
       :checked="getMetadataFieldValue(descriptor, entity) === 'true'"
@@ -100,6 +123,7 @@
 import { computed } from 'vue'
 import { useStore } from 'vuex'
 
+import { useFormat } from '@/composables/format'
 import {
   getDescriptorChecklistValues,
   getDescriptorChoicesOptions,
@@ -109,17 +133,22 @@ import {
 } from '@/lib/descriptors'
 
 import ComboboxTag from '@/components/widgets/ComboboxTag.vue'
+import DateField from '@/components/widgets/DateField.vue'
 
 const props = defineProps({
   descriptor: { type: Object, required: true },
   entity: { type: Object, required: true },
   // eslint-disable-next-line vue/no-unused-properties
-  indexes: { type: Object, default: () => ({}) }
+  indexes: { type: Object, default: () => ({}) },
+  // null: always editable (assets/shots lists). true/false: gate the editor
+  // on row selection (task list), showing a read-only value until selected.
+  selected: { type: Boolean, default: null }
 })
 
 const emit = defineEmits(['metadata-changed'])
 
 const store = useStore()
+const { dateFormat, formatDisplayDate } = useFormat()
 
 // Computed
 
@@ -143,14 +172,41 @@ const isEditable = computed(
     )
 )
 
+const isReadonly = computed(() => props.selected === false)
+
+const isTextType = computed(
+  () => !props.descriptor.data_type || props.descriptor.data_type === 'string'
+)
+
+// The read-only value uses a plain display, so the editor-specific layout
+// classes must not apply (is-date/is-checklist flip the wrapper to static
+// flow, which would break the centering). Boolean keeps its checkbox even
+// read-only, so is-boolean stays.
 const metadataInputClass = computed(() => ({
+  'is-readonly': isReadonly.value,
   'is-boolean': props.descriptor.data_type === 'boolean',
   'is-checklist':
+    !isReadonly.value &&
     props.descriptor.data_type === 'checklist' &&
     getDescriptorChecklistValues(props.descriptor).length,
-  'is-list': props.descriptor.data_type === 'list',
-  'is-taglist': props.descriptor.data_type === 'taglist'
+  'is-date': !isReadonly.value && props.descriptor.data_type === 'date',
+  'is-list': !isReadonly.value && props.descriptor.data_type === 'list',
+  'is-taglist': !isReadonly.value && props.descriptor.data_type === 'taglist'
 }))
+
+const displayValue = computed(() => {
+  const value = getMetadataFieldValue(props.descriptor, props.entity)
+  if (props.descriptor.data_type === 'date') {
+    return formatDisplayDate(value)
+  }
+  return value
+})
+
+// VueDatePicker's input format uses date-fns tokens; the stored date format
+// option (dateFormat) uses moment tokens. Only YYYY/MM/DD tokens are in play.
+const dateInputFormat = computed(() =>
+  dateFormat.value.replace(/YYYY/g, 'yyyy').replace(/DD/g, 'dd')
+)
 
 // Functions
 
@@ -233,6 +289,35 @@ const onNumberFieldKeyDown = event => {
 
 .metadata-input.is-checklist {
   position: static;
+}
+
+.metadata-input.is-readonly {
+  justify-content: center;
+}
+
+.metadata-readonly {
+  box-sizing: border-box;
+  overflow: hidden;
+  padding: 0.35rem 0.5rem;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.metadata-readonly.align-left {
+  text-align: left;
+}
+
+/* Let the datepicker flow like the schedule/task date cells instead of being
+   pinned by the absolute wrapper, and fill the column width. */
+.metadata-input.is-date {
+  position: static;
+
+  :deep(.datepicker) {
+    max-width: none;
+    width: 100%;
+  }
 }
 
 .metadata-input.is-checklist .metadata-value,

--- a/src/components/cells/MetadataInput.vue
+++ b/src/components/cells/MetadataInput.vue
@@ -130,6 +130,7 @@ const isCurrentUserSupervisor = computed(
 const selectedAssets = computed(() => store.getters.selectedAssets)
 const selectedEdits = computed(() => store.getters.selectedEdits)
 const selectedShots = computed(() => store.getters.selectedShots)
+const selectedTasks = computed(() => store.getters.selectedTasks)
 const user = computed(() => store.getters.user)
 
 const isEditable = computed(
@@ -184,6 +185,10 @@ const onMetadataFieldChanged = (entity, descriptor, event) => {
   } else if (selectedEdits.value.has(entity.id)) {
     selectedEdits.value.forEach(edit =>
       emitMetadataChanged(edit, descriptor, value)
+    )
+  } else if (selectedTasks.value.has(entity.id)) {
+    selectedTasks.value.forEach(task =>
+      emitMetadataChanged(task, descriptor, value)
     )
   } else {
     emitMetadataChanged(entity, descriptor, value)

--- a/src/components/cells/MetadataInput.vue
+++ b/src/components/cells/MetadataInput.vue
@@ -1,11 +1,24 @@
 <template>
   <div class="metadata-input" :class="metadataInputClass">
+    <!-- read-only URL: clickable link until the row is selected -->
+    <a
+      class="metadata-readonly align-left metadata-link"
+      :href="displayValue"
+      target="_blank"
+      rel="noopener noreferrer"
+      @click.stop
+      v-if="
+        selected === false && descriptor.data_type === 'url' && displayValue
+      "
+    >
+      {{ displayValue }}
+    </a>
     <!-- read-only value: editors only appear once the row is selected.
          Boolean keeps its checkbox (disabled below), so it is excluded here. -->
     <div
       class="metadata-readonly"
       :class="{ 'align-left': isTextType }"
-      v-if="selected === false && descriptor.data_type !== 'boolean'"
+      v-else-if="selected === false && descriptor.data_type !== 'boolean'"
     >
       {{ displayValue }}
     </div>
@@ -41,6 +54,15 @@
         value => onMetadataFieldChanged(entity, descriptor, value ?? '')
       "
       v-else-if="descriptor.data_type === 'date'"
+    />
+    <!-- url input -->
+    <input
+      class="input-editor"
+      :readonly="!isEditable"
+      type="url"
+      @input="event => onMetadataFieldChanged(entity, descriptor, event)"
+      :value="getMetadataFieldValue(descriptor, entity)"
+      v-else-if="descriptor.data_type === 'url'"
     />
     <!-- boolean input -->
     <input
@@ -175,7 +197,9 @@ const isEditable = computed(
 const isReadonly = computed(() => props.selected === false)
 
 const isTextType = computed(
-  () => !props.descriptor.data_type || props.descriptor.data_type === 'string'
+  () =>
+    !props.descriptor.data_type ||
+    ['string', 'url'].includes(props.descriptor.data_type)
 )
 
 // The read-only value uses a plain display, so the editor-specific layout
@@ -297,6 +321,7 @@ const onNumberFieldKeyDown = event => {
 
 .metadata-readonly {
   box-sizing: border-box;
+  display: block;
   overflow: hidden;
   padding: 0.35rem 0.5rem;
   text-align: center;
@@ -307,6 +332,11 @@ const onNumberFieldKeyDown = event => {
 
 .metadata-readonly.align-left {
   text-align: left;
+}
+
+.metadata-link {
+  color: inherit;
+  text-decoration: underline;
 }
 
 /* Let the datepicker flow like the schedule/task date cells instead of being

--- a/src/components/cells/MetadataInput.vue
+++ b/src/components/cells/MetadataInput.vue
@@ -201,6 +201,7 @@ const isCurrentUserSupervisor = computed(
 )
 const currentProduction = computed(() => store.getters.currentProduction)
 const personMap = computed(() => store.getters.personMap)
+const taskTypeMap = computed(() => store.getters.taskTypeMap)
 const selectedAssets = computed(() => store.getters.selectedAssets)
 const selectedEdits = computed(() => store.getters.selectedEdits)
 const selectedShots = computed(() => store.getters.selectedShots)
@@ -223,13 +224,21 @@ const personValue = computed(
     ) || null
 )
 
+// Task metadata editing is gated by the task type's department (matching the
+// zou permission), entity metadata by the descriptor's own departments.
+const editDepartments = computed(() =>
+  props.descriptor.entity_type === 'Task'
+    ? taskTypeMap.value.get(props.entity.task_type_id)?.department_id
+    : props.descriptor.departments
+)
+
 const isEditable = computed(
   () =>
     isCurrentUserManager.value ||
     isSupervisorInDepartments(
       user.value,
       isCurrentUserSupervisor.value,
-      props.descriptor.departments
+      editDepartments.value
     )
 )
 

--- a/src/components/cells/MetadataPerson.vue
+++ b/src/components/cells/MetadataPerson.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="metadata-person-cell">
+    <span
+      class="display"
+      :class="{ clickable: editable }"
+      role="button"
+      tabindex="0"
+      @click.stop="onOpen"
+      @keydown.enter.stop.prevent="onOpen"
+    >
+      <template v-if="person">
+        <people-avatar
+          :person="person"
+          :size="22"
+          :font-size="11"
+          :is-link="false"
+        />
+        <span class="ml05 ellipsis">{{ person.name }}</span>
+      </template>
+    </span>
+    <teleport to=".theme">
+      <template v-if="isOpen">
+        <div class="metadata-person-mask" @click="onClose"></div>
+        <div class="metadata-person-popup" :style="popupStyle">
+          <people-field
+            ref="fieldRef"
+            wide
+            :people="people"
+            :model-value="person"
+            @update:model-value="onSelect"
+          />
+        </div>
+      </template>
+    </teleport>
+  </div>
+</template>
+
+<script setup>
+import { nextTick, ref } from 'vue'
+
+import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
+import PeopleField from '@/components/widgets/PeopleField.vue'
+
+const props = defineProps({
+  person: { type: Object, default: null },
+  people: { type: Array, default: () => [] },
+  editable: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['select'])
+
+const isOpen = ref(false)
+const fieldRef = ref(null)
+const popupStyle = ref({})
+
+const WIDTH = 280
+
+const onOpen = event => {
+  if (!props.editable) return
+  const rect = event.currentTarget.getBoundingClientRect()
+  const left = Math.min(rect.left, window.innerWidth - WIDTH - 8)
+  popupStyle.value = {
+    top: `${rect.bottom + 4}px`,
+    left: `${Math.max(8, left)}px`,
+    width: `${WIDTH}px`
+  }
+  isOpen.value = true
+  nextTick(() => fieldRef.value?.focus())
+}
+
+const onSelect = person => {
+  emit('select', person?.id ?? '')
+  isOpen.value = false
+}
+
+const onClose = () => {
+  isOpen.value = false
+}
+</script>
+
+<style lang="scss" scoped>
+.metadata-person-cell {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  width: 100%;
+}
+
+.display {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+  padding: 0 0.5rem;
+  width: 100%;
+
+  &.clickable {
+    cursor: pointer;
+  }
+}
+
+.ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.metadata-person-mask {
+  inset: 0;
+  position: fixed;
+  z-index: 1200;
+}
+
+.metadata-person-popup {
+  position: fixed;
+  z-index: 1201;
+}
+</style>

--- a/src/components/cells/MetadataTextarea.vue
+++ b/src/components/cells/MetadataTextarea.vue
@@ -1,0 +1,114 @@
+<template>
+  <div
+    class="metadata-textarea"
+    role="button"
+    tabindex="0"
+    :title="modelValue"
+    @click.stop="onOpen"
+    @keydown.enter.stop.prevent="onOpen"
+  >
+    <span class="preview">{{ modelValue }}</span>
+    <teleport to=".theme">
+      <template v-if="isOpen">
+        <div class="metadata-textarea-mask" @click="onClose"></div>
+        <div class="metadata-textarea-popup" :style="popupStyle">
+          <textarea
+            ref="editorRef"
+            class="metadata-textarea-editor"
+            :value="modelValue"
+            :readonly="!editable"
+            @keyup.esc="onClose"
+          />
+        </div>
+      </template>
+    </teleport>
+  </div>
+</template>
+
+<script setup>
+import { nextTick, ref } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  editable: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['update:model-value'])
+
+const isOpen = ref(false)
+const editorRef = ref(null)
+const popupStyle = ref({})
+
+const WIDTH = 300
+
+const onOpen = event => {
+  const rect = event.currentTarget.getBoundingClientRect()
+  const left = Math.min(rect.left, window.innerWidth - WIDTH - 8)
+  popupStyle.value = {
+    top: `${rect.bottom + 4}px`,
+    left: `${Math.max(8, left)}px`,
+    width: `${WIDTH}px`
+  }
+  isOpen.value = true
+  nextTick(() => editorRef.value?.focus())
+}
+
+const onClose = () => {
+  if (!isOpen.value) return
+  const value = editorRef.value?.value ?? ''
+  isOpen.value = false
+  if (props.editable && value !== props.modelValue) {
+    emit('update:model-value', value)
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.metadata-textarea {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  height: 100%;
+  width: 100%;
+}
+
+.preview {
+  overflow: hidden;
+  padding: 0.35rem 0.5rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.metadata-textarea-mask {
+  inset: 0;
+  position: fixed;
+  z-index: 1200;
+}
+
+.metadata-textarea-popup {
+  background: var(--background);
+  border: 1px solid $green;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px var(--box-shadow);
+  padding: 0.4rem;
+  position: fixed;
+  z-index: 1201;
+}
+
+.metadata-textarea-editor {
+  background: transparent;
+  border: none;
+  box-sizing: border-box;
+  color: var(--text);
+  font-size: 0.95em;
+  line-height: 1.5em;
+  min-height: 8em;
+  resize: vertical;
+  width: 100%;
+
+  &:focus {
+    outline: none;
+  }
+}
+</style>

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -76,6 +76,10 @@
             <metadata-header
               :key="descriptor.id"
               :descriptor="descriptor"
+              resizable
+              :width="metadataColumnWidths[descriptor.id]"
+              @resize="width => onMetadataColumnResize(descriptor.id, width)"
+              @resize-end="persistMetadataColumnWidths"
               @show-metadata-header-menu="
                 event => showMetadataHeaderMenu(descriptor.id, event)
               "
@@ -285,6 +289,14 @@
             <td
               class="metadata-descriptor"
               :key="`${task.id}-${descriptor.id}`"
+              :style="
+                metadataColumnWidths[descriptor.id]
+                  ? {
+                      width: `${metadataColumnWidths[descriptor.id]}px`,
+                      minWidth: `${metadataColumnWidths[descriptor.id]}px`
+                    }
+                  : undefined
+              "
               v-for="descriptor in visibleMetadataDescriptors"
             >
               <metadata-input
@@ -559,6 +571,31 @@ const isColumnVisible = name => metadataDisplayHeaders.value[name] !== false
 
 const toggleColumnSelector = () => {
   columnSelectorDisplayed.value = !columnSelectorDisplayed.value
+}
+
+// Metadata column widths (keyed by descriptor id), drag-resized and persisted.
+const METADATA_WIDTHS_KEY = 'metadataColumnWidths:task-type'
+const readMetadataColumnWidths = () => {
+  try {
+    return JSON.parse(localStorage.getItem(METADATA_WIDTHS_KEY)) || {}
+  } catch {
+    return {}
+  }
+}
+const metadataColumnWidths = ref(readMetadataColumnWidths())
+
+const onMetadataColumnResize = (descriptorId, width) => {
+  metadataColumnWidths.value = {
+    ...metadataColumnWidths.value,
+    [descriptorId]: width
+  }
+}
+
+const persistMetadataColumnWidths = () => {
+  localStorage.setItem(
+    METADATA_WIDTHS_KEY,
+    JSON.stringify(metadataColumnWidths.value)
+  )
 }
 
 const bodyRef = useTemplateRef('body')

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -808,7 +808,11 @@ const isMetadataMenuEditAllowed = computed(() => {
 const showMetadataHeaderMenu = (descriptorId, event) => {
   const menuEl = headerMetadataMenuRef.value?.$el
   if (!menuEl) return
-  if (!event || !menuEl.classList.contains('hidden')) {
+  const isHidden = menuEl.classList.contains('hidden')
+  if (
+    !event ||
+    (!isHidden && descriptorId === lastMetadataHeaderMenuDisplayed.value)
+  ) {
     menuEl.classList.add('hidden')
     return
   }
@@ -819,7 +823,7 @@ const showMetadataHeaderMenu = (descriptorId, event) => {
   }
   const headerBox = headerElement.getBoundingClientRect()
   menuEl.style.left = `${headerBox.left - 3}px`
-  menuEl.style.top = `${headerBox.bottom + 11}px`
+  menuEl.style.top = `${headerBox.bottom + 4}px`
   menuEl.style.width = `${Math.max(100, headerBox.width - 1)}px`
   lastMetadataHeaderMenuDisplayed.value = descriptorId
 }
@@ -837,6 +841,15 @@ const onDeleteMetadataClicked = () => {
 const onSortByMetadataClicked = () => {
   emit('sort-metadata', lastMetadataHeaderMenuDisplayed.value)
   showMetadataHeaderMenu()
+}
+
+const onClickOutsideMenu = event => {
+  const menuEl = headerMetadataMenuRef.value?.$el
+  if (!menuEl || menuEl.classList.contains('hidden')) return
+  // The chevron buttons drive the menu themselves (toggle or reposition).
+  if (menuEl.contains(event.target)) return
+  if (event.target.closest?.('.metadata-menu-button')) return
+  menuEl.classList.add('hidden')
 }
 
 const onMetadataChanged = ({ entry, descriptor, value }) => {
@@ -931,10 +944,12 @@ watch(nbSelectedTasks, () => {
 // Lifecycle
 onMounted(() => {
   window.addEventListener('keydown', onKeyDown, false)
+  window.addEventListener('mousedown', onClickOutsideMenu)
 })
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onKeyDown)
+  window.removeEventListener('mousedown', onClickOutsideMenu)
 })
 
 defineExpose({

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -233,6 +233,7 @@
               <metadata-input
                 :entity="task"
                 :descriptor="descriptor"
+                :selected="Boolean(selectionGrid[task.id])"
                 @metadata-changed="onMetadataChanged"
               />
             </td>

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -39,7 +39,10 @@
             <th class="assignees">
               {{ $t('tasks.fields.assignees') }}
             </th>
-            <th class="frames number-cell" v-if="isShots && !isPaperProduction">
+            <th
+              class="frames number-cell"
+              v-if="isShots && !isPaperProduction && isColumnVisible('frames')"
+            >
               {{ $t('tasks.fields.frames') }}
             </th>
             <th
@@ -48,16 +51,26 @@
             >
               {{ $t('tasks.fields.drawings') }}
             </th>
-            <th class="difficulty number-cell">
+            <th
+              class="difficulty number-cell"
+              v-if="isColumnVisible('difficulty')"
+            >
               {{ $t('tasks.fields.difficulty') }}
             </th>
-            <th class="estimation number-cell" :title="$t('main.estimation')">
+            <th
+              class="estimation number-cell"
+              :title="$t('main.estimation')"
+              v-if="isColumnVisible('estimation')"
+            >
               {{ $t('tasks.fields.estimation').substring(0, 3) }}.
             </th>
-            <th class="duration number-cell">
+            <th class="duration number-cell" v-if="isColumnVisible('duration')">
               {{ $t('tasks.fields.duration').substring(0, 3) }}.
             </th>
-            <th class="retake-count number-cell">
+            <th
+              class="retake-count number-cell"
+              v-if="isColumnVisible('retakeCount')"
+            >
               {{ $t('tasks.fields.retake_count') }}
             </th>
             <metadata-header
@@ -66,27 +79,58 @@
               @show-metadata-header-menu="
                 event => showMetadataHeaderMenu(descriptor.id, event)
               "
-              v-for="descriptor in metadataDescriptors"
+              v-for="descriptor in visibleMetadataDescriptors"
             />
-            <th class="start-date" v-if="!withSchedule">
+            <th
+              class="start-date"
+              v-if="!withSchedule && isColumnVisible('startDate')"
+            >
               {{ $t('tasks.fields.start_date') }}
             </th>
-            <th class="due-date" v-if="!withSchedule">
+            <th
+              class="due-date"
+              v-if="!withSchedule && isColumnVisible('dueDate')"
+            >
               {{ $t('tasks.fields.due_date') }}
             </th>
-            <th class="real-start-date" v-if="!withSchedule">
+            <th
+              class="real-start-date"
+              v-if="!withSchedule && isColumnVisible('realStartDate')"
+            >
               {{ $t('tasks.fields.real_start_date') }}
             </th>
-            <th class="real-end-date" v-if="!withSchedule">
+            <th
+              class="real-end-date"
+              v-if="!withSchedule && isColumnVisible('realEndDate')"
+            >
               {{ $t('tasks.fields.real_end_date') }}
             </th>
-            <th class="done-date" v-if="!withSchedule">
+            <th
+              class="done-date"
+              v-if="!withSchedule && isColumnVisible('doneDate')"
+            >
               {{ $t('tasks.fields.done_date') }}
             </th>
-            <th class="last-comment-date" v-if="!withSchedule">
+            <th
+              class="last-comment-date"
+              v-if="!withSchedule && isColumnVisible('lastCommentDate')"
+            >
               {{ $t('tasks.fields.last_comment_date') }}
             </th>
-            <th class="empty" v-if="!withSchedule">&nbsp;</th>
+            <th class="column-selector">
+              <button-simple
+                class="is-small"
+                icon="down"
+                @click="toggleColumnSelector"
+              />
+              <table-metadata-selector-menu
+                :descriptors="metadataDescriptors"
+                :exclude="{ frames: !isShots }"
+                namespace="task-type"
+                v-model="metadataDisplayHeaders"
+                v-model:is-open="columnSelectorDisplayed"
+              />
+            </th>
           </tr>
         </thead>
 
@@ -158,7 +202,10 @@
                 />
               </div>
             </td>
-            <td class="frames number-cell" v-if="isShots && !isPaperProduction">
+            <td
+              class="frames number-cell"
+              v-if="isShots && !isPaperProduction && isColumnVisible('frames')"
+            >
               {{ getEntity(task.entity.id).nb_frames }}
             </td>
             <td
@@ -178,7 +225,10 @@
                 {{ task.nb_drawings || 0 }}
               </template>
             </td>
-            <td class="difficulty number-cell">
+            <td
+              class="difficulty number-cell"
+              v-if="isColumnVisible('difficulty')"
+            >
               <combobox
                 class="difficulty-combobox"
                 :options="difficultyOptions"
@@ -197,7 +247,10 @@
                 </span>
               </template>
             </td>
-            <td class="estimation number-cell">
+            <td
+              class="estimation number-cell"
+              v-if="isColumnVisible('estimation')"
+            >
               <input
                 class="input"
                 min="0"
@@ -217,10 +270,14 @@
                 'number-cell': true,
                 error: isEstimationBurned(task)
               }"
+              v-if="isColumnVisible('duration')"
             >
               {{ formatDuration(task.duration) }}
             </td>
-            <td class="retake-count number-cell">
+            <td
+              class="retake-count number-cell"
+              v-if="isColumnVisible('retakeCount')"
+            >
               <template v-for="index in task.retake_count" :key="index">
                 &bull;
               </template>
@@ -228,7 +285,7 @@
             <td
               class="metadata-descriptor"
               :key="`${task.id}-${descriptor.id}`"
-              v-for="descriptor in metadataDescriptors"
+              v-for="descriptor in visibleMetadataDescriptors"
             >
               <metadata-input
                 :entity="task"
@@ -237,7 +294,10 @@
                 @metadata-changed="onMetadataChanged"
               />
             </td>
-            <td class="start-date" v-if="!withSchedule">
+            <td
+              class="start-date"
+              v-if="!withSchedule && isColumnVisible('startDate')"
+            >
               <date-field
                 class="flexrow-item"
                 :with-margin="false"
@@ -250,7 +310,10 @@
                 {{ formatDisplayDate(task.start_date) }}
               </template>
             </td>
-            <td class="due-date" v-if="!withSchedule">
+            <td
+              class="due-date"
+              v-if="!withSchedule && isColumnVisible('dueDate')"
+            >
               <date-field
                 class="flexrow-item"
                 :with-margin="false"
@@ -263,19 +326,31 @@
                 {{ formatDisplayDate(task.due_date) }}
               </template>
             </td>
-            <td class="real-start-date" v-if="!withSchedule">
+            <td
+              class="real-start-date"
+              v-if="!withSchedule && isColumnVisible('realStartDate')"
+            >
               {{ formatDisplayDate(task.real_start_date) }}
             </td>
-            <td class="real-end-date" v-if="!withSchedule">
+            <td
+              class="real-end-date"
+              v-if="!withSchedule && isColumnVisible('realEndDate')"
+            >
               {{ formatDisplayDate(task.end_date) }}
             </td>
-            <td class="done-date" v-if="!withSchedule">
+            <td
+              class="done-date"
+              v-if="!withSchedule && isColumnVisible('doneDate')"
+            >
               {{ formatDisplayDate(task.done_date) }}
             </td>
-            <td class="last-comment-date" v-if="!withSchedule">
+            <td
+              class="last-comment-date"
+              v-if="!withSchedule && isColumnVisible('lastCommentDate')"
+            >
               {{ formatDisplayDate(task.last_comment_date) }}
             </td>
-            <td v-if="!withSchedule"></td>
+            <td class="column-selector"></td>
           </tr>
         </tbody>
       </table>
@@ -376,6 +451,7 @@ import {
 import MetadataHeader from '@/components/cells/MetadataHeader.vue'
 import MetadataInput from '@/components/cells/MetadataInput.vue'
 import ValidationCell from '@/components/cells/ValidationCell.vue'
+import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import Combobox from '@/components/widgets/Combobox.vue'
 import DateField from '@/components/widgets/DateField.vue'
 import EntityPreview from '@/components/widgets/EntityPreview.vue'
@@ -383,6 +459,7 @@ import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
 import PeopleAvatarWithMenu from '@/components/widgets/PeopleAvatarWithMenu.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
 import TableMetadataHeaderMenu from '@/components/widgets/TableMetadataHeaderMenu.vue'
+import TableMetadataSelectorMenu from '@/components/widgets/TableMetadataSelectorMenu.vue'
 import TaskListNumbers from '@/components/widgets/TaskListNumbers.vue'
 import ValidationTag from '@/components/widgets/ValidationTag.vue'
 
@@ -452,6 +529,37 @@ const difficultyOptions = [
 const lastSelection = ref(null)
 const page = ref(1)
 const selectionGrid = ref({})
+
+// Column show/hide, mirroring the assets/shots lists' selector menu. Keys
+// are the fixed task columns; metadata columns are keyed by field_name and
+// merged in by TableMetadataSelectorMenu (localStorage-backed).
+const columnSelectorDisplayed = ref(false)
+const metadataDisplayHeaders = ref({
+  difficulty: true,
+  estimation: true,
+  duration: true,
+  retakeCount: true,
+  frames: true,
+  startDate: true,
+  dueDate: true,
+  realStartDate: true,
+  realEndDate: true,
+  doneDate: true,
+  lastCommentDate: true
+})
+
+const visibleMetadataDescriptors = computed(() =>
+  props.metadataDescriptors.filter(descriptor => {
+    const header = metadataDisplayHeaders.value[descriptor.field_name]
+    return header === undefined || header
+  })
+)
+
+const isColumnVisible = name => metadataDisplayHeaders.value[name] !== false
+
+const toggleColumnSelector = () => {
+  columnSelectorDisplayed.value = !columnSelectorDisplayed.value
+}
 
 const bodyRef = useTemplateRef('body')
 const headerMetadataMenuRef = useTemplateRef('header-metadata-menu')
@@ -1050,7 +1158,8 @@ td.retake-count {
   white-space: nowrap;
 }
 
-.empty {
+.column-selector {
+  text-align: right;
   width: 100%;
 }
 

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -3,10 +3,10 @@
     <table-metadata-header-menu
       ref="header-metadata-menu"
       :is-edit-allowed="isMetadataMenuEditAllowed"
-      :show-sort="false"
       :show-stick="false"
       @edit-clicked="onEditMetadataClicked"
       @delete-clicked="onDeleteMetadataClicked"
+      @sort-by-clicked="onSortByMetadataClicked"
     />
     <div
       ref="body"
@@ -435,6 +435,7 @@ const emit = defineEmits([
   'delete-metadata',
   'edit-metadata',
   'scroll',
+  'sort-metadata',
   'task-selected'
 ])
 
@@ -830,6 +831,11 @@ const onEditMetadataClicked = () => {
 
 const onDeleteMetadataClicked = () => {
   emit('delete-metadata', lastMetadataHeaderMenuDisplayed.value)
+  showMetadataHeaderMenu()
+}
+
+const onSortByMetadataClicked = () => {
+  emit('sort-metadata', lastMetadataHeaderMenuDisplayed.value)
   showMetadataHeaderMenu()
 }
 

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -1,5 +1,13 @@
 <template>
   <div class="data-list">
+    <table-metadata-header-menu
+      ref="header-metadata-menu"
+      :is-edit-allowed="isMetadataMenuEditAllowed"
+      :show-sort="false"
+      :show-stick="false"
+      @edit-clicked="onEditMetadataClicked"
+      @delete-clicked="onDeleteMetadataClicked"
+    />
     <div
       ref="body"
       class="datatable-wrapper"
@@ -52,6 +60,14 @@
             <th class="retake-count number-cell">
               {{ $t('tasks.fields.retake_count') }}
             </th>
+            <metadata-header
+              :key="descriptor.id"
+              :descriptor="descriptor"
+              @show-metadata-header-menu="
+                event => showMetadataHeaderMenu(descriptor.id, event)
+              "
+              v-for="descriptor in metadataDescriptors"
+            />
             <th class="start-date" v-if="!withSchedule">
               {{ $t('tasks.fields.start_date') }}
             </th>
@@ -209,6 +225,17 @@
                 &bull;
               </template>
             </td>
+            <td
+              class="metadata-descriptor"
+              :key="`${task.id}-${descriptor.id}`"
+              v-for="descriptor in metadataDescriptors"
+            >
+              <metadata-input
+                :entity="task"
+                :descriptor="descriptor"
+                @metadata-changed="onMetadataChanged"
+              />
+            </td>
             <td class="start-date" v-if="!withSchedule">
               <date-field
                 class="flexrow-item"
@@ -331,7 +358,10 @@ import { pauseEvent } from '@/composables/dom'
 import { getEntityMap } from '@/composables/entity'
 import { useFormat } from '@/composables/format'
 import { useGrabList } from '@/composables/grabList'
-import { isSupervisorInDepartments } from '@/lib/descriptors'
+import {
+  getMetadataFieldValue,
+  isSupervisorInDepartments
+} from '@/lib/descriptors'
 import {
   daysToMinutes,
   formatSimpleDate,
@@ -342,6 +372,8 @@ import {
   range
 } from '@/lib/time'
 
+import MetadataHeader from '@/components/cells/MetadataHeader.vue'
+import MetadataInput from '@/components/cells/MetadataInput.vue'
 import ValidationCell from '@/components/cells/ValidationCell.vue'
 import Combobox from '@/components/widgets/Combobox.vue'
 import DateField from '@/components/widgets/DateField.vue'
@@ -349,6 +381,7 @@ import EntityPreview from '@/components/widgets/EntityPreview.vue'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
 import PeopleAvatarWithMenu from '@/components/widgets/PeopleAvatarWithMenu.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
+import TableMetadataHeaderMenu from '@/components/widgets/TableMetadataHeaderMenu.vue'
 import TaskListNumbers from '@/components/widgets/TaskListNumbers.vue'
 import ValidationTag from '@/components/widgets/ValidationTag.vue'
 
@@ -384,6 +417,10 @@ const props = defineProps({
     type: Boolean,
     default: false
   },
+  metadataDescriptors: {
+    type: Array,
+    default: () => []
+  },
   tasks: {
     type: Array,
     default: () => []
@@ -394,7 +431,12 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['scroll', 'task-selected'])
+const emit = defineEmits([
+  'delete-metadata',
+  'edit-metadata',
+  'scroll',
+  'task-selected'
+])
 
 // State
 const difficultyOptions = [
@@ -410,6 +452,8 @@ const page = ref(1)
 const selectionGrid = ref({})
 
 const bodyRef = useTemplateRef('body')
+const headerMetadataMenuRef = useTemplateRef('header-metadata-menu')
+const lastMetadataHeaderMenuDisplayed = ref(null)
 // Row elements for scrollToLine, no reactivity needed
 const taskRows = new Map()
 
@@ -654,7 +698,7 @@ const selectTask = (event, index, task) => {
     event &&
     event.target &&
     // Dirty hack needed to make date picker and inputs work properly
-    (['INPUT'].includes(event.target.nodeName) ||
+    (['INPUT', 'LABEL', 'SELECT', 'TEXTAREA'].includes(event.target.nodeName) ||
       // Combo box should not trigger selection
       event.target.className.indexOf('selected-line') >= 0 ||
       event.target.className.indexOf('down-icon') >= 0 ||
@@ -746,6 +790,58 @@ const isInDepartment = task =>
     taskTypeMap.value.get(task.task_type_id)?.department_id
   )
 
+const isMetadataMenuEditAllowed = computed(() => {
+  const descriptor = props.metadataDescriptors.find(
+    d => d.id === lastMetadataHeaderMenuDisplayed.value
+  )
+  return (
+    isCurrentUserManager.value ||
+    isSupervisorInDepartments(
+      user.value,
+      isCurrentUserSupervisor.value,
+      descriptor?.departments
+    )
+  )
+})
+
+const showMetadataHeaderMenu = (descriptorId, event) => {
+  const menuEl = headerMetadataMenuRef.value?.$el
+  if (!menuEl) return
+  if (!event || !menuEl.classList.contains('hidden')) {
+    menuEl.classList.add('hidden')
+    return
+  }
+  menuEl.classList.remove('hidden')
+  let headerElement = event.srcElement.parentNode.parentNode
+  if (headerElement.tagName !== 'TH') {
+    headerElement = headerElement.parentNode
+  }
+  const headerBox = headerElement.getBoundingClientRect()
+  menuEl.style.left = `${headerBox.left - 3}px`
+  menuEl.style.top = `${headerBox.bottom + 11}px`
+  menuEl.style.width = `${Math.max(100, headerBox.width - 1)}px`
+  lastMetadataHeaderMenuDisplayed.value = descriptorId
+}
+
+const onEditMetadataClicked = () => {
+  emit('edit-metadata', lastMetadataHeaderMenuDisplayed.value)
+  showMetadataHeaderMenu()
+}
+
+const onDeleteMetadataClicked = () => {
+  emit('delete-metadata', lastMetadataHeaderMenuDisplayed.value)
+  showMetadataHeaderMenu()
+}
+
+const onMetadataChanged = ({ entry, descriptor, value }) => {
+  store
+    .dispatch('updateTask', {
+      taskId: entry.id,
+      data: { data: { [descriptor.field_name]: value } }
+    })
+    .catch(console.error)
+}
+
 const resetSelection = () => {
   selectionGrid.value = {}
   lastSelection.value = null
@@ -761,6 +857,7 @@ const getTableData = () => {
     t('tasks.fields.estimation'),
     t('tasks.fields.duration'),
     t('tasks.fields.retake_count'),
+    ...props.metadataDescriptors.map(descriptor => descriptor.name),
     t('tasks.fields.start_date'),
     t('tasks.fields.due_date'),
     t('tasks.fields.real_start_date'),
@@ -791,6 +888,9 @@ const getTableData = () => {
       formatDuration(task.estimation, false),
       formatDuration(task.duration, false),
       task.retake_count,
+      ...props.metadataDescriptors.map(descriptor =>
+        getMetadataFieldValue(descriptor, task)
+      ),
       formatSimpleDate(task.start_date),
       formatSimpleDate(task.due_date),
       formatSimpleDate(task.real_start_date),
@@ -912,6 +1012,11 @@ td.due-date {
 .retake-count {
   min-width: 90px;
   width: 90px;
+}
+
+td.metadata-descriptor {
+  height: 3.1rem;
+  padding: 0;
 }
 
 td.retake-count {

--- a/src/components/mixins/descriptors.js
+++ b/src/components/mixins/descriptors.js
@@ -154,7 +154,7 @@ export const descriptorMixin = {
         'headerMetadataMenu',
         event,
         event => event.srcElement.parentNode.parentNode,
-        { left: -3, top: 11 }
+        { left: -3, top: 4 }
       )
       this.lastMetadataHeaderMenuDisplayed = columnId
     },

--- a/src/components/mixins/descriptors.js
+++ b/src/components/mixins/descriptors.js
@@ -153,7 +153,7 @@ export const descriptorMixin = {
       this.showHeaderMenuAt(
         'headerMetadataMenu',
         event,
-        event => event.srcElement.parentNode.parentNode,
+        event => event.target.closest('th'),
         { left: -3, top: 4 }
       )
       this.lastMetadataHeaderMenuDisplayed = columnId

--- a/src/components/mixins/entity_list.js
+++ b/src/components/mixins/entity_list.js
@@ -326,13 +326,12 @@ export const entityListMixin = {
     },
 
     showHeaderMenu(columnId, columnIndexInGrid, event) {
-      this.showHeaderMenuAt('headerMenu', event, event => {
-        let headerElement = event.srcElement.parentNode.parentNode
-        if (headerElement.tagName !== 'TH') {
-          headerElement = headerElement.parentNode
-        }
-        return headerElement
-      })
+      this.showHeaderMenuAt(
+        'headerMenu',
+        event,
+        event => event.target.closest('th'),
+        { left: -3, top: 4 }
+      )
       this.lastHeaderMenuDisplayed = columnId
       this.lastHeaderMenuDisplayedIndexInGrid = columnIndexInGrid
     },
@@ -341,8 +340,8 @@ export const entityListMixin = {
       this.showHeaderMenuAt(
         'headerFieldMenu',
         event,
-        event => event.currentTarget.closest('th'),
-        { left: -3, top: 11 }
+        event => event.target.closest('th'),
+        { left: -3, top: 4 }
       )
       this.lastFieldHeaderMenuDisplayed = fieldName
       if (label !== undefined) this.lastFieldHeaderMenuLabel = label

--- a/src/components/modals/AddMetadataModal.vue
+++ b/src/components/modals/AddMetadataModal.vue
@@ -181,7 +181,7 @@ import DepartmentName from '@/components/widgets/DepartmentName.vue'
 import ModalFooter from '@/components/modals/ModalFooter.vue'
 import TextField from '@/components/widgets/TextField.vue'
 
-const SIMPLE_TYPES = ['string', 'number', 'boolean']
+const SIMPLE_TYPES = ['string', 'number', 'boolean', 'date']
 const VALUE_LIST_TYPES = ['list', 'taglist']
 
 const props = defineProps({
@@ -224,6 +224,7 @@ const typeOptions = computed(() => [
   { label: t('productions.metadata.string'), value: 'string' },
   { label: t('productions.metadata.number'), value: 'number' },
   { label: t('productions.metadata.boolean'), value: 'boolean' },
+  { label: t('productions.metadata.date'), value: 'date' },
   { label: t('productions.metadata.choices'), value: 'list' },
   { label: t('productions.metadata.tags'), value: 'taglist' },
   { label: t('productions.metadata.checklist'), value: 'checklist' }

--- a/src/components/modals/AddMetadataModal.vue
+++ b/src/components/modals/AddMetadataModal.vue
@@ -38,6 +38,13 @@
           @enter="confirm"
         />
 
+        <combobox-task-type
+          :label="$t('tasks.fields.task_type')"
+          :task-type-list="taskTypes"
+          v-model="form.task_type_id"
+          v-if="entityType === 'Task' && taskTypes.length"
+        />
+
         <div v-if="['list', 'taglist'].includes(form.data_type)">
           <p class="strong">
             {{ $t('productions.metadata.available_values') }}
@@ -169,6 +176,7 @@ import Checklist from '@/components/widgets/Checklist.vue'
 import Combobox from '@/components/widgets/Combobox.vue'
 import ComboboxBoolean from '@/components/widgets/ComboboxBoolean.vue'
 import ComboboxDepartment from '@/components/widgets/ComboboxDepartment.vue'
+import ComboboxTaskType from '@/components/widgets/ComboboxTaskType.vue'
 import DepartmentName from '@/components/widgets/DepartmentName.vue'
 import ModalFooter from '@/components/modals/ModalFooter.vue'
 import TextField from '@/components/widgets/TextField.vue'
@@ -181,7 +189,10 @@ const props = defineProps({
   descriptorToEdit: { type: Object, default: () => ({}) },
   entityType: { type: String, default: 'Asset' },
   isError: { type: Boolean, default: false },
-  isLoading: { type: Boolean, default: false }
+  isLoading: { type: Boolean, default: false },
+  // Task descriptors only: when provided, the user picks the task type
+  // the column is scoped to. Left empty when the caller sets it itself.
+  taskTypes: { type: Array, default: () => [] }
 })
 
 const emit = defineEmits(['cancel', 'confirm'])
@@ -263,7 +274,11 @@ const isFormFilled = computed(() => {
     !user.value.departments.length ||
     form.value.departments.length ||
     (props.entityType === 'Project' && selectableDepartments.value.length === 0)
-  return form.value.name.length && dataTypeOk && supervisorDeptOk
+  const taskTypeOk =
+    props.entityType !== 'Task' ||
+    !props.taskTypes.length ||
+    Boolean(form.value.task_type_id)
+  return form.value.name.length && dataTypeOk && supervisorDeptOk && taskTypeOk
 })
 
 // Functions
@@ -274,6 +289,7 @@ const reset = () => {
       id: props.descriptorToEdit.id,
       name: props.descriptorToEdit.name,
       data_type: props.descriptorToEdit.data_type,
+      task_type_id: props.descriptorToEdit.task_type_id ?? null,
       for_client: props.descriptorToEdit.for_client ? 'true' : 'false',
       values: [...props.descriptorToEdit.choices],
       departments: [...props.descriptorToEdit.departments]
@@ -286,6 +302,7 @@ const reset = () => {
     form.value = {
       name: '',
       data_type: 'string',
+      task_type_id: props.taskTypes[0]?.id ?? null,
       for_client: 'false',
       values: [],
       departments: []

--- a/src/components/modals/AddMetadataModal.vue
+++ b/src/components/modals/AddMetadataModal.vue
@@ -181,7 +181,15 @@ import DepartmentName from '@/components/widgets/DepartmentName.vue'
 import ModalFooter from '@/components/modals/ModalFooter.vue'
 import TextField from '@/components/widgets/TextField.vue'
 
-const SIMPLE_TYPES = ['string', 'number', 'boolean', 'date', 'url', 'person']
+const SIMPLE_TYPES = [
+  'string',
+  'textarea',
+  'number',
+  'boolean',
+  'date',
+  'url',
+  'person'
+]
 const VALUE_LIST_TYPES = ['list', 'taglist']
 
 const props = defineProps({
@@ -222,6 +230,7 @@ const selectedDepartment = ref(null)
 
 const typeOptions = computed(() => [
   { label: t('productions.metadata.string'), value: 'string' },
+  { label: t('productions.metadata.textarea'), value: 'textarea' },
   { label: t('productions.metadata.number'), value: 'number' },
   { label: t('productions.metadata.boolean'), value: 'boolean' },
   { label: t('productions.metadata.date'), value: 'date' },

--- a/src/components/modals/AddMetadataModal.vue
+++ b/src/components/modals/AddMetadataModal.vue
@@ -181,7 +181,7 @@ import DepartmentName from '@/components/widgets/DepartmentName.vue'
 import ModalFooter from '@/components/modals/ModalFooter.vue'
 import TextField from '@/components/widgets/TextField.vue'
 
-const SIMPLE_TYPES = ['string', 'number', 'boolean', 'date', 'url']
+const SIMPLE_TYPES = ['string', 'number', 'boolean', 'date', 'url', 'person']
 const VALUE_LIST_TYPES = ['list', 'taglist']
 
 const props = defineProps({
@@ -226,6 +226,7 @@ const typeOptions = computed(() => [
   { label: t('productions.metadata.boolean'), value: 'boolean' },
   { label: t('productions.metadata.date'), value: 'date' },
   { label: t('productions.metadata.url'), value: 'url' },
+  { label: t('productions.metadata.person'), value: 'person' },
   { label: t('productions.metadata.choices'), value: 'list' },
   { label: t('productions.metadata.tags'), value: 'taglist' },
   { label: t('productions.metadata.checklist'), value: 'checklist' }

--- a/src/components/modals/AddMetadataModal.vue
+++ b/src/components/modals/AddMetadataModal.vue
@@ -181,7 +181,7 @@ import DepartmentName from '@/components/widgets/DepartmentName.vue'
 import ModalFooter from '@/components/modals/ModalFooter.vue'
 import TextField from '@/components/widgets/TextField.vue'
 
-const SIMPLE_TYPES = ['string', 'number', 'boolean', 'date']
+const SIMPLE_TYPES = ['string', 'number', 'boolean', 'date', 'url']
 const VALUE_LIST_TYPES = ['list', 'taglist']
 
 const props = defineProps({
@@ -225,6 +225,7 @@ const typeOptions = computed(() => [
   { label: t('productions.metadata.number'), value: 'number' },
   { label: t('productions.metadata.boolean'), value: 'boolean' },
   { label: t('productions.metadata.date'), value: 'date' },
+  { label: t('productions.metadata.url'), value: 'url' },
   { label: t('productions.metadata.choices'), value: 'list' },
   { label: t('productions.metadata.tags'), value: 'taglist' },
   { label: t('productions.metadata.checklist'), value: 'checklist' }

--- a/src/components/pages/ProjectTemplateSettings.vue
+++ b/src/components/pages/ProjectTemplateSettings.vue
@@ -755,6 +755,7 @@ const cleanDescriptors = () =>
   descriptors.value.map(d => ({
     name: d.name,
     entity_type: d.entity_type,
+    task_type_id: d.task_type_id || null,
     data_type: d.data_type,
     choices: d.choices || [],
     for_client: Boolean(d.for_client),
@@ -818,6 +819,7 @@ const confirmMetadataModal = async form => {
     if (descriptorToEditIndex.value >= 0) {
       const existing = descriptors.value[descriptorToEditIndex.value]
       entry.entity_type = existing.entity_type
+      entry.task_type_id = existing.task_type_id
       entry.field_name = existing.field_name
       entry.position = existing.position
       descriptors.value[descriptorToEditIndex.value] = entry

--- a/src/components/pages/ProjectTemplateSettings.vue
+++ b/src/components/pages/ProjectTemplateSettings.vue
@@ -284,6 +284,12 @@
                 <th class="descriptor-name">
                   {{ $t('project_templates.fields.name') }}
                 </th>
+                <th
+                  class="descriptor-task-type"
+                  v-if="metadataEntityTab === 'Task'"
+                >
+                  {{ $t('tasks.fields.task_type') }}
+                </th>
                 <th class="descriptor-type">{{ $t('main.type') }}</th>
                 <th class="descriptor-for-client">
                   {{ $t('assets.fields.hidden_from_client') }}
@@ -304,6 +310,12 @@
                 :key="descriptor.__index"
               >
                 <td class="descriptor-name">{{ descriptor.name }}</td>
+                <td
+                  class="descriptor-task-type"
+                  v-if="metadataEntityTab === 'Task'"
+                >
+                  {{ taskTypeMap.get(descriptor.task_type_id)?.name || '—' }}
+                </td>
                 <td class="descriptor-type">{{ descriptor.data_type }}</td>
                 <td class="descriptor-for-client">
                   {{ descriptor.for_client ? $t('main.yes') : $t('main.no') }}
@@ -357,6 +369,7 @@
       :is-error="errors.saveDescriptor"
       :descriptor-to-edit="descriptorToEdit"
       :entity-type="metadataEntityTab"
+      :task-types="metadataEntityTab === 'Task' ? templateTaskTypes : []"
       @cancel="modals.addMetadata = false"
       @confirm="confirmMetadataModal"
     />
@@ -399,7 +412,14 @@ const router = useRouter()
 const store = useStore()
 
 const activeTab = ref('parameters')
-const VALID_METADATA_ENTITIES = ['Asset', 'Shot', 'Sequence', 'Episode', 'Edit']
+const VALID_METADATA_ENTITIES = [
+  'Asset',
+  'Shot',
+  'Sequence',
+  'Episode',
+  'Edit',
+  'Task'
+]
 const initialMetadataEntity = VALID_METADATA_ENTITIES.includes(
   route.query.entity
 )
@@ -418,7 +438,8 @@ const metadataEntityTabs = computed(() => [
   { label: t('shots.title'), name: 'Shot' },
   { label: t('sequences.title'), name: 'Sequence' },
   { label: t('episodes.title'), name: 'Episode' },
-  { label: t('edits.title'), name: 'Edit' }
+  { label: t('edits.title'), name: 'Edit' },
+  { label: t('tasks.tasks'), name: 'Task' }
 ])
 
 const descriptorsForEntity = computed(() => {
@@ -483,6 +504,7 @@ const allAssetTypes = computed(() => store.getters.assetTypes || [])
 const allAutomations = computed(() => store.getters.statusAutomations || [])
 const allBackgrounds = computed(() => store.getters.backgrounds || [])
 const departmentMap = computed(() => store.getters.departmentMap || new Map())
+const taskTypeMap = computed(() => store.getters.taskTypeMap || new Map())
 
 const isActiveTab = tab => activeTab.value === tab
 
@@ -792,6 +814,7 @@ const openEditDescriptor = index => {
     id: `template-descriptor-${index}`,
     name: d.name,
     data_type: d.data_type,
+    task_type_id: d.task_type_id ?? null,
     for_client: Boolean(d.for_client),
     choices: [...(d.choices || [])],
     departments: [...(d.departments || [])]
@@ -811,6 +834,7 @@ const confirmMetadataModal = async form => {
     name: form.name,
     data_type: form.data_type,
     entity_type: metadataEntityTab.value,
+    task_type_id: form.task_type_id ?? null,
     choices: form.values || [],
     for_client: form.for_client === 'true',
     departments: form.departments || []
@@ -819,7 +843,7 @@ const confirmMetadataModal = async form => {
     if (descriptorToEditIndex.value >= 0) {
       const existing = descriptors.value[descriptorToEditIndex.value]
       entry.entity_type = existing.entity_type
-      entry.task_type_id = existing.task_type_id
+      entry.task_type_id = form.task_type_id ?? existing.task_type_id
       entry.field_name = existing.field_name
       entry.position = existing.position
       descriptors.value[descriptorToEditIndex.value] = entry

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -253,6 +253,30 @@
                     </td>
                     <td>{{ formatDisplayDate(task.done_date) }}</td>
                   </tr>
+                  <tr
+                    class="datatable-row"
+                    :key="descriptor.id"
+                    v-for="descriptor in taskMetadata"
+                  >
+                    <td class="field-label">{{ descriptor.name }}</td>
+                    <td>
+                      <a
+                        :href="task.data[descriptor.field_name]"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        v-if="
+                          descriptor.data_type === 'url' &&
+                          task.data &&
+                          task.data[descriptor.field_name]
+                        "
+                      >
+                        {{ task.data[descriptor.field_name] }}
+                      </a>
+                      <template v-else>
+                        {{ getTaskMetadataValue(descriptor) }}
+                      </template>
+                    </td>
+                  </tr>
                 </tbody>
               </table>
             </div>
@@ -590,9 +614,17 @@ export default {
       'taskStatus',
       'taskStatusForCurrentUser',
       'taskMap',
+      'taskMetadataDescriptors',
       'taskTypeMap',
       'user'
     ]),
+
+    taskMetadata() {
+      if (!this.task) return []
+      return this.taskMetadataDescriptors.filter(
+        descriptor => descriptor.task_type_id === this.task.task_type_id
+      )
+    },
 
     assetList() {
       return assetsStore.cache.assets
@@ -973,6 +1005,18 @@ export default {
   },
 
   methods: {
+    getTaskMetadataValue(descriptor) {
+      const value = this.task?.data?.[descriptor.field_name]
+      if (value == null || value === '') return ''
+      if (descriptor.data_type === 'date') {
+        return this.formatDisplayDate(value)
+      }
+      if (descriptor.data_type === 'boolean') {
+        return value === 'true' ? this.$t('main.yes') : this.$t('main.no')
+      }
+      return value
+    },
+
     ...mapActions([
       'addAttachmentToComment',
       'ackComment',

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -259,7 +259,11 @@
                     v-for="descriptor in taskMetadata"
                   >
                     <td class="field-label">{{ descriptor.name }}</td>
-                    <td>
+                    <td
+                      :class="{
+                        'pre-wrap': descriptor.data_type === 'textarea'
+                      }"
+                    >
                       <a
                         :href="task.data[descriptor.field_name]"
                         target="_blank"
@@ -2012,6 +2016,10 @@ video {
 .field-label {
   width: 130px;
   max-width: 130px;
+}
+
+.pre-wrap {
+  white-space: pre-wrap;
 }
 
 .title {

--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -272,6 +272,24 @@
                       >
                         {{ task.data[descriptor.field_name] }}
                       </a>
+                      <span
+                        class="flexrow"
+                        v-else-if="
+                          descriptor.data_type === 'person' &&
+                          personForDescriptor(descriptor)
+                        "
+                      >
+                        <people-avatar
+                          class="flexrow-item"
+                          :person="personForDescriptor(descriptor)"
+                          :size="22"
+                          :font-size="11"
+                          :is-link="false"
+                        />
+                        <span class="flexrow-item">
+                          {{ personForDescriptor(descriptor).name }}
+                        </span>
+                      </span>
                       <template v-else>
                         {{ getTaskMetadataValue(descriptor) }}
                       </template>
@@ -1014,7 +1032,16 @@ export default {
       if (descriptor.data_type === 'boolean') {
         return value === 'true' ? this.$t('main.yes') : this.$t('main.no')
       }
+      if (descriptor.data_type === 'person') {
+        return this.personMap.get(value)?.name || ''
+      }
       return value
+    },
+
+    personForDescriptor(descriptor) {
+      return (
+        this.personMap.get(this.task?.data?.[descriptor.field_name]) || null
+      )
     },
 
     ...mapActions([

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -23,6 +23,16 @@
             />
             <div
               class="flexrow-item"
+              v-if="isActiveTab('tasks') && isSupervisorInDepartment"
+            >
+              <button-simple
+                icon="plus"
+                :title="$t('productions.metadata.title')"
+                @click="onAddMetadataClicked"
+              />
+            </div>
+            <div
+              class="flexrow-item"
               v-if="
                 !isActiveTab('schedule') &&
                 !isActiveTab('estimation') &&
@@ -264,8 +274,11 @@
           :is-error="errors.entities"
           :is-grouped="currentSort === 'entity_name'"
           :is-loading="loading.entities"
+          :metadata-descriptors="taskMetadataDescriptors"
           :tasks="tasks"
           :with-schedule="isScheduleVisible"
+          @delete-metadata="onDeleteMetadataClicked"
+          @edit-metadata="onEditMetadataClicked"
           @task-selected="updateTaskInQuery"
           @scroll="onTaskListScroll"
           v-if="isActiveTab('tasks')"
@@ -364,6 +377,26 @@
           @cancel="hideImportModal"
           @confirm="renderImport"
         />
+
+        <add-metadata-modal
+          :active="modals.isAddMetadataDisplayed"
+          :is-loading="loading.addMetadata"
+          :is-error="errors.addMetadata"
+          :descriptor-to-edit="descriptorToEdit"
+          entity-type="Task"
+          @confirm="confirmAddMetadata"
+          @cancel="modals.isAddMetadataDisplayed = false"
+        />
+
+        <delete-modal
+          :active="modals.isDeleteMetadataDisplayed"
+          :is-loading="loading.deleteMetadata"
+          :is-error="errors.deleteMetadata"
+          :text="$t('productions.metadata.delete_task_text')"
+          :error-text="$t('productions.metadata.delete_error')"
+          @confirm="confirmDeleteMetadata"
+          @cancel="modals.isDeleteMetadataDisplayed = false"
+        />
       </div>
     </div>
 
@@ -421,6 +454,8 @@ import taskStatusStore from '@/store/modules/taskstatus.js'
 import taskTypeStore from '@/store/modules/tasktypes.js'
 
 import TaskList from '@/components/lists/TaskList.vue'
+import AddMetadataModal from '@/components/modals/AddMetadataModal.vue'
+import DeleteModal from '@/components/modals/DeleteModal.vue'
 import ImportModal from '@/components/modals/ImportModal.vue'
 import ImportRenderModal from '@/components/modals/ImportRenderModal.vue'
 import EstimationHelper from '@/components/pages/tasktype/EstimationHelper.vue'
@@ -513,6 +548,8 @@ const dataDisplay = ref({
   timesheets: false,
   beforeAfterTasks: false
 })
+const descriptorIdToDelete = ref(null)
+const descriptorToEdit = ref({})
 const difficultyFilter = ref('-1')
 const dueDateFilter = ref('all')
 const entityType = ref('Asset')
@@ -583,18 +620,24 @@ const sortOptions = [
 ].map(name => ({ label: name, value: name }))
 
 const errors = reactive({
+  addMetadata: false,
+  deleteMetadata: false,
   entities: false,
   importing: false,
   importingError: null
 })
 
 const loading = reactive({
+  addMetadata: false,
+  deleteMetadata: false,
   entities: false,
   importing: false,
   savingSearch: false
 })
 
 const modals = reactive({
+  isAddMetadataDisplayed: false,
+  isDeleteMetadataDisplayed: false,
   isImportRenderDisplayed: false,
   importing: false
 })
@@ -710,6 +753,12 @@ const isSupervisorInDepartment = computed(
       isCurrentUserSupervisor.value,
       currentTaskType.value?.department_id
     )
+)
+
+const taskMetadataDescriptors = computed(() =>
+  store.getters.taskMetadataDescriptors.filter(
+    descriptor => descriptor.task_type_id === currentTaskType.value?.id
+  )
 )
 
 const optionalColumns = computed(() =>
@@ -971,7 +1020,10 @@ const onSearchChange = query => {
   if (query && query.length !== 1) {
     query = query.toLowerCase().trim()
     const descriptors = (currentProduction.value.descriptors || []).filter(
-      d => d.entity_type === entityType.value
+      d =>
+        d.entity_type === entityType.value ||
+        (d.entity_type === 'Task' &&
+          d.task_type_id === currentTaskType.value.id)
     )
     const keywords = getKeyWords(query) || []
     const excludingKeyWords = getExcludingKeyWords(query) || []
@@ -1647,6 +1699,59 @@ const expandPersonElement = personElement => {
 }
 
 // Import
+
+const onAddMetadataClicked = () => {
+  descriptorToEdit.value = {}
+  modals.isAddMetadataDisplayed = true
+}
+
+const onEditMetadataClicked = descriptorId => {
+  descriptorToEdit.value = currentProduction.value.descriptors.find(
+    descriptor => descriptor.id === descriptorId
+  )
+  modals.isAddMetadataDisplayed = true
+}
+
+const onDeleteMetadataClicked = descriptorId => {
+  descriptorIdToDelete.value = descriptorId
+  modals.isDeleteMetadataDisplayed = true
+}
+
+const confirmAddMetadata = form => {
+  loading.addMetadata = true
+  errors.addMetadata = false
+  store
+    .dispatch('addMetadataDescriptor', {
+      ...form,
+      entity_type: 'Task',
+      task_type_id: currentTaskType.value.id
+    })
+    .then(() => {
+      loading.addMetadata = false
+      modals.isAddMetadataDisplayed = false
+    })
+    .catch(err => {
+      console.error(err)
+      loading.addMetadata = false
+      errors.addMetadata = true
+    })
+}
+
+const confirmDeleteMetadata = () => {
+  loading.deleteMetadata = true
+  errors.deleteMetadata = false
+  store
+    .dispatch('deleteMetadataDescriptor', descriptorIdToDelete.value)
+    .then(() => {
+      loading.deleteMetadata = false
+      modals.isDeleteMetadataDisplayed = false
+    })
+    .catch(err => {
+      console.error(err)
+      loading.deleteMetadata = false
+      errors.deleteMetadata = true
+    })
+}
 
 const showImportModal = () => {
   modals.importing = true

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -191,6 +191,7 @@
             <div class="flexrow-item" v-if="isActiveTab('tasks')">
               <combobox-styled
                 :label="$t('main.sorted_by')"
+                open-left
                 :options="sortOptions"
                 locale-key-prefix="tasks.fields."
                 v-model="currentSort"
@@ -763,13 +764,16 @@ const taskMetadataDescriptors = computed(() =>
   )
 )
 
+// Metadata columns come right after the default sort so they stay above
+// the fold of the scrollable option list.
 const sortOptions = computed(() => [
-  ...staticSortOptions,
+  staticSortOptions[0],
   ...taskMetadataDescriptors.value.map(descriptor => ({
     label: descriptor.name,
     value: METADATA_SORT_PREFIX + descriptor.field_name,
     raw: true
-  }))
+  })),
+  ...staticSortOptions.slice(1)
 ])
 
 const optionalColumns = computed(() =>

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -279,6 +279,7 @@
           :with-schedule="isScheduleVisible"
           @delete-metadata="onDeleteMetadataClicked"
           @edit-metadata="onEditMetadataClicked"
+          @sort-metadata="onSortByMetadata"
           @task-selected="updateTaskInQuery"
           @scroll="onTaskListScroll"
           v-if="isActiveTab('tasks')"
@@ -440,7 +441,7 @@ import {
 import { buildSupervisorTaskIndex, indexSearch } from '@/lib/indexing'
 import { getPersonPath } from '@/lib/path'
 import preferences from '@/lib/preferences'
-import { sortByName, sortPeople } from '@/lib/sorting'
+import { sortByMetadata, sortByName, sortPeople } from '@/lib/sorting'
 import stringHelpers from '@/lib/string'
 import {
   addBusinessDays,
@@ -603,7 +604,8 @@ const retakeCountOptions = [
   { label: 'retake_filter_none', value: 'none' },
   { label: 'retake_filter_with_retakes', value: 'with_retakes' }
 ]
-const sortOptions = [
+const METADATA_SORT_PREFIX = 'metadata.'
+const staticSortOptions = [
   'entity_name',
   'task_status_short_name',
   'priority',
@@ -760,6 +762,15 @@ const taskMetadataDescriptors = computed(() =>
     descriptor => descriptor.task_type_id === currentTaskType.value?.id
   )
 )
+
+const sortOptions = computed(() => [
+  ...staticSortOptions,
+  ...taskMetadataDescriptors.value.map(descriptor => ({
+    label: descriptor.name,
+    value: METADATA_SORT_PREFIX + descriptor.field_name,
+    raw: true
+  }))
+])
 
 const optionalColumns = computed(() =>
   isPaperProduction.value
@@ -1218,6 +1229,20 @@ const getTasks = entities => {
 }
 
 const sortTasks = (list = tasks.value) => {
+  if (currentSort.value.startsWith(METADATA_SORT_PREFIX)) {
+    const fieldName = currentSort.value.slice(METADATA_SORT_PREFIX.length)
+    const descriptor = taskMetadataDescriptors.value.find(
+      d => d.field_name === fieldName
+    )
+    return list.sort(
+      firstBy(
+        sortByMetadata({
+          column: fieldName,
+          data_type: descriptor?.data_type
+        })
+      ).thenBy('entity_name')
+    )
+  }
   if (currentSort.value === 'nb_frames') {
     return list.sort((ta, tb) => {
       const nbFramesA = getEntity(ta.entity.id)?.nb_frames || 0
@@ -1715,6 +1740,15 @@ const onEditMetadataClicked = descriptorId => {
 const onDeleteMetadataClicked = descriptorId => {
   descriptorIdToDelete.value = descriptorId
   modals.isDeleteMetadataDisplayed = true
+}
+
+const onSortByMetadata = descriptorId => {
+  const descriptor = taskMetadataDescriptors.value.find(
+    d => d.id === descriptorId
+  )
+  if (descriptor) {
+    currentSort.value = METADATA_SORT_PREFIX + descriptor.field_name
+  }
 }
 
 const confirmAddMetadata = form => {

--- a/src/components/widgets/ComboboxStyled.vue
+++ b/src/components/widgets/ComboboxStyled.vue
@@ -159,7 +159,7 @@ const optionList = computed(() => {
 })
 
 const getOptionLabel = option => {
-  if (props.localeKeyPrefix && option.label) {
+  if (props.localeKeyPrefix && option.label && !option.raw) {
     return t(props.localeKeyPrefix + option.label.toLowerCase())
   }
   return option.label

--- a/src/components/widgets/ComboboxStyled.vue
+++ b/src/components/widgets/ComboboxStyled.vue
@@ -38,7 +38,13 @@
         ></span>
         <chevron-down-icon class="down-icon flexrow-item" />
       </div>
-      <div class="select-input" ref="listRef" role="listbox" v-if="showList">
+      <div
+        class="select-input"
+        :class="{ 'open-left': openLeft }"
+        ref="listRef"
+        role="listbox"
+        v-if="showList"
+      >
         <div
           :id="optionId(index)"
           :key="option.id"
@@ -132,6 +138,10 @@ const props = defineProps({
     type: Boolean
   },
   keepOrder: {
+    default: false,
+    type: Boolean
+  },
+  openLeft: {
     default: false,
     type: Boolean
   },
@@ -336,6 +346,19 @@ watch(
   width: inherit;
   top: 38px;
   z-index: 2000;
+
+  // Anchor the list to the right edge so it grows leftward instead of
+  // overflowing the viewport when the combo sits near the right border.
+  // The part extending past the combo needs its own top-left rounding.
+  &.open-left {
+    border-top-left-radius: 1em;
+    left: auto;
+    margin-left: 0;
+    margin-right: -1px;
+    right: 0;
+    width: max-content;
+    min-width: 100%;
+  }
 
   .option-line {
     padding-right: 0.4em;

--- a/src/components/widgets/DateField.vue
+++ b/src/components/widgets/DateField.vue
@@ -10,6 +10,7 @@
       :formats="{ input: format }"
       :input-attrs="{ clearable: canDelete, hideInputIcon: true }"
       :locale="dateFnsLocale"
+      :model-type="modelType"
       :min-date="minDate"
       :max-date="maxDate"
       :placeholder="placeholder"
@@ -101,6 +102,12 @@ const props = defineProps({
   maxDate: {
     default: null,
     type: [Date, String]
+  },
+  // Null keeps vue-date-picker's default Date model. Set to a format string
+  // (e.g. "yyyy-MM-dd") to make v-model that formatted string instead.
+  modelType: {
+    default: null,
+    type: String
   },
   modelValue: {
     default: () => new Date(),

--- a/src/components/widgets/MetadataField.vue
+++ b/src/components/widgets/MetadataField.vue
@@ -60,6 +60,15 @@
     @update:model-value="updateValue"
     v-else-if="descriptor.data_type === 'taglist'"
   />
+  <!-- person field -->
+  <people-field
+    :label="label ?? descriptor.name"
+    wide
+    :people="teamPeople"
+    :model-value="personMap.get(modelValue) || null"
+    @update:model-value="person => updateValue(person?.id ?? '')"
+    v-else-if="descriptor.data_type === 'person'"
+  />
   <!-- number or text field-->
   <text-field
     :label="label ?? descriptor.name"
@@ -76,11 +85,13 @@
 import { computed } from 'vue'
 import { useStore } from 'vuex'
 
+import { sortPeople } from '@/lib/sorting'
 import { descriptorMixin } from '@/components/mixins/descriptors'
 
 import Combobox from '@/components/widgets/Combobox.vue'
 import ComboboxBoolean from '@/components/widgets/ComboboxBoolean.vue'
 import ComboboxTag from '@/components/widgets/ComboboxTag.vue'
+import PeopleField from '@/components/widgets/PeopleField.vue'
 import TextField from '@/components/widgets/TextField.vue'
 
 const store = useStore()
@@ -89,6 +100,16 @@ const isCurrentUserSupervisor = computed(
   () => store.getters.isCurrentUserSupervisor
 )
 const user = computed(() => store.getters.user)
+const currentProduction = computed(() => store.getters.currentProduction)
+const personMap = computed(() => store.getters.personMap)
+
+const teamPeople = computed(() =>
+  sortPeople(
+    (currentProduction.value?.team || [])
+      .map(personId => personMap.value.get(personId))
+      .filter(Boolean)
+  )
+)
 
 const props = defineProps({
   descriptor: {

--- a/src/components/widgets/MetadataField.vue
+++ b/src/components/widgets/MetadataField.vue
@@ -60,6 +60,13 @@
     @update:model-value="updateValue"
     v-else-if="descriptor.data_type === 'taglist'"
   />
+  <!-- textarea field -->
+  <textarea-field
+    :label="label ?? descriptor.name"
+    :model-value="modelValue"
+    @update:model-value="updateValue"
+    v-else-if="descriptor.data_type === 'textarea'"
+  />
   <!-- person field -->
   <people-field
     :label="label ?? descriptor.name"
@@ -93,6 +100,7 @@ import ComboboxBoolean from '@/components/widgets/ComboboxBoolean.vue'
 import ComboboxTag from '@/components/widgets/ComboboxTag.vue'
 import PeopleField from '@/components/widgets/PeopleField.vue'
 import TextField from '@/components/widgets/TextField.vue'
+import TextareaField from '@/components/widgets/TextareaField.vue'
 
 const store = useStore()
 const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)

--- a/src/components/widgets/MetadataValue.vue
+++ b/src/components/widgets/MetadataValue.vue
@@ -14,18 +14,50 @@
       </label>
     </div>
   </div>
+  <!-- url: clickable link -->
+  <a
+    :href="rawValue"
+    target="_blank"
+    rel="noopener noreferrer"
+    v-else-if="descriptor.data_type === 'url' && rawValue"
+  >
+    {{ rawValue }}
+  </a>
+  <!-- person: avatar + name -->
+  <span class="person" v-else-if="descriptor.data_type === 'person'">
+    <template v-if="person">
+      <people-avatar
+        :person="person"
+        :size="22"
+        :font-size="11"
+        :is-link="false"
+      />
+      <span class="ml05">{{ person.name }}</span>
+    </template>
+  </span>
+  <!-- date: honour the date format option -->
+  <span v-else-if="descriptor.data_type === 'date'">
+    {{ formatDisplayDate(rawValue) }}
+  </span>
   <span v-else>{{ rawValue }}</span>
 </template>
 
 <script setup>
 import { computed } from 'vue'
+import { useStore } from 'vuex'
 
+import { useFormat } from '@/composables/format'
 import { descriptorMixin } from '@/components/mixins/descriptors'
+
+import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
 
 const props = defineProps({
   descriptor: { type: Object, required: true },
   entity: { type: Object, required: true }
 })
+
+const store = useStore()
+const { formatDisplayDate } = useFormat()
 
 const { getDescriptorChecklistValues, getMetadataChecklistValues } =
   descriptorMixin.methods
@@ -56,6 +88,10 @@ const checklistValues = computed(() =>
 const rawValue = computed(() =>
   getMetadataFieldValue(props.descriptor, props.entity)
 )
+
+const person = computed(
+  () => store.getters.personMap.get(rawValue.value) || null
+)
 </script>
 
 <style lang="scss" scoped>
@@ -71,5 +107,10 @@ const rawValue = computed(() =>
   padding-right: 0.5rem;
   position: relative;
   white-space: normal;
+}
+
+.person {
+  align-items: center;
+  display: inline-flex;
 }
 </style>

--- a/src/components/widgets/MetadataValue.vue
+++ b/src/components/widgets/MetadataValue.vue
@@ -14,6 +14,10 @@
       </label>
     </div>
   </div>
+  <!-- long text: keep line breaks -->
+  <span class="pre-wrap" v-else-if="descriptor.data_type === 'textarea'">
+    {{ rawValue }}
+  </span>
   <!-- url: clickable link -->
   <a
     :href="rawValue"
@@ -107,6 +111,10 @@ const person = computed(
   padding-right: 0.5rem;
   position: relative;
   white-space: normal;
+}
+
+.pre-wrap {
+  white-space: pre-wrap;
 }
 
 .person {

--- a/src/components/widgets/TableHeaderMenu.vue
+++ b/src/components/widgets/TableHeaderMenu.vue
@@ -1,42 +1,52 @@
 <template>
   <div class="header-menu hidden">
     <div
+      class="menu-item"
       role="button"
       tabindex="0"
       @click="$emit('minimize-clicked')"
       @keydown.enter.prevent="$emit('minimize-clicked')"
       @keydown.space.prevent="$emit('minimize-clicked')"
     >
+      <maximize2-icon class="menu-icon" :size="14" v-if="isMinimized" />
+      <minimize2-icon class="menu-icon" :size="14" v-else />
       <span v-if="isMinimized">
         {{ $t('main.maximize') }}
       </span>
       <span v-else>{{ $t('main.minimize') }}</span>
     </div>
     <div
+      class="menu-item"
       role="button"
       tabindex="0"
       @click="$emit('sort-by-clicked')"
       @keydown.enter.prevent="$emit('sort-by-clicked')"
       @keydown.space.prevent="$emit('sort-by-clicked')"
     >
+      <arrow-up-down-icon class="menu-icon" :size="14" />
       {{ $t('main.sort_by') }}
     </div>
     <div
+      class="menu-item"
       role="button"
       tabindex="0"
       @click="$emit('select-column')"
       @keydown.enter.prevent="$emit('select-column')"
       @keydown.space.prevent="$emit('select-column')"
     >
+      <mouse-pointer-click-icon class="menu-icon" :size="14" />
       {{ $t('main.select_column') }}
     </div>
     <div
+      class="menu-item"
       role="button"
       tabindex="0"
       @click="$emit('toggle-stick')"
       @keydown.enter.prevent="$emit('toggle-stick')"
       @keydown.space.prevent="$emit('toggle-stick')"
     >
+      <pin-off-icon class="menu-icon" :size="14" v-if="isSticked" />
+      <pin-icon class="menu-icon" :size="14" v-else />
       <template v-if="isSticked">
         {{ $t('main.unstick') }}
       </template>
@@ -45,7 +55,7 @@
       </template>
     </div>
     <div
-      class="error"
+      class="menu-item destructive"
       role="button"
       tabindex="0"
       @click="$emit('delete-all-clicked')"
@@ -53,12 +63,23 @@
       @keydown.space.prevent="$emit('delete-all-clicked')"
       v-if="isEditAllowed"
     >
+      <trash2-icon class="menu-icon" :size="14" />
       {{ $t('main.delete_all') }}
     </div>
   </div>
 </template>
 
 <script setup>
+import {
+  ArrowUpDownIcon,
+  Maximize2Icon,
+  Minimize2Icon,
+  MousePointerClickIcon,
+  PinIcon,
+  PinOffIcon,
+  Trash2Icon
+} from 'lucide-vue-next'
+
 defineProps({
   isMinimized: {
     type: Boolean,
@@ -84,27 +105,49 @@ defineEmits([
 </script>
 
 <style lang="scss" scoped>
-.dark .header-menu {
-  background-color: $dark-grey-light;
-  box-shadow: 0 2px 6px $dark-grey-light;
-}
-
 .header-menu {
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 2px 6px var(--box-shadow);
+  color: var(--text);
+  overflow: hidden;
+  padding: 0.3em 0;
   position: absolute;
-  background: white;
-  border-bottom-left-radius: 10px;
-  border-bottom-right-radius: 10px;
-  box-shadow: 0 2px 6px $light-grey;
   top: 90px;
-  width: 118px;
+  width: 128px;
   z-index: 100;
 }
 
-.header-menu div {
+.menu-item {
+  align-items: center;
   cursor: pointer;
+  display: flex;
+  gap: 0.6em;
+  padding: 0.5em 0.9em;
+
+  &:hover {
+    background: var(--background-selectable);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $green;
+    outline-offset: -2px;
+  }
+
+  // "destructive" and not "delete": Bulma globally styles .delete as a
+  // round close button and hijacks the entry rendering.
+  &.destructive {
+    color: $red;
+
+    &:hover {
+      background: rgba($red, 0.1);
+    }
+  }
 }
 
-.header-menu div {
-  padding: 0.5em;
+.menu-icon {
+  flex-shrink: 0;
+  opacity: 0.7;
 }
 </style>

--- a/src/components/widgets/TableMetadataHeaderMenu.vue
+++ b/src/components/widgets/TableMetadataHeaderMenu.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="header-menu hidden">
     <div
+      class="menu-item"
       role="button"
       tabindex="0"
       @click="$emit('edit-clicked')"
@@ -8,9 +9,11 @@
       @keydown.space.prevent="$emit('edit-clicked')"
       v-if="isEditAllowed"
     >
+      <pencil-icon class="menu-icon" :size="14" />
       {{ $t('main.edit') }}
     </div>
     <div
+      class="menu-item"
       role="button"
       tabindex="0"
       @click="$emit('sort-by-clicked')"
@@ -18,9 +21,11 @@
       @keydown.space.prevent="$emit('sort-by-clicked')"
       v-if="showSort"
     >
+      <arrow-up-down-icon class="menu-icon" :size="14" />
       {{ $t('main.sort_by') }}
     </div>
     <div
+      class="menu-item"
       role="button"
       tabindex="0"
       @click="$emit('toggle-stick')"
@@ -28,6 +33,8 @@
       @keydown.space.prevent="$emit('toggle-stick')"
       v-if="showStick"
     >
+      <pin-off-icon class="menu-icon" :size="14" v-if="isSticked" />
+      <pin-icon class="menu-icon" :size="14" v-else />
       <template v-if="isSticked">
         {{ $t('main.unstick') }}
       </template>
@@ -36,7 +43,7 @@
       </template>
     </div>
     <div
-      class="error"
+      class="menu-item destructive"
       role="button"
       tabindex="0"
       @click="$emit('delete-clicked')"
@@ -44,12 +51,21 @@
       @keydown.space.prevent="$emit('delete-clicked')"
       v-if="isEditAllowed"
     >
+      <trash2-icon class="menu-icon" :size="14" />
       {{ $t('main.delete') }}
     </div>
   </div>
 </template>
 
 <script setup>
+import {
+  ArrowUpDownIcon,
+  PencilIcon,
+  PinIcon,
+  PinOffIcon,
+  Trash2Icon
+} from 'lucide-vue-next'
+
 defineProps({
   isEditAllowed: {
     type: Boolean,
@@ -78,27 +94,49 @@ defineEmits([
 </script>
 
 <style lang="scss" scoped>
-.dark .header-menu {
-  background-color: $dark-grey-light;
-  box-shadow: 0 2px 6px $dark-grey-light;
-}
-
 .header-menu {
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 2px 6px var(--box-shadow);
+  color: var(--text);
+  overflow: hidden;
+  padding: 0.3em 0;
   position: absolute;
-  background: white;
-  width: 128px;
-  box-shadow: 0 2px 6px $light-grey;
-  border-bottom-left-radius: 10px;
-  border-bottom-right-radius: 10px;
   top: 90px;
+  width: 128px;
   z-index: 1001; // Needed to be above the sticky cells
 }
 
-.header-menu div {
+.menu-item {
+  align-items: center;
   cursor: pointer;
+  display: flex;
+  gap: 0.6em;
+  padding: 0.5em 0.9em;
+
+  &:hover {
+    background: var(--background-selectable);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $green;
+    outline-offset: -2px;
+  }
+
+  // "destructive" and not "delete": Bulma globally styles .delete as a
+  // round close button and hijacks the entry rendering.
+  &.destructive {
+    color: $red;
+
+    &:hover {
+      background: rgba($red, 0.1);
+    }
+  }
 }
 
-.header-menu div {
-  padding: 0.5em;
+.menu-icon {
+  flex-shrink: 0;
+  opacity: 0.7;
 }
 </style>

--- a/src/components/widgets/TableMetadataSelectorMenu.vue
+++ b/src/components/widgets/TableMetadataSelectorMenu.vue
@@ -117,14 +117,23 @@ const sortedMetadataDescriptors = ref([])
 // Computed
 
 const FIELD_TO_NAME = computed(() => ({
+  difficulty: t('tasks.fields.difficulty'),
+  doneDate: t('tasks.fields.done_date'),
+  dueDate: t('tasks.fields.due_date'),
+  duration: t('tasks.fields.duration'),
   estimation: t('main.estimation'),
   fps: t('main.fps'),
   frameIn: t('main.frame_in'),
   frameOut: t('main.frame_out'),
   frames: t('main.frames'),
+  lastCommentDate: t('tasks.fields.last_comment_date'),
   maxRetakes: t('shots.fields.max_retakes'),
   readyFor: t('assets.fields.ready_for'),
+  realEndDate: t('tasks.fields.real_end_date'),
+  realStartDate: t('tasks.fields.real_start_date'),
   resolution: t('shots.fields.resolution'),
+  retakeCount: t('tasks.fields.retake_count'),
+  startDate: t('tasks.fields.start_date'),
   stdby: t('breakdown.fields.standby'),
   timeSpent: t('main.timeSpent')
 }))

--- a/src/lib/descriptors.js
+++ b/src/lib/descriptors.js
@@ -22,7 +22,12 @@ export const getMetadataFieldValue = (descriptor, entity) => {
   ) {
     return entity.data[descriptor.field_name]
   }
+  // Task descriptors live only in the task's own `data`. Never fall back to
+  // the linked entity's metadata (entity_data), or a same-named entity column
+  // (e.g. a "reviewer" on both Shot and the task type) would leak its value
+  // into the task column.
   if (
+    descriptor.entity_type !== 'Task' &&
     entity.entity_data &&
     descriptor.field_name in entity.entity_data &&
     entity.entity_data[descriptor.field_name] != null

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -88,7 +88,11 @@ const applyFiltersFunctions = {
 
   descriptor(entry, filter, taskMap) {
     let isOk = false
-    let dataValue = entry.data?.[filter.descriptor.field_name]
+    // Tasks carry their own metadata in data and the linked entity's in
+    // entity_data: match on either, like getMetadataFieldValue does.
+    let dataValue =
+      entry.data?.[filter.descriptor.field_name] ??
+      entry.entity_data?.[filter.descriptor.field_name]
     if ((dataValue || dataValue === 0) && filter.values) {
       if (typeof dataValue === 'string') dataValue = dataValue.toLowerCase()
 

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -89,10 +89,14 @@ const applyFiltersFunctions = {
   descriptor(entry, filter, taskMap) {
     let isOk = false
     // Tasks carry their own metadata in data and the linked entity's in
-    // entity_data: match on either, like getMetadataFieldValue does.
+    // entity_data: match on either, like getMetadataFieldValue does. Task
+    // descriptors stay in data only, so a same-named entity column does not
+    // leak into the task filter.
     let dataValue =
       entry.data?.[filter.descriptor.field_name] ??
-      entry.entity_data?.[filter.descriptor.field_name]
+      (filter.descriptor.entity_type === 'Task'
+        ? undefined
+        : entry.entity_data?.[filter.descriptor.field_name])
     if ((dataValue || dataValue === 0) && filter.values) {
       if (typeof dataValue === 'string') dataValue = dataValue.toLowerCase()
 

--- a/src/lib/sorting.js
+++ b/src/lib/sorting.js
@@ -437,7 +437,7 @@ const getMetadataValues = (sortInfo, a, b, defaultValue = '') => {
   return { dataA, dataB }
 }
 
-const sortByMetadata = sortInfo => {
+export const sortByMetadata = sortInfo => {
   if (sortInfo.data_type === 'number') {
     return (a, b) => {
       const { dataA, dataB } = getMetadataValues(sortInfo, a, b)

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1475,6 +1475,8 @@ export default {
       choices: 'List of values',
       delete_list_column_text:
         'This will remove the column “{name}” from all projects, including stored values. Continue?',
+      delete_task_text:
+        'Are you sure you want to delete this column and related data for all tasks of this task type?',
       delete_text: 'Are you sure you want to delete this column and related data for all assets of this production?',
       delete_error: 'An error occurred while deleting this metadata column.',
       edit_title: 'Edit metadata column',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1473,6 +1473,7 @@ export default {
       boolean: 'Checkbox',
       checklist: 'Checklist',
       choices: 'List of values',
+      date: 'Date',
       delete_list_column_text:
         'This will remove the column “{name}” from all projects, including stored values. Continue?',
       delete_task_text:

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1485,6 +1485,7 @@ export default {
       number: 'Number',
       string: 'Text',
       tags: 'List of tags',
+      url: 'Link',
       target_project: 'Project',
       title: 'Add metadata column'
     },

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1485,6 +1485,7 @@ export default {
       number: 'Number',
       person: 'Person',
       string: 'Text',
+      textarea: 'Long text',
       tags: 'List of tags',
       url: 'Link',
       target_project: 'Project',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1483,6 +1483,7 @@ export default {
       edit_title: 'Edit metadata column',
       error: 'An error occurred while adding the metadata column. Make sure there is no column with a similar name and that all fields are filled. If the problem persists, please contact the support team.',
       number: 'Number',
+      person: 'Person',
       string: 'Text',
       tags: 'List of tags',
       url: 'Link',

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1049,6 +1049,7 @@
         "boolean": "Choix vrai/faux",
         "number": "Nombre",
         "string": "Texte",
+        "date": "Date",
         "tags": "Liste des étiquettes",
         "applies_to_all_projects": "Cette colonne est ajoutée à tous les projets de la liste. Chaque projet peut avoir sa propre valeur dans la vue en liste.",
         "target_project": "Projet"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1050,6 +1050,7 @@
         "number": "Nombre",
         "string": "Texte",
         "date": "Date",
+        "url": "Lien",
         "tags": "Liste des étiquettes",
         "applies_to_all_projects": "Cette colonne est ajoutée à tous les projets de la liste. Chaque projet peut avoir sa propre valeur dans la vue en liste.",
         "target_project": "Projet"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1051,6 +1051,7 @@
         "string": "Texte",
         "date": "Date",
         "url": "Lien",
+        "person": "Personne",
         "tags": "Liste des étiquettes",
         "applies_to_all_projects": "Cette colonne est ajoutée à tous les projets de la liste. Chaque projet peut avoir sa propre valeur dans la vue en liste.",
         "target_project": "Projet"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1038,6 +1038,7 @@
         "add_new_values": "Il n'y a pour le moment aucune valeur enregistrée.",
         "available_values": "Valeurs disponibles",
         "choices": "Liste de valeurs",
+        "delete_task_text": "Êtes-vous sûr de vouloir supprimer cette colonne et les données associées pour toutes les tâches de ce type de tâche ?",
         "delete_text": "Êtes-vous sûr de vouloir supprimer cette colonne et toutes les données liées ?",
         "delete_list_column_text": "Cela retirera la colonne « {name} » de tous les projets, y compris les valeurs enregistrées. Continuer ?",
         "delete_error": "Une erreur est survenue en supprimant une colonne de métadonnées.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1051,6 +1051,7 @@
         "string": "Texte",
         "date": "Date",
         "url": "Lien",
+        "textarea": "Texte long",
         "person": "Personne",
         "tags": "Liste des étiquettes",
         "applies_to_all_projects": "Cette colonne est ajoutée à tous les projets de la liste. Chaque projet peut avoir sa propre valeur dans la vue en liste.",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -20,7 +20,7 @@
       "title": "어셋",
       "fields": {
         "description": "설명",
-        "episode": "에피소드.",
+        "episode": "에피소드",
         "name": "이름",
         "production": "제작",
         "time_spent": "시간",
@@ -153,7 +153,10 @@
         "mute": "음소거",
         "unmute": "음소거 해제",
         "fullscreen": "전체 화면",
-        "download": "다운로드"
+        "download": "다운로드",
+        "video_unavailable": "비디오를 사용할 수 없음",
+        "audio_unavailable": "오디오를 사용할 수 없음",
+        "image_unavailable": "이미지를 사용할 수 없음"
       }
     },
     "custom_actions": {
@@ -480,7 +483,9 @@
         "generic_fields": "메타데이터 및 작업 열(선택 사항):",
         "export_current_view": "현재 화면 내보내기",
         "legend_line_ok": "생성될 대사",
-        "legend_missing_optional": "찾을 수 없는 옵션 열"
+        "legend_missing_optional": "찾을 수 없는 옵션 열",
+        "new_entities_confirmation": "이 새 항목을 생성하는 것을 확인합니다 | {count}개의 새 항목을 생성하는 것을 확인합니다",
+        "new_entities_to_create": "{count}개의 행이 기존 항목과 일치하지 않아 새 항목으로 생성됩니다: | {count}개의 행이 기존 항목과 일치하지 않아 새 항목으로 생성됩니다:"
       },
       "after": "이후",
       "before": "이전",
@@ -558,7 +563,7 @@
       "tasks": "작업",
       "week": "주",
       "clear_sorting": "현재 정렬 지우기",
-      "days": "일수",
+      "days": "일 | 일",
       "drop_files_here": "여기에 파일 드롭",
       "import": "가져오기",
       "is_shared": "전체 팀과 공유",
@@ -1027,7 +1032,8 @@
         "code": "짧은 이름",
         "is_publish_default": "게시 모드에서 아티스트의 댓글 위젯을 기본적으로 설정합니다.",
         "is_single_preview_per_revision": "수정본당 미리 보기 파일 하나만 허용",
-        "revision_padding": "수정본 번호 자릿수 채우기 (0 = 채우지 않음)"
+        "revision_padding": "수정본 번호 자릿수 채우기 (0 = 채우지 않음)",
+        "is_frame_in_numbering": "플레이어 프레임 카운터를 프레임 인부터 시작"
       },
       "metadata": {
         "add_explanation": "이 프로젝트에 필요한 특정 데이터를 추가합니다.",
@@ -1229,7 +1235,9 @@
         "status_disabled": "비활성화됨",
         "status_enabled": "활성화됨"
       },
-      "notifications_title": "알림"
+      "notifications_title": "알림",
+      "date_format": "날짜 형식",
+      "use_12_hour_clock": "12시간제 (오전/오후)"
     },
     "settings": {
       "change_logo": "로고 변경",
@@ -1397,7 +1405,9 @@
         "new": "새 일정",
         "name": "버전 이름",
         "locked": "잠긴 버전"
-      }
+      },
+      "hours": "시간",
+      "confirm_move_children": "이 바를 이동하면 {count}개의 하위 항목이 새 범위에 맞게 잘리거나 조정됩니다. 계속하시겠습니까? | 이 바를 이동하면 {count}개의 하위 항목이 새 범위에 맞게 잘리거나 조정됩니다. 계속하시겠습니까?"
     },
     "quota": {
       "average": "평균",
@@ -1475,7 +1485,10 @@
         "max_retakes": "최대 재촬영 횟수",
         "resolution": "해상도",
         "placeholder": "SH01",
-        "nb_drawings": "도면"
+        "nb_drawings": "도면",
+        "start": "시작",
+        "count": "개수",
+        "step": "단계"
       },
       "cancel_text": "정말 {name}을(를) 보관하시겠습니까?",
       "delete_for_selection": "선택한 샷 삭제 | 선택한 {nbSelectedShots}개 샷 삭제",
@@ -1487,7 +1500,12 @@
       "wrong_file_duration": "업로드한 동영상 파일 길이 중 하나가 현재 샷의 예상 길이와 일치하지 않습니다.",
       "delete_for_selection_hard_text": "선택한 샷을 영구적으로 삭제하시겠습니까? 관련 작업, 댓글, 미리보기도 모두 삭제됩니다. 아래에 '삭제'를 입력하여 확인해주세요.",
       "delete_for_selection_hard_lock_text": "삭제",
-      "show_timecode": "타임코드로 체크인 및 체크아웃 표시"
+      "show_timecode": "타임코드로 체크인 및 체크아웃 표시",
+      "single_tab": "단일",
+      "bulk_tab": "일괄",
+      "bulk_error": "일괄 생성에 실패했습니다. 다시 시도해 주세요.",
+      "bulk_generate": "생성",
+      "bulk_invalid_start": "시작 이름은 숫자로 끝나야 합니다."
     },
     "server_down": {
       "text": "문제에 대해 업체의 고객 지원팀이나 시스템 관리자, 또는 IT 부서에 문의해 주십시오.",
@@ -1791,7 +1809,7 @@
       "title": "편집본",
       "fields": {
         "name": "이름",
-        "episode": "에피소드.",
+        "episode": "에피소드",
         "description": "설명",
         "person": "수정자"
       },

--- a/src/store/api/productions.js
+++ b/src/store/api/productions.js
@@ -163,6 +163,9 @@ export default {
       entity_type: descriptor.entity_type,
       departments: descriptor.departments
     }
+    if (descriptor.task_type_id) {
+      data.task_type_id = descriptor.task_type_id
+    }
     return client.ppost(
       `/api/data/projects/${productionId}/metadata-descriptors`,
       data

--- a/src/store/modules/productions.js
+++ b/src/store/modules/productions.js
@@ -349,6 +349,7 @@ const getters = {
   sequenceMetadataDescriptors: entityMetadataDescriptors('Sequence'),
   episodeMetadataDescriptors: entityMetadataDescriptors('Episode'),
   editMetadataDescriptors: entityMetadataDescriptors('Edit'),
+  taskMetadataDescriptors: entityMetadataDescriptors('Task'),
 
   /**
    * Union of all Project-entity metadata descriptors (field definitions) that

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -1378,7 +1378,13 @@ const mutations = {
   [EDIT_TASK_DATES](state, { taskId, data }) {
     const task = state.taskMap.get(taskId)
     if (task) {
-      Object.assign(task, data)
+      const { data: metadata, ...taskFields } = data
+      Object.assign(task, taskFields)
+      // Mirror the server-side merge of the metadata bag instead of
+      // replacing it wholesale.
+      if (metadata) {
+        task.data = { ...(task.data || {}), ...metadata }
+      }
     }
   },
 
@@ -1603,7 +1609,9 @@ const mutations = {
   },
 
   [SET_TASK_EXTRA_DATA](state, { task, data }) {
-    task.data = data
+    // Linked entity metadata lands in entity_data: task.data holds the
+    // task's own metadata and must not be shadowed by the entity's.
+    task.entity_data = data
   },
 
   [RESET_ALL](state) {

--- a/tests/unit/components/widgets/ComboboxStyled.spec.js
+++ b/tests/unit/components/widgets/ComboboxStyled.spec.js
@@ -1,0 +1,33 @@
+import { mount } from '@vue/test-utils'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: key => key })
+}))
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ resolve: () => ({ href: '' }) })
+}))
+
+import ComboboxStyled from '@/components/widgets/ComboboxStyled.vue'
+
+const options = [
+  { label: 'entity_name', value: 'entity_name' },
+  { label: 'priority', value: 'priority' },
+  { label: 'Render layer', value: 'metadata.render_layer', raw: true }
+]
+
+describe('widgets/ComboboxStyled', () => {
+  test('renders every option, raw metadata labels untranslated', async () => {
+    const wrapper = mount(ComboboxStyled, {
+      props: {
+        options,
+        localeKeyPrefix: 'tasks.fields.',
+        modelValue: 'entity_name'
+      }
+    })
+    await wrapper.find('.combo').trigger('click')
+    const lines = wrapper.findAll('.option-line')
+    expect(lines).toHaveLength(3)
+    expect(lines[0].text()).toContain('tasks.fields.entity_name')
+    expect(lines[2].text()).toContain('Render layer')
+  })
+})

--- a/tests/unit/lib/descriptors.spec.js
+++ b/tests/unit/lib/descriptors.spec.js
@@ -1,0 +1,31 @@
+import { getMetadataFieldValue } from '@/lib/descriptors'
+
+describe('lib/descriptors', () => {
+  describe('getMetadataFieldValue', () => {
+    test('returns the value from the entity own data', () => {
+      const descriptor = { field_name: 'reviewer', entity_type: 'Shot' }
+      const entity = { data: { reviewer: 'shot-value' } }
+      expect(getMetadataFieldValue(descriptor, entity)).toBe('shot-value')
+    })
+
+    test('entity descriptor falls back to the linked entity_data', () => {
+      const descriptor = { field_name: 'reviewer', entity_type: 'Shot' }
+      const entity = { data: {}, entity_data: { reviewer: 'shot-value' } }
+      expect(getMetadataFieldValue(descriptor, entity)).toBe('shot-value')
+    })
+
+    test('task descriptor never leaks a same-named entity_data value', () => {
+      // A "reviewer" descriptor exists on both Shot and the task type: the
+      // task column must stay empty, not show the shot's reviewer.
+      const descriptor = { field_name: 'reviewer', entity_type: 'Task' }
+      const task = { data: {}, entity_data: { reviewer: 'shot-value' } }
+      expect(getMetadataFieldValue(descriptor, task)).toBe('')
+    })
+
+    test('task descriptor reads its own data', () => {
+      const descriptor = { field_name: 'reviewer', entity_type: 'Task' }
+      const task = { data: { reviewer: 'task-value' }, entity_data: { reviewer: 'shot-value' } }
+      expect(getMetadataFieldValue(descriptor, task)).toBe('task-value')
+    })
+  })
+})

--- a/tests/unit/lib/sorting.spec.js
+++ b/tests/unit/lib/sorting.spec.js
@@ -1,5 +1,6 @@
 import {
   sortAssets,
+  sortByMetadata,
   sortByName,
   sortByDate,
   sortPeople,
@@ -21,6 +22,27 @@ const taskTypeMap = new Map(Object.entries({
 
 describe('lib/sorting', () => {
   beforeEach(() => {
+  })
+
+  it('sortByMetadata', () => {
+    const entries = [
+      { id: 1, data: { render_layer: 'fg' } },
+      { id: 2, data: {} },
+      { id: 3, data: { render_layer: 'bg' } }
+    ]
+    let results = [...entries].sort(
+      sortByMetadata({ column: 'render_layer', data_type: 'string' })
+    )
+    expect(results.map(entry => entry.id)).toEqual([3, 1, 2])
+
+    const numberEntries = [
+      { id: 1, data: { weight: '10' } },
+      { id: 2, data: { weight: '2' } }
+    ]
+    results = [...numberEntries].sort(
+      sortByMetadata({ column: 'weight', data_type: 'number' })
+    )
+    expect(results.map(entry => entry.id)).toEqual([2, 1])
   })
 
   it('sortByName', () => {


### PR DESCRIPTION
**Problem**
- The task list and task page had no way to show or edit per-task-type metadata.

**Solution**
- Add metadata columns to the task list and task type page, supporting date, url, textarea and person types alongside the existing ones.
- Add a column visibility menu, resizable columns, metadata sorting, and display of task metadata in the task info panel.
- Add a task tab to the template metadata settings, and gate metadata editing by the task type's department.