### PR TITLE
[tasks] Show the comment box to someone who was mentioned

### DIFF
--- a/src/components/pages/Task.vue
+++ b/src/components/pages/Task.vue
@@ -317,6 +317,7 @@
                 :is-loading="loading.addComment"
                 :is-movie="isMovie"
                 :is-picture="isPicture"
+                :is-status-locked="isMentionedOnly"
                 :team="currentTeam"
                 :task-types="currentTaskTypes"
                 :task="task"
@@ -365,6 +366,7 @@
                     :is-replyable="
                       (user && user.id === comment.person?.id) ||
                       isAssigned ||
+                      isMentioned ||
                       isDepartmentSupervisor ||
                       isCurrentUserManager
                     "
@@ -951,9 +953,38 @@ export default {
       )
     },
 
+    isMentioned() {
+      const personId = this.user?.id
+      if (!personId) return false
+      const departmentIds = this.user.departments || []
+      // Replies carry their own mentions, and that is where people usually
+      // get named once a conversation is going.
+      const namesUser = entry =>
+        (entry.mentions || []).includes(personId) ||
+        (entry.department_mentions || []).some(departmentId =>
+          departmentIds.includes(departmentId)
+        )
+      return this.taskComments.some(
+        comment => namesUser(comment) || (comment.replies || []).some(namesUser)
+      )
+    },
+
+    // In the conversation only because someone named them: they may answer,
+    // but the status stays where the assignees left it.
+    isMentionedOnly() {
+      return (
+        this.isMentioned &&
+        !this.isAssigned &&
+        !this.isCurrentUserClient &&
+        !this.isDepartmentSupervisor &&
+        !this.isCurrentUserManager
+      )
+    },
+
     isCommentingAllowed() {
       return (
         this.isAssigned ||
+        this.isMentioned ||
         this.isCurrentUserClient ||
         this.isDepartmentSupervisor ||
         this.isCurrentUserManager

--- a/src/components/sides/TaskInfo.vue
+++ b/src/components/sides/TaskInfo.vue
@@ -193,6 +193,7 @@
                   :revision="currentRevision"
                   :is-movie="isMoviePreview"
                   :is-picture="isPicturePreview"
+                  :is-status-locked="isMentionedOnly"
                   @add-comment="postComment"
                   @add-preview="onAddPreviewClicked"
                   @file-drop="selectFile"
@@ -237,6 +238,7 @@
                       :is-replyable="
                         (user && user.id === comment.person?.id) ||
                         isAssigned ||
+                        isMentioned ||
                         isDepartmentSupervisor ||
                         isCurrentUserManager ||
                         isClientFromSameStudio(comment.person)
@@ -653,10 +655,38 @@ const isAssigned = computed(
   () => props.task?.assignees?.includes(user.value?.id) ?? false
 )
 
+const isMentioned = computed(() => {
+  const personId = user.value?.id
+  if (!personId) return false
+  const departmentIds = user.value.departments || []
+  // Replies carry their own mentions, and that is where people usually get
+  // named once a conversation is going.
+  const namesUser = entry =>
+    (entry.mentions || []).includes(personId) ||
+    (entry.department_mentions || []).some(departmentId =>
+      departmentIds.includes(departmentId)
+    )
+  return taskComments.value.some(
+    comment => namesUser(comment) || (comment.replies || []).some(namesUser)
+  )
+})
+
+// In the conversation only because someone named them: they may answer,
+// but the status stays where the assignees left it.
+const isMentionedOnly = computed(
+  () =>
+    isMentioned.value &&
+    !isAssigned.value &&
+    !isCurrentUserClient.value &&
+    !isDepartmentSupervisor.value &&
+    !isCurrentUserManager.value
+)
+
 const isCommentingAllowed = computed(
   () =>
     props.task &&
     (isAssigned.value ||
+      isMentioned.value ||
       isCurrentUserClient.value ||
       isDepartmentSupervisor.value ||
       isCurrentUserManager.value)

--- a/src/components/widgets/AddComment.vue
+++ b/src/components/widgets/AddComment.vue
@@ -331,6 +331,7 @@
             :task-status-list="taskStatus"
             :production-id="task.project_id"
             v-model="task_status_id"
+            v-if="!isStatusLocked"
           />
           <button-simple
             class="post-button"
@@ -480,6 +481,13 @@ const props = defineProps({
   isLoading: {
     type: Boolean,
     default: null
+  },
+  // Set for someone who is in the conversation only because they were
+  // mentioned: they may answer, but the status stays where the assignees
+  // left it. The API enforces the same rule.
+  isStatusLocked: {
+    type: Boolean,
+    default: false
   },
   task: {
     type: Object,
@@ -718,6 +726,12 @@ const runAddComment = (
   if (!isValidForm.value) {
     return
   }
+  if (props.isStatusLocked) {
+    // The selector is hidden in this mode, so nothing could have moved the
+    // status. Re-read it from the task anyway: the API rejects a comment
+    // that carries any other one.
+    task_status_id.value = props.task.task_status_id
+  }
   // A status id that no longer resolves usually means a stale cache, so tell
   // the user to reload rather than posting a comment with no status.
   const taskStatus = taskStatusMap.value.get(task_status_id.value)
@@ -820,6 +834,10 @@ const onInsertChecklistItem = item => {
 }
 
 const resetStatus = () => {
+  if (props.isStatusLocked) {
+    task_status_id.value = props.task.task_status_id
+    return
+  }
   const taskStatus = taskStatusMap.value.get(props.task.task_status_id)
   if (
     (!isCurrentUserArtist.value || taskStatus?.is_artist_allowed) &&


### PR DESCRIPTION
### Problem

Mentioning someone in a task sends them a notification and an email, they open the task — and there is no comment box. `isCommentingAllowed` covers assignees, clients, department supervisors and managers only, so the mention brings them in and the UI gives them no way to answer.

### What this changes

A mention counts as admission to the conversation. `isCommentingAllowed` and `is-replyable` also accept someone named in a comment of that task, directly or through one of their departments. The comment payload already carries `mentions` and `department_mentions`, so this needs no extra request.

Someone who is *only* there because they were mentioned should not move the task, so `AddComment` takes `isStatusLocked`: the status selector is hidden and the task's current status is sent. This is purely about not offering an action that would be refused — the API enforces the rule.

### Requires the API change

The permission check lives in Zou: cgwire/zou#1184. **Please do not merge this one alone** — without it the comment box appears and the API rejects the post.

### Status

Running in production since 2026-08-03 alongside the Zou patch, on 1.0.55 / Zou 1.0.62. Mentioned artists can answer, they see no status selector, and preview upload is still refused. `prettier --check` passes on the three files.