### PR TITLE
[imports] Restyle CSV import modals and fix task type metadata matching

### DIFF
--- a/src/components/modals/ImportModal.vue
+++ b/src/components/modals/ImportModal.vue
@@ -4,29 +4,23 @@
     :title="$t('main.csv.import_title')"
     @cancel="$emit('cancel')"
   >
-    <div v-if="columns.length > 0" class="mb1">
-      {{ $t('main.csv.required_fields') }}
-      <ul>
-        <li v-for="column in columns" :key="column">
-          {{ column }}
-        </li>
-      </ul>
-    </div>
-    <div v-if="optionalColumns.length > 0" class="mb1">
-      {{ $t('main.csv.optional_fields') }}
-      <ul>
-        <li v-for="optionalColumn in optionalColumns" :key="optionalColumn">
-          {{ optionalColumn }}
-        </li>
-      </ul>
-    </div>
-    <div v-if="genericColumns.length > 0" class="mb1">
-      {{ $t('main.csv.generic_fields') }}
-      <ul>
-        <li v-for="genericColumn in genericColumns" :key="genericColumn">
-          {{ genericColumn }}
-        </li>
-      </ul>
+    <div class="columns-info" v-if="columnGroups.length > 0">
+      <div
+        class="column-group"
+        :key="group.label"
+        v-for="group in columnGroups"
+      >
+        <span class="group-label">{{ group.label }}</span>
+        <div class="column-tags">
+          <span
+            :class="{ 'column-tag': true, required: group.required }"
+            :key="column"
+            v-for="column in group.columns"
+          >
+            {{ column }}
+          </span>
+        </div>
+      </div>
     </div>
 
     <div class="tabs">
@@ -49,16 +43,17 @@
     </div>
     <div v-show="activeTab === 'file'">
       <p>{{ $t('main.csv.select_file') }}</p>
-      <file-upload
+      <file-upload-zone
         ref="inputFile"
-        @fileselected="onFileSelected"
+        accept=".csv"
         :label="$t('main.csv.upload_file')"
+        @fileselected="onFileSelected"
       />
     </div>
     <div v-show="activeTab === 'text'">
       <p>{{ $t('main.csv.paste_code') }}</p>
       <textarea
-        class="paste-area"
+        class="paste-area input"
         :placeholder="pasteAreaPlaceholder"
         v-model.trim="pastedCode"
       ></textarea>
@@ -83,7 +78,7 @@ import { useI18n } from 'vue-i18n'
 import BaseModal from '@/components/modals/BaseModal.vue'
 import ModalFooter from '@/components/modals/ModalFooter.vue'
 // eslint-disable-next-line no-unused-vars
-import FileUpload from '@/components/widgets/FileUpload.vue'
+import FileUploadZone from '@/components/widgets/FileUploadZone.vue'
 
 const { t } = useI18n()
 
@@ -113,6 +108,18 @@ const tabs = computed(() => [
   { id: 'file', name: t('main.csv.tab_select_file') },
   { id: 'text', name: t('main.csv.tab_paste_code') }
 ])
+
+const columnGroups = computed(() =>
+  [
+    {
+      label: t('main.csv.required_fields'),
+      columns: props.columns,
+      required: true
+    },
+    { label: t('main.csv.optional_fields'), columns: props.optionalColumns },
+    { label: t('main.csv.generic_fields'), columns: props.genericColumns }
+  ].filter(group => group.columns.length > 0)
+)
 
 const isValid = computed(
   () =>
@@ -150,15 +157,61 @@ defineExpose({ reset })
 </script>
 
 <style lang="scss" scoped>
+:deep(.modal-content) {
+  width: 800px;
+  max-width: calc(100vw - 4rem);
+}
+
+.columns-info {
+  background: var(--background-alt);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  margin-bottom: 1.6em;
+  padding: 1.2em 1.4em;
+}
+
+.group-label {
+  color: var(--text-alt);
+  display: block;
+  font-size: 0.9em;
+  margin-bottom: 0.5em;
+}
+
+.column-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4em;
+}
+
+.column-tag {
+  background: var(--background-tag);
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 0.9em;
+  padding: 0.2em 0.6em;
+
+  &.required {
+    font-weight: 600;
+  }
+}
+
 .tabs ul {
   margin-left: 0;
 }
 
 .paste-area {
-  margin: 0 0 1rem;
-  width: 100%;
-  min-height: 10rem;
-  padding: 0.5rem;
+  font-family: monospace;
+  font-size: 0.95em;
+  height: auto;
+  line-height: 1.6;
+  margin: 1em 0;
+  min-height: 12rem;
+  padding: 0.8em 1em;
   resize: vertical;
+  white-space: pre;
+  width: 100%;
 }
 </style>

