### PR TITLE
[tasks] Resolve reply authors when a realtime reply arrives

### DIFF
--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -1532,6 +1532,11 @@ const mutations = {
       const localComment = state.taskComments[comment.object_id].find(
         c => c.id === comment.id
       )
+      if (!localComment) return
+      // Raw replies only carry person_id, so the author has to be resolved
+      // here too. Without it a reply arriving through the realtime event
+      // renders with a broken avatar until the page is reloaded.
+      helpers.enrichCommentAuthors(comment)
       localComment.replies = comment.replies
     }
   },


### PR DESCRIPTION
### Problem

When a reply is posted, everyone else in the conversation sees it appear with a broken avatar. Reloading the page fixes it.

`UPDATE_COMMENT_REPLIES` assigns `comment.replies` exactly as received. Raw replies only carry `person_id`, so the reply that arrives through the `comment:reply` realtime event never gets its author resolved. The POST response path goes through `enrichCommentAuthors`, which is why the author of the reply sees it render correctly and only the other participants see it break.

### Fix

Call the same `helpers.enrichCommentAuthors(comment)` before assigning the replies. It already walks `comment.replies`, so no separate handling is needed.

Also return early when the comment is not in the local store — `find()` can return `undefined` and the next line dereferences it.

### Notes

Reproduced on 1.0.55 and running with this patch in production since 2026-08-03: replies now render with the correct avatar immediately, no reload needed.