### PR TITLE
[metadata] Fix person CSV export and asset task values lost on reload

### DIFF
--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -1225,7 +1225,7 @@ const getTasks = entities => {
       if (task) {
         // Hack to allow filtering on linked entity metadata. Guarded so
         // the repeated resets do not commit the same reference again.
-        if (task.data !== entity.data) {
+        if (task.entity_data !== entity.data) {
           store.commit('SET_TASK_EXTRA_DATA', {
             task,
             data: entity.data

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -188,7 +188,6 @@ const helpers = {
         task = taskMap.get(task)
       }
       if (!task) return
-      task.data = asset.data || {}
       asset.full_name = `${asset.asset_type_name} / ${asset.name}`
       helpers.populateTask(task, asset)
 

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -761,6 +761,9 @@ const actions = {
             assetLine.push(
               asset.data[descriptor.field_name]?.toLowerCase() === 'true'
             )
+          } else if (descriptor.data_type === 'person') {
+            const person = personMap.get(asset.data[descriptor.field_name])
+            assetLine.push(person ? person.full_name : '')
           } else {
             assetLine.push(asset.data[descriptor.field_name])
           }

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -556,6 +556,9 @@ const actions = {
             editLine.push(
               edit.data[descriptor.field_name]?.toLowerCase() === 'true'
             )
+          } else if (descriptor.data_type === 'person') {
+            const person = personMap.get(edit.data[descriptor.field_name])
+            editLine.push(person ? person.full_name : '')
           } else {
             editLine.push(edit.data[descriptor.field_name])
           }

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -719,6 +719,9 @@ const actions = {
           shotLine.push(
             shot.data[descriptor.field_name]?.toLowerCase() === 'true'
           )
+        } else if (descriptor.data_type === 'person') {
+          const person = personMap.get(shot.data[descriptor.field_name])
+          shotLine.push(person ? person.full_name : '')
         } else {
           shotLine.push(shot.data[descriptor.field_name])
         }

--- a/tests/unit/store/assets.spec.js
+++ b/tests/unit/store/assets.spec.js
@@ -164,6 +164,46 @@ describe('Assets store', () => {
     })
   })
 
+  describe('getAssetsCsvLines', () => {
+    test('exports the full name for person descriptors, not the id', () => {
+      const asset = {
+        id: 'a1',
+        name: 'A1',
+        asset_type_name: 'Char',
+        description: '',
+        ready_for: 'None',
+        data: { reviewer: 'person-1' },
+        validations: new Map()
+      }
+      assetsStore.cache.assets = [asset]
+      assetsStore.cache.result = []
+      const rootGetters = baseRootGetters()
+      rootGetters.currentProduction = {
+        id: 'p1',
+        descriptors: [
+          {
+            name: 'Reviewer',
+            field_name: 'reviewer',
+            data_type: 'person',
+            entity_type: 'Asset'
+          }
+        ]
+      }
+      rootGetters.personMap = new Map([
+        ['person-1', { id: 'person-1', full_name: 'John Doe' }]
+      ])
+      const state = { assetValidationColumns: [] }
+
+      const lines = assetsStore.actions.getAssetsCsvLines({
+        state,
+        rootGetters
+      })
+
+      expect(lines[0]).toContain('John Doe')
+      expect(lines[0]).not.toContain('person-1')
+    })
+  })
+
   describe('cache.result maintenance', () => {
     test('REMOVE_ASSET drops the asset from cache.result so it cannot reappear on "show more" (BUG-10)', () => {
       const asset = { id: 'a1', name: 'A1', asset_type_name: 'Char', tasks: [] }

--- a/tests/unit/store/assets.spec.js
+++ b/tests/unit/store/assets.spec.js
@@ -7,6 +7,7 @@ vi.mock('@/store', () => ({ default: {} }))
 import assetsStore from '@/store/modules/assets'
 import assetsApi from '@/store/api/assets'
 import entitiesApi from '@/store/api/entities'
+import taskStatusStore from '@/store/modules/taskstatus'
 import { buildAssetIndex } from '@/lib/indexing'
 
 const baseRootGetters = () => ({
@@ -161,6 +162,50 @@ describe('Assets store', () => {
       expect(
         assetsStore.cache.assets.filter(a => a.id === 'a2')
       ).toHaveLength(1)
+    })
+  })
+
+  describe('LOAD_ASSETS_END', () => {
+    test('keeps the task own metadata (task descriptors) on reload', () => {
+      taskStatusStore.cache.taskStatusMap = new Map([
+        ['ts1', { id: 'ts1', short_name: 'wip' }]
+      ])
+      const task = {
+        id: 't1',
+        task_type_id: 'tt1',
+        task_status_id: 'ts1',
+        assignees: [],
+        duration: 0,
+        estimation: 0,
+        data: { revision_note: 'keep me' }
+      }
+      const asset = {
+        id: 'a1',
+        name: 'A1',
+        asset_type_id: 'type1',
+        asset_type_name: 'Char',
+        canceled: false,
+        data: { color: 'blue' },
+        tasks: [task]
+      }
+      const taskMap = new Map()
+
+      assetsStore.mutations.LOAD_ASSETS_END(
+        { assetSearchText: '' },
+        {
+          production: { id: 'p1' },
+          assets: [asset],
+          userFilters: {},
+          userFilterGroups: {},
+          personMap: new Map(),
+          taskMap,
+          taskTypeMap: new Map([
+            ['tt1', { id: 'tt1', name: 'Modeling', priority: 1 }]
+          ])
+        }
+      )
+
+      expect(taskMap.get('t1').data).toEqual({ revision_note: 'keep me' })
     })
   })
 


### PR DESCRIPTION
**Problem**

- CSV exports of assets, shots and edits write the raw ID for person-type metadata columns instead of the person's name
- Metadata set on asset tasks disappears on page reload: asset loading overwrites each task's own data with the asset's metadata

**Solution**

- Resolve person descriptors through personMap and export the full name (empty when the person is unknown)
- Stop overwriting task.data when registering asset tasks; fix the SET_TASK_EXTRA_DATA guard to compare entity_data instead
- Add unit tests covering both regressions