### PR TITLE
Stability fixes and client access tightening

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "chartkick": "5.0.1",
         "color": "5.0.3",
         "color-hash": "2.0.2",
-        "core-js": "3.49.0",
+        "core-js": "3.50.0",
         "date-fns": "4.4.0",
         "diff2html": "3.4.56",
         "exceljs": "4.4.0",
@@ -78,7 +78,7 @@
         "localStorage": "1.0.4",
         "prettier": "3.9.6",
         "sass": "1.102.0",
-        "vite": "8.2.0",
+        "vite": "8.2.1",
         "vitest": "4.1.10",
         "vitest-localstorage-mock": "0.1.2",
         "vue-eslint-parser": "10.4.1"
@@ -3474,11 +3474,14 @@
       "license": "MIT"
     },
     "node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -8517,16 +8520,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
-      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.23",
-        "rolldown": "~1.2.0",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chartkick": "5.0.1",
     "color": "5.0.3",
     "color-hash": "2.0.2",
-    "core-js": "3.49.0",
+    "core-js": "3.50.0",
     "date-fns": "4.4.0",
     "diff2html": "3.4.56",
     "exceljs": "4.4.0",
@@ -91,7 +91,7 @@
     "localStorage": "1.0.4",
     "prettier": "3.9.6",
     "sass": "1.102.0",
-    "vite": "8.2.0",
+    "vite": "8.2.1",
     "vitest": "4.1.10",
     "vitest-localstorage-mock": "0.1.2",
     "vue-eslint-parser": "10.4.1"

--- a/src/App.vue
+++ b/src/App.vue
@@ -2557,6 +2557,10 @@ th.validation-cell {
   width: 118px;
 }
 
+#app .range .dp--input {
+  width: 190px;
+}
+
 #app .datatable .dp--input {
   border-radius: 3px;
   height: 43px;

