### PR TITLE
Fix the batch deletion of an already canceled selection

### DIFF
--- a/src/store/api/entities.js
+++ b/src/store/api/entities.js
@@ -5,11 +5,9 @@ export default {
     return client.pget(`/api/data/entities/${entityId}/news`)
   },
 
-  deleteEntities(projectId, entityIds) {
-    return client.ppost(
-      `/api/actions/projects/${projectId}/delete-entities`,
-      entityIds
-    )
+  deleteEntities(projectId, entityIds, force = false) {
+    const path = `/api/actions/projects/${projectId}/delete-entities`
+    return client.ppost(force ? `${path}?force=true` : path, entityIds)
   },
 
   getEntityPreviewFiles(entityId) {

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -835,19 +835,23 @@ const actions = {
   },
 
   async deleteSelectedAssets({ state, commit, rootGetters }) {
-    let selectedAssetIds = [...state.selectedAssets.values()]
-      .filter(asset => !asset.canceled)
-      .map(asset => asset.id)
-    if (selectedAssetIds.length === 0) {
-      selectedAssetIds = [...state.selectedAssets.keys()]
-    }
+    const activeAssets = [...state.selectedAssets.values()].filter(
+      asset => !asset.canceled
+    )
+    // Nothing left to cancel: the selection is already canceled, so the gesture
+    // is the hard deletion the unitary path forces on a canceled asset.
+    const force = activeAssets.length === 0
+    const selectedAssetIds = force
+      ? [...state.selectedAssets.keys()]
+      : activeAssets.map(asset => asset.id)
     const assets = selectedAssetIds
       .map(assetId => cache.assetMap.get(assetId))
       .filter(asset => asset)
     if (assets.length === 0) return
     await entitiesApi.deleteEntities(
       rootGetters.currentProduction.id,
-      assets.map(asset => asset.id)
+      assets.map(asset => asset.id),
+      force
     )
     // Store bookkeeping batched into a single mutation: a per-asset commit
     // costs a full list pass each.

--- a/src/store/modules/concepts.js
+++ b/src/store/modules/concepts.js
@@ -151,7 +151,10 @@ const actions = {
     if (concepts.length === 0) return
     await entitiesApi.deleteEntities(
       rootGetters.currentProduction.id,
-      concepts.map(concept => concept.id)
+      concepts.map(concept => concept.id),
+      // The unitary concept deletion always forces, so the selection does too:
+      // the store drops every concept below, canceled ones included.
+      true
     )
     concepts.forEach(concept => {
       commit(DELETE_CONCEPT_END, concept)

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -668,19 +668,23 @@ const actions = {
   },
 
   async deleteSelectedEdits({ state, commit, rootGetters }) {
-    let selectedEditIds = [...state.selectedEdits.values()]
-      .filter(edit => !edit.canceled)
-      .map(edit => edit.id)
-    if (selectedEditIds.length === 0) {
-      selectedEditIds = [...state.selectedEdits.keys()]
-    }
+    const activeEdits = [...state.selectedEdits.values()].filter(
+      edit => !edit.canceled
+    )
+    // Nothing left to cancel: the selection is already canceled, so the gesture
+    // is the hard deletion the unitary path forces on a canceled edit.
+    const force = activeEdits.length === 0
+    const selectedEditIds = force
+      ? [...state.selectedEdits.keys()]
+      : activeEdits.map(edit => edit.id)
     const edits = selectedEditIds
       .map(editId => cache.editMap.get(editId))
       .filter(edit => edit)
     if (edits.length === 0) return
     await entitiesApi.deleteEntities(
       rootGetters.currentProduction.id,
-      edits.map(edit => edit.id)
+      edits.map(edit => edit.id),
+      force
     )
     edits.forEach(edit => {
       if (edit.tasks.length > 0 && !edit.canceled) {

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -817,19 +817,23 @@ const actions = {
   },
 
   async deleteSelectedShots({ state, commit, rootGetters }) {
-    let selectedShotIds = [...state.selectedShots.values()]
-      .filter(shot => !shot.canceled)
-      .map(shot => shot.id)
-    if (selectedShotIds.length === 0) {
-      selectedShotIds = [...state.selectedShots.keys()]
-    }
+    const activeShots = [...state.selectedShots.values()].filter(
+      shot => !shot.canceled
+    )
+    // Nothing left to cancel: the selection is already canceled, so the gesture
+    // is the hard deletion the unitary path forces on a canceled shot.
+    const force = activeShots.length === 0
+    const selectedShotIds = force
+      ? [...state.selectedShots.keys()]
+      : activeShots.map(shot => shot.id)
     const shots = selectedShotIds
       .map(shotId => cache.shotMap.get(shotId))
       .filter(shot => shot)
     if (shots.length === 0) return
     await entitiesApi.deleteEntities(
       rootGetters.currentProduction.id,
-      shots.map(shot => shot.id)
+      shots.map(shot => shot.id),
+      force
     )
     // Store bookkeeping batched into a single mutation: a per-shot commit
     // costs a full list pass each.

--- a/tests/unit/store/api/entities.spec.js
+++ b/tests/unit/store/api/entities.spec.js
@@ -1,0 +1,36 @@
+import { vi } from 'vitest'
+
+vi.mock('@/store/api/client', () => ({
+  default: { ppost: vi.fn() }
+}))
+
+import client from '@/store/api/client'
+import entitiesApi from '@/store/api/entities'
+
+describe('store/api/entities', () => {
+  beforeEach(() => {
+    client.ppost.mockClear()
+  })
+
+  describe('deleteEntities', () => {
+    test('posts the ids alone when the deletion is not forced', () => {
+      entitiesApi.deleteEntities('p1', ['asset-1', 'asset-2'])
+
+      expect(client.ppost).toHaveBeenCalledWith(
+        '/api/actions/projects/p1/delete-entities',
+        ['asset-1', 'asset-2']
+      )
+    })
+
+    // Same serialization as the unitary routes (`/data/assets/<id>?force=true`):
+    // without it the backend only cancels entities that still have tasks.
+    test('appends force=true when the deletion is forced', () => {
+      entitiesApi.deleteEntities('p1', ['asset-1'], true)
+
+      expect(client.ppost).toHaveBeenCalledWith(
+        '/api/actions/projects/p1/delete-entities?force=true',
+        ['asset-1']
+      )
+    })
+  })
+})

--- a/tests/unit/store/assets.spec.js
+++ b/tests/unit/store/assets.spec.js
@@ -349,14 +349,48 @@ describe('Assets store', () => {
       })
 
       expect(entitiesApi.deleteEntities).toHaveBeenCalledTimes(1)
-      expect(entitiesApi.deleteEntities).toHaveBeenCalledWith('p1', [
-        'asset-1',
-        'asset-2'
-      ])
+      expect(entitiesApi.deleteEntities).toHaveBeenCalledWith(
+        'p1',
+        ['asset-1', 'asset-2'],
+        false
+      )
       expect(commit).toHaveBeenCalledTimes(1)
       expect(commit).toHaveBeenCalledWith('REMOVE_ASSETS', {
         removedAssets: [assetToRemove],
         canceledAssets: [assetToCancel]
+      })
+    })
+
+    test('deleteSelectedAssets forces the deletion of an already canceled selection', async () => {
+      const canceledAsset = buildAsset('asset-1', {
+        canceled: true,
+        tasks: ['task-1']
+      })
+      buildState([canceledAsset])
+      const state = {
+        selectedAssets: new Map([['asset-1', canceledAsset]])
+      }
+      const rootGetters = { currentProduction: { id: 'p1' } }
+
+      vi.spyOn(entitiesApi, 'deleteEntities').mockResolvedValue()
+      const commit = vi.fn()
+
+      await assetsStore.actions.deleteSelectedAssets({
+        state,
+        commit,
+        rootGetters
+      })
+
+      expect(entitiesApi.deleteEntities).toHaveBeenCalledWith(
+        'p1',
+        ['asset-1'],
+        true
+      )
+      // Really deleted server-side, so it leaves the list instead of staying
+      // struck through.
+      expect(commit).toHaveBeenCalledWith('REMOVE_ASSETS', {
+        removedAssets: [canceledAsset],
+        canceledAssets: []
       })
     })
   })

--- a/tests/unit/store/shots.spec.js
+++ b/tests/unit/store/shots.spec.js
@@ -187,14 +187,48 @@ describe('Shots store', () => {
       })
 
       expect(entitiesApi.deleteEntities).toHaveBeenCalledTimes(1)
-      expect(entitiesApi.deleteEntities).toHaveBeenCalledWith('p1', [
-        'shot-1',
-        'shot-2'
-      ])
+      expect(entitiesApi.deleteEntities).toHaveBeenCalledWith(
+        'p1',
+        ['shot-1', 'shot-2'],
+        false
+      )
       expect(commit).toHaveBeenCalledTimes(1)
       expect(commit).toHaveBeenCalledWith('REMOVE_SHOTS', {
         removedShots: [shotToRemove],
         canceledShots: [shotToCancel]
+      })
+    })
+
+    test('deleteSelectedShots forces the deletion of an already canceled selection', async () => {
+      const canceledShot = buildShot('shot-1', {
+        canceled: true,
+        tasks: ['task-1']
+      })
+      buildState([canceledShot])
+      const state = {
+        selectedShots: new Map([['shot-1', canceledShot]])
+      }
+      const rootGetters = { currentProduction: { id: 'p1' } }
+
+      vi.spyOn(entitiesApi, 'deleteEntities').mockResolvedValue()
+      const commit = vi.fn()
+
+      await shotsStore.actions.deleteSelectedShots({
+        state,
+        commit,
+        rootGetters
+      })
+
+      expect(entitiesApi.deleteEntities).toHaveBeenCalledWith(
+        'p1',
+        ['shot-1'],
+        true
+      )
+      // Really deleted server-side, so it leaves the list instead of staying
+      // struck through.
+      expect(commit).toHaveBeenCalledWith('REMOVE_SHOTS', {
+        removedShots: [canceledShot],
+        canceledShots: []
       })
     })
 


### PR DESCRIPTION
**Problem**
- Deleting a selection of already canceled assets removed them from the list, but they came back on the next reload.

**Solution**
- Send the `force` parameter to delete the selected assets and their tasks for real.