### PR TITLE
Fix drag, drop, and side panel bugs in the production schedule

### DIFF
--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -147,9 +147,9 @@
           class="close-button"
           role="button"
           tabindex="0"
-          @click="toggleSidePanel"
-          @keydown.enter.prevent="toggleSidePanel"
-          @keydown.space.prevent="toggleSidePanel"
+          @click="unselectAndCloseSidePanel"
+          @keydown.enter.prevent="unselectAndCloseSidePanel"
+          @keydown.space.prevent="unselectAndCloseSidePanel"
         >
           <x-icon class="align-middle" :size="16" />
         </a>
@@ -462,7 +462,10 @@
                   :text="$t('main.apply')"
                   type="submit"
                 />
-                <button class="button is-link ml05" @click="closeSidePanel()">
+                <button
+                  class="button is-link ml05"
+                  @click="unselectAndCloseSidePanel()"
+                >
                   {{ $t('main.cancel') }}
                 </button>
               </template>
@@ -1999,6 +2002,15 @@ export default {
     closeSidePanel() {
       this.isSidePanelOpen = false
       this.resetSidePanel()
+    },
+
+    // explicit close (close button, task cancel): also drop the schedule
+    // selection, or the bar keeps its ring and its resize handles swallow
+    // the next click. closeSidePanel alone must not do it: it also runs
+    // when a multi-selection starts and would clear it.
+    unselectAndCloseSidePanel() {
+      this.$refs.schedule?.resetSelection()
+      this.closeSidePanel()
     },
 
     onAssignmentItemSelected(item) {

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -1755,6 +1755,16 @@ export default {
       this.selectedTaskType = this.scheduleItems.find(
         item => item.task_type_id === taskTypeId
       )
+      // clear the entity filter when it hides the selected row, or the
+      // expand below would fill the panel while the schedule shows nothing
+      if (
+        this.entityType &&
+        this.selectedTaskType &&
+        this.selectedTaskType.for_entity !== this.entityType
+      ) {
+        this.entityType = null
+        this.updateRoute({ type: null })
+      }
       // refresh schedule
       this.expandTaskTypeElement(
         this.selectedTaskType,

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -736,7 +736,11 @@ export default {
           person.role !== 'client' &&
           (['admin', 'manager'].includes(person.role) ||
             !person.departments.length ||
-            person.departments.includes(taskType?.department_id))
+            person.departments.includes(taskType?.department_id) ||
+            // an out-of-department person already assigned to the edited
+            // task stays listed: saveTask replaces the full assignee list,
+            // so hiding them here would silently unassign them
+            this.assignments.task?.assignees?.includes(person.id))
       )
     },
 

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -1502,7 +1502,7 @@ export default {
         } catch (err) {
           console.error(err)
           taskTypeElement.children = []
-          taskTypeElement.people = []
+          taskTypeElement.people = {}
         } finally {
           taskTypeElement.loading = false
         }
@@ -2326,7 +2326,11 @@ export default {
       // update task to refresh the schedule
       task.assignees = task.assignees.filter(id => id !== personId)
       const tasks = task.parentElement.children.get(personId)
-      tasks.splice(tasks.indexOf(task), 1)
+      // guard: splice(-1, 1) on a miss would silently drop another task's bar
+      const taskIndex = tasks?.indexOf(task) ?? -1
+      if (taskIndex !== -1) {
+        tasks.splice(taskIndex, 1)
+      }
 
       // save change
       if (this.isVersioned) {

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -121,7 +121,7 @@
         is-estimation-linked
         hide-man-days
         :multiline="isAllEpisodes"
-        :reassignable="!isLockedSchedule"
+        :reassignable="!isLockedSchedule && !isAllEpisodes"
         show-expand-all
         :subchildren="!isAllEpisodes"
         :type="mode"

--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -2183,7 +2183,12 @@ export default {
 
                 // save versioned task
                 if (!versionedTask.id) {
-                  await this.createScheduleVersionedTask(versionedTask)
+                  const createdTask =
+                    await this.createScheduleVersionedTask(versionedTask)
+                  // keep the created id: without it the task edits right
+                  // after an assignment would post duplicates
+                  versionedTask.id = createdTask.id
+                  task.versionedTaskId = createdTask.id
                 } else {
                   await this.updateScheduleVersionedTask(versionedTask)
                 }

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -2419,8 +2419,8 @@ watch(isAnnotationsDisplayed, () => {
 
 watch(isComparisonOverlay, () => {
   nextTick(() => {
-    previewViewer.value.resize()
-    comparisonViewer.value.resize()
+    previewViewer.value?.resize()
+    comparisonViewer.value?.resize()
   })
 })
 
@@ -2444,7 +2444,7 @@ watch(speed, () => {
 })
 
 watch(volume, () => {
-  previewViewer.value.setVolume(volume.value)
+  previewViewer.value?.setVolume(volume.value)
   localPreferences.setPreference('player:volume', volume.value)
 })
 
@@ -2471,13 +2471,13 @@ onMounted(() => {
   }
 
   if (isMuted.value) {
-    previewViewer.value.setVolume(0)
+    previewViewer.value?.setVolume(0)
   } else {
     volume.value = localPreferences.getIntPreference(
       'player:volume',
       volume.value
     )
-    previewViewer.value.setVolume(volume.value)
+    previewViewer.value?.setVolume(volume.value)
   }
 
   reloadAnnotations()

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -2398,12 +2398,17 @@ const addMilestoneTitle = day => {
 }
 
 const checkUserIsAllowed = (item, person) => {
-  if (!item) {
+  // person may be any root element (e.g. a task type row on the production
+  // schedule): only actual person rows carry a departments list
+  if (!item || !person?.departments) {
     return false
   }
   const production = openProductions.value.find(
     ({ id }) => id === item.project_id
   )
+  if (!production) {
+    return false
+  }
   const isTeamMember = production.team.includes(person.id)
   const isDepartmentMember =
     !person.departments.length ||

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -2615,6 +2615,7 @@ defineExpose({
   refreshItemPositions,
   refreshManDays,
   resetScheduleSize,
+  resetSelection,
   scrollToDate,
   scrollToToday,
   setScrollPosition

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -2552,13 +2552,6 @@ watch(
   }
 )
 
-watch(
-  () => props.height,
-  () => {
-    nextTick(resetScheduleSize)
-  }
-)
-
 watch(currentElement, () => {
   if (currentElement.value && currentElement.value.task_type_id) {
     const task = taskMap.value.get(currentElement.value.id)

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -2469,13 +2469,21 @@ const onTaskDrop = (event, rootElement) => {
     return // invalid user rights
   }
 
-  const position =
-    timelineContentWrapperRef.value.scrollLeft +
-    getClientX(event) -
-    300 -
-    cellWidth.value * 1.5
-  const dayPosition = Math.floor(position / cellWidth.value)
-  const dropDate = props.startDate.clone().add(dayPosition, 'days')
+  // resolve the hovered column the same way as the position bar: the
+  // previous math hardcoded a 300px entity panel offset and counted week
+  // cells as days, landing drops on the wrong date
+  const columns = isWeekMode.value ? weeksAvailable.value : displayedDays.value
+  if (!columns.length) {
+    return
+  }
+  if (!wrapperRect) {
+    wrapperRect = timelineContentWrapperRef.value.getBoundingClientRect()
+  }
+  const cursorX = getClientX(event) - wrapperRect.left
+  const index = Math.floor(
+    (timelineContentWrapperRef.value.scrollLeft + cursorX) / cellWidth.value
+  )
+  const dropDate = columns[Math.min(Math.max(index, 0), columns.length - 1)]
   const startDate = addBusinessDays(dropDate, 0, rootElement.daysOff)
   const endDate = item.estimation
     ? addBusinessDays(

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -1096,6 +1096,10 @@ let lastEndDate = null
 // person row the drag started on: a multi-assignee task renders one bar per
 // assignee, so assignees[0] is not necessarily the person being reassigned
 let dragSourcePersonId = null
+// person row each dragged bar last hopped to during the drag: once the bar
+// left its source row, the source id is gone from assignees and only this
+// map knows which row the next hop must unassign
+const dragPersonByItem = new Map()
 
 // cached wrapper rect: getBoundingClientRect on every mousemove forces a
 // layout; invalidated on resize and zoom via resetScheduleSize
@@ -1517,17 +1521,25 @@ const changeDates = event => {
 
       target.classList.add('droppable')
 
+      const newAssigneeId = target.dataset.personId
       selection.value.forEach(item => {
+        // multi-selection: an item already on the hovered row would get the
+        // assignee id and its bar duplicated
+        if (item.assignees.includes(newAssigneeId)) return
+        // unassign the row the bar currently sits on: past the first hop the
+        // source person is gone from assignees, and the assignees[0]
+        // fallback would unassign an untouched co-assignee
+        const previousAssigneeId =
+          dragPersonByItem.get(item) ??
+          (dragSourcePersonId && item.assignees.includes(dragSourcePersonId)
+            ? dragSourcePersonId
+            : item.assignees[0])
+
         // the handlers own the assignees and person-line updates: mutating
         // them here too duplicated the new assignee id
-        const previousAssigneeId =
-          dragSourcePersonId && item.assignees.includes(dragSourcePersonId)
-            ? dragSourcePersonId
-            : item.assignees[0]
-        const newAssigneeId = target.dataset.personId
-
         emit('item-unassign', item, previousAssigneeId)
         emit('item-assign', item, newAssigneeId)
+        dragPersonByItem.set(item, newAssigneeId)
         refreshItemPositions(currentRootElement)
       })
     } else if (
@@ -1847,6 +1859,7 @@ const moveTimebar = (timeElement, event) => {
     initialClientX = getClientX(event)
     dragSourcePersonId =
       event.target.closest?.('[data-person-id]')?.dataset.personId ?? null
+    dragPersonByItem.clear()
     document.body.style.cursor = props.reassignable ? 'all-scroll' : 'ew-resize'
 
     startMoveTracking()
@@ -2036,6 +2049,7 @@ const stopBrowsing = event => {
   initialClientX = null
   initialClientY = null
   dragSourcePersonId = null
+  dragPersonByItem.clear()
   currentElement.value = null
 }
 

--- a/src/store/api/schedule.js
+++ b/src/store/api/schedule.js
@@ -43,7 +43,8 @@ export default {
 
   createScheduleItem(scheduleItem) {
     if (!scheduleItem.endDate) {
-      scheduleItem.endDate = scheduleItem.startDate.add(1, 'days').clone()
+      // clone before add: moment mutates the start date in place
+      scheduleItem.endDate = scheduleItem.startDate.clone().add(1, 'days')
     }
     const manDays = scheduleItem.man_days
     const data = {
@@ -100,7 +101,8 @@ export default {
 
   updateScheduleItem(scheduleItem) {
     if (!scheduleItem.endDate) {
-      scheduleItem.endDate = scheduleItem.startDate.add(1, 'days').clone()
+      // clone before add: moment mutates the start date in place
+      scheduleItem.endDate = scheduleItem.startDate.clone().add(1, 'days')
     }
     const manDays = scheduleItem.man_days
     const data = {


### PR DESCRIPTION
**Problem**
- Dragging an episode bar over another row of the all-episodes planning throws on every mouse move and freezes the drag.
- Dragging a multi-assignee task across several person rows unassigns an untouched co-assignee and keeps the intermediate row assigned.
- Drops from the assignment panel land on the wrong date: week cells are counted as days, and the cursor offset is hardcoded.
- Saving a schedule item without an end date shifts its start date by one day at every save.
- Closing the task side panel takes two clicks, and the task keeps a selection whose resize handles swallow the next click.
- A watcher observes a `height` prop that was removed from the widget.
- The unassign handler can splice the wrong bar on a lookup miss, and the drill-down error fallback resets `people` to the wrong type.
- Versioned tasks created from the assignment flow lose their ID, so the next edit posts a duplicate.
- The task panel hides out-of-department assignees, and saving silently unassigns them.
- Picking a task type hidden by the entity filter expands a row that the schedule does not show.

**Solution**
- Disable the row reassignment on the all-episodes planning and guard `checkUserIsAllowed` against non-person rows.
- Track the person row each dragged bar last hopped to and unassign that one; skip items already on the target row.
- Resolve the hovered column like the position bar does, from the wrapper rect and the day/week columns.
- Clone the start date before computing the fallback end date, on create and update.
- The close and cancel buttons close in one click and clear the schedule selection (`resetSelection` is now exposed).
- Drop the dead watcher.
- Guard the splice with an index check and reset `people` to an object.
- Report the created ID on the versioned task after the POST.
- Keep persons already assigned to the edited task listed, whatever their department.
- Clear the entity filter when the selected task type is not visible.
