### PR TITLE
[Project Schedule] Fix bar drag trailing click

### DIFF
--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -465,7 +465,7 @@
                     v-show="isVisible(rootElement)"
                     role="button"
                     tabindex="0"
-                    @click="$emit('root-element-selected', rootElement)"
+                    @click="onRootBarClick(rootElement)"
                     @keydown.enter.prevent="
                       $emit('root-element-selected', rootElement)
                     "
@@ -648,7 +648,7 @@
                     v-show="subchildren || isVisible(childElement)"
                     role="button"
                     tabindex="0"
-                    @click="$emit('item-selected', rootElement, childElement)"
+                    @click="onChildBarClick(rootElement, childElement)"
                     @keydown.enter.prevent="
                       $emit('item-selected', rootElement, childElement)
                     "
@@ -750,13 +750,7 @@
                           @mousedown="moveTimebar(task, $event)"
                           @touchstart="moveTimebar(task, $event)"
                           @click="
-                            $emit(
-                              'task-selected',
-                              rootElement,
-                              childElement,
-                              task,
-                              selection
-                            )
+                            onTaskBarClick(rootElement, childElement, task)
                           "
                           @keydown.enter.prevent="
                             $emit(
@@ -1100,6 +1094,12 @@ let dragSourcePersonId = null
 // left its source row, the source id is gone from assignees and only this
 // map knows which row the next hop must unassign
 const dragPersonByItem = new Map()
+
+// a native click still fires on mouseup after a genuine drag (mousedown and
+// mouseup landed on the same bar), so an unguarded click handler would
+// re-select/expand the row right after every move. stopBrowsing sets this
+// once it detects the pointer actually moved; the next click consumes it.
+let justDragged = false
 
 // cached wrapper rect: getBoundingClientRect on every mousemove forces a
 // layout; invalidated on resize and zoom via resetScheduleSize
@@ -2012,6 +2012,11 @@ const stopBrowsing = event => {
   }
   if (currentElement.value) {
     if (initialClientX !== getClientX(event)) {
+      // the mouseup below still dispatches a click on this same bar; without
+      // this it would fall straight through to root-element-selected /
+      // item-selected / task-selected and re-expand or re-select right after
+      // every drag
+      justDragged = true
       // on moving or resizing selected items
       selection.value.forEach(item => {
         emit('item-changed', item)
@@ -2257,6 +2262,30 @@ const timebarSubchildTitle = task => {
     ? formatDuration(task.duration)
     : formatDuration(task.estimation)
   return `${name} (${startDate} - ${endDate}) ${duration} ${durationUnit.value}`
+}
+
+// True the first time it's called after a drag, then resets: a click fires
+// on mouseup even after a real drag, so callers use this to skip acting on
+// that trailing click without also swallowing the next genuine click.
+const consumeDragClick = () => {
+  if (!justDragged) return false
+  justDragged = false
+  return true
+}
+
+const onRootBarClick = rootElement => {
+  if (consumeDragClick()) return
+  emit('root-element-selected', rootElement)
+}
+
+const onChildBarClick = (rootElement, childElement) => {
+  if (consumeDragClick()) return
+  emit('item-selected', rootElement, childElement)
+}
+
+const onTaskBarClick = (rootElement, childElement, task) => {
+  if (consumeDragClick()) return
+  emit('task-selected', rootElement, childElement, task, selection.value)
 }
 
 const getTimebarLeft = timeElement => {

--- a/src/components/widgets/Schedule.vue
+++ b/src/components/widgets/Schedule.vue
@@ -2012,10 +2012,6 @@ const stopBrowsing = event => {
   }
   if (currentElement.value) {
     if (initialClientX !== getClientX(event)) {
-      // the mouseup below still dispatches a click on this same bar; without
-      // this it would fall straight through to root-element-selected /
-      // item-selected / task-selected and re-expand or re-select right after
-      // every drag
       justDragged = true
       // on moving or resizing selected items
       selection.value.forEach(item => {
@@ -2264,9 +2260,8 @@ const timebarSubchildTitle = task => {
   return `${name} (${startDate} - ${endDate}) ${duration} ${durationUnit.value}`
 }
 
-// True the first time it's called after a drag, then resets: a click fires
-// on mouseup even after a real drag, so callers use this to skip acting on
-// that trailing click without also swallowing the next genuine click.
+// True the first time it's called after a drag, then resets, so it skips
+// only that one trailing click and not the next genuine one.
 const consumeDragClick = () => {
   if (!justDragged) return false
   justDragged = false

--- a/tests/unit/components/widgets/schedule-root-bar-drag-click.spec.js
+++ b/tests/unit/components/widgets/schedule-root-bar-drag-click.spec.js
@@ -92,10 +92,9 @@ describe('Schedule widget - dragging a collapsed root row bar', () => {
     const bar = wrapper.find('.timebar-center')
     await dragBar(wrapper, bar, 500, 560)
 
-    // the drag itself moved the bar's dates
+    // sanity check: a drag actually happened
     expect(rootElement.startDate.isSame(moment('2026-08-15'))).toBe(false)
 
-    // but the trailing click must not also select/expand the row
     expect(wrapper.emitted('root-element-selected')).toBeFalsy()
 
     wrapper.unmount()

--- a/tests/unit/components/widgets/schedule-root-bar-drag-click.spec.js
+++ b/tests/unit/components/widgets/schedule-root-bar-drag-click.spec.js
@@ -1,0 +1,115 @@
+import { mount } from '@vue/test-utils'
+import moment from 'moment'
+import { vi } from 'vitest'
+
+vi.mock('vuex', () => ({
+  useStore: () => ({
+    getters: {
+      currentProduction: { id: 'production-1', name: 'Production' },
+      dateFormat: 'YYYY-MM-DD',
+      departmentMap: new Map(),
+      isCurrentUserProductionManager: true,
+      isDarkTheme: false,
+      milestones: [],
+      openProductions: [],
+      organisation: { hours_by_day: 8 },
+      taskMap: new Map(),
+      taskStatuses: []
+    },
+    dispatch: vi.fn()
+  })
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: key => key })
+}))
+
+import Schedule from '@/components/widgets/Schedule.vue'
+
+const buildRootElement = () => ({
+  id: 'task-type-1',
+  name: 'Asset / Rigging',
+  color: '#888888',
+  editable: true,
+  expanded: false,
+  loading: false,
+  man_days: 0,
+  daysOff: [],
+  startDate: moment('2026-08-15'),
+  endDate: moment('2026-08-29'),
+  children: []
+})
+
+const mountSchedule = rootElement =>
+  mount(Schedule, {
+    props: {
+      startDate: moment('2026-07-05'),
+      endDate: moment('2026-10-23'),
+      hierarchy: [rootElement],
+      zoomLevel: 1,
+      withMilestones: false,
+      isLoading: false
+    },
+    attachTo: document.body
+  })
+
+// Mirrors what a real browser does: mousedown then mouseup on the same
+// element still dispatches a trailing click, drag or not.
+const dragBar = async (wrapper, bar, fromX, toX) => {
+  await bar.trigger('mousedown', { clientX: fromX })
+  document.dispatchEvent(
+    new MouseEvent('mousemove', { bubbles: true, clientX: toX })
+  )
+  document.dispatchEvent(
+    new MouseEvent('mouseup', { bubbles: true, clientX: toX })
+  )
+  bar.element.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: toX }))
+  await wrapper.vm.$nextTick()
+}
+
+describe('Schedule widget - dragging a collapsed root row bar', () => {
+  let rafSpy
+
+  beforeEach(() => {
+    // the drag is throttled through requestAnimationFrame, which never fires
+    // on its own in jsdom
+    rafSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(callback => {
+        callback()
+        return 0
+      })
+  })
+
+  afterEach(() => {
+    rafSpy.mockRestore()
+  })
+
+  test('does not unfold the row via the trailing click after the drag', async () => {
+    const rootElement = buildRootElement()
+    const wrapper = mountSchedule(rootElement)
+
+    const bar = wrapper.find('.timebar-center')
+    await dragBar(wrapper, bar, 500, 560)
+
+    // the drag itself moved the bar's dates
+    expect(rootElement.startDate.isSame(moment('2026-08-15'))).toBe(false)
+
+    // but the trailing click must not also select/expand the row
+    expect(wrapper.emitted('root-element-selected')).toBeFalsy()
+
+    wrapper.unmount()
+  })
+
+  test('a real click with no movement still selects the row', async () => {
+    const rootElement = buildRootElement()
+    const wrapper = mountSchedule(rootElement)
+
+    const bar = wrapper.find('.timebar-center')
+    await dragBar(wrapper, bar, 500, 500)
+
+    expect(wrapper.emitted('root-element-selected')).toBeTruthy()
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
**Problem**

- Dragging a schedule bar (department/task-type row, entity row, or a person's task) always fired a trailing click on top of the drag itself, because a native click still fires on mouseup whenever mousedown and mouseup land on the same element, regardless of pointer movement in between.
- For a task-type row (e.g. Asset/Rigging), that trailing click re-triggered `root-element-selected`, which expands the row — so moving the bar unfolded it every time.
- The same pattern also re-fired `item-selected` on entity rows and `task-selected` on a person's task bars.

**Solution**

- `stopBrowsing` now flags when it detects real pointer movement during a drag.
- New `onRootBarClick` / `onChildBarClick` / `onTaskBarClick` handlers consume that flag once and skip the select/expand event for the trailing click only; a genuine no-movement click still works as before.
- Added a test that drives a real `mousedown → mousemove → mouseup → click` sequence and is confirmed to fail before the fix, pass after.


**Comment** 
I am not 100% sure if this patch is against anything that is intended. It felt a bit annoying when the tasks always collapse as soon as I move a task schedule and reveal everything below. Sometimes you just want to move timelines and not always look on whats underneath. There is a pop up message in case you are changing anything drastically that would affect start dates and end dates below. Then you can collapse the tasks yourself. 