--- a/src/components/modals/ImportModal.vue
+++ b/src/components/modals/ImportModal.vue
@@ -162,8 +162,12 @@ defineExpose({ reset })
   max-width: calc(100vw - 4rem);
 }
 
+:deep(.modal-content .box h2.title) {
+  margin-bottom: 0.5em;
+}
+
 .columns-info {
-  background: var(--background-alt);
+  background: $white-grey-light;
   border: 1px solid var(--border);
   border-radius: 10px;
   display: flex;
@@ -200,6 +204,10 @@ defineExpose({ reset })
 
 .tabs ul {
   margin-left: 0;
+}
+
+.dark .columns-info {
+  background: var(--background-alt);
 }
 
 .paste-area {

--- a/src/components/modals/ImportRenderModal.vue
+++ b/src/components/modals/ImportRenderModal.vue
@@ -173,6 +173,9 @@ const shotMetadataDescriptors = computed(
 const editMetadataDescriptors = computed(
   () => store.getters.editMetadataDescriptors
 )
+const taskMetadataDescriptors = computed(
+  () => store.getters.taskMetadataDescriptors
+)
 
 const columnsRequired = computed(() => {
   if (props.parsedCsv.length === 0) return []
@@ -192,6 +195,13 @@ const columnsOptional = computed(() => {
 
 const metadataDescriptors = computed(() => {
   const path = route.path
+  // The task type route also contains the entity type segment
+  // (/productions/:id/:type/task-types/:id), so check task-types first.
+  if (path.indexOf('task-types') > 0) {
+    return taskMetadataDescriptors.value.filter(
+      descriptor => descriptor.task_type_id === route.params.task_type_id
+    )
+  }
   if (path.indexOf('assets') > 0) return assetMetadataDescriptors.value
   if (path.indexOf('shots') > 0) return shotMetadataDescriptors.value
   if (path.indexOf('edits') > 0) return editMetadataDescriptors.value

--- a/src/components/modals/ImportRenderModal.vue
+++ b/src/components/modals/ImportRenderModal.vue
@@ -7,53 +7,20 @@
     <p>
       {{ $t('main.csv.preview_required') }}
     </p>
-    <div class="description">
+    <div class="preview-info">
       <div v-if="!disableUpdate">
-        <h2 class="legend-title">
-          {{ $t('main.csv.options.title') }}
-        </h2>
+        <span class="group-label">{{ $t('main.csv.options.title') }}</span>
         <checkbox
           :toggle="true"
           :label="$t('main.csv.options.update')"
           v-model="updateData"
         />
       </div>
-      <h3 class="legend-title">
-        {{ $t('main.csv.legend') }}
-      </h3>
-      <div class="flexrow legends">
-        <ul class="legend flexrow-item">
-          <li class="legend-definition">
-            <span class="legend-term"></span>
-            {{ $t('main.csv.legend_ok') }}
-          </li>
-          <li class="legend-definition">
-            <span class="legend-term ignored"></span>
-            {{ $t('main.csv.legend_ignored') }}
-          </li>
-          <li class="legend-definition">
-            <span class="legend-term missing"></span>
-            {{ $t('main.csv.legend_missing') }}
-          </li>
-          <li class="legend-definition">
-            <span class="legend-term missing-optional"></span>
-            {{ $t('main.csv.legend_missing_optional') }}
-          </li>
-        </ul>
-        <ul class="legend flexrow-item">
-          <li class="legend-definition">
-            <span class="legend-term"></span>
-            {{ $t('main.csv.legend_line_ok') }}
-          </li>
-          <li class="legend-definition">
-            <span class="legend-term disabled"></span>
-            {{ $t('main.csv.legend_disabled') }}
-          </li>
-          <li v-if="!disableUpdate" class="legend-definition">
-            <span class="legend-term overwrite"></span>
-            {{ $t('main.csv.legend_overwrite') }}
-          </li>
-        </ul>
+      <div class="legend-items">
+        <span class="legend-item" :key="item.label" v-for="item in legendItems">
+          <span class="legend-term" :class="item.state"></span>
+          {{ item.label }}
+        </span>
       </div>
     </div>
 
@@ -249,6 +216,21 @@ const columnOptions = computed(() => {
   return options
 })
 
+const legendItems = computed(() => {
+  const items = [
+    { state: '', label: t('main.csv.legend_ok') },
+    { state: 'ignored', label: t('main.csv.legend_ignored') },
+    { state: 'missing', label: t('main.csv.legend_missing') },
+    { state: 'missing-optional', label: t('main.csv.legend_missing_optional') },
+    { state: '', label: t('main.csv.legend_line_ok') },
+    { state: 'disabled', label: t('main.csv.legend_disabled') }
+  ]
+  if (!props.disableUpdate) {
+    items.push({ state: 'overwrite', label: t('main.csv.legend_overwrite') })
+  }
+  return items
+})
+
 // columnSelect intentionally returns parsedCsv[0] directly so that
 // `v-model="columnSelect[index]"` mutates the underlying array — the
 // template expects to write back into the parsed CSV header row.
@@ -314,92 +296,98 @@ watch(
 </script>
 
 <style lang="scss" scoped>
-.dark {
-  .render-container {
-    .render {
-      th,
-      td {
-        border: 1px solid $dark-grey-lightest;
-        color: $white;
-      }
-      tr:not(.render-headers):hover {
-        background-color: $dark-grey-lightmore;
-      }
-    }
-  }
-  .render-select {
-    border-color: $dark-grey-lightest;
-  }
-  .legend-term {
-    border: 1px solid $dark-grey-lightest;
-  }
-  .ignored {
-    background-color: $dark-grey;
-  }
-  .disabled {
-    background: repeating-linear-gradient(
-      -45deg,
-      rgba($dark-grey, 0.6),
-      rgba($dark-grey, 0.6) 2px,
-      transparent 2px,
-      transparent 10px
-    );
-  }
-}
-.modal-content {
-  margin: 6rem auto 1.4rem;
+:deep(.modal-content) {
   max-width: calc(100vw - 4rem);
-  max-height: calc(100% - 6rem);
+  min-width: min(800px, calc(100vw - 4rem));
   width: auto;
 }
-.modal-content .box p.text {
-  margin-bottom: 1em;
+
+:deep(.modal-content .box h2.title) {
+  margin-bottom: 0.5em;
 }
-.error {
-  margin-top: 1em;
+
+.preview-info {
+  background: $white-grey-light;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2em;
+  margin: 1.6em 0;
+  padding: 1.2em 1.4em;
 }
-.description {
-  margin-bottom: 1em;
-  margin-top: 2em;
-  .flex-item {
-    flex: 1 1 50%;
-  }
+
+.group-label {
+  color: var(--text-alt);
+  display: block;
+  font-size: 0.9em;
+  margin-bottom: 0.5em;
 }
+
+.legend-items {
+  column-gap: 1.5em;
+  display: flex;
+  flex-wrap: wrap;
+  row-gap: 0.5em;
+}
+
+.legend-item {
+  align-items: center;
+  color: var(--text);
+  display: flex;
+  font-size: 0.9em;
+  gap: 0.5em;
+}
+
+.legend-term {
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  display: inline-block;
+  flex-shrink: 0;
+  height: 1.2em;
+  width: 1.2em;
+}
+
 .render-container {
-  max-height: 300px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  max-height: 50vh;
   overflow: auto;
-  .render-headers {
-    .field {
-      margin: 0;
-    }
+
+  .render-headers .field {
+    margin: 0;
   }
+
   .render {
     width: 100%;
-    border: 1px solid $light-grey-light;
+
     th,
     td {
-      color: $dark-grey;
-      border: 1px solid $light-grey-light;
+      border: 1px solid var(--border);
+      color: var(--text);
       padding: 0.75rem;
     }
+
     tr:hover {
       background: none;
     }
+
     tr:not(.render-headers):hover {
-      background-color: $white-grey-light;
+      background-color: var(--background-hover);
     }
   }
 }
 
 .render-select {
+  border-bottom: 1px solid var(--border);
   margin-bottom: 0.75rem;
   padding-bottom: 0.75rem;
-  border-bottom: 1px solid $light-grey-light;
 }
 
 .new-entities {
   border: 1px solid $orange-carrot;
-  border-radius: 4px;
+  border-radius: 10px;
   margin-top: 1em;
   padding: 1em;
 
@@ -421,47 +409,12 @@ watch(
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-top: 2rem;
-}
+  margin-top: 1rem;
 
-.modal-content .box h2.title {
-  margin-bottom: 0;
-}
-
-.legend-title {
-  color: var(--text);
-  font-size: 1em;
-  font-weight: bold;
-  margin-bottom: 1.5em;
-  margin-top: 0;
-  text-transform: uppercase;
-}
-
-.legends {
-  align-items: flex-start;
-}
-
-.legend {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.legend-term {
-  display: inline-block;
-  margin-right: 0.5rem;
-  width: 1.5rem;
-  height: 1.5rem;
-  border: 1px solid $light-grey-light;
-}
-.legend-definition {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  margin: 0 1rem 0.5rem 0;
+  // The row provides the spacing, neutralize ModalFooter's own top margin
+  .modal-footer {
+    margin-top: 0;
+  }
 }
 
 .ignored {
@@ -476,18 +429,10 @@ watch(
   background-color: rgba($red, 0.2);
 }
 
-.optional-header,
-.required-header {
-  vertical-align: bottom;
-}
-
-col.missing-optional,
-col.missing {
+th.optional-header,
+th.required-header {
   min-width: 150px;
-
-  th {
-    vertical-align: bottom;
-  }
+  vertical-align: bottom;
 }
 
 .disabled {
@@ -500,11 +445,32 @@ col.missing {
     transparent 10px
   );
 }
+
 .overwrite {
   background-color: rgba($blue, 0.2);
 
   &:hover td {
     background-color: rgba($blue, 0.3);
+  }
+}
+
+.dark {
+  .preview-info {
+    background: var(--background-alt);
+  }
+
+  .ignored {
+    background-color: $dark-grey;
+  }
+
+  .disabled {
+    background: repeating-linear-gradient(
+      -45deg,
+      rgba($dark-grey, 0.6),
+      rgba($dark-grey, 0.6) 2px,
+      transparent 2px,
+      transparent 10px
+    );
   }
 }
 </style>

--- a/src/components/pages/TaskType.vue
+++ b/src/components/pages/TaskType.vue
@@ -376,6 +376,7 @@
           :form-data="importCsvFormData"
           :columns="dataMatchers"
           :optional-columns="optionalColumns"
+          :generic-columns="genericColumns"
           @cancel="hideImportModal"
           @confirm="renderImport"
         />
@@ -573,6 +574,7 @@ const taskStatusIdFilter = ref(null)
 let taskIndex = null
 
 const dataMatchers = ['Parent', 'Entity']
+const genericColumns = ['Metadata column name (text value)']
 const difficultyOptions = [
   { label: 'all_tasks', value: '-1' },
   { label: 'difficulty.very_easy', value: '1' },

--- a/src/components/widgets/FileUploadZone.vue
+++ b/src/components/widgets/FileUploadZone.vue
@@ -82,9 +82,10 @@ defineExpose({
     cursor: pointer;
     font-weight: 500;
 
+    // Neutralize Bulma's button hover, the zone-level hover is enough feedback
     &:hover {
       background: transparent;
-      color: var(--background-selectable, $purple-strong);
+      color: var(--text);
     }
   }
 }


### PR DESCRIPTION
**Problem**

- The CSV import and preview modals were stuck at 640px, with raw column lists, a bulky legend and dead scoped width styles
- On task type pages the preview offered the entity metadata descriptors instead of those of the current task type (route sniffing matched the entity segment first)

**Solution**

- Widen both modals, present column hints and legend as compact info panels, reuse the shared upload drop zone and switch the paste area to monospace
- Match task-types routes first, filter Task descriptors on the current task type, and list metadata columns in the task type import modal (server side handled in cgwire/zou#1181)