### PR TITLE
Silence unit test suite warnings

### DIFF
--- a/tests/unit/components/widgets/PeopleName.spec.js
+++ b/tests/unit/components/widgets/PeopleName.spec.js
@@ -2,8 +2,13 @@ import { mount } from '@vue/test-utils'
 
 import PeopleName from '@/components/widgets/PeopleName.vue'
 
+// withLink is false in every case, so router-link never renders, yet Vue
+// still resolves it at the top of the render fn, so stub it to avoid the warning.
 const mountName = person =>
-  mount(PeopleName, { props: { person, withLink: false } })
+  mount(PeopleName, {
+    props: { person, withLink: false },
+    global: { stubs: { RouterLink: true } }
+  })
 
 describe('widgets/PeopleName', () => {
   test('renders the embedded full_name', () => {

--- a/tests/unit/composables/desktopNotifications.spec.js
+++ b/tests/unit/composables/desktopNotifications.spec.js
@@ -242,7 +242,7 @@ describe('composables/desktopNotifications', () => {
 
     it('swallows Notification constructor errors', async () => {
       const NotificationMock = setupNotification('granted')
-      NotificationMock.mockImplementationOnce(() => {
+      NotificationMock.mockImplementationOnce(function () {
         throw new Error('boom')
       })
       localStorage.setItem('desktop-notifications:enabled', 'true')

--- a/tests/unit/players/videoviewer.spec.js
+++ b/tests/unit/players/videoviewer.spec.js
@@ -49,6 +49,10 @@ describe('players/VideoViewer (canvas pipeline)', () => {
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
       fakeContext
     )
+    // jsdom implements neither play() nor pause() on media elements; without
+    // these it logs "Not implemented" on every unmount (pause) and play.
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue()
+    vi.spyOn(HTMLMediaElement.prototype, 'pause').mockImplementation(() => {})
     fakeContext.drawImage.mockClear()
     installRvfcMock()
   })


### PR DESCRIPTION
**Problem**
- Some warnings when running unit tests:
  - The Notification mock is an arrow function, which vitest cannot invoke with `new` (constructor warning).
  - The VideoViewer spec calls play/pause on media elements, unimplemented in jsdom, logging "Not implemented" on every unmount.
  - The PeopleName spec mounts a component using router-link without providing it, so Vue warns it cannot resolve the component.

**Solution**
- Remove warning messages:
  - Mock the Notification constructor with a `function` so it is constructable.
  - Stub play/pause on media elements in the VideoViewer spec.
  - Stub router-link in the PeopleName spec so Vue resolves it.
