### PR TITLE
[fixes] Fix schedule drag resets and player replay bugs

### DIFF
--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -1037,14 +1037,7 @@ const setVideoFrameContext = frame => {
     if (!isPlaying.value) loadAnnotation()
     if (isPlaying.value && hasTrimEnd.value && frame >= handleOut.value) {
       if (isRepeating.value) {
-        // Loop from the frame START (see the play() jump) and repaint the
-        // bar at the loop target right away: on this tick the playing
-        // channel has already filled past the handle-out marker.
-        const startTime = trimStartFrame.value * frameDuration.value
-        pendingTrimSeek = true
-        previewViewer.value.setCurrentTimeRaw(startTime)
-        comparisonViewer.value?.setCurrentTimeRaw(startTime)
-        progress.value?.updateProgressBar(trimStartFrame.value - 1)
+        seekTrimStart()
       } else {
         pause()
         setCurrentFrame(handleOut.value)
@@ -1160,6 +1153,26 @@ const getCurrentFrame = () => {
   return Math.round(time / frameDuration.value) + 1
 }
 
+// Restart seek shared by the manual replay and the repeat loop. Seeks the
+// START of the trim frame, not the usual mid-frame (setCurrentFrame):
+// starting mid-frame only shows half of the handle-in frame, which reads
+// as playing one frame late. Also wraps the displayed frame right away:
+// the first playback emission after the seek lands is ceil+1-based
+// (~start + 2), so the counter would visibly restart a few frames in.
+const seekTrimStart = () => {
+  const startTime = trimStartFrame.value * frameDuration.value
+  pendingTrimSeek = true
+  previewViewer.value.setCurrentTimeRaw(startTime)
+  comparisonViewer.value?.setCurrentTimeRaw(startTime)
+  currentFrame.value = trimStartFrame.value
+  currentTimeRaw.value = startTime
+  currentTime.value = formatTime(startTime, fps.value)
+  emit('frame-updated', trimStartFrame.value)
+  // park the fill ON the start frame (paused convention), so the playback
+  // repaints that resume at ~start + 2 read as a continuous 1, 2, 3…
+  progress.value?.updateProgressBar(trimStartFrame.value)
+}
+
 const play = () => {
   isPlaying.value = true
   isDrawing.value = false
@@ -1173,13 +1186,7 @@ const play = () => {
         currentFrame.value >= endFrame ||
         currentFrame.value < trimStartFrame.value
       ) {
-        // Seek the START of the trim frame, not the usual mid-frame
-        // (setCurrentFrame): starting mid-frame only shows half of the
-        // handle-in frame, which reads as playing one frame late.
-        const startTime = trimStartFrame.value * frameDuration.value
-        pendingTrimSeek = true
-        previewViewer.value.setCurrentTimeRaw(startTime)
-        comparisonViewer.value?.setCurrentTimeRaw(startTime)
+        seekTrimStart()
       }
       previewViewer.value.play()
       if (comparisonViewer.value && isComparing.value) {

--- a/src/components/players/viewers/VideoViewer.vue
+++ b/src/components/players/viewers/VideoViewer.vue
@@ -462,6 +462,14 @@ const play = () => {
   ) {
     setCurrentTime(0)
   }
+  // a replay seek is issued while the video is still paused, so
+  // setCurrentTimeRaw could not arm the seek guard: once playback starts,
+  // stale pre-seek frames still coming out of the decoder would emit
+  // end-range frame numbers and re-trigger the trim stop, parking the
+  // player a few frames in, paused
+  if (video.value.seeking) {
+    seekGuardTarget = video.value.currentTime
+  }
   video.value.play()?.catch(() => {})
 }
 

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1546,6 +1546,20 @@ const changeDates = event => {
     }
   }
 
+  // a bar whose real dates lie outside the displayed range has no exact
+  // index: the boundary-resolved index math would compute the move against
+  // the window edge and teleport the bar there on the first tick, then the
+  // drop would persist the reset dates. Keep such bars unmovable (their
+  // dates must be fixed from the task panel first).
+  if (
+    !isValidItemDates(
+      currentElement.value.startDate,
+      currentElement.value.endDate
+    )
+  ) {
+    return
+  }
+
   if (lastStartDate.isBefore(props.startDate)) {
     lastStartDate = props.startDate.clone()
   }

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1297,6 +1297,19 @@ const refreshAllItemPositions = () => {
   })
 }
 
+// Drag-time variant: the collision relayout walks every child of the
+// section (moment clones + line scan) and re-renders the moved bars, which
+// stalls fast drags on large sections. During a drag a ~100ms cadence is
+// enough for live feedback; the drop (stopBrowsing) still runs the exact
+// relayout on every moved item.
+let lastDragRelayoutAt = 0
+const refreshItemPositionsDuringDrag = rootElements => {
+  const now = performance.now()
+  if (now - lastDragRelayoutAt < 100) return
+  lastDragRelayoutAt = now
+  rootElements.forEach(refreshItemPositions)
+}
+
 const refreshItemPositions = rootElement => {
   if (!rootElement?.children) {
     return
@@ -1596,7 +1609,7 @@ const changeDates = event => {
           const parentElements = [
             ...new Set(selection.value.map(item => item.parentElement))
           ]
-          parentElements.forEach(refreshItemPositions)
+          refreshItemPositionsDuringDrag(parentElements)
         }
       }
     }
@@ -1650,7 +1663,7 @@ const changeStartDate = event => {
     currentElement.value.startDate = newStartDate.clone()
     updateItemEstimation(currentElement.value)
     propagateClipToChildren(currentElement.value)
-    refreshItemPositions(currentElement.value.parentElement)
+    refreshItemPositionsDuringDrag([currentElement.value.parentElement])
     resetSelection([currentElement.value])
   }
 }
@@ -1705,7 +1718,7 @@ const changeEndDate = event => {
     currentElement.value.endDate = newEndDate.clone()
     updateItemEstimation(currentElement.value)
     propagateClipToChildren(currentElement.value)
-    refreshItemPositions(currentElement.value.parentElement)
+    refreshItemPositionsDuringDrag([currentElement.value.parentElement])
     resetSelection([currentElement.value])
   }
 }


### PR DESCRIPTION
## Problems

- Dragging a schedule bar whose dates lie outside the displayed range teleported it to the window edge and persisted the reset dates.
- Fast drags stalled on large sections: the collision relayout re-ran on every animation frame.
- Replaying a trimmed preview after the end parked the player a few frames in, paused.
- After a loop or replay, the counter and progress fill restarted on ~frame 3 instead of the trim start.

## Solutions

- Keep bars with out-of-range dates unmovable instead of snapping them to the window boundary.
- Run the drag-time relayout on a 100ms cadence; the drop still runs the exact pass.
- Arm the viewer seek guard when play() starts with a seek in flight, so stale decoder frames stop re-triggering the trim stop.
- Wrap the frame context and progress fill to the trim start in the shared restart helper.