### PR TITLE
[imports] Export and accept per-task-type assignations CSV columns

### DIFF
--- a/src/components/pages/Assets.vue
+++ b/src/components/pages/Assets.vue
@@ -548,6 +548,7 @@ export default {
       this.productionAssetTaskTypes.forEach(item => {
         collection.push(item.name)
         collection.push(`${item.name} comment`)
+        collection.push(`${item.name} assignations`)
       })
 
       return collection
@@ -794,8 +795,11 @@ export default {
           headers.push(this.$t('shots.fields.resolution'))
         }
         this.assetValidationColumns.forEach(taskTypeId => {
-          headers.push(this.taskTypeMap.get(taskTypeId)?.name || '')
-          headers.push('Assignations')
+          const taskTypeName = this.taskTypeMap.get(taskTypeId)?.name || ''
+          headers.push(taskTypeName)
+          // Qualified by the task type so a re-import can tell the columns
+          // apart: bare duplicated headers collapse in the server's reader.
+          headers.push(`${taskTypeName} assignations`)
         })
         csv.buildCsvFile(name, [headers].concat(assetLines))
       })

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -552,6 +552,7 @@ export default {
       this.productionShotTaskTypes.forEach(item => {
         collection.push(item.name)
         collection.push(`${item.name} comment`)
+        collection.push(`${item.name} assignations`)
       })
 
       return collection
@@ -878,8 +879,11 @@ export default {
           headers.push(this.$t('shots.fields.max_retakes'))
         }
         this.shotValidationColumns.forEach(taskTypeId => {
-          headers.push(this.taskTypeMap.get(taskTypeId)?.name || '')
-          headers.push('Assignations')
+          const taskTypeName = this.taskTypeMap.get(taskTypeId)?.name || ''
+          headers.push(taskTypeName)
+          // Qualified by the task type so a re-import can tell the columns
+          // apart: bare duplicated headers collapse in the server's reader.
+          headers.push(`${taskTypeName} assignations`)
         })
         csv.buildCsvFile(name, [headers].concat(shotLines))
       })


### PR DESCRIPTION
**Problem**

- The CSV export wrote a bare Assignations header per task type: duplicated headers collapse in the server's reader, and the import marked the column as ignored, so assignees never round-tripped (fixes #1272).

**Solution**

- Qualify the export header with the task type name and accept "<task type> assignations" in the shot and asset import mappers, matching the new zou-side import support.