### PR TITLE
[lists] Fix task cell links and extend them to all entity grids

### DIFF
--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -242,21 +242,11 @@ const onClick = event => {
   if (props.clickable) select(event)
 }
 
+// The href only serves middle click and the context menu, which never fire
+// click: block navigation on every click so modified clicks (ctrl = additive
+// select, shift = range select in entity_list.js) keep bubbling to onClick.
 const onTaskLinkClick = event => {
-  if (!props.taskHref) return
-  if (
-    // Preserve native non-left-click behavior.
-    event.button !== 0 ||
-    // Preserve native modifier-click behavior.
-    event.ctrlKey ||
-    event.metaKey ||
-    event.shiftKey ||
-    event.altKey
-  ) {
-    event.stopPropagation()
-  } else {
-    event.preventDefault()
-  }
+  if (props.taskHref) event.preventDefault()
 }
 
 watch(() => props.taskTest, resolveTask)

--- a/src/components/cells/ValidationCell.vue
+++ b/src/components/cells/ValidationCell.vue
@@ -291,8 +291,12 @@ defineExpose({
 .task-link {
   color: inherit;
   display: block;
-  margin-block: -0.275rem;
-  padding-block: 0.275rem;
+  // Not the margin-block/padding-block shorthands: Safari 14.1+, the
+  // supported floor is Safari 14.
+  margin-top: -0.275rem;
+  margin-bottom: -0.275rem;
+  padding-top: 0.275rem;
+  padding-bottom: 0.275rem;
   text-decoration: none;
 }
 

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -1048,17 +1048,25 @@ export default {
 
     taskHref(taskId) {
       const task = this.taskMap.get(taskId)
-      return task
-        ? this.$router.resolve(
-            getTaskPath(
-              task,
-              this.currentProduction,
-              this.isTVShow,
-              this.currentEpisode,
-              this.taskTypeMap
-            )
-          ).href
-        : ''
+      if (!task) return ''
+      // Called for every cell on every render: memoize the router.resolve,
+      // the result only changes with the production/episode context
+      // (watchers below reset the cache).
+      if (!this.taskHrefCache) this.taskHrefCache = new Map()
+      let href = this.taskHrefCache.get(taskId)
+      if (href === undefined) {
+        href = this.$router.resolve(
+          getTaskPath(
+            task,
+            this.currentProduction,
+            this.isTVShow,
+            this.currentEpisode,
+            this.taskTypeMap
+          )
+        ).href
+        this.taskHrefCache.set(taskId, href)
+      }
+      return href
     },
 
     assetPath(assetId) {
@@ -1150,6 +1158,14 @@ export default {
   watch: {
     displayedAssets() {
       this.$options.lineIndex = {}
+    },
+
+    currentProduction() {
+      this.taskHrefCache = null
+    },
+
+    currentEpisode() {
+      this.taskHrefCache = null
     },
 
     validationColumns: {

--- a/src/components/lists/AssetList.vue
+++ b/src/components/lists/AssetList.vue
@@ -612,7 +612,7 @@ import { selectionListMixin } from '@/components/mixins/selection'
 
 import emptyAssetIllustration from '@/assets/illustrations/empty_asset.png'
 import preferences from '@/lib/preferences'
-import { getTaskPath } from '@/lib/path'
+import { getTaskHref } from '@/lib/path'
 import { sortTaskTypes } from '@/lib/sorting'
 import { range } from '@/lib/time'
 
@@ -1047,26 +1047,14 @@ export default {
     },
 
     taskHref(taskId) {
-      const task = this.taskMap.get(taskId)
-      if (!task) return ''
-      // Called for every cell on every render: memoize the router.resolve,
-      // the result only changes with the production/episode context
-      // (watchers below reset the cache).
-      if (!this.taskHrefCache) this.taskHrefCache = new Map()
-      let href = this.taskHrefCache.get(taskId)
-      if (href === undefined) {
-        href = this.$router.resolve(
-          getTaskPath(
-            task,
-            this.currentProduction,
-            this.isTVShow,
-            this.currentEpisode,
-            this.taskTypeMap
-          )
-        ).href
-        this.taskHrefCache.set(taskId, href)
-      }
-      return href
+      return getTaskHref(
+        this.$router,
+        this.taskMap.get(taskId),
+        this.currentProduction,
+        this.isTVShow,
+        this.currentEpisode,
+        this.taskTypeMap
+      )
     },
 
     assetPath(assetId) {
@@ -1158,14 +1146,6 @@ export default {
   watch: {
     displayedAssets() {
       this.$options.lineIndex = {}
-    },
-
-    currentProduction() {
-      this.taskHrefCache = null
-    },
-
-    currentEpisode() {
-      this.taskHrefCache = null
     },
 
     validationColumns: {

--- a/src/components/lists/EditList.vue
+++ b/src/components/lists/EditList.vue
@@ -344,6 +344,7 @@
                   :row-x="i"
                   :selected="isSelected(i, j)"
                   :sticked="true"
+                  :task-href="taskHref(edit.validations.get(columnId))"
                   :task-test="taskMap.get(edit.validations.get(columnId))"
                   @select="infos => onTaskSelected(infos, true)"
                   @unselect="infos => onTaskUnselected(infos, true)"
@@ -421,6 +422,7 @@
                   :key="`${columnId}-${edit.id}`"
                   :column="taskTypeMap.get(columnId)"
                   :entity="edit"
+                  :task-href="taskHref(edit.validations?.get(columnId))"
                   :task-test="
                     taskMap.get(
                       edit.validations ? edit.validations.get(columnId) : null
@@ -496,6 +498,7 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 
+import { getTaskHref } from '@/lib/path'
 import preferences from '@/lib/preferences'
 import { range } from '@/lib/time'
 
@@ -729,6 +732,17 @@ export default {
 
     loadMoreEdits() {
       this.displayMoreEdits()
+    },
+
+    taskHref(taskId) {
+      return getTaskHref(
+        this.$router,
+        this.taskMap.get(taskId),
+        this.currentProduction,
+        this.isTVShow,
+        this.currentEpisode,
+        this.taskTypeMap
+      )
     },
 
     editPath(editId) {

--- a/src/components/lists/EpisodeList.vue
+++ b/src/components/lists/EpisodeList.vue
@@ -326,6 +326,7 @@
                   :row-x="i"
                   :selected="isSelected(i, j)"
                   :sticked="true"
+                  :task-href="taskHref(episode.validations.get(columnId))"
                   :task-test="taskMap.get(episode.validations.get(columnId))"
                   @select="infos => onTaskSelected(infos, true)"
                   @unselect="infos => onTaskUnselected(infos, true)"
@@ -467,6 +468,7 @@
                   :contact-sheet="displaySettings.contactSheetMode"
                   :column="taskTypeMap.get(columnId)"
                   :entity="episode"
+                  :task-href="taskHref(episode.validations?.get(columnId))"
                   :task-test="
                     taskMap.get(
                       episode.validations
@@ -542,6 +544,8 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex'
+
+import { getTaskHref } from '@/lib/path'
 
 import { descriptorMixin } from '@/components/mixins/descriptors'
 import { domMixin } from '@/components/mixins/dom'
@@ -676,6 +680,7 @@ export default {
       'isCurrentUserAdmin',
       'isCurrentUserClient',
       'isSingleEpisode',
+      'isTVShow',
       'isEpisodeDescription',
       'isEpisodeEstimation',
       'isEpisodeResolution',
@@ -734,6 +739,17 @@ export default {
 
     isSelected(lineIndex, columnIndex) {
       return this.episodeSelectionGrid.has(`${lineIndex}-${columnIndex}`)
+    },
+
+    taskHref(taskId) {
+      return getTaskHref(
+        this.$router,
+        this.taskMap.get(taskId),
+        this.currentProduction,
+        this.isTVShow,
+        this.currentEpisode,
+        this.taskTypeMap
+      )
     },
 
     episodePath(episodeId) {

--- a/src/components/lists/SequenceList.vue
+++ b/src/components/lists/SequenceList.vue
@@ -313,6 +313,7 @@
                   :row-x="i"
                   :selected="isSelected(i, j)"
                   :sticked="true"
+                  :task-href="taskHref(sequence.validations.get(columnId))"
                   :task-test="taskMap.get(sequence.validations.get(columnId))"
                   @select="infos => onTaskSelected(infos, true)"
                   @unselect="infos => onTaskUnselected(infos, true)"
@@ -432,6 +433,7 @@
                   :key="`${columnId}-${sequence.id}`"
                   :column="taskTypeMap.get(columnId)"
                   :entity="sequence"
+                  :task-href="taskHref(sequence.validations?.get(columnId))"
                   :task-test="
                     taskMap.get(
                       sequence.validations
@@ -510,7 +512,7 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 
-import { getEntityPath } from '@/lib/path'
+import { getEntityPath, getTaskHref } from '@/lib/path'
 import { descriptorMixin } from '@/components/mixins/descriptors'
 import { domMixin } from '@/components/mixins/dom'
 import { entityListMixin } from '@/components/mixins/entity_list'
@@ -636,6 +638,7 @@ export default {
       'isCurrentUserAdmin',
       'isCurrentUserClient',
       'isSingleSequence',
+      'isTVShow',
       'isSequenceDescription',
       'isSequenceEstimation',
       'isSequenceResolution',
@@ -700,6 +703,17 @@ export default {
 
     isSelected(lineIndex, columnIndex) {
       return this.sequenceSelectionGrid.has(`${lineIndex}-${columnIndex}`)
+    },
+
+    taskHref(taskId) {
+      return getTaskHref(
+        this.$router,
+        this.taskMap.get(taskId),
+        this.currentProduction,
+        this.isTVShow,
+        this.currentEpisode,
+        this.taskTypeMap
+      )
     },
 
     sequencePath(sequenceId) {

--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -415,6 +415,7 @@
                   :row-x="getIndex(i, k)"
                   :selected="isSelected(i, k, j)"
                   :sticked="true"
+                  :task-href="taskHref(shot.validations.get(columnId))"
                   :task-test="taskMap.get(shot.validations.get(columnId))"
                   @select="infos => onTaskSelected(infos, true)"
                   @unselect="infos => onTaskUnselected(infos, true)"
@@ -734,6 +735,7 @@
                   :column="taskTypeMap.get(columnId)"
                   :contact-sheet="displaySettings.contactSheetMode"
                   :entity="shot"
+                  :task-href="taskHref(shot.validations?.get(columnId))"
                   :task-test="
                     taskMap.get(
                       shot.validations ? shot.validations.get(columnId) : null
@@ -824,6 +826,7 @@
 <script>
 import { mapGetters, mapActions } from 'vuex'
 
+import { getTaskHref } from '@/lib/path'
 import preferences from '@/lib/preferences'
 import { range } from '@/lib/time'
 import { formatToTimecode } from '@/lib/video'
@@ -1120,6 +1123,17 @@ export default {
 
     loadMoreShots() {
       this.displayMoreShots()
+    },
+
+    taskHref(taskId) {
+      return getTaskHref(
+        this.$router,
+        this.taskMap.get(taskId),
+        this.currentProduction,
+        this.isTVShow,
+        this.currentEpisode,
+        this.taskTypeMap
+      )
     },
 
     shotPath(shotId) {

--- a/src/components/lists/TaskList.vue
+++ b/src/components/lists/TaskList.vue
@@ -188,6 +188,7 @@
             </td>
             <validation-cell
               class="status unselectable"
+              :task-href="taskHref(task)"
               :task-test="task"
               :is-border="false"
               :is-assignees="false"
@@ -442,6 +443,7 @@ import {
   watch
 } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 
 import { pauseEvent } from '@/composables/dom'
@@ -452,6 +454,7 @@ import {
   getMetadataFieldValue,
   isSupervisorInDepartments
 } from '@/lib/descriptors'
+import { getTaskHref } from '@/lib/path'
 import {
   daysToMinutes,
   formatSimpleDate,
@@ -479,6 +482,7 @@ import ValidationTag from '@/components/widgets/ValidationTag.vue'
 
 // Composables
 const { t } = useI18n()
+const router = useRouter()
 const store = useStore()
 const { formatDuration, formatDisplayDate, isDurationInHours, organisation } =
   useFormat()
@@ -609,7 +613,9 @@ const taskRows = new Map()
 const { startBrowsing } = useGrabList(bodyRef)
 
 // Computed
+const currentEpisode = computed(() => store.getters.currentEpisode)
 const currentProduction = computed(() => store.getters.currentProduction)
+const isTVShow = computed(() => store.getters.isTVShow)
 const isCurrentUserProductionManager = computed(
   () => store.getters.isCurrentUserProductionManager
 )
@@ -683,6 +689,16 @@ const groupTasks = (entityMap, groupKey, nameField) => {
 }
 
 const getEntity = entityId => entityMap.value.get(entityId) || {}
+
+const taskHref = task =>
+  getTaskHref(
+    router,
+    task,
+    currentProduction.value,
+    isTVShow.value,
+    currentEpisode.value,
+    taskTypeMap.value
+  )
 
 const setTaskRow = (taskId, el) => {
   if (el) {

--- a/src/lib/path.js
+++ b/src/lib/path.js
@@ -42,6 +42,31 @@ export const getTaskPath = (
   return route
 }
 
+const taskHrefCache = new Map()
+
+// Grids call this for every cell on every render: resolving a route each
+// time is costly, so memoize by task and context. Entries are tiny and
+// contexts few, no eviction needed.
+export const getTaskHref = (
+  router,
+  task,
+  production,
+  isTVShow,
+  episode,
+  taskTypeMap
+) => {
+  if (!task) return ''
+  const key = [task.id, task.episode_id, production?.id, episode?.id].join(':')
+  let href = taskHrefCache.get(key)
+  if (href === undefined) {
+    href = router.resolve(
+      getTaskPath(task, production, isTVShow, episode, taskTypeMap)
+    ).href
+    taskHrefCache.set(key, href)
+  }
+  return href
+}
+
 export const getTaskEntityPath = (task, episodeId) => {
   if (task) {
     let type = task.entity_type_name


### PR DESCRIPTION
**Problem**

- The task cell links (#2150) hijacked ctrl/shift/alt clicks, breaking additive and range selection on the assets grid
- `margin-block`/`padding-block` need Safari 14.1, below the supported browser floor
- `router.resolve` ran for every cell on every grid render
- Only the assets grid offered the links

**Solution**

- Block navigation on every click so modified clicks bubble to the selection; middle click and the context menu keep the native link
- Physical margin/padding properties instead of the logical shorthands
- Hrefs memoized in a shared `getTaskHref` helper keyed by task and production/episode context
- Links wired into the shot, sequence, episode, edit and task type grids