### PR TITLE
[calendar] Modernize the user calendar and show logged time

### DIFF
--- a/src/components/lists/TimesheetList.vue
+++ b/src/components/lists/TimesheetList.vue
@@ -295,6 +295,10 @@ export default {
     hideDayOff: {
       default: true,
       type: Boolean
+    },
+    initialDate: {
+      default: null,
+      type: String
     }
   },
 
@@ -307,7 +311,9 @@ export default {
       colTypePosX: '',
       disabledDates: {},
       page: 1,
-      selectedDate: today,
+      selectedDate: this.initialDate
+        ? moment(this.initialDate, 'YYYY-MM-DD').toDate()
+        : today,
       modals: {
         setDayOff: false,
         unsetDayOff: false

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -100,11 +100,15 @@
             :is-loading="isTasksLoading"
             :days-off="daysOff"
             :tasks="sortedAllTasks"
+            :time-spents="calendarTimeSpents"
+            @dates-changed="onCalendarDatesChanged"
+            @time-clicked="onCalendarTimeClicked"
             v-else-if="isActiveTab('calendar')"
           />
 
           <timesheet-list
             ref="timesheet-list"
+            :initial-date="selectedDate"
             :tasks="loggablePersonTasks"
             :done-tasks="loggableDoneTasks"
             :is-loading="isTasksLoading"
@@ -213,6 +217,7 @@ export default {
   data() {
     return {
       activeTab: 'todos',
+      calendarTimeSpents: [],
       currentSort: 'entity_name',
       daysOff: [],
       dayOffError: false,
@@ -497,6 +502,7 @@ export default {
       'loadPersonDoneTasks',
       'loadPersonTasks',
       'loadPersonTimeSpents',
+      'loadPersonTimeSpentsByPeriod',
       'setPersonTasksSearch',
       'savePersonTasksSearch',
       'removePersonTasksSearch',
@@ -506,6 +512,28 @@ export default {
       'unsetDayOff',
       'updateTask'
     ]),
+
+    onCalendarTimeClicked(date) {
+      this.$router.push({
+        query: { ...this.$route.query, section: 'timesheets', day: date }
+      })
+    },
+
+    async onCalendarDatesChanged({ start, end }) {
+      if (!this.person) {
+        return
+      }
+      try {
+        this.calendarTimeSpents = await this.loadPersonTimeSpentsByPeriod({
+          personId: this.person.id,
+          startDate: start,
+          endDate: end
+        })
+      } catch (err) {
+        console.error(err)
+        this.calendarTimeSpents = []
+      }
+    },
 
     sortTasks(tasks) {
       const isName = this.currentSort === 'entity_name'
@@ -750,6 +778,18 @@ export default {
         ? currentSection
         : 'todos'
 
+      const day = this.$route.query.day
+      if (
+        day &&
+        day !== this.selectedDate &&
+        moment(day, 'YYYY-MM-DD', true).isValid()
+      ) {
+        this.selectedDate = day
+        if (this.person) {
+          this.loadTimeSpents()
+        }
+      }
+
       const currentProduction = this.userOpenProductions.find(
         ({ id }) => id === this.$route.query.productionId
       )
@@ -776,6 +816,12 @@ export default {
 
     async onDateChanged(date) {
       this.selectedDate = moment(date).format('YYYY-MM-DD')
+      // keep the day shareable in the URL, without stacking history entries
+      if (this.$route.query.day !== this.selectedDate) {
+        this.$router.replace({
+          query: { ...this.$route.query, day: this.selectedDate }
+        })
+      }
       await this.loadTimeSpents()
     },
 
@@ -867,6 +913,10 @@ export default {
     },
 
     '$route.query.section'() {
+      this.updateActiveTab()
+    },
+
+    '$route.query.day'() {
       this.updateActiveTab()
     },
 

--- a/src/components/pages/Todos.vue
+++ b/src/components/pages/Todos.vue
@@ -100,11 +100,15 @@
           :days-off="daysOff"
           :is-loading="isTodosLoading"
           :tasks="sortedTasks"
+          :time-spents="calendarTimeSpents"
+          @dates-changed="onCalendarDatesChanged"
+          @time-clicked="onCalendarTimeClicked"
           v-if="isActiveTab('calendar')"
         />
 
         <timesheet-list
           ref="timesheet-list"
+          :initial-date="selectedDate"
           :tasks="loggableTodos"
           :done-tasks="loggableDoneTasks"
           :is-loading="loading.timesheets || isTodosLoading"
@@ -198,6 +202,7 @@ export default {
         savingSearch: false
       },
       productionId: undefined,
+      calendarTimeSpents: [],
       selectedDate: moment().format('YYYY-MM-DD'),
       sortOptions: [
         'entity_name',
@@ -391,6 +396,7 @@ export default {
       'clearSelectedTasks',
       'loadAggregatedPersonDaysOff',
       'loadOpenProductions',
+      'loadPersonTimeSpentsByPeriod',
       'loadUserTimeSpents',
       'loadTodos',
       'loadDoneTasks',
@@ -455,6 +461,16 @@ export default {
         ? currentSection
         : 'todos'
 
+      const day = this.$route.query.day
+      if (
+        day &&
+        day !== this.selectedDate &&
+        moment(day, 'YYYY-MM-DD', true).isValid()
+      ) {
+        this.selectedDate = day
+        this.loadTimeSpents()
+      }
+
       const currentProduction = this.openProductions.find(
         ({ id }) => id === this.$route.query.productionId
       )
@@ -502,8 +518,33 @@ export default {
     async onDateChanged(date) {
       this.loading.timesheets = true
       this.selectedDate = moment(date).format('YYYY-MM-DD')
+      // keep the day shareable in the URL, without stacking history entries
+      if (this.$route.query.day !== this.selectedDate) {
+        this.$router.replace({
+          query: { ...this.$route.query, day: this.selectedDate }
+        })
+      }
       await this.loadTimeSpents()
       this.loading.timesheets = false
+    },
+
+    onCalendarTimeClicked(date) {
+      this.$router.push({
+        query: { ...this.$route.query, section: 'timesheets', day: date }
+      })
+    },
+
+    async onCalendarDatesChanged({ start, end }) {
+      try {
+        this.calendarTimeSpents = await this.loadPersonTimeSpentsByPeriod({
+          personId: this.user.id,
+          startDate: start,
+          endDate: end
+        })
+      } catch (err) {
+        console.error(err)
+        this.calendarTimeSpents = []
+      }
     },
 
     async onSetDayOff(dayOff) {
@@ -665,6 +706,10 @@ export default {
     },
 
     '$route.query.section'() {
+      this.updateActiveTab()
+    },
+
+    '$route.query.day'() {
       this.updateActiveTab()
     },
 

--- a/src/components/widgets/UserCalendar.vue
+++ b/src/components/widgets/UserCalendar.vue
@@ -3,11 +3,39 @@
     <spinner />
   </div>
   <div class="user-calendar mt1" ref="rootRef" v-else>
+    <div class="week-rail" v-if="weekRows.length">
+      <div
+        class="week-total"
+        :class="{ attached: row.attached, 'attached-next': row.attachedNext }"
+        :key="`${row.top}-${row.label}`"
+        :style="{ top: `${row.top}px`, height: `${row.height}px` }"
+        v-for="row in weekRows"
+      >
+        {{ row.label }}
+      </div>
+    </div>
     <full-calendar
       ref="calendarRef"
       class="app-calendar"
       :options="calendarOptions"
     >
+      <template #dayCellContent="arg">
+        <span class="day-cell-content">
+          <span>{{ arg.dayNumberText }}</span>
+          <span
+            class="day-hours"
+            role="button"
+            tabindex="0"
+            @click.stop="emit('time-clicked', toDateKey(arg.date))"
+            @keydown.enter.stop.prevent="
+              emit('time-clicked', toDateKey(arg.date))
+            "
+            v-if="timeByDay.get(toDateKey(arg.date))"
+          >
+            {{ formatHours(timeByDay.get(toDateKey(arg.date))) }}
+          </span>
+        </span>
+      </template>
       <template #eventContent="{ event }">
         <div
           class="calendar-day-off"
@@ -67,7 +95,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onBeforeUnmount, onMounted } from 'vue'
+import { ref, computed, watch, nextTick, onBeforeUnmount, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 import { BriefcaseIcon } from 'lucide-vue-next'
@@ -99,11 +127,17 @@ const props = defineProps({
     type: Array,
     default: () => []
   },
+  timeSpents: {
+    type: Array,
+    default: () => []
+  },
   isLoading: {
     type: Boolean,
     default: true
   }
 })
+
+const emit = defineEmits(['dates-changed', 'time-clicked'])
 
 const currentTask = ref(null)
 const calendarRef = ref(null)
@@ -114,20 +148,130 @@ const rootRef = ref(null)
 // then scrolls sideways). Nudge it on every container resize.
 const resizeObserver = new ResizeObserver(() => {
   calendarRef.value?.getApi().updateSize()
+  computeWeekRows()
 })
+
+const toDateKey = date =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-` +
+  `${String(date.getDate()).padStart(2, '0')}`
+
+// time spent durations are stored in minutes
+const formatHours = minutes => {
+  const hours = minutes / 60
+  return `${Number.isInteger(hours) ? hours : hours.toFixed(1)}h`
+}
+
+const timeByDay = computed(() => {
+  const byDay = new Map()
+  props.timeSpents.forEach(timeSpent => {
+    const key = timeSpent.date?.slice(0, 10)
+    byDay.set(key, (byDay.get(key) || 0) + timeSpent.duration)
+  })
+  return byDay
+})
+
+const weekRows = ref([])
+const currentRange = ref(null)
+const currentViewType = ref('dayGridMonth')
+
+// the dedicated week column lives outside the FullCalendar table, so its
+// cells are aligned by measuring the rendered week rows
+const computeWeekRows = () => {
+  // the dedicated column only makes sense on the month grid
+  if (
+    !rootRef.value ||
+    !props.timeSpents.length ||
+    currentViewType.value !== 'dayGridMonth'
+  ) {
+    weekRows.value = []
+    return
+  }
+  const rootRect = rootRef.value.getBoundingClientRect()
+  const rows = rootRef.value.querySelectorAll('.fc-daygrid-body tbody tr')
+  const cells = []
+  Array.from(rows).forEach(row => {
+    const rect = row.getBoundingClientRect()
+    const total = Array.from(
+      row.querySelectorAll('.fc-daygrid-day[data-date]')
+    ).reduce(
+      (sum, cell) => sum + (timeByDay.value.get(cell.dataset.date) || 0),
+      0
+    )
+    if (total) {
+      const top = rect.top - rootRect.top
+      const previous = cells[cells.length - 1]
+      // contiguous cells fuse into one block: square the shared corners
+      // and draw a separator instead
+      const attached =
+        Boolean(previous) && Math.abs(previous.top + previous.height - top) < 2
+      if (attached) {
+        previous.attachedNext = true
+      }
+      cells.push({
+        top,
+        height: rect.height,
+        label: formatHours(total),
+        attached,
+        attachedNext: false
+      })
+    }
+  })
+  weekRows.value = cells
+}
+
+const refreshMonthTotal = () => {
+  const range = currentRange.value
+  let total = 0
+  if (range) {
+    timeByDay.value.forEach((minutes, date) => {
+      if (date >= range.start && date < range.end) {
+        total += minutes
+      }
+    })
+  }
+  calendarOptions.value.customButtons = {
+    monthTotal: { text: total ? formatHours(total) : '', click: () => {} }
+  }
+}
+
+const refreshTimeDisplays = () => {
+  computeWeekRows()
+  refreshMonthTotal()
+}
+
+const onDatesSet = info => {
+  currentViewType.value = info.view.type
+  // currentStart/currentEnd cover the actual month or week, without the
+  // leading and trailing days of the neighbour months
+  currentRange.value = {
+    start: toDateKey(info.view.currentStart),
+    end: toDateKey(info.view.currentEnd)
+  }
+  const endDate = new Date(info.end)
+  endDate.setDate(endDate.getDate() - 1)
+  emit('dates-changed', {
+    start: toDateKey(info.start),
+    end: toDateKey(endDate)
+  })
+  nextTick(refreshTimeDisplays)
+}
 
 const calendarOptions = ref({
   plugins: [dayGridPlugin, multiMonthPlugin],
+  customButtons: {
+    monthTotal: { text: '', click: () => {} }
+  },
   headerToolbar: {
     left: 'prev,next today',
     center: 'title',
     // multiMonthYear stays wired up, only its button is hidden for now
-    right: 'dayGridMonth,dayGridWeek'
+    right: 'monthTotal dayGridMonth,dayGridWeek'
   },
   initialView: 'dayGridMonth',
   firstDay: 1,
   locales: allLocales,
-  locale: localeCode.value
+  locale: localeCode.value,
+  datesSet: onDatesSet
 })
 
 const resetEvents = () => {
@@ -262,6 +406,13 @@ watch(
   }
 )
 
+watch(
+  () => props.timeSpents,
+  () => {
+    nextTick(refreshTimeDisplays)
+  }
+)
+
 watch(localeCode, code => {
   calendarOptions.value.locale = code
   calendarRef.value?.getApi().setOption('locale', code)
@@ -283,9 +434,46 @@ watch(localeCode, code => {
   --calendar-day-off: rgba(255, 200, 80, 0.09);
 }
 
+.user-calendar {
+  display: flex;
+  gap: 8px;
+}
+
 .app-calendar {
-  width: 100%;
+  flex: 1;
   height: 100%;
+  min-width: 0;
+}
+
+.week-rail {
+  flex-shrink: 0;
+  position: relative;
+  width: 52px;
+}
+
+.week-total {
+  align-items: center;
+  background: var(--background-panel);
+  border-radius: 8px;
+  color: var(--text);
+  display: flex;
+  font-size: 0.75rem;
+  font-weight: 600;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  right: 0;
+
+  &.attached {
+    border-top: 1px solid rgba(var(--skeleton-rgb), 0.25);
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  &.attached-next {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
 }
 
 .calendar-day-off {
@@ -420,20 +608,52 @@ watch(localeCode, code => {
 :deep(.fc-daygrid-day-number) {
   color: var(--text);
   font-size: 0.8rem;
+  font-weight: 700;
   opacity: 0.7;
   padding: 6px 8px;
   text-decoration: none;
+  width: 100%;
+}
+
+:deep(.fc-daygrid-day-top) {
+  // fc defaults to row-reverse, which parks the day number on the right
+  flex-direction: row;
+}
+
+:deep(.day-cell-content) {
+  align-items: center;
+  display: flex;
+  gap: 4px;
+  justify-content: space-between;
+  width: 100%;
+}
+
+:deep(.day-hours) {
+  background: var(--background-selectable);
+  border-radius: 4px;
+  color: var(--text-strong);
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0 4px;
+
+  &:hover {
+    background: var(--background-selected);
+  }
 }
 
 :deep(.fc-day-today .fc-daygrid-day-number) {
+  opacity: 1;
+}
+
+// the today pill hugs the day number, not the hours badge next to it
+:deep(.fc-day-today .day-cell-content > span:first-child) {
   background: var(--background-selected);
   border-radius: 999px;
   color: var(--text-strong);
   font-weight: 700;
-  margin: 3px;
-  min-width: 26px;
-  opacity: 1;
-  padding: 4px 8px;
+  min-width: 22px;
+  padding: 2px 7px;
   text-align: center;
 }
 
@@ -523,6 +743,24 @@ watch(localeCode, code => {
     &:hover,
     &:not(:disabled):active,
     &:not(:disabled):focus {
+      border: none;
+    }
+  }
+
+  // plain text, not a button: fc customButtons is just the vehicle to get
+  // the period total into the toolbar
+  .fc-monthTotal-button {
+    background: transparent;
+    border: none;
+    color: var(--text-strong);
+    cursor: default;
+    font-weight: 700;
+    pointer-events: none;
+
+    &:hover,
+    &:not(:disabled):active,
+    &:not(:disabled):focus {
+      background: transparent;
       border: none;
     }
   }

--- a/src/components/widgets/UserCalendar.vue
+++ b/src/components/widgets/UserCalendar.vue
@@ -2,7 +2,7 @@
   <div class="loading-wrapper" v-if="isLoading">
     <spinner />
   </div>
-  <div class="user-calendar mt1" v-else>
+  <div class="user-calendar mt1" ref="rootRef" v-else>
     <full-calendar
       ref="calendarRef"
       class="app-calendar"
@@ -21,10 +21,14 @@
         </div>
         <div
           class="calendar-event"
-          :style="{
-            background: event.backgroundColor
+          :class="{
+            selected: currentTask?.id === event.extendedProps.taskId
           }"
-          :title="event.title"
+          :style="{
+            background: `${event.extendedProps.typeColor}26`,
+            '--event-color': event.extendedProps.typeColor
+          }"
+          :title="getEventTooltip(event)"
           role="button"
           tabindex="0"
           @click="onEventClicked(event)"
@@ -32,24 +36,21 @@
           @keydown.space.prevent="onEventClicked(event)"
           v-else
         >
-          <production-name
-            only-avatar
-            :production="event.extendedProps.production"
-            :size="25"
-          />
-          <entity-thumbnail
-            :preview-file-id="event.extendedProps.previewFileId"
-          />
+          <span class="event-thumbnail">
+            <img
+              loading="lazy"
+              :src="`/api/pictures/previews/preview-files/${event.extendedProps.previewFileId}.png`"
+              alt=""
+              v-if="event.extendedProps.previewFileId"
+            />
+          </span>
           <span
-            class="tag"
+            class="status-dot"
             :style="{
-              background: getStatusColor(event.extendedProps.taskStatus),
-              color: getStatusTextColor(event.extendedProps.taskStatus)
+              background: getStatusColor(event.extendedProps.taskStatus)
             }"
             :title="event.extendedProps.taskStatus.name"
-          >
-            {{ event.extendedProps.taskStatus.short_name }}
-          </span>
+          ></span>
           <div class="event-title">
             <span class="ellipsis">{{ event.extendedProps.title[0] }}</span>
             <span class="ellipsis" v-if="event.extendedProps.title[1]">
@@ -66,7 +67,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, computed, watch, onBeforeUnmount, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
 import { BriefcaseIcon } from 'lucide-vue-next'
@@ -78,8 +79,6 @@ import multiMonthPlugin from '@fullcalendar/multimonth'
 
 import { localeCode } from '@/lib/lang'
 
-import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
-import ProductionName from '@/components/widgets/ProductionName.vue'
 import Spinner from '@/components/widgets/Spinner.vue'
 
 const { t } = useI18n()
@@ -108,13 +107,22 @@ const props = defineProps({
 
 const currentTask = ref(null)
 const calendarRef = ref(null)
+const rootRef = ref(null)
+
+// FullCalendar only tracks window resizes: when the task side panel opens,
+// the container shrinks and the grid keeps its stale width (the calendar
+// then scrolls sideways). Nudge it on every container resize.
+const resizeObserver = new ResizeObserver(() => {
+  calendarRef.value?.getApi().updateSize()
+})
 
 const calendarOptions = ref({
   plugins: [dayGridPlugin, multiMonthPlugin],
   headerToolbar: {
     left: 'prev,next today',
     center: 'title',
-    right: 'dayGridMonth,dayGridWeek,multiMonthYear'
+    // multiMonthYear stays wired up, only its button is hidden for now
+    right: 'dayGridMonth,dayGridWeek'
   },
   initialView: 'dayGridMonth',
   firstDay: 1,
@@ -132,7 +140,8 @@ const resetEvents = () => {
   calendarApi.addEvent({
     display: 'background',
     daysOfWeek: [0, 6],
-    backgroundColor: '#ddd',
+    // resolved against the local theme-aware palette defined in the styles
+    backgroundColor: 'var(--calendar-weekend)',
     extendedProps: {
       isOff: true
     }
@@ -152,14 +161,17 @@ const resetEvents = () => {
         allDay: true,
         start,
         end,
-        borderColor: '#666',
-        backgroundColor: taskType.color,
+        // the tinted chip in the eventContent slot paints itself
+        borderColor: 'transparent',
+        backgroundColor: 'transparent',
         extendedProps: {
           previewFileId: task.entity_preview_file_id,
           taskStatus,
           taskId: task.id,
           title: task.full_entity_name.split(' / '),
-          production
+          production,
+          typeColor: taskType.color,
+          typeName: taskType.name
         }
       }
       calendarApi.addEvent(event)
@@ -174,7 +186,7 @@ const resetEvents = () => {
         title: t('timesheets.day_off'),
         display: 'background',
         start: startDate.toISOString().slice(0, 10),
-        backgroundColor: '#ffffe0',
+        backgroundColor: 'var(--calendar-day-off)',
         extendedProps: {
           isOff: true,
           description
@@ -205,12 +217,11 @@ const getStatusColor = status => {
   }
 }
 
-const getStatusTextColor = status => {
-  if (status.name === 'Todo' && !isDarkTheme.value) {
-    return '#333'
-  } else {
-    return 'white'
-  }
+const getEventTooltip = event => {
+  const { production, taskStatus, typeName } = event.extendedProps
+  return [production?.name, event.title, typeName, taskStatus.name]
+    .filter(Boolean)
+    .join(' · ')
 }
 
 const getDayOffInfo = dayOff => {
@@ -221,6 +232,19 @@ const getDayOffInfo = dayOff => {
 
 onMounted(() => {
   resetEvents()
+})
+
+// the root div sits behind a v-else on isLoading, so it can appear after
+// mount: observe whenever the element actually exists
+watch(rootRef, el => {
+  resizeObserver.disconnect()
+  if (el) {
+    resizeObserver.observe(el)
+  }
+})
+
+onBeforeUnmount(() => {
+  resizeObserver.disconnect()
 })
 
 watch(
@@ -248,6 +272,15 @@ watch(localeCode, code => {
 .user-calendar {
   width: 100%;
   max-height: 80%;
+  // local theme-aware palette, consumed by FullCalendar through the
+  // backgroundColor values passed in resetEvents
+  --calendar-weekend: rgba(0, 0, 0, 0.045);
+  --calendar-day-off: rgba(235, 170, 0, 0.14);
+}
+
+.dark .user-calendar {
+  --calendar-weekend: rgba(0, 0, 0, 0.16);
+  --calendar-day-off: rgba(255, 200, 80, 0.09);
 }
 
 .app-calendar {
@@ -261,7 +294,7 @@ watch(localeCode, code => {
   align-items: center;
   height: 100%;
   padding: 4px;
-  color: $black;
+  color: var(--text);
   font-weight: 500;
   cursor: default;
 
@@ -277,23 +310,66 @@ watch(localeCode, code => {
 
 .calendar-event {
   align-items: center;
+  border-radius: 5px;
+  color: var(--text-strong);
+  cursor: pointer;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5em;
-  overflow-x: auto;
-  padding: 0.25em;
+  flex-wrap: nowrap;
+  gap: 6px;
+  overflow: hidden;
+  padding: 4px 8px 4px 12px;
+  position: relative;
+  width: 100%;
+
+  > * {
+    flex-shrink: 0;
+  }
+
+  // inset rounded rail: a border-left would square the left corners
+  &::before {
+    background: var(--event-color);
+    border-radius: 2px;
+    bottom: 3px;
+    content: '';
+    left: 3px;
+    position: absolute;
+    top: 3px;
+    width: 3px;
+  }
+
+  // inset ring: an outer ring would be clipped by the calendar rows
+  &.selected {
+    box-shadow: inset 0 0 0 2px var(--background-selected);
+  }
 }
 
-.tag {
-  font-weight: 500;
-  letter-spacing: 1px;
-  text-transform: uppercase;
+.status-dot {
+  border-radius: 50%;
+  height: 9px;
+  width: 9px;
+}
+
+.event-thumbnail {
+  background: rgba(var(--border-rgb), 0.5);
+  border-radius: 3px;
+  height: 18px;
+  overflow: hidden;
+  width: 32px;
+
+  img {
+    display: block;
+    height: 100%;
+    object-fit: cover;
+    width: 100%;
+  }
 }
 
 .event-title {
   display: flex;
-  flex-wrap: wrap;
+  flex-shrink: 1;
+  flex-wrap: nowrap;
   gap: 0 0.25em;
+  min-width: 0;
   overflow: hidden;
   font-weight: 500;
 
@@ -303,6 +379,78 @@ watch(localeCode, code => {
 }
 
 // Customize style of FullCalendar
+:deep(.fc) {
+  // --border matches the panel background in dark theme, so the day grid
+  // needs its own visible hairline value
+  --fc-border-color: rgba(var(--skeleton-rgb), 0.25);
+  --fc-today-bg-color: transparent;
+  // defaults to white: the multimonth (year) view paints its month tiles
+  // with it, which breaks dark theme
+  --fc-page-bg-color: transparent;
+  --fc-neutral-bg-color: rgba(var(--skeleton-rgb), 0.15);
+  // our background colors already carry their alpha
+  --fc-bg-event-opacity: 1;
+}
+
+// the grid becomes a panel surface, like the kanban board columns
+:deep(.fc-view-harness) {
+  background: var(--background-panel);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+:deep(.fc-scrollgrid) {
+  border: none;
+}
+
+:deep(.fc-col-header-cell) {
+  padding: 8px 0 6px;
+
+  .fc-col-header-cell-cushion {
+    color: var(--text);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    opacity: 0.6;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+}
+
+:deep(.fc-daygrid-day-number) {
+  color: var(--text);
+  font-size: 0.8rem;
+  opacity: 0.7;
+  padding: 6px 8px;
+  text-decoration: none;
+}
+
+:deep(.fc-day-today .fc-daygrid-day-number) {
+  background: var(--background-selected);
+  border-radius: 999px;
+  color: var(--text-strong);
+  font-weight: 700;
+  margin: 3px;
+  min-width: 26px;
+  opacity: 1;
+  padding: 4px 8px;
+  text-align: center;
+}
+
+:deep(.fc-h-event) {
+  background: transparent;
+  border: none;
+}
+
+:deep(.fc-daygrid-event) {
+  border-radius: 5px;
+  margin-left: 2px;
+  margin-right: 2px;
+  // vertical gap between stacked bars: fc positions harnesses from their
+  // MEASURED height (margins excluded), so the gap must be padding
+  padding-bottom: 3px;
+}
+
 :deep(.fc-toolbar-chunk) {
   h2 {
     text-decoration: none;
@@ -314,8 +462,10 @@ watch(localeCode, code => {
   .fc-button {
     background: transparent;
     border: 1px solid var(--border);
+    border-radius: 8px;
     color: var(--text);
     outline: none;
+    text-transform: capitalize;
 
     &:not(:disabled):active,
     &:not(:disabled):focus {
@@ -344,6 +494,52 @@ watch(localeCode, code => {
     background: transparent;
     border: 1px solid var(--border);
     color: var(--text);
+  }
+}
+
+:deep(.fc-header-toolbar) {
+  margin-bottom: 1em;
+
+  .fc-toolbar-title {
+    color: var(--text-strong);
+    font-size: 1.25rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: capitalize;
+  }
+
+  .fc-button {
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0.35em 0.9em;
+  }
+
+  // ghost chevrons: plain icon buttons, the border only weighs them down
+  .fc-prev-button,
+  .fc-next-button {
+    border: none;
+    padding: 0.35em 0.5em;
+
+    &:hover,
+    &:not(:disabled):active,
+    &:not(:disabled):focus {
+      border: none;
+    }
+  }
+
+  // segmented groups: round the outer corners only
+  .fc-button-group {
+    .fc-button {
+      border-radius: 0;
+    }
+
+    .fc-button:first-child {
+      border-radius: 8px 0 0 8px;
+    }
+
+    .fc-button:last-child {
+      border-radius: 0 8px 8px 0;
+    }
   }
 }
 </style>


### PR DESCRIPTION
**Problem**

- The user calendar on the Person and Todos pages kept its legacy styling, out of step with the refreshed board
- Logged time is invisible from the calendar; checking hours requires switching to the timesheet tab

**Solution**

- Restyle the calendar with theme tokens so light and dark modes both look current
- Show logged time per day, week and month, fetched for the displayed period
- Clicking a day's time opens the timesheet tab on that date