### PR TITLE
[players] Stop resizes from corrupting text notes in editing

### DIFF
--- a/src/components/players/annotations/AnnotationCanvas.vue
+++ b/src/components/players/annotations/AnnotationCanvas.vue
@@ -100,6 +100,14 @@ const updateBounds = () => {
     canvas &&
     (canvas.width !== mediaRect.width || canvas.height !== mediaRect.height)
   ) {
+    // A text note still in editing must exit before the dimensions change:
+    // exiting fires object:modified, whose serialization pairs the live
+    // coordinates with the current canvas box. Exited here it saves
+    // correctly; exited later (fabric does it from the clear() the resized
+    // reload triggers) the coordinates would belong to the old box and the
+    // stored note would drift by the resize ratio.
+    const active = canvas.getActiveObject?.()
+    if (active?.isEditing) active.exitEditing()
     canvas.setDimensions({ width: mediaRect.width, height: mediaRect.height })
     emit('resized', { width: mediaRect.width, height: mediaRect.height })
   }

--- a/src/composables/players/annotation.js
+++ b/src/composables/players/annotation.js
@@ -897,6 +897,13 @@ export const useAnnotation = ({
   }
 
   const onObjectModified = event => {
+    // fabric fires object:modified from Canvas.clear() when an IText still
+    // in editing gets discarded (exitEditing on a changed text). That
+    // programmatic exit must not post an update: after a resize the canvas
+    // dimensions no longer match the object's live coordinates, and the
+    // serialization would corrupt the stored note (coordinates multiplied
+    // by the resize ratio, note rendered off-canvas for everyone).
+    if (silentAnnotation) return
     const movedObject = event.target
     if (!movedObject._objects) {
       addToUpdates(movedObject)
@@ -1418,7 +1425,15 @@ export const useAnnotation = ({
     // don't land after this clear.
     mainLoadToken++
     if (isFabricReady(fabricCanvas.value)) {
-      fabricCanvas.value.clear()
+      // clear() discards the active object first, and discarding an IText
+      // still in editing fires object:modified while it is attached to the
+      // canvas: mute the handler so a programmatic wipe never posts updates.
+      silentAnnotation = true
+      try {
+        fabricCanvas.value.clear()
+      } finally {
+        silentAnnotation = false
+      }
     }
     clearComparisonCanvas()
   }

--- a/tests/unit/composables/annotation.spec.js
+++ b/tests/unit/composables/annotation.spec.js
@@ -454,6 +454,39 @@ describe('composables/annotation', () => {
     })
   })
 
+  describe('clearCanvas', () => {
+    // fabric's Canvas.clear() discards the active object before removing
+    // anything: an IText still in editing exits editing there and fires
+    // object:modified while attached. When the clear follows a resize
+    // (setDimensions ran just before), that serialization pairs old-box
+    // coordinates with the new dimensions and corrupts the stored note.
+    it('mutes the object:modified fabric fires while clearing', () => {
+      const canvas = createFakeCanvas()
+      const { api, postAnnotationUpdate, saveAnnotationsCb, wrapper } =
+        mountAnnotation({ canvas })
+      canvas.clear = vi.fn(() => {
+        api.onObjectModified({ target: createSerializableObject() })
+        canvas._objects.splice(0, canvas._objects.length)
+      })
+      api.clearCanvas()
+      expect(canvas.clear).toHaveBeenCalled()
+      expect(api.updates.value).toHaveLength(0)
+      expect(postAnnotationUpdate).not.toHaveBeenCalled()
+      expect(saveAnnotationsCb).not.toHaveBeenCalled()
+      wrapper.unmount()
+    })
+
+    it('keeps posting updates for a user-driven object:modified', () => {
+      const { api, postAnnotationUpdate, saveAnnotationsCb, wrapper } =
+        mountAnnotation()
+      api.onObjectModified({ target: createSerializableObject() })
+      expect(api.updates.value).toHaveLength(1)
+      expect(postAnnotationUpdate).toHaveBeenCalledTimes(1)
+      expect(saveAnnotationsCb).toHaveBeenCalled()
+      wrapper.unmount()
+    })
+  })
+
   describe('onErasingEnd', () => {
     it('routes erased objects to updates, not additions', () => {
       const { api, postAnnotationUpdate, saveAnnotationsCb, wrapper } =


### PR DESCRIPTION
**Problem**

- A canvas resize while a text note was still in editing (fullscreen exit via the toolbar button, window resize) corrupted the stored annotation: fabric's clear() fires object:modified after setDimensions, so the note was serialized with old-box coordinates against the new dimensions. left/top/scale were multiplied by the resize ratio and the note rendered off-canvas for everyone, while its timeline mark survived.

**Solution**

- Exit text editing before setDimensions so the final text is saved against matching dimensions.
- Mute onObjectModified during programmatic canvas clears, like onObjectAdded and onErasingEnd already were, with a regression test on the clear path.