--- a/src/App.vue
+++ b/src/App.vue
@@ -169,15 +169,20 @@ export default {
 
     setupAuthChannel() {
       if (auth.getBroadcastChannel()) {
-        auth.getBroadcastChannel().onmessage = event => {
+        auth.getBroadcastChannel().onmessage = async event => {
           if (this.$route.name !== 'login' && event.data === 'logout') {
             // Another tab logged out: purge this tab's session too,
             // otherwise store and socket keep the previous user's data.
-            this.$store.dispatch('logoutLocal')
-            this.$router.push({
+            // Navigate first: purging while the current page is still
+            // mounted crashes the computed properties reading the user.
+            // The push resolves before the render flush unmounts the page,
+            // so also wait for the next tick.
+            await this.$router.push({
               name: 'login',
               query: { redirect: this.$route.fullPath }
             })
+            await this.$nextTick()
+            this.$store.dispatch('logoutLocal')
           }
         }
       }

--- a/src/components/modals/SharePlaylistModal.vue
+++ b/src/components/modals/SharePlaylistModal.vue
@@ -8,7 +8,10 @@
       <p class="description">
         {{ $t('playlists.share_modal.description') }}
       </p>
-      <p class="empty-links" v-if="shareLinks.length === 0">
+      <div class="has-text-centered" v-if="loading.links && !shareLinks.length">
+        <spinner />
+      </div>
+      <p class="empty-links" v-else-if="!shareLinks.length">
         {{ $t('playlists.share_modal.no_links') }}
       </p>
       <div v-else class="existing-links">
@@ -216,6 +219,7 @@ import BaseModal from '@/components/modals/BaseModal.vue'
 import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import Checkbox from '@/components/widgets/Checkbox.vue'
 import DateField from '@/components/widgets/DateField.vue'
+import Spinner from '@/components/widgets/Spinner.vue'
 
 const { t } = useI18n()
 const { tomorrow, dateFormat } = useTime()
@@ -231,7 +235,7 @@ const emit = defineEmits(['cancel', 'links-updated'])
 const shareLinks = ref([])
 const expirationDate = ref(null)
 const canComment = ref(true)
-const loading = reactive({ create: false })
+const loading = reactive({ links: false, create: false })
 const errors = reactive({ create: false })
 
 const openInviteToken = ref(null)
@@ -351,6 +355,7 @@ const buildShareUrl = token => {
 }
 
 const loadLinks = async () => {
+  loading.links = true
   try {
     const links = await store.dispatch(
       'loadPlaylistShareLinks',
@@ -361,6 +366,8 @@ const loadLinks = async () => {
     emit('links-updated', links.length)
   } catch (err) {
     console.error(err)
+  } finally {
+    loading.links = false
   }
 }
 

--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -19,14 +19,14 @@
               @click="modals.isBuildFilterDisplayed = true"
             />
             <div class="flexrow-item filler"></div>
-            <div class="flexrow flexrow-item" v-if="!isCurrentUserClient">
+            <div class="flexrow flexrow-item">
               <combobox-department
                 class="combobox-department flexrow-item"
                 :selectable-departments="selectableDepartments('Asset')"
                 :display-all-and-my-departments="true"
                 rounded
                 v-model="selectedDepartment"
-                v-if="departments.length > 0"
+                v-if="departments.length > 0 && !isCurrentUserClient"
               />
               <combobox-display-options
                 class="flexrow-item"

--- a/src/components/pages/Edits.vue
+++ b/src/components/pages/Edits.vue
@@ -19,16 +19,16 @@
               @click="() => (modals.isBuildFilterDisplayed = true)"
             />
             <div class="filler"></div>
-            <combobox-department
-              class="combobox-department flexrow-item"
-              :selectable-departments="selectableDepartments('Edit')"
-              :display-all-and-my-departments="true"
-              :width="230"
-              rounded
-              v-model="selectedDepartment"
-              v-if="departments.length > 0"
-            />
-            <div class="flexrow flexrow-item" v-if="!isCurrentUserClient">
+            <div class="flexrow flexrow-item">
+              <combobox-department
+                class="combobox-department flexrow-item"
+                :selectable-departments="selectableDepartments('Edit')"
+                :display-all-and-my-departments="true"
+                :width="230"
+                rounded
+                v-model="selectedDepartment"
+                v-if="departments.length > 0 && !isCurrentUserClient"
+              />
               <combobox-display-options
                 class="flexrow-item"
                 :type="type"

--- a/src/components/pages/Episodes.vue
+++ b/src/components/pages/Episodes.vue
@@ -18,14 +18,14 @@
               @click="() => (modals.isBuildFilterDisplayed = true)"
             />
             <div class="filler"></div>
-            <div class="flexrow flexrow-item" v-if="!isCurrentUserClient">
+            <div class="flexrow flexrow-item">
               <combobox-department
                 class="combobox-department flexrow-item"
                 :selectable-departments="selectableDepartments('Episode')"
                 :display-all-and-my-departments="true"
                 rounded
                 v-model="selectedDepartment"
-                v-if="departments.length > 0"
+                v-if="departments.length > 0 && !isCurrentUserClient"
               />
               <combobox-display-options
                 class="flexrow-item"

--- a/src/components/pages/Logs.vue
+++ b/src/components/pages/Logs.vue
@@ -11,7 +11,6 @@
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
-import { useStore } from 'vuex'
 
 import EventLogs from '@/components/pages/logs/EventLogs.vue'
 import LoginLogs from '@/components/pages/logs/LoginLogs.vue'
@@ -20,24 +19,16 @@ import RouteTabs from '@/components/widgets/RouteTabs.vue'
 
 const { t } = useI18n()
 const route = useRoute()
-const store = useStore()
 
 // Computed
 
-const isCurrentUserAdmin = computed(() => store.getters.isCurrentUserAdmin)
+const tabs = computed(() => [
+  { name: 'events', label: t('logs.audit.title') },
+  { name: 'logins', label: t('logs.logins.title') },
+  { name: 'preview_files', label: t('logs.preview_files.title') }
+])
 
-// Login logs expose everyone's IP address: the API restricts them to admins.
-const tabs = computed(() =>
-  [
-    { name: 'events', label: t('logs.audit.title') },
-    isCurrentUserAdmin.value
-      ? { name: 'logins', label: t('logs.logins.title') }
-      : null,
-    { name: 'preview_files', label: t('logs.preview_files.title') }
-  ].filter(Boolean)
-)
-
-// A bookmarked or shared ?tab=logins must not 403 a non-admin.
+// Fall back to the audit tab when the URL carries an unknown ?tab= value.
 const activeTab = computed(() => {
   const tab = route.query.tab || 'events'
   return tabs.value.some(({ name }) => name === tab) ? tab : 'events'

--- a/src/components/pages/Sequences.vue
+++ b/src/components/pages/Sequences.vue
@@ -18,14 +18,14 @@
               @click="() => (modals.isBuildFilterDisplayed = true)"
             />
             <div class="filler"></div>
-            <div class="flexrow flexrow-item" v-if="!isCurrentUserClient">
+            <div class="flexrow flexrow-item">
               <combobox-department
                 class="combobox-department flexrow-item"
                 :selectable-departments="selectableDepartments('Sequence')"
                 :display-all-and-my-departments="true"
                 rounded
                 v-model="selectedDepartment"
-                v-if="departments.length > 0"
+                v-if="departments.length > 0 && !isCurrentUserClient"
               />
               <combobox-display-options
                 class="flexrow-item"

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -24,14 +24,14 @@
               v-if="currentEpisode && currentEpisode.description"
             />
             <div class="filler"></div>
-            <div class="flexrow flexrow-item" v-if="!isCurrentUserClient">
+            <div class="flexrow flexrow-item">
               <combobox-department
                 class="combobox-department flexrow-item"
                 :selectable-departments="selectableDepartments('Shot')"
                 :display-all-and-my-departments="true"
                 rounded
                 v-model="selectedDepartment"
-                v-if="departments.length > 0"
+                v-if="departments.length > 0 && !isCurrentUserClient"
               />
               <combobox-display-options
                 class="flexrow-item"

--- a/src/components/pages/Todos.vue
+++ b/src/components/pages/Todos.vue
@@ -413,9 +413,11 @@ export default {
         date: this.selectedDate,
         forced
       })
-      this.loadDoneTasks().then(() => {
-        this.loading.doneTasks = false
-      })
+      this.loadDoneTasks()
+        .catch(console.error)
+        .finally(() => {
+          this.loading.doneTasks = false
+        })
       this.$nextTick(() => {
         this.todoList?.setScrollPosition(this.todoListScrollPosition)
       })

--- a/src/components/pages/logs/EventLogs.vue
+++ b/src/components/pages/logs/EventLogs.vue
@@ -3,10 +3,11 @@
     <div class="flexrow filters">
       <date-field
         class="flexrow-item"
-        range
+        :can-delete="false"
         :label="$t('logs.date_range_label')"
         :max-date="today"
         :placeholder="$t('logs.date_range_placeholder')"
+        range
         v-model="dateRange"
         @change="onDateRangeChange"
       />
@@ -358,6 +359,14 @@ const loadEventNames = async () => {
   }
 }
 
+const loadProductions = async () => {
+  try {
+    await store.dispatch('loadProductions')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
 const selectLine = event => {
   selectedEvents.value[event.id] = !selectedEvents.value[event.id]
 }
@@ -434,7 +443,10 @@ watch(personMap, () => {
 
 // Lifecycle
 
-onMounted(loadEventNames)
+onMounted(() => {
+  loadEventNames()
+  loadProductions()
+})
 
 // Head
 

--- a/src/components/pages/logs/LoginLogs.vue
+++ b/src/components/pages/logs/LoginLogs.vue
@@ -3,10 +3,11 @@
     <div class="flexrow filters">
       <date-field
         class="flexrow-item"
-        range
+        :can-delete="false"
         :label="$t('logs.date_range_label')"
         :max-date="today"
         :placeholder="$t('logs.date_range_placeholder')"
+        range
         v-model="dateRange"
         @change="onDateRangeChange"
       />

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -688,7 +688,11 @@ export default {
     ]),
 
     async onLogout() {
+      // The push resolves before the render flush unmounts the current
+      // page: wait for the next tick so the session purge cannot race
+      // against watchers still reading the store.
       await this.$router.push({ name: 'login' })
+      await this.$nextTick()
       try {
         await this.logout()
       } catch (error) {

--- a/src/components/widgets/ComboboxDisplayOptions.vue
+++ b/src/components/widgets/ComboboxDisplayOptions.vue
@@ -9,6 +9,7 @@
 <script setup>
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useStore } from 'vuex'
 
 import ComboboxOptions from '@/components/widgets/ComboboxOptions.vue'
 
@@ -28,6 +29,9 @@ const props = defineProps({
 })
 
 const { t } = useI18n()
+const store = useStore()
+
+const isCurrentUserClient = computed(() => store.getters.isCurrentUserClient)
 
 const options = computed(() => {
   const isTaskType = props.type.includes('tasktype-')
@@ -36,7 +40,7 @@ const options = computed(() => {
     {
       label: t('tasks.show_assignations'),
       value: 'showAssignations',
-      when: !isTaskType
+      when: !isTaskType && !isCurrentUserClient.value
     },
     {
       label: t('tasks.show_infos'),

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -580,6 +580,7 @@ import {
 import stringHelpers from '@/lib/string'
 
 import { useAtMentionsMembers } from '@/composables/atMentions'
+import { useTime } from '@/composables/time'
 import { domMixin } from '@/components/mixins/dom'
 
 import AddAttachmentModal from '@/components/modals/AddAttachmentModal.vue'
@@ -599,6 +600,7 @@ const { pauseEvent } = domMixin.methods
 
 const store = useStore()
 const route = useRoute()
+const { timezone } = useTime()
 
 const emit = defineEmits([
   'ack-comment',
@@ -712,7 +714,6 @@ const isCurrentUserManager = computed(() =>
 const personMap = computed(() => store.getters.personMap)
 const taskTypeMap = computed(() => store.getters.taskTypeMap)
 const use12HourClock = computed(() => store.getters.use12HourClock)
-const user = computed(() => store.getters.user)
 
 const attachmentNamePrefix = computed(() =>
   stringHelpers.attachmentNamePrefix(
@@ -860,7 +861,7 @@ const commentDate = computed(() => {
 })
 
 const fullDate = computed(() => {
-  const date = commentDate.value.tz(user.value.timezone)
+  const date = commentDate.value.tz(timezone.value)
   return `${formatDisplayDate(date, dateFormat.value)} ${formatTimeOfDay(date, use12HourClock.value)}`
 })
 
@@ -884,7 +885,7 @@ const shortenText = (text, length) => {
 }
 
 const replyFullDate = date => {
-  const d = moment(parseDate(date)).tz(user.value.timezone)
+  const d = moment(parseDate(date)).tz(timezone.value)
   return `${formatDisplayDate(d, dateFormat.value)} ${formatTimeOfDay(d, use12HourClock.value)}`
 }
 
@@ -895,9 +896,9 @@ const replyShortDate = date => {
 const renderDate = date => {
   date = moment(date)
   if (moment().isSame(date, 'd')) {
-    return formatTimeOfDay(date.tz(user.value.timezone), use12HourClock.value)
+    return formatTimeOfDay(date.tz(timezone.value), use12HourClock.value)
   } else {
-    return formatShortDate(date.tz(user.value.timezone), dateFormat.value)
+    return formatShortDate(date.tz(timezone.value), dateFormat.value)
   }
 }
 

--- a/src/components/widgets/DateField.vue
+++ b/src/components/widgets/DateField.vue
@@ -5,17 +5,17 @@
       auto-apply
       class="datepicker"
       :class="{ range }"
-      :range="range"
       :dark="isDark || isDarkTheme"
       :disabled="disabled"
       :filters="{ weekDays: weekDaysDisabled ? [6, 0] : [] }"
-      :formats="{ input: format }"
+      :formats="{ input: inputFormat }"
       :input-attrs="{ clearable: canDelete, hideInputIcon: true }"
       :locale="dateFnsLocale"
       :model-type="modelType"
       :min-date="minDate"
       :max-date="maxDate"
       :placeholder="placeholder"
+      :range="range ? { partialRange: false } : false"
       :teleport="true"
       :time-config="{ enableTimePicker: false }"
       :timezone="utc ? 'utc' : undefined"
@@ -26,6 +26,7 @@
 </template>
 
 <script setup>
+import { format as formatDate } from 'date-fns'
 import {
   da,
   de,
@@ -71,7 +72,7 @@ const isDarkTheme = computed(() => store.getters.isDarkTheme)
 const user = computed(() => store.getters.user)
 
 const dateFnsLocale = computed(() => {
-  const locale = user.value.locale || 'en_US'
+  const locale = user.value?.locale || 'en_US'
   if (locale.startsWith('zh_Hant')) return zhTW
   return DATE_FNS_LOCALES[locale.substring(0, 2)] || enUS
 })
@@ -141,15 +142,26 @@ const props = defineProps({
 
 const emit = defineEmits(['update:model-value', 'change'])
 
+// In range mode, formats.input receives [start, end]: a same-day range is collapsed to a single date in the input.
+const inputFormat = computed(() => {
+  if (!props.range) return props.format
+  return ([start, end]) => {
+    const fmt = date => formatDate(date, props.format)
+    if (fmt(start) === fmt(end)) return fmt(start)
+    return `${fmt(start)} - ${fmt(end)}`
+  }
+})
+
 const localValue = computed({
   get() {
     return props.modelValue
   },
   set(value) {
     if (props.range) {
-      // The picker emits [start, null] while the user is still choosing the
-      // second date. Only a complete range is worth propagating, otherwise
-      // every first click would trigger a reload.
+      // partialRange is disabled in the template: combined with auto-apply,
+      // the picker would otherwise apply [start, null] and close the menu on
+      // the very first click. This filter is a backstop so an incomplete
+      // range can never reach the parent and trigger a reload.
       const dates = value?.filter(Boolean) ?? []
       if (value?.length && dates.length !== 2) return
       const range = dates.length === 2 ? dates : null
@@ -171,9 +183,5 @@ const localValue = computed({
 .datepicker {
   display: inline-flex;
   max-width: 200px;
-
-  &.range {
-    max-width: 260px;
-  }
 }
 </style>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -153,7 +153,11 @@ export const routes = [
         (!userStore.getters.isCurrentUserAdmin(userStore.state) &&
           to?.matched.some(record => record.meta.requiresAdmin)) ||
         (!isSupervisorOrManager &&
-          to?.matched.some(record => record.meta.requiresSupervisorOrManager))
+          to?.matched.some(
+            record => record.meta.requiresSupervisorOrManager
+          )) ||
+        (userStore.getters.isCurrentUserClient(userStore.state) &&
+          to?.matched.some(record => record.meta.forbiddenForClient))
 
       if (taskTypeStore.state.taskTypes.length === 0) {
         try {
@@ -175,7 +179,8 @@ export const routes = [
       {
         path: 'asset-library',
         component: AssetLibrary,
-        name: 'asset-library'
+        name: 'asset-library',
+        meta: { forbiddenForClient: true }
       },
 
       {
@@ -250,12 +255,14 @@ export const routes = [
       {
         name: 'software-licenses',
         path: 'software-licenses',
+        meta: { requiresAdmin: true },
         component: SoftwareLicenses
       },
 
       {
         name: 'hardware-items',
         path: 'hardware-items',
+        meta: { requiresAdmin: true },
         component: HardwareItems
       },
 
@@ -268,7 +275,8 @@ export const routes = [
       {
         path: 'all-tasks',
         component: AllTasks,
-        name: 'all-tasks'
+        name: 'all-tasks',
+        meta: { forbiddenForClient: true }
       },
 
       {
@@ -280,19 +288,22 @@ export const routes = [
       {
         path: 'new-production',
         component: NewProduction,
-        name: 'new-production'
+        name: 'new-production',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'entity-search',
         component: EntitySearch,
-        name: 'entity-search'
+        name: 'entity-search',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'entity-chats',
         component: EntityChats,
-        name: 'entity-chats'
+        name: 'entity-chats',
+        meta: { forbiddenForClient: true }
       },
 
       {
@@ -305,7 +316,8 @@ export const routes = [
       {
         path: 'people/:person_id',
         component: Person,
-        name: 'person'
+        name: 'person',
+        meta: { forbiddenForClient: true }
       },
 
       {
@@ -326,6 +338,7 @@ export const routes = [
         path: '/timesheets',
         component: Timesheets,
         name: 'timesheets',
+        meta: { forbiddenForClient: true },
         children: [
           {
             path: 'year/:year',
@@ -386,7 +399,8 @@ export const routes = [
       {
         path: '/plugins/:plugin_id',
         component: Plugin,
-        name: 'plugin'
+        name: 'plugin',
+        meta: { forbiddenForClient: true }
       },
 
       {
@@ -412,13 +426,15 @@ export const routes = [
       {
         path: 'my-tasks',
         component: Todos,
-        name: 'todos'
+        name: 'todos',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'my-checks',
         component: MyChecks,
-        name: 'checks'
+        name: 'checks',
+        meta: { forbiddenForClient: true }
       },
 
       {
@@ -431,13 +447,15 @@ export const routes = [
       {
         path: 'productions/:production_id/team',
         component: Team,
-        name: 'team'
+        name: 'team',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'productions/:production_id/budget',
         component: Budget,
-        name: 'budget'
+        name: 'budget',
+        meta: { requiresAdmin: true }
       },
 
       {
@@ -450,49 +468,57 @@ export const routes = [
       {
         path: 'productions/:production_id/news-feed',
         component: ProductionNewsFeed,
-        name: 'news-feed'
+        name: 'news-feed',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'productions/:production_id/schedule',
         component: ProductionSchedule,
-        name: 'schedule'
+        name: 'schedule',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'productions/:production_id/episodes/:episode_id/schedule',
         component: ProductionSchedule,
-        name: 'episode-schedule'
+        name: 'episode-schedule',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'productions/:production_id/production-settings',
         component: ProductionSettings,
-        name: 'production-settings'
+        name: 'production-settings',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'productions/:production_id/brief',
         component: Brief,
-        name: 'brief'
+        name: 'brief',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'productions/:production_id/plugins/:plugin_id',
         component: Plugin,
-        name: 'production-plugin'
+        name: 'production-plugin',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'productions/:production_id/episodes/:episode_id/plugins/:plugin_id',
         component: Plugin,
-        name: 'episode-production-plugin'
+        name: 'episode-production-plugin',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'productions/:production_id/quota',
         component: ProductionQuota,
         name: 'quota',
+        meta: { forbiddenForClient: true },
         children: [
           {
             path: 'month/:year',
@@ -531,6 +557,7 @@ export const routes = [
         path: 'productions/:production_id/episodes/:episode_id/quota',
         component: ProductionQuota,
         name: 'episode-quota',
+        meta: { forbiddenForClient: true },
         children: [
           {
             path: 'month/:year',
@@ -582,6 +609,7 @@ export const routes = [
         path: 'productions/:production_id/breakdown',
         component: Breakdown,
         name: 'breakdown',
+        meta: { forbiddenForClient: true },
         children: [
           {
             path: 'sequences/:sequence_id',
@@ -599,7 +627,8 @@ export const routes = [
       {
         path: 'productions/:production_id/concepts',
         component: Concepts,
-        name: 'concepts'
+        name: 'concepts',
+        meta: { forbiddenForClient: true }
       },
 
       {
@@ -642,24 +671,28 @@ export const routes = [
         path: 'productions/:production_id/episodes',
         component: Episodes,
         name: 'episodes',
+        meta: { forbiddenForClient: true },
         children: []
       },
       {
         path: 'productions/:production_id/episodes/:episode_id',
         component: Episode,
-        name: 'episode'
+        name: 'episode',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'productions/:production_id/sequences/:sequence_id',
         component: Sequence,
-        name: 'sequence'
+        name: 'sequence',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'productions/:production_id/sequences',
         component: Sequences,
-        name: 'sequences'
+        name: 'sequences',
+        meta: { forbiddenForClient: true }
       },
 
       {
@@ -742,6 +775,7 @@ export const routes = [
         path: 'productions/:production_id/episodes/:episode_id/breakdown',
         component: Breakdown,
         name: 'episode-breakdown',
+        meta: { forbiddenForClient: true },
         children: [
           {
             path: 'sequences/:sequence_id',
@@ -802,13 +836,15 @@ export const routes = [
       {
         path: 'productions/:production_id/episodes/:episode_id/sequences',
         component: Sequences,
-        name: 'episode-sequences'
+        name: 'episode-sequences',
+        meta: { forbiddenForClient: true }
       },
 
       {
         path: 'productions/:production_id/episodes/:episode_id/sequences/:sequence_id',
         component: Sequence,
-        name: 'episode-sequence'
+        name: 'episode-sequence',
+        meta: { forbiddenForClient: true }
       },
 
       {
@@ -840,7 +876,8 @@ export const routes = [
         component: TaskType,
         name: 'episodes-task-type',
         meta: {
-          section: 'episodes'
+          section: 'episodes',
+          forbiddenForClient: true
         },
         children: [
           {

--- a/src/store/modules/people.js
+++ b/src/store/modules/people.js
@@ -806,7 +806,9 @@ const mutations = {
     state,
     { personId, tasks, userFilters, taskTypeMap }
   ) {
-    state.person = cache.personMap.get(personId)
+    // The unmount reset commits no personId: fall back to the initial {}
+    // so state.person never becomes undefined for later consumers.
+    state.person = cache.personMap.get(personId) || {}
 
     tasks.forEach(populateTask)
     tasks.forEach(task => {
@@ -909,7 +911,7 @@ const mutations = {
   },
 
   [SET_TIME_SPENT](state, timeSpent) {
-    if (state.person.id === timeSpent.person_id) {
+    if (state.person?.id === timeSpent.person_id) {
       state.personTimeSpentMap[timeSpent.task_id] = timeSpent
     }
     state.personTimeSpentTotal =

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -318,20 +318,22 @@ const actions = {
     }
   },
 
+  // pget resolves null on a 2xx response that carries no JSON body (proxy
+  // maintenance page): default these lists so the mutations can iterate.
   async loadDoneTasks({ commit, state, rootGetters }) {
-    const doneTasks = await peopleApi.loadDone()
+    const doneTasks = (await peopleApi.loadDone()) || []
     commit(USER_LOAD_DONE_TASKS_END, doneTasks)
     commit(REGISTER_USER_TASKS, { tasks: doneTasks })
     return doneTasks
   },
 
   async loadUserTimeSpents({ commit }, { date }) {
-    const timeSpents = await peopleApi.loadTimeSpents(date)
+    const timeSpents = (await peopleApi.loadTimeSpents(date)) || []
     commit(USER_LOAD_TIME_SPENTS_END, timeSpents)
   },
 
   async loadTasksToCheck({ commit }) {
-    const tasks = await peopleApi.loadTasksToCheck()
+    const tasks = (await peopleApi.loadTasksToCheck()) || []
     commit(REGISTER_USER_TASKS, { tasks })
     return tasks
   },

--- a/tests/unit.setup.js
+++ b/tests/unit.setup.js
@@ -9,6 +9,17 @@ config.global.mocks = {
   $t: tKey => tKey // just return translation key
 }
 
+// v-focus only exists on the real app built by main.js, which the specs
+// never load: mirror it here so mounted components resolve it instead of
+// logging a warning.
+config.global.directives = {
+  focus: {
+    mounted(el, binding) {
+      el.focus(binding.value)
+    }
+  }
+}
+
 // Stub indexedDB for libraries (e.g. vue3-emoji-picker) that rely on it at import time
 const noop = () => {}
 class IDBRequestStub {

--- a/tests/unit/router/routes.spec.js
+++ b/tests/unit/router/routes.spec.js
@@ -2,6 +2,7 @@ import { vi } from 'vitest'
 
 const h = vi.hoisted(() => ({
   isAdmin: false,
+  isClient: false,
   isManager: false,
   isSupervisor: false
 }))
@@ -33,6 +34,7 @@ vi.mock('@/store/modules/user', () => ({
     getters: {
       isCurrentUserAdmin: () => h.isAdmin,
       isCurrentUserArtist: () => false,
+      isCurrentUserClient: () => h.isClient,
       isCurrentUserManager: () => h.isAdmin || h.isManager,
       isCurrentUserSupervisor: () => h.isSupervisor
     }
@@ -78,6 +80,7 @@ const SUPERVISOR_OR_MANAGER_ROUTES = ['team-schedule']
 describe('router/routes', () => {
   beforeEach(() => {
     h.isAdmin = false
+    h.isClient = false
     h.isManager = false
     h.isSupervisor = false
     taskTypeStore.state.taskTypes = [{ id: 'task-type-1' }]
@@ -147,6 +150,21 @@ describe('router/routes', () => {
         matched: [{ meta: { requiresSupervisorOrManager: true } }]
       })
       expect(result).toEqual({ name: 'not-found' })
+    })
+
+    test('redirects a client to not-found on a client-forbidden route', async () => {
+      h.isClient = true
+      const result = await runGuard({
+        matched: [{ meta: { forbiddenForClient: true } }]
+      })
+      expect(result).toEqual({ name: 'not-found' })
+    })
+
+    test('lets a non-client through on a client-forbidden route', async () => {
+      const result = await runGuard({
+        matched: [{ meta: { forbiddenForClient: true } }]
+      })
+      expect(result).toBeUndefined()
     })
 
     test('still blocks admin routes when data loads first', async () => {

--- a/tests/unit/store/people.spec.js
+++ b/tests/unit/store/people.spec.js
@@ -48,6 +48,44 @@ describe('People store', () => {
       expect(state.displayedPeople).toEqual(store.cache.people)
     })
 
+    // Person.vue's unmount reset commits no personId; state.person must fall
+    // back to an object so a later SET_TIME_SPENT can read .id safely.
+    test('LOAD_PERSON_TASKS_END keeps person an object when personId is absent', () => {
+      state.personTasksSearchText = ''
+      store.mutations.LOAD_PERSON_TASKS_END(state, {
+        tasks: [],
+        userFilters: {},
+        taskTypeMap: new Map()
+      })
+      expect(state.person).toEqual({})
+    })
+
+    // A My Tasks timesheet save landing after the person page unmount must
+    // skip the person-page cache without throwing.
+    test('SET_TIME_SPENT skips the person cache when no person is displayed', () => {
+      state.person = undefined
+      state.personTimeSpentMap = { 'task-9': { duration: 60 } }
+      store.mutations.SET_TIME_SPENT(state, {
+        task_id: 'task-1',
+        person_id: 'person-1',
+        duration: 120
+      })
+      expect(state.personTimeSpentMap['task-1']).toBeUndefined()
+      expect(state.personTimeSpentTotal).toEqual(1)
+    })
+
+    test('SET_TIME_SPENT stores the entry for the displayed person', () => {
+      state.person = { id: 'person-1' }
+      state.personTimeSpentMap = {}
+      store.mutations.SET_TIME_SPENT(state, {
+        task_id: 'task-1',
+        person_id: 'person-1',
+        duration: 120
+      })
+      expect(state.personTimeSpentMap['task-1'].duration).toEqual(120)
+      expect(state.personTimeSpentTotal).toEqual(2)
+    })
+
     // The done tasks of the person page never reach the tasks module map,
     // unlike the todo ones registered on LOAD_PERSON_TASKS_END.
     test('SET_PREVIEW refreshes the person done list', () => {

--- a/tests/unit/store/user.spec.js
+++ b/tests/unit/store/user.spec.js
@@ -2,7 +2,15 @@ import { vi } from 'vitest'
 
 vi.mock('@/store', () => ({ default: {} }))
 vi.mock('@/lib/auth', () => ({ default: { logIn: vi.fn(), logOut: vi.fn() } }))
+vi.mock('@/store/api/people', () => ({
+  default: {
+    loadDone: vi.fn(),
+    loadTasksToCheck: vi.fn(),
+    loadTimeSpents: vi.fn()
+  }
+}))
 
+import peopleApi from '@/store/api/people'
 import store from '@/store/modules/user'
 
 describe('User store', () => {
@@ -143,6 +151,69 @@ describe('User store', () => {
       }
       store.mutations.USER_LOGOUT(state)
       expect(state.projectRoles).toEqual({})
+    })
+  })
+
+  describe('Actions', () => {
+    afterEach(() => {
+      vi.clearAllMocks()
+    })
+
+    // A 2xx response without a JSON body (proxy maintenance page) makes pget
+    // resolve null; the actions must hand arrays to the forEach mutations.
+    describe('loadDoneTasks', () => {
+      test('commits an empty list when the API resolves null', async () => {
+        peopleApi.loadDone.mockResolvedValue(null)
+        const commit = vi.fn()
+
+        const doneTasks = await store.actions.loadDoneTasks({ commit })
+
+        expect(doneTasks).toEqual([])
+        expect(commit).toHaveBeenCalledWith('USER_LOAD_DONE_TASKS_END', [])
+        expect(commit).toHaveBeenCalledWith('REGISTER_USER_TASKS', {
+          tasks: []
+        })
+      })
+
+      test('passes the loaded tasks through', async () => {
+        const tasks = [{ id: 'task-1' }]
+        peopleApi.loadDone.mockResolvedValue(tasks)
+        const commit = vi.fn()
+
+        const doneTasks = await store.actions.loadDoneTasks({ commit })
+
+        expect(doneTasks).toEqual(tasks)
+        expect(commit).toHaveBeenCalledWith('USER_LOAD_DONE_TASKS_END', tasks)
+      })
+    })
+
+    describe('loadUserTimeSpents', () => {
+      test('commits an empty list when the API resolves null', async () => {
+        peopleApi.loadTimeSpents.mockResolvedValue(null)
+        const commit = vi.fn()
+
+        await store.actions.loadUserTimeSpents(
+          { commit },
+          { date: '2026-08-06' }
+        )
+
+        expect(peopleApi.loadTimeSpents).toHaveBeenCalledWith('2026-08-06')
+        expect(commit).toHaveBeenCalledWith('USER_LOAD_TIME_SPENTS_END', [])
+      })
+    })
+
+    describe('loadTasksToCheck', () => {
+      test('commits an empty list when the API resolves null', async () => {
+        peopleApi.loadTasksToCheck.mockResolvedValue(null)
+        const commit = vi.fn()
+
+        const tasks = await store.actions.loadTasksToCheck({ commit })
+
+        expect(tasks).toEqual([])
+        expect(commit).toHaveBeenCalledWith('REGISTER_USER_TASKS', {
+          tasks: []
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
**Problem**
- With `vue-datepicker` v14, the date field applied a partial range and closed the picker on the first click, so a range could never be picked.
- The production filter of the event logs stayed empty unless the production settings page had been visited first.
- Purging the session while a page was still mounted crashed its computed properties, both on logout and when another tab logged out.
- Comment dates crashed for anonymous guests on shared playlists, which store no user to read the timezone from.
- The share playlist modal showed the empty state while the links were still loading.
- Client users got no display options on the entity pages, while Edits wrongly exposed the department filter to them.
- Routes hidden from the client and admin menus stayed reachable by URL.
- Leaving the person page cleared the displayed person, so the next My Tasks timesheet save threw, and the duration never showed up.
- A 2xx response without a JSON body, like a proxy maintenance page, broke the task list loaders and left the done tab spinner stuck.
- Component mounts using `v-focus` logged an unresolved directive warning in the unit tests.
- Some npm dependencies are outdated.

**Solution**
- Disable partial ranges, only propagate complete ones, and collapse a same-day range in the input.
- Load the productions from the logs screen itself.
- Navigate to the login page and wait for the render flush before purging, in both logout paths.
- Read the timezone through the useTime composable, which falls back to the browser one.
- Show a spinner during the initial fetch and keep the list visible during reloads.
- Show the display options to clients, minus the assignations toggle, and keep the department filter studio-only.
- Enforce the same restrictions in the route guard with a forbiddenForClient meta and missing requiresAdmin ones.
- Keep the store person an object and skip the person page cache when nobody is displayed.
- Default the raw list loaders to empty arrays and release the spinner on failure.
- Register the directive in the shared test setup.
- Bump npm dependencies.
