### PR TITLE
[board] Modernize kanban board visuals and drag feedback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1327,9 +1327,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1351,9 +1348,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1375,9 +1369,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1399,9 +1390,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1423,9 +1411,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1447,9 +1432,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1644,9 +1626,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1664,9 +1643,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1684,9 +1660,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1704,9 +1677,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1724,9 +1694,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1744,9 +1711,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6076,9 +6040,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6100,9 +6061,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6124,9 +6082,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6148,9 +6103,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/components/lists/KanbanBoard.vue
+++ b/src/components/lists/KanbanBoard.vue
@@ -832,9 +832,9 @@ export default {
 }
 
 .dark .board-card .ui-droppable {
-  // faint light edge: border-alt (#666) frames too hard against the
-  // darker panel
-  border-color: rgba(255, 255, 255, 0.08);
+  // faint light edge, as a solid color: an alpha border would let the
+  // cover image bleed through and look milky
+  border-color: #55585d;
 }
 
 .preview-placeholder {

--- a/src/components/lists/KanbanBoard.vue
+++ b/src/components/lists/KanbanBoard.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="board">
-    <div class="box" v-if="!columns.length && !isLoading">
-      {{ $t('board.empty') }}
+    <div class="board-empty" v-if="!visibleColumns.length && !isLoading">
+      <square-dashed-kanban-icon :size="40" />
+      <p>{{ $t('board.empty') }}</p>
     </div>
     <ol
       class="board-columns"
@@ -18,32 +19,37 @@
       <li
         class="board-column"
         :class="{
-          disabled: !checkStatusIsAllowed(column.status, draggedTask)
+          disabled: !checkStatusIsAllowed(column.status, draggedTask),
+          droppable: dropColumnId === column.id
         }"
         :key="column.id"
-        @dragenter="onCardDragEnter($event, column.status)"
+        :style="{
+          '--status-tint': `${getStatusColor(column.status)}14`
+        }"
+        :data-status-id="column.id"
         @dragover="onCardDragOver"
-        @dragleave="onCardDragLeave"
         @drop="onCardDrop($event, column.status)"
-        v-for="column in columns"
+        v-for="column in visibleColumns"
       >
-        <h2 class="board-column-title">
+        <h2 class="board-column-title" :title="column.status.name">
           <span
             class="tag"
             :style="{
               background: getStatusColor(column.status),
               color: getStatusTextColor(column.status)
             }"
-            :title="column.status.name"
           >
             {{ column.status.short_name }}
           </span>
+          <span class="task-count">{{ column.tasks.length }}</span>
         </h2>
         <ol class="board-cards">
           <li
             class="board-card"
             :class="{
-              selected: isSelected(task)
+              selected: isSelected(task),
+              dragging: draggedTask?.id === task.id,
+              pending: modals.addPreview && modals.task?.id === task.id
             }"
             draggable="true"
             :key="task.id"
@@ -53,21 +59,24 @@
               onSelectTask(task, $event.ctrlKey || $event.metaKey)
             "
             @dragstart="onCardDragStart($event, task, column.status)"
-            @drag="onCardDrag"
             @dragend="onCardDragEnd"
             @mouseenter="onCardMouseEnter"
             @mouseleave="onCardMouseLeave"
             tabindex="0"
-            v-for="task in column.tasks"
+            :style="{ order: index * 2 }"
+            v-for="(task, index) in column.tasks"
           >
-            <div class="ui-droppable">
-              <entity-preview
-                class="entity-preview"
-                :empty-height="100"
-                :entity="{ preview_file_id: task.entity_preview_file_id }"
-                cover
-                is-rounded-top-border
-              />
+            <div
+              class="ui-droppable"
+              :class="{ 'has-preview': task.entity_preview_file_id }"
+              :style="getCardStyle(task)"
+            >
+              <div
+                class="preview-placeholder"
+                v-if="!task.entity_preview_file_id"
+              >
+                <image-icon :size="18" />
+              </div>
               <div class="avatars">
                 <people-avatar
                   :is-link="false"
@@ -108,6 +117,20 @@
               </div>
             </div>
           </li>
+          <li
+            class="board-drop-ghost"
+            :style="{ order: getGhostOrder(column) }"
+            v-if="isGhostVisible(column)"
+          >
+            <image-up-icon
+              :size="18"
+              v-if="column.status.is_feedback_request"
+            />
+          </li>
+          <li
+            class="board-empty-zone"
+            v-if="!column.tasks.length && !isGhostVisible(column)"
+          ></li>
         </ol>
       </li>
     </ol>
@@ -131,6 +154,7 @@
 </template>
 
 <script>
+import { ImageIcon, ImageUpIcon, SquareDashedKanbanIcon } from 'lucide-vue-next'
 import { mapActions, mapGetters } from 'vuex'
 
 import { sortPeople } from '@/lib/sorting'
@@ -139,7 +163,6 @@ import { domMixin } from '@/components/mixins/dom'
 import { formatListMixin } from '@/components/mixins/format'
 
 import AddPreviewModal from '@/components/modals/AddPreviewModal.vue'
-import EntityPreview from '@/components/widgets/EntityPreview.vue'
 import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
 import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
@@ -151,8 +174,10 @@ export default {
 
   components: {
     AddPreviewModal,
-    EntityPreview,
+    ImageIcon,
+    ImageUpIcon,
     PeopleAvatar,
+    SquareDashedKanbanIcon,
     TableInfo,
     TaskTypeName
   },
@@ -188,6 +213,7 @@ export default {
     return {
       addPreviewFormData: null,
       draggedTask: null,
+      dropColumnId: null,
       initialClientX: null,
       isScrollingX: false,
       errors: {
@@ -207,6 +233,24 @@ export default {
     }
   },
 
+  created() {
+    // Non-reactive drag helpers. The transparent image replaces the native
+    // drag snapshot so the DOM proxy below can tilt while following the
+    // cursor (a native drag image is a bitmap frozen at dragstart).
+    this.emptyDragImage = new Image()
+    this.emptyDragImage.src =
+      'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+    this.dragProxy = null
+    this.dragProxyInner = null
+    this.dragOffset = { x: 0, y: 0 }
+    this.lastDragX = 0
+    this.proxyRotation = 0
+  },
+
+  beforeUnmount() {
+    this.removeDragProxy()
+  },
+
   computed: {
     ...mapGetters([
       'isDarkTheme',
@@ -224,10 +268,21 @@ export default {
         return {
           id: status.id,
           status,
-          tasks
+          tasks,
+          droppable: this.checkColumnIsDroppable(status)
         }
       })
       return columns
+    },
+
+    visibleColumns() {
+      return this.columns.filter(
+        column => column.tasks.length || column.droppable
+      )
+    },
+
+    taskIndexMap() {
+      return new Map(this.tasks.map((task, index) => [task.id, index]))
     }
   },
 
@@ -256,9 +311,33 @@ export default {
       )
     },
 
+    checkColumnIsDroppable(taskStatus) {
+      if (!this.checkUserIsAllowed(taskStatus, this.user)) {
+        return false
+      }
+      if (this.production) {
+        return this.tasks.length > 0
+      }
+      // Without a selected production, a drop is only possible when at least
+      // one visible task belongs to a production exposing this status
+      // (mirrors checkStatusIsAllowed at drag time).
+      return this.tasks.some(task =>
+        taskStatus.productions?.includes(task.project_id)
+      )
+    },
+
     getSortedPeople(personIds) {
       const people = personIds.map(id => this.personMap.get(id)).filter(Boolean)
       return sortPeople(people)
+    },
+
+    getCardStyle(task) {
+      if (!task.entity_preview_file_id) {
+        return null
+      }
+      return {
+        backgroundImage: `url(/api/pictures/previews/preview-files/${task.entity_preview_file_id}.png)`
+      }
     },
 
     getStatusColor(status) {
@@ -335,44 +414,124 @@ export default {
 
     onCardDragStart(event, task, taskStatus) {
       event.stopPropagation()
-      event.target.classList.add('drag')
       event.dataTransfer.dropEffect = 'move'
       event.dataTransfer.effectAllowed = 'move'
       event.dataTransfer.setData('taskId', task.id)
       event.dataTransfer.setData('taskStatusId', taskStatus.id)
       this.draggedTask = task
-    },
-
-    onCardDrag(event) {
-      event.stopPropagation()
-      event.target.classList.add('dragging')
-    },
-
-    onCardDragEnd(event) {
-      event.target.classList.remove('drag')
-      event.target.classList.remove('dragging')
-      this.draggedTask = null
-    },
-
-    onCardDragEnter(event, taskStatus) {
-      const isAllowed =
-        this.draggedTask && this.checkUserIsAllowed(taskStatus, this.user)
-      if (!isAllowed) {
-        return
+      // dragenter/dragleave bubble from children and would make the drop
+      // state flicker, so the target column is derived from the pointer
+      // position in the document-level dragover instead.
+      document.addEventListener('dragover', this.onDocumentDragOver)
+      if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        event.dataTransfer.setDragImage(this.emptyDragImage, 0, 0)
+        this.createDragProxy(event)
       }
-      event.currentTarget.classList.add('droppable')
+    },
+
+    onCardDragEnd() {
+      this.draggedTask = null
+      this.dropColumnId = null
+      this.removeDragProxy()
     },
 
     onCardDragOver(event) {
       event.preventDefault()
     },
 
-    onCardDragLeave(event) {
-      event.target.classList.remove('droppable')
+    getGhostOrder(column) {
+      const movedTask = this.draggedTask || this.modals.task
+      if (!movedTask) {
+        return 0
+      }
+      // Cards use even order values (index * 2): the odd value slots the
+      // ghost where the dragged card will land in the column sort order.
+      const movedIndex = this.taskIndexMap.get(movedTask.id)
+      const before = column.tasks.filter(
+        task => this.taskIndexMap.get(task.id) < movedIndex
+      ).length
+      return before * 2 - 1
+    },
+
+    isGhostVisible(column) {
+      // during the drag, then while the preview-upload modal holds the
+      // pending move on a feedback-request status
+      return (
+        this.dropColumnId === column.id ||
+        (this.modals.addPreview && this.form.taskStatusId === column.id)
+      )
+    },
+
+    updateDropColumn(event) {
+      const columnEl = event.target.closest?.('.board-column')
+      const status = columnEl
+        ? this.statuses.find(({ id }) => id === columnEl.dataset.statusId)
+        : null
+      const isAllowed =
+        status &&
+        this.draggedTask &&
+        this.draggedTask.task_status_id !== status.id &&
+        this.checkUserIsAllowed(status, this.user) &&
+        this.checkStatusIsAllowed(status, this.draggedTask)
+      this.dropColumnId = isAllowed ? status.id : null
+    },
+
+    createDragProxy(event) {
+      const card = event.currentTarget
+      const rect = card.getBoundingClientRect()
+      this.dragOffset = {
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top
+      }
+      this.lastDragX = event.clientX
+      this.proxyRotation = 0
+      // The li clone keeps its board-card class and scoped data attributes,
+      // so the card styles apply outside the component tree.
+      const inner = card.cloneNode(true)
+      inner.style.cssText =
+        'margin: 0; list-style: none; transition: transform 120ms ease-out;'
+      const proxy = document.createElement('div')
+      proxy.style.cssText =
+        `position: fixed; left: 0; top: 0; width: ${rect.width}px; ` +
+        'margin: 0; pointer-events: none; z-index: 2000; will-change: transform;'
+      proxy.style.transform = `translate(${rect.left}px, ${rect.top}px)`
+      proxy.appendChild(inner)
+      // Kept inside the component tree: the theme class carrying the CSS
+      // custom properties wraps the app, so a body-level clone would
+      // resolve them to their light values.
+      this.$el.appendChild(proxy)
+      this.dragProxy = proxy
+      this.dragProxyInner = inner
+    },
+
+    onDocumentDragOver(event) {
+      this.updateDropColumn(event)
+      // The last dragover of a cancelled drag reports (0, 0)
+      if (!this.dragProxy || (event.clientX === 0 && event.clientY === 0)) {
+        return
+      }
+      const x = event.clientX - this.dragOffset.x
+      const y = event.clientY - this.dragOffset.y
+      this.dragProxy.style.transform = `translate(${x}px, ${y}px)`
+      const target = Math.max(
+        -6,
+        Math.min(6, (event.clientX - this.lastDragX) * 1.5)
+      )
+      this.lastDragX = event.clientX
+      // low-pass filter so the tilt follows the drag direction without jitter
+      this.proxyRotation = this.proxyRotation * 0.7 + target * 0.3
+      this.dragProxyInner.style.transform = `rotate(${this.proxyRotation}deg)`
+    },
+
+    removeDragProxy() {
+      document.removeEventListener('dragover', this.onDocumentDragOver)
+      this.dragProxy?.remove()
+      this.dragProxy = null
+      this.dragProxyInner = null
     },
 
     onCardDrop(event, taskStatus) {
-      event.currentTarget.classList.remove('droppable')
+      this.dropColumnId = null
 
       const isAllowed =
         this.draggedTask &&
@@ -416,14 +575,25 @@ export default {
       this.modals.task = null
     },
 
-    confirmAddPreviewModal(forms) {
+    async confirmAddPreviewModal(forms) {
+      this.loading.addPreview = true
+      this.errors.addPreview = false
       this.loadPreviewFileFormData(forms)
-      this.commentTaskWithPreview({
-        comment: '',
-        taskId: this.form.taskId,
-        taskStatusId: this.form.taskStatusId
-      })
-      this.closeAddPreviewModal()
+      try {
+        // keep the modal (and the pending ghost) up until the upload went
+        // through, so a failure does not silently drop the move
+        await this.commentTaskWithPreview({
+          comment: '',
+          taskId: this.form.taskId,
+          taskStatusId: this.form.taskStatusId
+        })
+        this.closeAddPreviewModal()
+      } catch (err) {
+        console.error(err)
+        this.errors.addPreview = true
+      } finally {
+        this.loading.addPreview = false
+      }
     }
   }
 }
@@ -436,9 +606,23 @@ export default {
   flex-direction: column;
   display: flex;
   overflow-y: auto;
+}
 
-  > .box {
-    margin: 2px; // avoid the overflow from hiding the box-shadow
+.board-empty {
+  align-items: center;
+  color: var(--text);
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.75em;
+  justify-content: flex-start;
+  opacity: 0.55;
+  padding: 2em 1em 0;
+  text-align: center;
+
+  p {
+    margin: 0;
+    max-width: 40ch;
   }
 }
 
@@ -453,9 +637,9 @@ export default {
   display: flex;
   flex: 1;
   flex-direction: row;
-  gap: 20px;
+  gap: 16px;
   overflow-x: auto;
-  padding-bottom: 2em;
+  padding-bottom: 1em;
 }
 
 .board-column {
@@ -464,10 +648,12 @@ export default {
   width: 300px;
   min-width: 300px;
   max-width: 300px;
-  align-items: center;
-  overflow-y: auto;
-  border: 2px solid var(--border-alt);
-  border-radius: 0.5em;
+  // the panel hugs its content, so its bottom edge is a real end and can
+  // keep the full radius
+  align-self: flex-start;
+  background: var(--background-panel);
+  border-radius: 12px;
+  max-height: 100%;
 
   &.disabled {
     opacity: 0.3;
@@ -475,7 +661,7 @@ export default {
   }
 
   &.droppable:not(.disabled) {
-    background: var(--background-selectable);
+    background: var(--status-tint);
 
     * {
       pointer-events: none;
@@ -484,87 +670,188 @@ export default {
 }
 
 .board-column-title {
-  position: sticky;
-  top: 0;
-  margin: 0;
-  padding-top: 5px;
-  width: 100%;
-  text-align: center;
-  background: var(--border-alt);
+  align-items: center;
   border: none;
-  z-index: 1;
+  display: flex;
+  gap: 0.5em;
+  margin: 0;
+  padding: 0.5em 12px 0.25em;
+  width: 100%;
 
   .tag {
     font-weight: bold;
+  }
+
+  .task-count {
+    color: var(--text);
+    font-size: 0.75rem;
+    font-weight: 600;
+    opacity: 0.6;
   }
 }
 
 .board-cards {
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: 1em;
-  padding: 2em 1em;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.75em 12px 1em;
+  // Chrome >= 121 ignores ::-webkit-scrollbar-* once scrollbar-width is set,
+  // so the thumb color must also go through scrollbar-color; the webkit rules
+  // below still cover the older Chromiums of the browser floor.
+  scrollbar-color: rgba(var(--skeleton-rgb), 0.4) transparent;
+  scrollbar-width: thin;
   width: 100%;
+
+  &::-webkit-scrollbar {
+    background: transparent;
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-button {
+    display: none;
+    height: 0;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(var(--skeleton-rgb), 0.4);
+    border-radius: 4px;
+  }
+}
+
+.board-empty-zone {
+  align-items: center;
+  border: 1px dashed rgba(var(--skeleton-rgb), 0.7);
+  border-radius: 10px;
+  color: var(--text);
+  display: flex;
+  height: 120px;
+  justify-content: center;
+}
+
+.board-drop-ghost {
+  align-items: center;
+  background: var(--status-tint);
+  border: 1px dashed rgba(var(--skeleton-rgb), 0.7);
+  border-radius: 10px;
+  // announces that dropping here will ask for a preview file
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  min-height: 180px;
+  opacity: 0.9;
 }
 
 .board-card {
   cursor: grab;
+  // the box-shadow ring below replaces the square native focus outline
+  outline: none;
   position: relative;
 
   .ui-droppable {
     border-radius: 10px;
-    border: 1px solid var(--border-alt);
-    background-color: var(--background-alt);
-  }
+    // borderless in light: crisp shadows carry the edge there, while the
+    // dark override below restores the border that dark mode relies on
+    border: 1px solid transparent;
+    // background-alt-2 is white in light theme: the cards must stand out
+    // from the column panel, which sits close to background-alt there
+    background-color: var(--background-alt-2);
+    background-position: center;
+    background-size: cover;
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.12),
+      0 2px 8px rgba(0, 0, 0, 0.06);
+    display: flex;
+    flex-direction: column;
+    min-height: 180px;
+    position: relative;
+    transition:
+      transform 150ms ease-out,
+      box-shadow 150ms ease-out;
 
-  &.selected {
-    cursor: grab;
+    &.has-preview {
+      // dark fallback keeps the white overlay text readable if the
+      // thumbnail fails to load or is transparent
+      background-color: #2a2d33;
 
-    .ui-droppable {
-      outline: 3px solid var(--background-selected);
-    }
-  }
+      .infos {
+        background: linear-gradient(transparent, rgba(0, 0, 0, 0.8));
+        border-radius: 0 0 9px 9px;
+        margin-top: auto;
+        padding-top: 1.5em;
 
-  &:focus-within {
-    .ui-droppable {
-      outline: 3px solid var(--background-selectable);
-    }
-    &.selected {
-      .ui-droppable {
-        outline: 3px solid var(--background-selected);
+        .production-name {
+          color: #eee;
+          opacity: 0.9;
+        }
+
+        .entity-name {
+          color: $white;
+        }
       }
     }
   }
 
-  &.drag {
-    transform: translate(0, 0); // fix dragging style
+  &:hover .ui-droppable {
+    box-shadow:
+      0 2px 6px rgba(0, 0, 0, 0.14),
+      0 6px 16px rgba(0, 0, 0, 0.08);
+    transform: translateY(-2px);
+  }
 
-    .ui-droppable {
-      background: var(--background-selected);
-      transform: rotate(5deg);
-    }
+  // Box-shadow rings follow the border radius, unlike outlines, and
+  // :focus-visible keeps the ring for keyboard focus only: cards are
+  // focused on mouse hover too (Enter-to-select), which would otherwise
+  // flash the ring on every hover.
+  &:focus-visible .ui-droppable {
+    box-shadow:
+      0 0 0 3px var(--background-selectable),
+      0 4px 12px rgba(0, 0, 0, 0.05);
+  }
+
+  &.selected .ui-droppable {
+    box-shadow:
+      0 0 0 3px var(--background-selected),
+      0 4px 12px rgba(0, 0, 0, 0.05);
+  }
+
+  &.dragging,
+  &.pending {
+    opacity: 0.4;
   }
 
   &.dragging {
     cursor: grabbing;
-    opacity: 0.5;
-
-    .ui-droppable {
-      transform: rotate(0);
-      border: 1px solid var(--border-alt);
-      background-color: var(--background-alt);
-    }
   }
 }
 
-.entity-preview {
-  cursor: inherit;
+.dark .board-card .ui-droppable {
+  // faint light edge: border-alt (#666) frames too hard against the
+  // darker panel
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.preview-placeholder {
+  align-items: center;
+  background: rgba(var(--border-rgb), 0.25);
+  border-radius: 10px 10px 0 0;
+  color: var(--text);
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  opacity: 0.8;
 }
 
 .avatars {
   position: absolute;
-  right: 5px;
-  top: 75px;
+  right: 8px;
+  top: 8px;
   display: flex;
   flex-direction: row;
   gap: 0.25em;
@@ -593,7 +880,7 @@ export default {
 }
 
 .infos {
-  padding: 0.5em;
+  padding: 0.6em 0.7em 0.7em;
   word-break: break-word;
 
   .entity {
@@ -603,12 +890,15 @@ export default {
 
   .production-name {
     color: var(--text);
-    font-size: 0.9em;
-    font-weight: 400;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    opacity: 0.65;
     text-transform: uppercase;
   }
 
   .entity-name {
+    color: var(--text-strong);
     font-size: 1.1em;
     font-weight: 600;
   }
@@ -620,6 +910,16 @@ export default {
     max-width: 50%;
     overflow: hidden;
     text-overflow: ellipsis;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .board-card .ui-droppable {
+    transition: none;
+  }
+
+  .board-card:hover .ui-droppable {
+    transform: none;
   }
 }
 </style>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -82,7 +82,7 @@ export default {
 
   board: {
     title: 'Board',
-    empty: 'Your kanban board is currently empty. This means no task statuses are configured for your users role in the production settings.',
+    empty: 'Nothing to show on the board: you have no ongoing tasks, your search returned no results, or no task statuses are enabled for your role in the production settings.',
     settings: {
       title: 'Board Status',
       visible: 'Displayed on kanban board of...',


### PR DESCRIPTION
**Problem**

- Board columns were heavy grey boxes with no task counts and a stray scrollbar over the header; empty previews rendered as black boxes with a 404 request per card
- Cards left little room to the artwork and drag & drop gave poor feedback (fixed tilt, no drop location preview, no hint when a status requires a preview file)
- Empty columns looked the same whether or not a drop was possible, and the empty-board message only mentioned role configuration

**Solution**

- Columns become content-hugging panels with a status pill + task count header; columns that cannot receive any task are hidden and the empty state got an illustration and a wording covering all its causes
- Cards show the preview as a full cover background with a translucent scrim, uniform heights, and a placeholder icon when there is no preview
- Drag shows a theme-aware proxy tilting with the drag direction, a ghost slot at the card's real insertion position in the status-tinted target column, and an upload icon when the target status will request a preview file; the ghost holds the pending move while the upload modal is open, which now waits for the upload before closing
- Keyboard focus keeps a rounded `:focus-visible` ring and `prefers-reduced-motion` falls back to the native drag