### PR TITLE
[tasks] Migrate the My Tasks and Person pages to Composition API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,13 @@ const emit = defineEmits([...])
 
 Skip sections that are not relevant. Order within each section is by usage proximity (related items together) rather than alphabetical.
 
+Underline every section title with a dashed line padded to the 80-column limit:
+
+```js
+// State
+// --------------------------------------------------------------------------
+```
+
 #### Import order
 
 Within `<script setup>`, sort imports **alphabetically by source path** within each of these blocks (separate blocks with a blank line):

--- a/src/components/cells/TimeSliderCell.vue
+++ b/src/components/cells/TimeSliderCell.vue
@@ -4,38 +4,48 @@
       <span class="value flexrow-item">
         {{ value }}
       </span>
-      <vue-slider
-        class="flexrow-item slider"
-        :dot-options="{ focusStyle: { 'box-shadow': '0 0 1px 1px #8F91EBA0' } }"
-        :interval="0.25"
-        :lazy="true"
-        :min="0"
-        :max="12"
-        :marks="marks"
-        :piecewise="true"
-        :process-style="{ 'background-color': '#8F91EB' }"
-        :tooltip="'hover'"
-        :use-keyboard="true"
-        :step-style="stepStyle"
-        :width="400"
-        v-model="value"
+      <span class="flexrow-item" @wheel.prevent="onWheel">
+        <vue-slider
+          ref="slider"
+          class="slider"
+          :adsorb="true"
+          :dot-size="16"
+          :height="6"
+          :interval="0.25"
+          :lazy="true"
+          :min="0"
+          :max="12"
+          :marks="marks"
+          :tooltip="'active'"
+          :use-keyboard="true"
+          :width="400"
+          @drag-end="onDragEnd"
+          v-model="value"
+        />
+      </span>
+      <button-simple
+        class="flexrow-item"
+        :active="value === preset"
+        :key="`preset-${preset}`"
+        :text="`${preset}`"
+        @click="setValue(preset)"
+        v-for="preset in presets"
       />
-      <button class="button flexrow-item" @click="setValue(1)">1</button>
-      <button class="button flexrow-item" @click="setValue(4)">4</button>
-      <button class="button flexrow-item" @click="setValue(hoursByDay)">
-        {{ hoursByDay }}
-      </button>
     </div>
   </td>
 </template>
 
 <script setup>
+import { computed, ref, useTemplateRef, watch } from 'vue'
 import VueSlider from 'vue-3-slider-component'
-import { computed, ref, watch } from 'vue'
 import { useStore } from 'vuex'
+
+import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 
 const store = useStore()
 
+// Props / Emits
+// --------------------------------------------------------------------------
 const props = defineProps({
   duration: { type: Number, default: 0 },
   taskId: { type: String, default: '' }
@@ -43,34 +53,50 @@ const props = defineProps({
 
 const emit = defineEmits(['change'])
 
-const labelStyle = { fontSize: '.6em', top: '3px', left: '1px' }
+// State
+// --------------------------------------------------------------------------
 const marks = {
-  0: { label: '0', labelStyle },
-  2: { label: '' },
-  4: { label: '4', labelStyle },
-  6: { label: '' },
-  8: { label: '8', labelStyle },
-  10: { label: '' },
-  12: { label: '12', labelStyle }
-}
-const stepStyle = {
-  display: 'block',
-  borderRadius: 0,
-  height: '10px',
-  width: '4px',
-  top: '-1px',
-  backgroundColor: 'gray'
+  0: '0',
+  2: '',
+  4: '4',
+  6: '',
+  8: '8',
+  10: '',
+  12: '12'
 }
 
 const value = ref(props.duration)
 
+const sliderRef = useTemplateRef('slider')
+
+// Computed
+// --------------------------------------------------------------------------
 const organisation = computed(() => store.getters.organisation)
 const hoursByDay = computed(() => organisation.value.hours_by_day || 8)
+const presets = computed(() => [...new Set([1, 4, hoursByDay.value])])
 
+// Functions
+// --------------------------------------------------------------------------
 const setValue = v => {
   value.value = v || 0
 }
 
+// the tooltip follows the slider's internal focus state, which survives
+// the pointer release: blur it so the tooltip closes with the drag
+const onDragEnd = () => {
+  sliderRef.value?.blur()
+}
+
+const onWheel = event => {
+  const step = event.deltaY < 0 ? 0.25 : -0.25
+  value.value = Math.min(
+    12,
+    Math.max(0, Math.round((value.value + step) * 4) / 4)
+  )
+}
+
+// Watchers
+// --------------------------------------------------------------------------
 watch(value, v => {
   emit('change', { taskId: props.taskId, duration: v })
 })
@@ -78,12 +104,68 @@ watch(value, v => {
 
 <style lang="scss" scoped>
 .value {
+  color: var(--text-strong);
   font-size: 1.5em;
+  font-variant-numeric: tabular-nums;
   font-weight: bold;
   width: 40px;
 }
 
 .slider {
   cursor: pointer;
+
+  :deep(.vue-slider-rail) {
+    background: rgba(var(--skeleton-rgb), 0.4);
+    border-radius: 999px;
+  }
+
+  :deep(.vue-slider-process) {
+    background: $purple-strong;
+    border-radius: 999px;
+  }
+
+  :deep(.vue-slider-mark-step) {
+    background: rgba(var(--skeleton-rgb), 0.9);
+    border-radius: 50%;
+    box-shadow: none;
+    height: 4px;
+    width: 4px;
+  }
+
+  // the filled part of the rail hides its own ticks
+  :deep(.vue-slider-mark-active .vue-slider-mark-step) {
+    background: transparent;
+  }
+
+  :deep(.vue-slider-mark-label) {
+    color: var(--text-alt);
+    font-size: 0.85em;
+    margin-top: 6px;
+  }
+
+  // keep the edge labels inside the rail instead of centered on its ends
+  :deep(.vue-slider-mark:first-child .vue-slider-mark-label) {
+    transform: translateX(0);
+  }
+
+  :deep(.vue-slider-mark:last-child .vue-slider-mark-label) {
+    transform: translateX(-100%);
+  }
+
+  :deep(.vue-slider-dot-handle) {
+    background: var(--background-alt-2, white);
+    border: 2px solid $purple-strong;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  }
+
+  :deep(.vue-slider-dot-handle-focus) {
+    box-shadow: 0 0 0 3px var(--background-selectable);
+  }
+
+  :deep(.vue-slider-dot-tooltip-inner) {
+    background: $purple-strong;
+    border-color: $purple-strong;
+    font-variant-numeric: tabular-nums;
+  }
 }
 </style>

--- a/src/components/lists/DayOffList.vue
+++ b/src/components/lists/DayOffList.vue
@@ -114,6 +114,7 @@ import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
 
 // Props / Emits
+// --------------------------------------------------------------------------
 const props = defineProps({
   daysOff: {
     default: () => [],
@@ -136,6 +137,7 @@ const props = defineProps({
 defineEmits(['set-day-off', 'unset-day-off'])
 
 // State
+// --------------------------------------------------------------------------
 const dayOffToEdit = ref(null)
 const modals = reactive({
   setDayOff: false,
@@ -143,6 +145,7 @@ const modals = reactive({
 })
 
 // Computed
+// --------------------------------------------------------------------------
 const isDayOffError = computed(() => Boolean(props.dayOffError))
 
 const dayOffTextError = computed(() =>
@@ -164,6 +167,7 @@ const sortedDaysOff = computed(() =>
 )
 
 // Functions
+// --------------------------------------------------------------------------
 const openSetDayOffModal = (dayOff = null) => {
   dayOffToEdit.value = dayOff || { date: new Date() }
   modals.setDayOff = true

--- a/src/components/lists/DayOffList.vue
+++ b/src/components/lists/DayOffList.vue
@@ -102,115 +102,88 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import moment from 'moment-timezone'
+import { computed, reactive, ref } from 'vue'
 
 import { formatSimpleDate } from '@/lib/time'
 
-import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import DayOffModal from '@/components/modals/DayOffModal.vue'
 import DeleteModal from '@/components/modals/DeleteModal.vue'
+import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
 
-export default {
-  name: 'day-off-list',
-
-  components: {
-    ButtonSimple,
-    DayOffModal,
-    DeleteModal,
-    TableInfo
+// Props / Emits
+const props = defineProps({
+  daysOff: {
+    default: () => [],
+    type: Array
   },
-
-  props: {
-    daysOff: {
-      default: () => [],
-      type: Array
-    },
-    isLoading: {
-      default: false,
-      type: Boolean
-    },
-    isError: {
-      default: false,
-      type: Boolean
-    },
-    dayOffError: {
-      default: false,
-      type: [String, Boolean]
-    }
+  isLoading: {
+    default: false,
+    type: Boolean
   },
-
-  emits: ['set-day-off', 'unset-day-off'],
-
-  data() {
-    return {
-      dayOffToEdit: null,
-      modals: {
-        setDayOff: false,
-        unsetDayOff: false
-      }
-    }
+  isError: {
+    default: false,
+    type: Boolean
   },
-
-  computed: {
-    dayOffInfo() {
-      const { description, date, end_date } = this.personDayOff
-      const period =
-        end_date && date !== end_date ? `${date} - ${end_date}` : date
-      return `${description || this.$t('timesheets.day_off')} (${period})`
-    },
-
-    isDayOffError() {
-      return Boolean(this.dayOffError)
-    },
-
-    dayOffTextError() {
-      return this.dayOffError?.length ? this.dayOffError : null
-    },
-
-    sortedDaysOff() {
-      return [...this.daysOff]
-        .sort((a, b) => b.date.localeCompare(a.date))
-        .map(dayOff => {
-          return {
-            ...dayOff,
-            period:
-              dayOff.date !== dayOff.end_date
-                ? `${dayOff.date} - ${dayOff.end_date}`
-                : dayOff.date,
-            date: moment.utc(dayOff.date).toDate(),
-            end_date: moment.utc(dayOff.end_date || dayOff.date).toDate()
-          }
-        })
-    }
-  },
-
-  methods: {
-    formatSimpleDate,
-
-    openSetDayOffModal(dayOff = null) {
-      if (!dayOff) {
-        dayOff = { date: new Date() }
-      }
-      this.dayOffToEdit = dayOff
-      this.modals.setDayOff = true
-    },
-
-    openUnsetDayOffModal(dayOff) {
-      this.dayOffToEdit = dayOff
-      this.modals.unsetDayOff = true
-    },
-
-    closeSetDayOffModal() {
-      this.modals.setDayOff = false
-    },
-
-    closeUnsetDayOffModal() {
-      this.modals.unsetDayOff = false
-    }
+  dayOffError: {
+    default: false,
+    type: [String, Boolean]
   }
+})
+
+defineEmits(['set-day-off', 'unset-day-off'])
+
+// State
+const dayOffToEdit = ref(null)
+const modals = reactive({
+  setDayOff: false,
+  unsetDayOff: false
+})
+
+// Computed
+const isDayOffError = computed(() => Boolean(props.dayOffError))
+
+const dayOffTextError = computed(() =>
+  props.dayOffError?.length ? props.dayOffError : null
+)
+
+const sortedDaysOff = computed(() =>
+  [...props.daysOff]
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .map(dayOff => ({
+      ...dayOff,
+      period:
+        dayOff.date !== dayOff.end_date
+          ? `${dayOff.date} - ${dayOff.end_date}`
+          : dayOff.date,
+      date: moment.utc(dayOff.date).toDate(),
+      end_date: moment.utc(dayOff.end_date || dayOff.date).toDate()
+    }))
+)
+
+// Functions
+const openSetDayOffModal = (dayOff = null) => {
+  dayOffToEdit.value = dayOff || { date: new Date() }
+  modals.setDayOff = true
 }
+
+const openUnsetDayOffModal = dayOff => {
+  dayOffToEdit.value = dayOff
+  modals.unsetDayOff = true
+}
+
+const closeSetDayOffModal = () => {
+  modals.setDayOff = false
+}
+
+const closeUnsetDayOffModal = () => {
+  modals.unsetDayOff = false
+}
+
+// The parent pages close the modals from their day-off event handlers.
+defineExpose({ closeSetDayOffModal, closeUnsetDayOffModal })
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/lists/KanbanBoard.vue
+++ b/src/components/lists/KanbanBoard.vue
@@ -159,7 +159,7 @@ import { useStore } from 'vuex'
 
 import { getClientX } from '@/composables/dom'
 import { formatPrioritySymbol, useFormat } from '@/composables/format'
-import { sortPeople } from '@/lib/sorting'
+import { useTaskHelpers } from '@/composables/tasks'
 
 import AddPreviewModal from '@/components/modals/AddPreviewModal.vue'
 import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
@@ -168,6 +168,7 @@ import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
 
 const store = useStore()
 const { formatPriority } = useFormat()
+const { getSortedPeople, getTaskType } = useTaskHelpers()
 
 // Props / Emits
 // --------------------------------------------------------------------------
@@ -237,7 +238,6 @@ let proxyRotation = 0
 // Computed
 // --------------------------------------------------------------------------
 const isDarkTheme = computed(() => store.getters.isDarkTheme)
-const personMap = computed(() => store.getters.personMap)
 const productionMap = computed(() => store.getters.productionMap)
 const selectedTasks = computed(() => store.getters.selectedTasks)
 const taskTypeMap = computed(() => store.getters.taskTypeMap)
@@ -291,11 +291,6 @@ const checkColumnIsDroppable = taskStatus => {
   )
 }
 
-const getSortedPeople = personIds => {
-  const people = personIds.map(id => personMap.value.get(id)).filter(Boolean)
-  return sortPeople(people)
-}
-
 const getCardStyle = task => {
   if (!task.entity_preview_file_id) {
     return null
@@ -317,16 +312,6 @@ const getStatusTextColor = status => {
     return '#333'
   }
   return 'white'
-}
-
-const getTaskType = task => {
-  const taskType = { ...taskTypeMap.value.get(task.task_type_id) }
-  const production = productionMap.value.get(task.project_id)
-  taskType.episode_id = task.episode_id
-  if (production?.production_type === 'tvshow' && !task.episode_id) {
-    taskType.episode_id = production.first_episode_id
-  }
-  return taskType
 }
 
 const isSelected = task => selectedTasks.value.has(task.id)

--- a/src/components/lists/KanbanBoard.vue
+++ b/src/components/lists/KanbanBoard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="board">
+  <div class="board" ref="board">
     <div class="board-empty" v-if="!visibleColumns.length && !isLoading">
       <square-dashed-kanban-icon :size="40" />
       <p>{{ $t('board.empty') }}</p>
@@ -136,7 +136,6 @@
     </ol>
     <table-info :is-loading="isLoading" :is-error="isError" variant="kanban" />
     <add-preview-modal
-      ref="add-preview-modal"
       :active="modals.addPreview"
       :confirm-label="$t('main.confirmation')"
       :is-loading="loading.addPreview"
@@ -153,450 +152,411 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import { ImageIcon, ImageUpIcon, SquareDashedKanbanIcon } from 'lucide-vue-next'
-import { mapActions, mapGetters } from 'vuex'
+import { computed, onBeforeUnmount, reactive, ref, useTemplateRef } from 'vue'
+import { useStore } from 'vuex'
 
+import { getClientX } from '@/composables/dom'
+import { formatPrioritySymbol, useFormat } from '@/composables/format'
 import { sortPeople } from '@/lib/sorting'
-
-import { domMixin } from '@/components/mixins/dom'
-import { formatListMixin } from '@/components/mixins/format'
 
 import AddPreviewModal from '@/components/modals/AddPreviewModal.vue'
 import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
 import TaskTypeName from '@/components/widgets/TaskTypeName.vue'
 
-export default {
-  name: 'kanban-board',
+const store = useStore()
+const { formatPriority } = useFormat()
 
-  mixins: [domMixin, formatListMixin],
-
-  components: {
-    AddPreviewModal,
-    ImageIcon,
-    ImageUpIcon,
-    PeopleAvatar,
-    SquareDashedKanbanIcon,
-    TableInfo,
-    TaskTypeName
+// Props / Emits
+// --------------------------------------------------------------------------
+const props = defineProps({
+  isError: {
+    type: Boolean,
+    default: false
   },
-
-  props: {
-    isError: {
-      type: Boolean,
-      default: false
-    },
-    isLoading: {
-      type: Boolean,
-      default: false
-    },
-    production: {
-      type: Object,
-      default: () => {}
-    },
-    statuses: {
-      type: Array,
-      default: () => []
-    },
-    tasks: {
-      type: Array,
-      default: () => []
-    },
-    user: {
-      type: Object,
-      default: () => {}
-    }
+  isLoading: {
+    type: Boolean,
+    default: false
   },
-
-  data() {
-    return {
-      addPreviewFormData: null,
-      draggedTask: null,
-      dropColumnId: null,
-      initialClientX: null,
-      isScrollingX: false,
-      errors: {
-        addPreview: null
-      },
-      form: {
-        taskId: null,
-        taskStatusId: null
-      },
-      loading: {
-        addPreview: false
-      },
-      modals: {
-        addPreview: false,
-        task: null
-      }
-    }
+  production: {
+    type: Object,
+    default: () => {}
   },
-
-  created() {
-    // Non-reactive drag helpers. The transparent image replaces the native
-    // drag snapshot so the DOM proxy below can tilt while following the
-    // cursor (a native drag image is a bitmap frozen at dragstart).
-    this.emptyDragImage = new Image()
-    this.emptyDragImage.src =
-      'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
-    this.dragProxy = null
-    this.dragProxyInner = null
-    this.dragOffset = { x: 0, y: 0 }
-    this.lastDragX = 0
-    this.proxyRotation = 0
+  statuses: {
+    type: Array,
+    default: () => []
   },
-
-  beforeUnmount() {
-    this.removeDragProxy()
+  tasks: {
+    type: Array,
+    default: () => []
   },
+  user: {
+    type: Object,
+    default: () => {}
+  }
+})
 
-  computed: {
-    ...mapGetters([
-      'isDarkTheme',
-      'personMap',
-      'productionMap',
-      'selectedTasks',
-      'taskTypeMap'
-    ]),
+// State
+// --------------------------------------------------------------------------
+const addPreviewFormData = ref(null)
+const draggedTask = ref(null)
+const dropColumnId = ref(null)
+const initialClientX = ref(null)
+const isScrollingX = ref(false)
+const errors = reactive({
+  addPreview: null
+})
+const form = reactive({
+  taskId: null,
+  taskStatusId: null
+})
+const loading = reactive({
+  addPreview: false
+})
+const modals = reactive({
+  addPreview: false,
+  task: null
+})
 
-    columns() {
-      const columns = this.statuses.map(status => {
-        const tasks = this.tasks.filter(
-          task => task.task_status_id === status.id
-        )
-        return {
-          id: status.id,
-          status,
-          tasks,
-          droppable: this.checkColumnIsDroppable(status)
-        }
-      })
-      return columns
-    },
+const boardRef = useTemplateRef('board')
 
-    visibleColumns() {
-      return this.columns.filter(
-        column => column.tasks.length || column.droppable
-      )
-    },
+// Non-reactive drag helpers. The transparent image replaces the native
+// drag snapshot so the DOM proxy below can tilt while following the
+// cursor (a native drag image is a bitmap frozen at dragstart).
+const emptyDragImage = new Image()
+emptyDragImage.src =
+  'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+let dragProxy = null
+let dragProxyInner = null
+let dragOffset = { x: 0, y: 0 }
+let lastDragX = 0
+let proxyRotation = 0
 
-    taskIndexMap() {
-      return new Map(this.tasks.map((task, index) => [task.id, index]))
-    }
-  },
+// Computed
+// --------------------------------------------------------------------------
+const isDarkTheme = computed(() => store.getters.isDarkTheme)
+const personMap = computed(() => store.getters.personMap)
+const productionMap = computed(() => store.getters.productionMap)
+const selectedTasks = computed(() => store.getters.selectedTasks)
+const taskTypeMap = computed(() => store.getters.taskTypeMap)
 
-  methods: {
-    ...mapActions([
-      'addSelectedTasks',
-      'clearSelectedTasks',
-      'commentTask',
-      'commentTaskWithPreview',
-      'loadPreviewFileFormData'
-    ]),
+const columns = computed(() =>
+  props.statuses.map(status => ({
+    id: status.id,
+    status,
+    tasks: props.tasks.filter(task => task.task_status_id === status.id),
+    droppable: checkColumnIsDroppable(status)
+  }))
+)
 
-    checkUserIsAllowed(taskStatus, user) {
-      const role = user.role
-      return !(
-        (role === 'user' && !taskStatus.is_artist_allowed) ||
-        (role === 'client' && !taskStatus.is_client_allowed)
-      )
-    },
+const visibleColumns = computed(() =>
+  columns.value.filter(column => column.tasks.length || column.droppable)
+)
 
-    checkStatusIsAllowed(taskStatus, task) {
-      return Boolean(
-        this.production ||
-        !task ||
-        taskStatus.productions.includes(task.project_id)
-      )
-    },
+const taskIndexMap = computed(
+  () => new Map(props.tasks.map((task, index) => [task.id, index]))
+)
 
-    checkColumnIsDroppable(taskStatus) {
-      if (!this.checkUserIsAllowed(taskStatus, this.user)) {
-        return false
-      }
-      if (this.production) {
-        return this.tasks.length > 0
-      }
-      // Without a selected production, a drop is only possible when at least
-      // one visible task belongs to a production exposing this status
-      // (mirrors checkStatusIsAllowed at drag time).
-      return this.tasks.some(task =>
-        taskStatus.productions?.includes(task.project_id)
-      )
-    },
+// Functions
+// --------------------------------------------------------------------------
+const checkUserIsAllowed = (taskStatus, user) => {
+  const role = user.role
+  return !(
+    (role === 'user' && !taskStatus.is_artist_allowed) ||
+    (role === 'client' && !taskStatus.is_client_allowed)
+  )
+}
 
-    getSortedPeople(personIds) {
-      const people = personIds.map(id => this.personMap.get(id)).filter(Boolean)
-      return sortPeople(people)
-    },
+const checkStatusIsAllowed = (taskStatus, task) =>
+  Boolean(
+    props.production ||
+    !task ||
+    taskStatus.productions.includes(task.project_id)
+  )
 
-    getCardStyle(task) {
-      if (!task.entity_preview_file_id) {
-        return null
-      }
-      return {
-        backgroundImage: `url(/api/pictures/previews/preview-files/${task.entity_preview_file_id}.png)`
-      }
-    },
+const checkColumnIsDroppable = taskStatus => {
+  if (!checkUserIsAllowed(taskStatus, props.user)) {
+    return false
+  }
+  if (props.production) {
+    return props.tasks.length > 0
+  }
+  // Without a selected production, a drop is only possible when at least
+  // one visible task belongs to a production exposing this status
+  // (mirrors checkStatusIsAllowed at drag time).
+  return props.tasks.some(task =>
+    taskStatus.productions?.includes(task.project_id)
+  )
+}
 
-    getStatusColor(status) {
-      if (status.name === 'Todo' && this.isDarkTheme) {
-        return '#5F626A'
-      } else {
-        return status.color
-      }
-    },
+const getSortedPeople = personIds => {
+  const people = personIds.map(id => personMap.value.get(id)).filter(Boolean)
+  return sortPeople(people)
+}
 
-    getStatusTextColor(status) {
-      if (status.name === 'Todo' && !this.isDarkTheme) {
-        return '#333'
-      } else {
-        return 'white'
-      }
-    },
-
-    getTaskType(task) {
-      const taskType = { ...this.taskTypeMap.get(task.task_type_id) }
-      const production = this.productionMap.get(task.project_id)
-      taskType.episode_id = task.episode_id
-      if (production?.production_type === 'tvshow' && !task.episode_id) {
-        taskType.episode_id = production.first_episode_id
-      }
-      return taskType
-    },
-
-    isSelected(task) {
-      return this.selectedTasks.has(task.id)
-    },
-
-    onSelectTask(task, isMultipleSelection = false) {
-      const selection = isMultipleSelection
-        ? new Map(this.selectedTasks)
-        : new Map()
-      if (this.isSelected(task)) {
-        selection.delete(task.id)
-      } else {
-        selection.set(task.id, task)
-      }
-      this.clearSelectedTasks()
-      this.addSelectedTasks(
-        Array.from(selection.values()).map(task => ({
-          task
-        }))
-      )
-    },
-
-    onBoardScrollStart(event) {
-      event.currentTarget.style.cursor = 'grabbing'
-      this.isScrollingX = !event.target.closest('.board-card')
-      this.initialClientX = this.getClientX(event)
-    },
-
-    onBoardScrolling(event) {
-      if (!this.isScrollingX) {
-        return
-      }
-      event.preventDefault()
-      const clientX = this.getClientX(event)
-      const diffX = clientX - this.initialClientX
-      event.currentTarget.scrollLeft -= diffX
-      this.initialClientX = clientX
-    },
-
-    onBoardScrollEnd(event) {
-      if (!this.isScrollingX) {
-        return
-      }
-      event.currentTarget.style.cursor = 'default'
-      this.isScrollingX = false
-    },
-
-    onCardDragStart(event, task, taskStatus) {
-      event.stopPropagation()
-      event.dataTransfer.dropEffect = 'move'
-      event.dataTransfer.effectAllowed = 'move'
-      event.dataTransfer.setData('taskId', task.id)
-      event.dataTransfer.setData('taskStatusId', taskStatus.id)
-      this.draggedTask = task
-      // dragenter/dragleave bubble from children and would make the drop
-      // state flicker, so the target column is derived from the pointer
-      // position in the document-level dragover instead.
-      document.addEventListener('dragover', this.onDocumentDragOver)
-      if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-        event.dataTransfer.setDragImage(this.emptyDragImage, 0, 0)
-        this.createDragProxy(event)
-      }
-    },
-
-    onCardDragEnd() {
-      this.draggedTask = null
-      this.dropColumnId = null
-      this.removeDragProxy()
-    },
-
-    onCardDragOver(event) {
-      event.preventDefault()
-    },
-
-    getGhostOrder(column) {
-      const movedTask = this.draggedTask || this.modals.task
-      if (!movedTask) {
-        return 0
-      }
-      // Cards use even order values (index * 2): the odd value slots the
-      // ghost where the dragged card will land in the column sort order.
-      const movedIndex = this.taskIndexMap.get(movedTask.id)
-      const before = column.tasks.filter(
-        task => this.taskIndexMap.get(task.id) < movedIndex
-      ).length
-      return before * 2 - 1
-    },
-
-    isGhostVisible(column) {
-      // during the drag, then while the preview-upload modal holds the
-      // pending move on a feedback-request status
-      return (
-        this.dropColumnId === column.id ||
-        (this.modals.addPreview && this.form.taskStatusId === column.id)
-      )
-    },
-
-    updateDropColumn(event) {
-      const columnEl = event.target.closest?.('.board-column')
-      const status = columnEl
-        ? this.statuses.find(({ id }) => id === columnEl.dataset.statusId)
-        : null
-      const isAllowed =
-        status &&
-        this.draggedTask &&
-        this.draggedTask.task_status_id !== status.id &&
-        this.checkUserIsAllowed(status, this.user) &&
-        this.checkStatusIsAllowed(status, this.draggedTask)
-      this.dropColumnId = isAllowed ? status.id : null
-    },
-
-    createDragProxy(event) {
-      const card = event.currentTarget
-      const rect = card.getBoundingClientRect()
-      this.dragOffset = {
-        x: event.clientX - rect.left,
-        y: event.clientY - rect.top
-      }
-      this.lastDragX = event.clientX
-      this.proxyRotation = 0
-      // The li clone keeps its board-card class and scoped data attributes,
-      // so the card styles apply outside the component tree.
-      const inner = card.cloneNode(true)
-      inner.style.cssText =
-        'margin: 0; list-style: none; transition: transform 120ms ease-out;'
-      const proxy = document.createElement('div')
-      proxy.style.cssText =
-        `position: fixed; left: 0; top: 0; width: ${rect.width}px; ` +
-        'margin: 0; pointer-events: none; z-index: 2000; will-change: transform;'
-      proxy.style.transform = `translate(${rect.left}px, ${rect.top}px)`
-      proxy.appendChild(inner)
-      // Kept inside the component tree: the theme class carrying the CSS
-      // custom properties wraps the app, so a body-level clone would
-      // resolve them to their light values.
-      this.$el.appendChild(proxy)
-      this.dragProxy = proxy
-      this.dragProxyInner = inner
-    },
-
-    onDocumentDragOver(event) {
-      this.updateDropColumn(event)
-      // The last dragover of a cancelled drag reports (0, 0)
-      if (!this.dragProxy || (event.clientX === 0 && event.clientY === 0)) {
-        return
-      }
-      const x = event.clientX - this.dragOffset.x
-      const y = event.clientY - this.dragOffset.y
-      this.dragProxy.style.transform = `translate(${x}px, ${y}px)`
-      const target = Math.max(
-        -6,
-        Math.min(6, (event.clientX - this.lastDragX) * 1.5)
-      )
-      this.lastDragX = event.clientX
-      // low-pass filter so the tilt follows the drag direction without jitter
-      this.proxyRotation = this.proxyRotation * 0.7 + target * 0.3
-      this.dragProxyInner.style.transform = `rotate(${this.proxyRotation}deg)`
-    },
-
-    removeDragProxy() {
-      document.removeEventListener('dragover', this.onDocumentDragOver)
-      this.dragProxy?.remove()
-      this.dragProxy = null
-      this.dragProxyInner = null
-    },
-
-    onCardDrop(event, taskStatus) {
-      this.dropColumnId = null
-
-      const isAllowed =
-        this.draggedTask &&
-        this.checkUserIsAllowed(taskStatus, this.user) &&
-        this.checkStatusIsAllowed(taskStatus, this.draggedTask)
-      if (!isAllowed) {
-        return
-      }
-
-      const previousTaskStatusId = event.dataTransfer.getData('taskStatusId')
-      if (previousTaskStatusId === taskStatus.id) {
-        return
-      }
-
-      const taskId = event.dataTransfer.getData('taskId')
-
-      if (taskStatus.is_feedback_request) {
-        this.form.taskId = taskId
-        this.form.taskStatusId = taskStatus.id
-        this.modals.task = this.tasks.find(({ id }) => id === taskId)
-        this.modals.addPreview = true
-        return
-      }
-
-      this.commentTask({
-        taskId,
-        taskStatusId: taskStatus.id
-      })
-    },
-
-    onCardMouseEnter(event) {
-      event.currentTarget.focus()
-    },
-
-    onCardMouseLeave(event) {
-      event.currentTarget.blur()
-    },
-
-    closeAddPreviewModal() {
-      this.modals.addPreview = false
-      this.modals.task = null
-    },
-
-    async confirmAddPreviewModal(forms) {
-      this.loading.addPreview = true
-      this.errors.addPreview = false
-      this.loadPreviewFileFormData(forms)
-      try {
-        // keep the modal (and the pending ghost) up until the upload went
-        // through, so a failure does not silently drop the move
-        await this.commentTaskWithPreview({
-          comment: '',
-          taskId: this.form.taskId,
-          taskStatusId: this.form.taskStatusId
-        })
-        this.closeAddPreviewModal()
-      } catch (err) {
-        console.error(err)
-        this.errors.addPreview = true
-      } finally {
-        this.loading.addPreview = false
-      }
-    }
+const getCardStyle = task => {
+  if (!task.entity_preview_file_id) {
+    return null
+  }
+  return {
+    backgroundImage: `url(/api/pictures/previews/preview-files/${task.entity_preview_file_id}.png)`
   }
 }
+
+const getStatusColor = status => {
+  if (status.name === 'Todo' && isDarkTheme.value) {
+    return '#5F626A'
+  }
+  return status.color
+}
+
+const getStatusTextColor = status => {
+  if (status.name === 'Todo' && !isDarkTheme.value) {
+    return '#333'
+  }
+  return 'white'
+}
+
+const getTaskType = task => {
+  const taskType = { ...taskTypeMap.value.get(task.task_type_id) }
+  const production = productionMap.value.get(task.project_id)
+  taskType.episode_id = task.episode_id
+  if (production?.production_type === 'tvshow' && !task.episode_id) {
+    taskType.episode_id = production.first_episode_id
+  }
+  return taskType
+}
+
+const isSelected = task => selectedTasks.value.has(task.id)
+
+const onSelectTask = (task, isMultipleSelection = false) => {
+  const selection = isMultipleSelection
+    ? new Map(selectedTasks.value)
+    : new Map()
+  if (isSelected(task)) {
+    selection.delete(task.id)
+  } else {
+    selection.set(task.id, task)
+  }
+  store.dispatch('clearSelectedTasks')
+  store.dispatch(
+    'addSelectedTasks',
+    Array.from(selection.values()).map(task => ({
+      task
+    }))
+  )
+}
+
+const onBoardScrollStart = event => {
+  event.currentTarget.style.cursor = 'grabbing'
+  isScrollingX.value = !event.target.closest('.board-card')
+  initialClientX.value = getClientX(event)
+}
+
+const onBoardScrolling = event => {
+  if (!isScrollingX.value) {
+    return
+  }
+  event.preventDefault()
+  const clientX = getClientX(event)
+  const diffX = clientX - initialClientX.value
+  event.currentTarget.scrollLeft -= diffX
+  initialClientX.value = clientX
+}
+
+const onBoardScrollEnd = event => {
+  if (!isScrollingX.value) {
+    return
+  }
+  event.currentTarget.style.cursor = 'default'
+  isScrollingX.value = false
+}
+
+const onCardDragStart = (event, task, taskStatus) => {
+  event.stopPropagation()
+  event.dataTransfer.dropEffect = 'move'
+  event.dataTransfer.effectAllowed = 'move'
+  event.dataTransfer.setData('taskId', task.id)
+  event.dataTransfer.setData('taskStatusId', taskStatus.id)
+  draggedTask.value = task
+  // dragenter/dragleave bubble from children and would make the drop
+  // state flicker, so the target column is derived from the pointer
+  // position in the document-level dragover instead.
+  document.addEventListener('dragover', onDocumentDragOver)
+  if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    event.dataTransfer.setDragImage(emptyDragImage, 0, 0)
+    createDragProxy(event)
+  }
+}
+
+const onCardDragEnd = () => {
+  draggedTask.value = null
+  dropColumnId.value = null
+  removeDragProxy()
+}
+
+const onCardDragOver = event => {
+  event.preventDefault()
+}
+
+const getGhostOrder = column => {
+  const movedTask = draggedTask.value || modals.task
+  if (!movedTask) {
+    return 0
+  }
+  // Cards use even order values (index * 2): the odd value slots the
+  // ghost where the dragged card will land in the column sort order.
+  const movedIndex = taskIndexMap.value.get(movedTask.id)
+  const before = column.tasks.filter(
+    task => taskIndexMap.value.get(task.id) < movedIndex
+  ).length
+  return before * 2 - 1
+}
+
+const isGhostVisible = column =>
+  // during the drag, then while the preview-upload modal holds the
+  // pending move on a feedback-request status
+  dropColumnId.value === column.id ||
+  (modals.addPreview && form.taskStatusId === column.id)
+
+const updateDropColumn = event => {
+  const columnEl = event.target.closest?.('.board-column')
+  const status = columnEl
+    ? props.statuses.find(({ id }) => id === columnEl.dataset.statusId)
+    : null
+  const isAllowed =
+    status &&
+    draggedTask.value &&
+    draggedTask.value.task_status_id !== status.id &&
+    checkUserIsAllowed(status, props.user) &&
+    checkStatusIsAllowed(status, draggedTask.value)
+  dropColumnId.value = isAllowed ? status.id : null
+}
+
+const createDragProxy = event => {
+  const card = event.currentTarget
+  const rect = card.getBoundingClientRect()
+  dragOffset = {
+    x: event.clientX - rect.left,
+    y: event.clientY - rect.top
+  }
+  lastDragX = event.clientX
+  proxyRotation = 0
+  // The li clone keeps its board-card class and scoped data attributes,
+  // so the card styles apply outside the component tree.
+  const inner = card.cloneNode(true)
+  inner.style.cssText =
+    'margin: 0; list-style: none; transition: transform 120ms ease-out;'
+  const proxy = document.createElement('div')
+  proxy.style.cssText =
+    `position: fixed; left: 0; top: 0; width: ${rect.width}px; ` +
+    'margin: 0; pointer-events: none; z-index: 2000; will-change: transform;'
+  proxy.style.transform = `translate(${rect.left}px, ${rect.top}px)`
+  proxy.appendChild(inner)
+  // Kept inside the component tree: the theme class carrying the CSS
+  // custom properties wraps the app, so a body-level clone would
+  // resolve them to their light values.
+  boardRef.value.appendChild(proxy)
+  dragProxy = proxy
+  dragProxyInner = inner
+}
+
+const onDocumentDragOver = event => {
+  updateDropColumn(event)
+  // The last dragover of a cancelled drag reports (0, 0)
+  if (!dragProxy || (event.clientX === 0 && event.clientY === 0)) {
+    return
+  }
+  const x = event.clientX - dragOffset.x
+  const y = event.clientY - dragOffset.y
+  dragProxy.style.transform = `translate(${x}px, ${y}px)`
+  const target = Math.max(-6, Math.min(6, (event.clientX - lastDragX) * 1.5))
+  lastDragX = event.clientX
+  // low-pass filter so the tilt follows the drag direction without jitter
+  proxyRotation = proxyRotation * 0.7 + target * 0.3
+  dragProxyInner.style.transform = `rotate(${proxyRotation}deg)`
+}
+
+const removeDragProxy = () => {
+  document.removeEventListener('dragover', onDocumentDragOver)
+  dragProxy?.remove()
+  dragProxy = null
+  dragProxyInner = null
+}
+
+const onCardDrop = (event, taskStatus) => {
+  dropColumnId.value = null
+
+  const isAllowed =
+    draggedTask.value &&
+    checkUserIsAllowed(taskStatus, props.user) &&
+    checkStatusIsAllowed(taskStatus, draggedTask.value)
+  if (!isAllowed) {
+    return
+  }
+
+  const previousTaskStatusId = event.dataTransfer.getData('taskStatusId')
+  if (previousTaskStatusId === taskStatus.id) {
+    return
+  }
+
+  const taskId = event.dataTransfer.getData('taskId')
+
+  if (taskStatus.is_feedback_request) {
+    form.taskId = taskId
+    form.taskStatusId = taskStatus.id
+    modals.task = props.tasks.find(({ id }) => id === taskId)
+    modals.addPreview = true
+    return
+  }
+
+  store.dispatch('commentTask', {
+    taskId,
+    taskStatusId: taskStatus.id
+  })
+}
+
+const onCardMouseEnter = event => {
+  event.currentTarget.focus()
+}
+
+const onCardMouseLeave = event => {
+  event.currentTarget.blur()
+}
+
+const closeAddPreviewModal = () => {
+  modals.addPreview = false
+  modals.task = null
+}
+
+const confirmAddPreviewModal = async forms => {
+  loading.addPreview = true
+  errors.addPreview = false
+  store.dispatch('loadPreviewFileFormData', forms)
+  try {
+    // keep the modal (and the pending ghost) up until the upload went
+    // through, so a failure does not silently drop the move
+    await store.dispatch('commentTaskWithPreview', {
+      comment: '',
+      taskId: form.taskId,
+      taskStatusId: form.taskStatusId
+    })
+    closeAddPreviewModal()
+  } catch (err) {
+    console.error(err)
+    errors.addPreview = true
+  } finally {
+    loading.addPreview = false
+  }
+}
+
+// Lifecycle
+// --------------------------------------------------------------------------
+onBeforeUnmount(() => {
+  removeDragProxy()
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/lists/TimesheetList.vue
+++ b/src/components/lists/TimesheetList.vue
@@ -218,212 +218,188 @@
   </div>
 </template>
 
-<script>
+<script setup>
 import moment from 'moment-timezone'
-import { mapGetters } from 'vuex'
+import { computed, onMounted, reactive, ref, useTemplateRef, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useStore } from 'vuex'
 
 import { PAGE_SIZE } from '@/lib/pagination'
 import { getTaskEntityPath } from '@/lib/path'
-import { formatVerboseDate } from '@/lib/time'
 
-import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
-import DateField from '@/components/widgets/DateField.vue'
+import ProductionNameCell from '@/components/cells/ProductionNameCell.vue'
+import TaskTypeCell from '@/components/cells/TaskTypeCell.vue'
+import TimeSliderCell from '@/components/cells/TimeSliderCell.vue'
 import DayOffModal from '@/components/modals/DayOffModal.vue'
 import DeleteModal from '@/components/modals/DeleteModal.vue'
+import ButtonSimple from '@/components/widgets/ButtonSimple.vue'
+import DateField from '@/components/widgets/DateField.vue'
 import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
 import InfoQuestionMark from '@/components/widgets/InfoQuestionMark.vue'
 import PageSubtitle from '@/components/widgets/PageSubtitle.vue'
-import ProductionNameCell from '@/components/cells/ProductionNameCell.vue'
 import TableInfo from '@/components/widgets/TableInfo.vue'
-import TaskTypeCell from '@/components/cells/TaskTypeCell.vue'
-import TimeSliderCell from '@/components/cells/TimeSliderCell.vue'
 
-export default {
-  name: 'timesheet-list',
+const { t } = useI18n()
+const store = useStore()
 
-  components: {
-    ButtonSimple,
-    DayOffModal,
-    DateField,
-    DeleteModal,
-    EntityThumbnail,
-    InfoQuestionMark,
-    ProductionNameCell,
-    PageSubtitle,
-    TableInfo,
-    TaskTypeCell,
-    TimeSliderCell
+// Props / Emits
+const props = defineProps({
+  tasks: {
+    default: () => [],
+    type: Array
   },
-
-  props: {
-    tasks: {
-      default: () => [],
-      type: Array
-    },
-    doneTasks: {
-      default: () => [],
-      type: Array
-    },
-    isLoading: {
-      default: false,
-      type: Boolean
-    },
-    isError: {
-      default: false,
-      type: Boolean
-    },
-    daysOff: {
-      default: () => [],
-      type: Array
-    },
-    dayOffError: {
-      default: false,
-      type: [String, Boolean]
-    },
-    timeSpentMap: {
-      default: () => {},
-      type: Object
-    },
-    timeSpentTotal: {
-      default: 0,
-      type: Number
-    },
-    hideDone: {
-      default: false,
-      type: Boolean
-    },
-    hideDayOff: {
-      default: true,
-      type: Boolean
-    },
-    initialDate: {
-      default: null,
-      type: String
-    }
+  doneTasks: {
+    default: () => [],
+    type: Array
   },
-
-  emits: ['date-changed', 'set-day-off', 'time-spent-change', 'unset-day-off'],
-
-  data() {
-    const today = new Date()
-    return {
-      colNamePosX: '',
-      colTypePosX: '',
-      disabledDates: {},
-      page: 1,
-      selectedDate: this.initialDate
-        ? moment(this.initialDate, 'YYYY-MM-DD').toDate()
-        : today,
-      modals: {
-        setDayOff: false,
-        unsetDayOff: false
-      }
-    }
+  isLoading: {
+    default: false,
+    type: Boolean
   },
-
-  mounted() {
-    this.colTypePosX = `${this.$refs['th-prod'].offsetWidth}px`
-    this.colNamePosX = `${
-      this.$refs['th-prod'].offsetWidth + this.$refs['th-type'].offsetWidth
-    }px`
-    this.disabledDates = {
-      to:
-        this.isCurrentUserArtist && this.organisation.timesheets_locked
-          ? moment().subtract(1, 'weeks').toDate() // Disable dates older than one week
-          : undefined,
-      from: moment().toDate() // Disable dates after today
-    }
+  isError: {
+    default: false,
+    type: Boolean
   },
-
-  computed: {
-    ...mapGetters([
-      'dateFormat',
-      'isCurrentUserArtist',
-      'organisation',
-      'productionMap',
-      'taskTypeMap',
-      'user'
-    ]),
-
-    personDayOff() {
-      const selectedDate = moment(this.selectedDate).format('YYYY-MM-DD')
-      return this.daysOff.find(
-        dayOff =>
-          selectedDate >= dayOff.date &&
-          selectedDate <= (dayOff.end_date || dayOff.date)
-      )
-    },
-
-    personIsDayOff() {
-      return Boolean(this.personDayOff)
-    },
-
-    displayedTasks() {
-      return this.tasks.slice(0, this.page * (PAGE_SIZE / 2))
-    },
-
-    dayOffInfo() {
-      const { description, date, end_date } = this.personDayOff
-      const period =
-        end_date && date !== end_date ? `${date} - ${end_date}` : date
-      return `${description || this.$t('timesheets.day_off')} (${period})`
-    },
-
-    isDayOffError() {
-      return Boolean(this.dayOffError)
-    },
-
-    dayOffTextError() {
-      return this.dayOffError?.length ? this.dayOffError : null
-    }
+  daysOff: {
+    default: () => [],
+    type: Array
   },
-
-  methods: {
-    onBodyScroll(event) {
-      if (!this.$refs.body) return
-      const position = event.target
-      const maxHeight =
-        this.$refs.body.scrollHeight - this.$refs.body.offsetHeight
-      if (maxHeight < position.scrollTop + 100) {
-        this.page++
-      }
-    },
-
-    currentDate() {
-      return formatVerboseDate(moment(), this.dateFormat)
-    },
-
-    onSliderChange(valueInfo) {
-      this.$emit('time-spent-change', valueInfo)
-    },
-
-    entityPath(entity) {
-      return getTaskEntityPath(entity, entity.episode_id)
-    },
-
-    toggleDayOff() {
-      if (this.personIsDayOff) {
-        this.modals.unsetDayOff = true
-      } else {
-        this.modals.setDayOff = true
-      }
-    },
-
-    closeSetDayOffModal() {
-      this.modals.setDayOff = false
-    },
-
-    closeUnsetDayOffModal() {
-      this.modals.unsetDayOff = false
-    }
+  dayOffError: {
+    default: false,
+    type: [String, Boolean]
   },
+  timeSpentMap: {
+    default: () => {},
+    type: Object
+  },
+  timeSpentTotal: {
+    default: 0,
+    type: Number
+  },
+  hideDone: {
+    default: false,
+    type: Boolean
+  },
+  hideDayOff: {
+    default: true,
+    type: Boolean
+  },
+  initialDate: {
+    default: null,
+    type: String
+  }
+})
 
-  watch: {
-    selectedDate() {
-      this.$emit('date-changed', this.selectedDate)
-    }
+const emit = defineEmits([
+  'date-changed',
+  'set-day-off',
+  'time-spent-change',
+  'unset-day-off'
+])
+
+// State
+const colNamePosX = ref('')
+const colTypePosX = ref('')
+const disabledDates = ref({})
+const page = ref(1)
+const selectedDate = ref(
+  props.initialDate
+    ? moment(props.initialDate, 'YYYY-MM-DD').toDate()
+    : new Date()
+)
+const modals = reactive({
+  setDayOff: false,
+  unsetDayOff: false
+})
+
+const bodyRef = useTemplateRef('body')
+const thProdRef = useTemplateRef('th-prod')
+const thTypeRef = useTemplateRef('th-type')
+
+// Computed
+const isCurrentUserArtist = computed(() => store.getters.isCurrentUserArtist)
+const organisation = computed(() => store.getters.organisation)
+const productionMap = computed(() => store.getters.productionMap)
+const taskTypeMap = computed(() => store.getters.taskTypeMap)
+
+const personDayOff = computed(() => {
+  const date = moment(selectedDate.value).format('YYYY-MM-DD')
+  return props.daysOff.find(
+    dayOff => date >= dayOff.date && date <= (dayOff.end_date || dayOff.date)
+  )
+})
+
+const personIsDayOff = computed(() => Boolean(personDayOff.value))
+
+const displayedTasks = computed(() =>
+  props.tasks.slice(0, page.value * (PAGE_SIZE / 2))
+)
+
+const dayOffInfo = computed(() => {
+  const { description, date, end_date } = personDayOff.value
+  const period = end_date && date !== end_date ? `${date} - ${end_date}` : date
+  return `${description || t('timesheets.day_off')} (${period})`
+})
+
+const isDayOffError = computed(() => Boolean(props.dayOffError))
+
+const dayOffTextError = computed(() =>
+  props.dayOffError?.length ? props.dayOffError : null
+)
+
+// Functions
+const onBodyScroll = event => {
+  if (!bodyRef.value) return
+  const maxHeight = bodyRef.value.scrollHeight - bodyRef.value.offsetHeight
+  if (maxHeight < event.target.scrollTop + 100) {
+    page.value++
   }
 }
+
+const onSliderChange = valueInfo => {
+  emit('time-spent-change', valueInfo)
+}
+
+const entityPath = entity => getTaskEntityPath(entity, entity.episode_id)
+
+const toggleDayOff = () => {
+  if (personIsDayOff.value) {
+    modals.unsetDayOff = true
+  } else {
+    modals.setDayOff = true
+  }
+}
+
+const closeSetDayOffModal = () => {
+  modals.setDayOff = false
+}
+
+const closeUnsetDayOffModal = () => {
+  modals.unsetDayOff = false
+}
+
+// The parent pages close the modals from their day-off event handlers.
+defineExpose({ closeSetDayOffModal, closeUnsetDayOffModal })
+
+// Watchers
+watch(selectedDate, () => {
+  emit('date-changed', selectedDate.value)
+})
+
+// Lifecycle
+onMounted(() => {
+  colTypePosX.value = `${thProdRef.value.offsetWidth}px`
+  colNamePosX.value = `${
+    thProdRef.value.offsetWidth + thTypeRef.value.offsetWidth
+  }px`
+  disabledDates.value = {
+    to:
+      isCurrentUserArtist.value && organisation.value.timesheets_locked
+        ? moment().subtract(1, 'weeks').toDate() // Disable dates older than one week
+        : undefined,
+    from: moment().toDate() // Disable dates after today
+  }
+})
 </script>
 
 <style lang="scss" scoped>
@@ -457,16 +433,6 @@ export default {
   min-width: 230px;
 }
 
-.description {
-  width: 200px;
-  min-width: 200px;
-}
-
-.description li {
-  list-style-type: disc;
-  margin-left: 2em;
-}
-
 .name a {
   color: inherit;
 }
@@ -480,11 +446,6 @@ export default {
 .type {
   width: 160px;
   min-width: 160px;
-}
-
-.status {
-  width: 80px;
-  min-width: 80px;
 }
 
 .time-spent {
@@ -511,10 +472,6 @@ td.name {
   margin-top: 0.5em;
   margin-bottom: 0.5em;
   padding-left: 0.5em;
-}
-
-.calendar {
-  font-size: 0.6em;
 }
 
 .time-spent-total {

--- a/src/components/lists/TimesheetList.vue
+++ b/src/components/lists/TimesheetList.vue
@@ -243,6 +243,7 @@ const { t } = useI18n()
 const store = useStore()
 
 // Props / Emits
+// --------------------------------------------------------------------------
 const props = defineProps({
   tasks: {
     default: () => [],
@@ -298,6 +299,7 @@ const emit = defineEmits([
 ])
 
 // State
+// --------------------------------------------------------------------------
 const colNamePosX = ref('')
 const colTypePosX = ref('')
 const disabledDates = ref({})
@@ -317,6 +319,7 @@ const thProdRef = useTemplateRef('th-prod')
 const thTypeRef = useTemplateRef('th-type')
 
 // Computed
+// --------------------------------------------------------------------------
 const isCurrentUserArtist = computed(() => store.getters.isCurrentUserArtist)
 const organisation = computed(() => store.getters.organisation)
 const productionMap = computed(() => store.getters.productionMap)
@@ -348,6 +351,7 @@ const dayOffTextError = computed(() =>
 )
 
 // Functions
+// --------------------------------------------------------------------------
 const onBodyScroll = event => {
   if (!bodyRef.value) return
   const maxHeight = bodyRef.value.scrollHeight - bodyRef.value.offsetHeight
@@ -382,11 +386,13 @@ const closeUnsetDayOffModal = () => {
 defineExpose({ closeSetDayOffModal, closeUnsetDayOffModal })
 
 // Watchers
+// --------------------------------------------------------------------------
 watch(selectedDate, () => {
   emit('date-changed', selectedDate.value)
 })
 
 // Lifecycle
+// --------------------------------------------------------------------------
 onMounted(() => {
   colTypePosX.value = `${thProdRef.value.offsetWidth}px`
   colNamePosX.value = `${

--- a/src/components/lists/TodosList.vue
+++ b/src/components/lists/TodosList.vue
@@ -367,6 +367,7 @@ const { formatDisplayDate, formatDuration, isDurationInHours, organisation } =
   useFormat()
 
 // Props / Emits
+// --------------------------------------------------------------------------
 const props = defineProps({
   done: {
     type: Boolean,
@@ -401,6 +402,7 @@ const props = defineProps({
 const emit = defineEmits(['scroll', 'task-selected'])
 
 // State
+// --------------------------------------------------------------------------
 const colNamePosX = ref('')
 const colTypePosX = ref('')
 const lastSelection = ref(null)
@@ -411,6 +413,7 @@ const thProdRef = useTemplateRef('th-prod')
 const thTypeRef = useTemplateRef('th-type')
 
 // Computed
+// --------------------------------------------------------------------------
 const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
 const isCurrentUserSupervisor = computed(
   () => store.getters.isCurrentUserSupervisor
@@ -477,6 +480,7 @@ const isEpisodeVisible = computed(() =>
 )
 
 // Functions
+// --------------------------------------------------------------------------
 const assetEpisodes = (entry, full) => {
   if (['Episode', 'Sequence', 'Shot', 'Edit'].includes(entry.entity_type_name))
     return ''
@@ -757,6 +761,7 @@ const resetSelection = () => {
 defineExpose({ resizeHeaders, setScrollPosition })
 
 // Watchers
+// --------------------------------------------------------------------------
 watch(() => props.tasks, resetSelection)
 
 watch(nbSelectedTasks, () => {
@@ -764,6 +769,7 @@ watch(nbSelectedTasks, () => {
 })
 
 // Lifecycle
+// --------------------------------------------------------------------------
 onMounted(() => {
   window.addEventListener('keydown', onKeyDown, false)
   if (thProdRef.value) {

--- a/src/components/lists/TodosList.vue
+++ b/src/components/lists/TodosList.vue
@@ -339,8 +339,8 @@ import {
 } from '@/composables/descriptors'
 import { pauseEvent } from '@/composables/dom'
 import { useFormat } from '@/composables/format'
+import { useTaskHelpers } from '@/composables/tasks'
 import { getTaskEntityPath } from '@/lib/path'
-import { sortPeople } from '@/lib/sorting'
 import {
   daysToMinutes,
   formatSimpleDate,
@@ -365,6 +365,7 @@ import TableInfo from '@/components/widgets/TableInfo.vue'
 const store = useStore()
 const { formatDisplayDate, formatDuration, isDurationInHours, organisation } =
   useFormat()
+const { getSortedPeople, getTaskType } = useTaskHelpers()
 
 // Props / Emits
 // --------------------------------------------------------------------------
@@ -420,10 +421,8 @@ const isCurrentUserSupervisor = computed(
 )
 const nbSelectedTasks = computed(() => store.getters.nbSelectedTasks)
 const openProductions = computed(() => store.getters.openProductions)
-const personMap = computed(() => store.getters.personMap)
 const productionMap = computed(() => store.getters.productionMap)
 const taskMap = computed(() => store.getters.taskMap)
-const taskTypeMap = computed(() => store.getters.taskTypeMap)
 const user = computed(() => store.getters.user)
 
 const isEditable = computed(
@@ -488,24 +487,14 @@ const assetEpisodes = (entry, full) => {
   const episodeNames = (entry.episode_names || []).filter(
     name => name !== mainEpisodeName
   )
-  let episodeNameString = ''
-  if (episodeNames.length > 2) {
-    if (full) {
-      episodeNameString = episodeNames.join(', ')
-    } else {
-      episodeNameString = episodeNames.slice(0, 2).join(', ') + ', ...'
-    }
-  } else if (episodeNames.length > 0) {
-    episodeNameString = episodeNames.join(', ')
+  if (!episodeNames.length) {
+    return mainEpisodeName
   }
-  return episodeNames.length > 0
-    ? mainEpisodeName + ', ' + episodeNameString
-    : mainEpisodeName
-}
-
-const getSortedPeople = personIds => {
-  const people = personIds.map(id => personMap.value.get(id)).filter(Boolean)
-  return sortPeople(people)
+  const episodeNameString =
+    !full && episodeNames.length > 2
+      ? episodeNames.slice(0, 2).join(', ') + ', ...'
+      : episodeNames.join(', ')
+  return mainEpisodeName + ', ' + episodeNameString
 }
 
 const setScrollPosition = scrollPosition => {
@@ -523,20 +512,6 @@ const getDate = date => (date ? moment(date, 'YYYY-MM-DD').toDate() : null)
 const onBodyScroll = event => {
   if (!bodyRef.value) return
   emit('scroll', event.target.scrollTop)
-}
-
-const getTaskType = entry => {
-  const taskType = { ...taskTypeMap.value.get(entry.task_type_id) }
-  const production = productionMap.value.get(entry.project_id)
-  taskType.episode_id = entry.episode_id
-  if (
-    production &&
-    production.production_type === 'tvshow' &&
-    !entry.episode_id
-  ) {
-    taskType.episode_id = production.first_episode_id
-  }
-  return taskType
 }
 
 const entityPath = entity => {
@@ -590,13 +565,10 @@ const mergeMetadataDescriptors = descriptors => {
   return mergedDescriptors
 }
 
-const getMetadataDescriptor = (fieldName, entry) => {
-  const entityType = entry.task_type_for_entity
-  const projectId = entry.project_id
-  return metadataDescriptorsMap.value[fieldName]?.[entityType]?.[projectId]
-    ? metadataDescriptorsMap.value[fieldName][entityType][projectId]
-    : null
-}
+const getMetadataDescriptor = (fieldName, entry) =>
+  metadataDescriptorsMap.value[fieldName]?.[entry.task_type_for_entity]?.[
+    entry.project_id
+  ] ?? null
 
 const isTaskChanged = (task, data) => {
   const taskStart = task.start_date ? task.start_date.substring(0, 10) : ''
@@ -619,89 +591,72 @@ const updateEstimation = duration => {
   updateTasksEstimation({ estimation })
 }
 
-const updateTasksEstimation = ({ estimation }) => {
+// Applies buildData to every selected task; a null data skips the task.
+const updateSelectedTasks = buildData => {
   Object.keys(selectionGrid.value).forEach(taskId => {
     const task = taskMap.value.get(taskId)
     if (!task) return
-    let data = { estimation }
-    if (task.start_date) {
-      const startDate = moment(task.start_date)
-      const dueDate = task.due_date ? moment(task.due_date) : null
-      data = getDatesFromStartDate(
-        organisation.value,
-        startDate,
-        dueDate,
-        minutesToDays(organisation.value, estimation)
-      )
-      data.estimation = estimation
-    }
-    if (isTaskChanged(task, data)) {
+    const data = buildData(task)
+    if (data && isTaskChanged(task, data)) {
       store.dispatch('updateTask', { taskId, data }).catch(console.error)
     }
   })
 }
 
-const updateStartDate = date => {
-  Object.keys(selectionGrid.value).forEach(taskId => {
-    const task = taskMap.value.get(taskId)
-    if (!task) return
-    const dueDate = task.due_date ? parseSimpleDate(task.due_date) : null
-    let data
-    if (date) {
-      const startDate = moment(date)
-      if (
-        task.start_date &&
-        task.start_date.substring(0, 10) === formatSimpleDate(startDate)
-      )
-        return
-      data = getDatesFromStartDate(
-        organisation.value,
-        startDate,
-        dueDate,
-        minutesToDays(organisation.value, task.estimation)
-      )
-    } else {
-      data = {
-        start_date: null,
-        due_date: task.due_date
-      }
+const updateTasksEstimation = ({ estimation }) =>
+  updateSelectedTasks(task => {
+    if (!task.start_date) {
+      return { estimation }
     }
-    if (isTaskChanged(task, data)) {
-      store.dispatch('updateTask', { taskId, data }).catch(console.error)
-    }
+    const data = getDatesFromStartDate(
+      organisation.value,
+      moment(task.start_date),
+      task.due_date ? moment(task.due_date) : null,
+      minutesToDays(organisation.value, estimation)
+    )
+    data.estimation = estimation
+    return data
   })
-}
 
-const updateDueDate = date => {
-  Object.keys(selectionGrid.value).forEach(taskId => {
-    const task = taskMap.value.get(taskId)
-    if (!task) return
-    const startDate = task.start_date ? parseSimpleDate(task.start_date) : null
-    let data
-    if (date) {
-      const dueDate = moment(date)
-      if (
-        task.due_date &&
-        task.due_date.substring(0, 10) === formatSimpleDate(dueDate)
-      )
-        return
-      data = getDatesFromEndDate(
-        organisation.value,
-        startDate,
-        dueDate,
-        minutesToDays(organisation.value, task.estimation)
-      )
-    } else {
-      data = {
-        start_date: task.start_date,
-        due_date: null
-      }
+const updateStartDate = date =>
+  updateSelectedTasks(task => {
+    if (!date) {
+      return { start_date: null, due_date: task.due_date }
     }
-    if (isTaskChanged(task, data)) {
-      store.dispatch('updateTask', { taskId, data }).catch(console.error)
+    const startDate = moment(date)
+    if (
+      task.start_date &&
+      task.start_date.substring(0, 10) === formatSimpleDate(startDate)
+    ) {
+      return null
     }
+    return getDatesFromStartDate(
+      organisation.value,
+      startDate,
+      task.due_date ? parseSimpleDate(task.due_date) : null,
+      minutesToDays(organisation.value, task.estimation)
+    )
   })
-}
+
+const updateDueDate = date =>
+  updateSelectedTasks(task => {
+    if (!date) {
+      return { start_date: task.start_date, due_date: null }
+    }
+    const dueDate = moment(date)
+    if (
+      task.due_date &&
+      task.due_date.substring(0, 10) === formatSimpleDate(dueDate)
+    ) {
+      return null
+    }
+    return getDatesFromEndDate(
+      organisation.value,
+      task.start_date ? parseSimpleDate(task.start_date) : null,
+      dueDate,
+      minutesToDays(organisation.value, task.estimation)
+    )
+  })
 
 const selectTask = (event, index, task) => {
   if (

--- a/src/components/lists/TodosList.vue
+++ b/src/components/lists/TodosList.vue
@@ -22,7 +22,6 @@
             <th
               scope="col"
               class="name datatable-row-header"
-              ref="th-name"
               :style="{ left: colNamePosX }"
             >
               {{ $t('tasks.fields.entity') }}
@@ -31,7 +30,7 @@
               {{ $t('assets.fields.episode') }}
             </th>
 
-            <th class="assignees" ref="th-assignees" v-if="isToCheck">
+            <th class="assignees" v-if="isToCheck">
               {{ $t('tasks.fields.assignees') }}
             </th>
             <th
@@ -86,7 +85,7 @@
             tabindex="0"
             @click="selectTask($event, i, entry)"
             @keydown.enter.prevent="selectTask($event, i, entry)"
-            v-for="(entry, i) in displayedTasks"
+            v-for="(entry, i) in tasks"
           >
             <td
               class="production datatable-row-header datatable-row-header--nobd"
@@ -252,7 +251,6 @@
             </td>
             <validation-cell
               class="status unselectable"
-              :ref="'validation-' + i + '-0'"
               :clickable="false"
               :column="entry.taskStatus"
               :column-y="0"
@@ -322,14 +320,25 @@
   </div>
 </template>
 
-<script>
-import { mapActions, mapGetters } from 'vuex'
+<script setup>
+import moment from 'moment-timezone'
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useTemplateRef,
+  watch
+} from 'vue'
+import { useStore } from 'vuex'
 
-import { domMixin } from '@/components/mixins/dom'
-import { descriptorMixin } from '@/components/mixins/descriptors'
-import { formatListMixin } from '@/components/mixins/format'
-import { selectionListMixin } from '@/components/mixins/selection'
-
+import {
+  getDescriptorChecklistValues,
+  getMetadataChecklistValues,
+  getMetadataFieldValue
+} from '@/composables/descriptors'
+import { pauseEvent } from '@/composables/dom'
+import { useFormat } from '@/composables/format'
 import { getTaskEntityPath } from '@/lib/path'
 import { sortPeople } from '@/lib/sorting'
 import {
@@ -342,552 +351,431 @@ import {
   range
 } from '@/lib/time'
 
-import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
 import DescriptionCell from '@/components/cells/DescriptionCell.vue'
 import LastCommentCell from '@/components/cells/LastCommentCell.vue'
-import ProductionNameCell from '@/components/cells/ProductionNameCell.vue'
-import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
-import TaskTypeCell from '@/components/cells/TaskTypeCell.vue'
-import TableInfo from '@/components/widgets/TableInfo.vue'
-import ValidationCell from '@/components/cells/ValidationCell.vue'
 import MetadataHeader from '@/components/cells/MetadataHeader.vue'
-import moment from 'moment-timezone'
+import ProductionNameCell from '@/components/cells/ProductionNameCell.vue'
+import TaskTypeCell from '@/components/cells/TaskTypeCell.vue'
+import ValidationCell from '@/components/cells/ValidationCell.vue'
 import DateField from '@/components/widgets/DateField.vue'
+import EntityThumbnail from '@/components/widgets/EntityThumbnail.vue'
+import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
+import TableInfo from '@/components/widgets/TableInfo.vue'
 
-export default {
-  name: 'todos-list',
+const store = useStore()
+const { formatDisplayDate, formatDuration, isDurationInHours, organisation } =
+  useFormat()
 
-  mixins: [domMixin, formatListMixin, selectionListMixin, descriptorMixin],
-
-  components: {
-    EntityThumbnail,
-    DateField,
-    DescriptionCell,
-    LastCommentCell,
-    MetadataHeader,
-    PeopleAvatar,
-    ProductionNameCell,
-    TableInfo,
-    TaskTypeCell,
-    ValidationCell
+// Props / Emits
+const props = defineProps({
+  done: {
+    type: Boolean,
+    default: false
   },
-
-  props: {
-    done: {
-      type: Boolean,
-      default: false
-    },
-    tasks: {
-      type: Array,
-      default: () => []
-    },
-    isError: {
-      type: Boolean,
-      default: false
-    },
-    isLoading: {
-      type: Boolean,
-      default: false
-    },
-    isToCheck: {
-      type: Boolean,
-      default: false
-    },
-    emptyText: {
-      type: String,
-      default: ''
-    },
-    disabledDates: {
-      type: Object,
-      default: () => {}
-    }
+  tasks: {
+    type: Array,
+    default: () => []
   },
-
-  emits: ['scroll', 'task-selected'],
-
-  data() {
-    return {
-      colTypePosX: '',
-      colNamePosX: '',
-      lastSelection: null,
-      selectionGrid: {},
-      selectedDate: moment().toDate() // By default current day.
-    }
+  isError: {
+    type: Boolean,
+    default: false
   },
-
-  mounted() {
-    this.resizeHeaders()
-    window.addEventListener('keydown', this.onKeyDown, false)
-    if (this.$refs['th-prod']) {
-      this.colTypePosX = this.$refs['th-prod'].offsetWidth + 'px'
-      this.colNamePosX =
-        this.$refs['th-prod'].offsetWidth +
-        this.$refs['th-type'].offsetWidth +
-        'px'
-    }
+  isLoading: {
+    type: Boolean,
+    default: false
   },
-
-  beforeUnmount() {
-    window.removeEventListener('keydown', this.onKeyDown)
+  isToCheck: {
+    type: Boolean,
+    default: false
   },
-
-  computed: {
-    ...mapGetters([
-      'nbSelectedTasks',
-      'selectedTasks',
-      'openProductions',
-      'personMap',
-      'productionMap',
-      'taskMap',
-      'taskTypeMap',
-      'user',
-      'isCurrentUserManager',
-      'isCurrentUserSupervisor'
-    ]),
-
-    displayedTasks() {
-      return this.tasks
-    },
-
-    isEditable() {
-      return this.isCurrentUserManager || this.isCurrentUserSupervisor
-    },
-
-    isDescriptionPresent() {
-      return this.tasks.some(task => {
-        return task.entity_description && task.entity_description.length > 0
-      })
-    },
-
-    metadataDescriptorsMap() {
-      const metadataDescriptorsMap = {}
-      if (!this.isToCheck) {
-        this.openProductions.forEach(project => {
-          project.descriptors.forEach(descriptor => {
-            const isUserDepartment = this.user.departments.some(department =>
-              descriptor.departments.includes(department)
-            )
-            if (isUserDepartment) {
-              // group them by field_name if they have the same field_name
-              if (!(descriptor.field_name in metadataDescriptorsMap)) {
-                metadataDescriptorsMap[descriptor.field_name] = {}
-              }
-              const descriptorFieldNameEntry =
-                metadataDescriptorsMap[descriptor.field_name]
-              // group them by entity_type if the have the same entity_type
-              if (!(descriptor.entity_type in descriptorFieldNameEntry)) {
-                descriptorFieldNameEntry[descriptor.entity_type] = {}
-              }
-              descriptorFieldNameEntry[descriptor.entity_type][project.id] =
-                descriptor
-            }
-          })
-        })
-      }
-      return metadataDescriptorsMap
-    },
-
-    timeSpent() {
-      return this.displayedTasks.reduce((acc, task) => acc + task.duration, 0)
-    },
-
-    timeEstimated() {
-      return this.displayedTasks.reduce((acc, task) => acc + task.estimation, 0)
-    },
-
-    isEpisodeVisible() {
-      return this.displayedTasks.some(
-        task =>
-          task.source_id ||
-          task.episode_names?.length > 0 ||
-          (!['Shot', 'Sequence', 'Edit'].includes(task.entity_type_name) &&
-            task.episode_id)
-      )
-    }
+  emptyText: {
+    type: String,
+    default: ''
   },
+  disabledDates: {
+    type: Object,
+    default: () => {}
+  }
+})
 
-  methods: {
-    ...mapActions([
-      'addSelectedTask',
-      'addSelectedTasks',
-      'clearSelectedTasks',
-      'removeSelectedTask',
-      'updateTask'
-    ]),
+const emit = defineEmits(['scroll', 'task-selected'])
 
-    assetEpisodes(entry, full) {
-      if (
-        ['Episode', 'Sequence', 'Shot', 'Edit'].includes(entry.entity_type_name)
-      )
-        return ''
-      const mainEpisodeName = entry.episode_name || 'MP'
-      const episodeNames = (entry.episode_names || []).filter(
-        name => name !== mainEpisodeName
-      )
-      let episodeNameString = ''
-      if (episodeNames.length > 2) {
-        if (full) {
-          episodeNameString = episodeNames.join(', ')
-        } else {
-          episodeNameString = episodeNames.slice(0, 2).join(', ') + ', ...'
-        }
-      } else if (episodeNames.length > 0) {
-        episodeNameString = episodeNames.join(', ')
-      }
-      return episodeNames.length > 0
-        ? mainEpisodeName + ', ' + episodeNameString
-        : mainEpisodeName
-    },
+// State
+const colNamePosX = ref('')
+const colTypePosX = ref('')
+const lastSelection = ref(null)
+const selectionGrid = ref({})
 
-    getSortedPeople(personIds) {
-      const people = personIds.map(id => this.personMap.get(id)).filter(Boolean)
-      return sortPeople(people)
-    },
+const bodyRef = useTemplateRef('body')
+const thProdRef = useTemplateRef('th-prod')
+const thTypeRef = useTemplateRef('th-type')
 
-    setScrollPosition(scrollPosition) {
-      if (this.$refs.body) {
-        this.$refs.body.scrollTop = scrollPosition
-      }
-    },
+// Computed
+const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
+const isCurrentUserSupervisor = computed(
+  () => store.getters.isCurrentUserSupervisor
+)
+const nbSelectedTasks = computed(() => store.getters.nbSelectedTasks)
+const openProductions = computed(() => store.getters.openProductions)
+const personMap = computed(() => store.getters.personMap)
+const productionMap = computed(() => store.getters.productionMap)
+const taskMap = computed(() => store.getters.taskMap)
+const taskTypeMap = computed(() => store.getters.taskTypeMap)
+const user = computed(() => store.getters.user)
 
-    getDate(date) {
-      return date ? moment(date, 'YYYY-MM-DD').toDate() : null
-    },
+const isEditable = computed(
+  () => isCurrentUserManager.value || isCurrentUserSupervisor.value
+)
 
-    onBodyScroll(event) {
-      if (!this.$refs.body) return
-      const position = event.target
-      this.$emit('scroll', position.scrollTop)
-    },
+const isDescriptionPresent = computed(() =>
+  props.tasks.some(task => task.entity_description?.length > 0)
+)
 
-    getTaskType(entry) {
-      const taskType = { ...this.taskTypeMap.get(entry.task_type_id) }
-      const production = this.productionMap.get(entry.project_id)
-      taskType.episode_id = entry.episode_id
-      if (
-        production &&
-        production.production_type === 'tvshow' &&
-        !entry.episode_id
-      ) {
-        taskType.episode_id = production.first_episode_id
-      }
-      return taskType
-    },
-
-    entityPath(entity) {
-      const entityType = entity.entity_type_name
-      const production = this.productionMap.get(entity.project_id)
-      let episodeId = entity.episode_id
-      if (production && production.production_type === 'tvshow' && !episodeId) {
-        if (entityType === 'Shot') {
-          episodeId = production.first_episode_id
-        } else if (!['Edit', 'Episode', 'Sequence'].includes(entityType)) {
-          episodeId = 'main'
-        }
-      }
-      return getTaskEntityPath(entity, episodeId)
-    },
-
-    onKeyDown(event) {
-      if (this.tasks.length > 0 && event.altKey) {
-        let index = this.lastSelection ? this.lastSelection : 0
-        if ([37, 38].includes(event.keyCode)) {
-          index = index - 1 < 0 ? this.tasks.length - 1 : index - 1
-          this.selectTask({}, index, this.tasks[index])
-          this.pauseEvent(event)
-        } else if ([39, 40].includes(event.keyCode)) {
-          index = index + 1 >= this.tasks.length ? 0 : index + 1
-          this.selectTask({}, index, this.tasks[index])
-          this.pauseEvent(event)
-        }
-      }
-    },
-
-    scrollToValidationCell(validationCell) {
-      if (validationCell) {
-        const margin = 20
-        const rect = validationCell.$el.getBoundingClientRect()
-        const listRect = this.$refs.body.getBoundingClientRect()
-        const isBelow = rect.bottom > listRect.bottom - margin
-        const isAbove = rect.top < listRect.top + margin
-        const isRight = rect.right > listRect.right - margin
-        const isLeft = rect.left < listRect.left + margin
-
-        if (isBelow) {
-          const scrollingRequired = rect.bottom - listRect.bottom + margin
-          this.setScrollPosition(this.$refs.body.scrollTop + scrollingRequired)
-        } else if (isAbove) {
-          const scrollingRequired = listRect.top - rect.top + margin
-          this.setScrollPosition(this.$refs.body.scrollTop - scrollingRequired)
-        }
-
-        if (isRight) {
-          const scrollingRequired = rect.right - listRect.right + margin
-          this.setScrollLeftPosition(
-            this.$refs.body.scrollLeft + scrollingRequired
-          )
-        } else if (isLeft) {
-          const scrollingRequired = listRect.left - rect.left + margin
-          this.setScrollLeftPosition(
-            this.$refs.body.scrollLeft - scrollingRequired
-          )
-        }
-      }
-    },
-
-    select(i, j) {
-      const ref = 'validation-' + i + '-' + j
-      const validationCell = this.$refs[ref]
-      if (validationCell) validationCell[0].$el.click()
-      return validationCell ? validationCell[0] : 0
-    },
-
-    resizeHeaders() {
-      const tableBody = this.$refs['body-tbody']
-      const isTableBodyContainLines = tableBody && tableBody.children
-      if (isTableBodyContainLines) {
-        const bodyElement = tableBody.children[0]
-        const columnDescriptors = [
-          { index: 1, name: 'type' },
-          { index: 3, name: 'name' }
-        ]
-        columnDescriptors.forEach(desc => {
-          const width = Math.max(
-            bodyElement.children[desc.index].offsetWidth,
-            100
-          )
-          this.$refs['th-' + desc.name].style['min-width'] = `${width}px`
-        })
-      }
-    },
-
-    mergeMetadataDescriptors(descriptors) {
-      const firstKeyEntityType = Object.keys(descriptors)[0]
-      const firstKeyProjectId = Object.keys(descriptors[firstKeyEntityType])[0]
-      const mergedDescriptors = {
-        departments: [],
-        field_name:
-          descriptors[firstKeyEntityType][firstKeyProjectId].field_name,
-        name: descriptors[firstKeyEntityType][firstKeyProjectId].name
-      }
-      // merge departments
-      Object.keys(descriptors).forEach(entityType =>
-        Object.keys(descriptors[entityType]).forEach(projectId => {
-          mergedDescriptors.departments = [
-            ...new Set([
-              ...descriptors[entityType][projectId].departments,
-              ...mergedDescriptors.departments
-            ])
-          ]
-        })
-      )
-      return mergedDescriptors
-    },
-
-    getMetadataDescriptor(fieldName, entry) {
-      const entityType = entry.task_type_for_entity
-      const projectId = entry.project_id
-      return this.metadataDescriptorsMap[fieldName] &&
-        this.metadataDescriptorsMap[fieldName][entityType] &&
-        this.metadataDescriptorsMap[fieldName][entityType][projectId]
-        ? this.metadataDescriptorsMap[fieldName][entityType][projectId]
-        : null
-    },
-
-    isTaskChanged(task, data) {
-      const taskStart = task.start_date ? task.start_date.substring(0, 10) : ''
-      const taskDue = task.due_date ? task.due_date.substring(0, 10) : ''
-      return (
-        (data.start_date !== undefined && taskStart !== data.start_date) ||
-        (data.due_date !== undefined && taskDue !== data.due_date) ||
-        (data.estimation !== undefined && task.estimation !== data.estimation)
-      )
-    },
-
-    isEstimationBurned(task) {
-      return (
-        this.isToCheck && task.estimation > 0 && task.duration > task.estimation
-      )
-    },
-
-    updateEstimation(duration) {
-      const estimation = this.organisation.format_duration_in_hours
-        ? duration * 60
-        : daysToMinutes(this.organisation, duration)
-
-      this.updateTasksEstimation({ estimation })
-    },
-
-    updateTasksEstimation({ estimation }) {
-      Object.keys(this.selectionGrid).forEach(taskId => {
-        const task = this.taskMap.get(taskId)
-        if (!task) return
-        let data = { estimation }
-        if (task.start_date) {
-          const startDate = moment(task.start_date)
-          const dueDate = task.due_date ? moment(task.due_date) : null
-          data = getDatesFromStartDate(
-            this.organisation,
-            startDate,
-            dueDate,
-            minutesToDays(this.organisation, estimation)
-          )
-          data.estimation = estimation
-        }
-        if (this.isTaskChanged(task, data)) {
-          this.updateTask({ taskId, data }).catch(console.error)
-        }
-      })
-    },
-
-    updateStartDate(date) {
-      Object.keys(this.selectionGrid).forEach(taskId => {
-        const task = this.taskMap.get(taskId)
-        if (!task) return
-        const dueDate = task.due_date ? parseSimpleDate(task.due_date) : null
-        let data
-        if (date) {
-          const startDate = moment(date)
-          if (
-            task.start_date &&
-            task.start_date.substring(0, 10) === formatSimpleDate(startDate)
-          )
-            return
-          data = getDatesFromStartDate(
-            this.organisation,
-            startDate,
-            dueDate,
-            minutesToDays(this.organisation, task.estimation)
-          )
-        } else {
-          data = {
-            start_date: null,
-            due_date: task.due_date
+const metadataDescriptorsMap = computed(() => {
+  const descriptorsMap = {}
+  if (!props.isToCheck) {
+    openProductions.value.forEach(project => {
+      project.descriptors.forEach(descriptor => {
+        const isUserDepartment = user.value.departments.some(department =>
+          descriptor.departments.includes(department)
+        )
+        if (isUserDepartment) {
+          // group them by field_name if they have the same field_name
+          if (!(descriptor.field_name in descriptorsMap)) {
+            descriptorsMap[descriptor.field_name] = {}
           }
-        }
-        if (this.isTaskChanged(task, data)) {
-          this.updateTask({ taskId, data }).catch(console.error)
-        }
-      })
-    },
-
-    updateDueDate(date) {
-      Object.keys(this.selectionGrid).forEach(taskId => {
-        const task = this.taskMap.get(taskId)
-        if (!task) return
-        const startDate = task.start_date
-          ? parseSimpleDate(task.start_date)
-          : null
-        let data
-        if (date) {
-          const dueDate = moment(date)
-          if (
-            task.due_date &&
-            task.due_date.substring(0, 10) === formatSimpleDate(dueDate)
-          )
-            return
-          data = getDatesFromEndDate(
-            this.organisation,
-            startDate,
-            dueDate,
-            minutesToDays(this.organisation, task.estimation)
-          )
-        } else {
-          data = {
-            start_date: task.start_date,
-            due_date: null
+          const descriptorFieldNameEntry = descriptorsMap[descriptor.field_name]
+          // group them by entity_type if the have the same entity_type
+          if (!(descriptor.entity_type in descriptorFieldNameEntry)) {
+            descriptorFieldNameEntry[descriptor.entity_type] = {}
           }
-        }
-        if (this.isTaskChanged(task, data)) {
-          this.updateTask({ taskId, data }).catch(console.error)
+          descriptorFieldNameEntry[descriptor.entity_type][project.id] =
+            descriptor
         }
       })
-    },
+    })
+  }
+  return descriptorsMap
+})
 
-    selectTask(event, index, task) {
-      if (
-        event &&
-        event.target &&
-        // Dirty hack needed to make date picker and inputs work properly
-        (['INPUT'].includes(event.target.nodeName) ||
-          // Combo box should not trigger selection
-          event.target.className.indexOf('selected-line') >= 0 ||
-          event.target.className.indexOf('down-icon') >= 0 ||
-          event.target.className.indexOf('c-mask') >= 0 ||
-          event.target.className.indexOf('option-line') >= 0 ||
-          event.target.className.indexOf('combobox') >= 0 ||
-          (event.target.parentNode &&
-            ['HEADER'].includes(event.target.parentNode.nodeName)) ||
-          ['cell day selected'].includes(event.target.className))
-      )
-        return
-      const isSelected = this.selectionGrid[task.id]
-      const isManySelection = Object.keys(this.selectionGrid).length > 1
-      if (event && !(event.ctrlKey || event.metaKey) && !event.shiftKey) {
-        this.clearSelectedTasks()
-        this.resetSelection()
-      }
+const timeSpent = computed(() =>
+  props.tasks.reduce((acc, task) => acc + task.duration, 0)
+)
 
-      if (event && !event.shiftKey) {
-        if (isSelected && !isManySelection) {
-          this.removeSelectedTask({ task })
-          this.selectionGrid[task.id] = undefined
-        } else if (!isSelected || isManySelection) {
-          this.addSelectedTask({ task })
-          this.$emit('task-selected', task)
-          this.selectionGrid[task.id] = true
-          this.lastSelection = index
-        }
-      } else {
-        this.selectionGrid = {}
-        const taskIndices =
-          this.lastSelection > index
-            ? range(index, this.lastSelection)
-            : range(this.lastSelection, index)
-        const selection = taskIndices.map(i => ({ task: this.tasks[i] }))
-        selection.forEach(task => {
-          this.selectionGrid[task.task.id] = true
-        })
-        this.addSelectedTasks(selection)
-      }
-      this.scrollToLine(task.id)
-    },
+const timeEstimated = computed(() =>
+  props.tasks.reduce((acc, task) => acc + task.estimation, 0)
+)
 
-    resetSelection() {
-      this.selectionGrid = {}
-      this.lastSelection = null
-    },
+const isEpisodeVisible = computed(() =>
+  props.tasks.some(
+    task =>
+      task.source_id ||
+      task.episode_names?.length > 0 ||
+      (!['Shot', 'Sequence', 'Edit'].includes(task.entity_type_name) &&
+        task.episode_id)
+  )
+)
 
-    scrollToLine(taskId) {
-      const taskLine = this.$refs[`task-${taskId}`]
-      if (taskLine && this.$refs.body) {
-        const margin = 30
-        const rect = taskLine[0].getBoundingClientRect()
-        const listRect = this.$refs.body.getBoundingClientRect()
-        const isBelow = rect.bottom > listRect.bottom - margin
-        const isAbove = rect.top < listRect.top + margin
-
-        if (isBelow) {
-          const scrollingRequired = rect.bottom - listRect.bottom + margin
-          this.setScrollPosition(this.$refs.body.scrollTop + scrollingRequired)
-        } else if (isAbove) {
-          const scrollingRequired = listRect.top - rect.top + margin
-          this.setScrollPosition(this.$refs.body.scrollTop - scrollingRequired)
-        }
-      }
+// Functions
+const assetEpisodes = (entry, full) => {
+  if (['Episode', 'Sequence', 'Shot', 'Edit'].includes(entry.entity_type_name))
+    return ''
+  const mainEpisodeName = entry.episode_name || 'MP'
+  const episodeNames = (entry.episode_names || []).filter(
+    name => name !== mainEpisodeName
+  )
+  let episodeNameString = ''
+  if (episodeNames.length > 2) {
+    if (full) {
+      episodeNameString = episodeNames.join(', ')
+    } else {
+      episodeNameString = episodeNames.slice(0, 2).join(', ') + ', ...'
     }
-  },
+  } else if (episodeNames.length > 0) {
+    episodeNameString = episodeNames.join(', ')
+  }
+  return episodeNames.length > 0
+    ? mainEpisodeName + ', ' + episodeNameString
+    : mainEpisodeName
+}
 
-  watch: {
-    tasks() {
-      this.resetSelection()
-    },
+const getSortedPeople = personIds => {
+  const people = personIds.map(id => personMap.value.get(id)).filter(Boolean)
+  return sortPeople(people)
+}
 
-    nbSelectedTasks() {
-      if (this.nbSelectedTasks === 0) this.resetSelection()
+const setScrollPosition = scrollPosition => {
+  if (bodyRef.value) {
+    bodyRef.value.scrollTop = scrollPosition
+  }
+}
+
+// Historical no-op kept because parent pages still call it through the
+// template ref: the tbody ref it used to measure never existed here.
+const resizeHeaders = () => {}
+
+const getDate = date => (date ? moment(date, 'YYYY-MM-DD').toDate() : null)
+
+const onBodyScroll = event => {
+  if (!bodyRef.value) return
+  emit('scroll', event.target.scrollTop)
+}
+
+const getTaskType = entry => {
+  const taskType = { ...taskTypeMap.value.get(entry.task_type_id) }
+  const production = productionMap.value.get(entry.project_id)
+  taskType.episode_id = entry.episode_id
+  if (
+    production &&
+    production.production_type === 'tvshow' &&
+    !entry.episode_id
+  ) {
+    taskType.episode_id = production.first_episode_id
+  }
+  return taskType
+}
+
+const entityPath = entity => {
+  const entityType = entity.entity_type_name
+  const production = productionMap.value.get(entity.project_id)
+  let episodeId = entity.episode_id
+  if (production && production.production_type === 'tvshow' && !episodeId) {
+    if (entityType === 'Shot') {
+      episodeId = production.first_episode_id
+    } else if (!['Edit', 'Episode', 'Sequence'].includes(entityType)) {
+      episodeId = 'main'
+    }
+  }
+  return getTaskEntityPath(entity, episodeId)
+}
+
+const onKeyDown = event => {
+  if (props.tasks.length > 0 && event.altKey) {
+    let index = lastSelection.value ? lastSelection.value : 0
+    if ([37, 38].includes(event.keyCode)) {
+      index = index - 1 < 0 ? props.tasks.length - 1 : index - 1
+      selectTask({}, index, props.tasks[index])
+      pauseEvent(event)
+    } else if ([39, 40].includes(event.keyCode)) {
+      index = index + 1 >= props.tasks.length ? 0 : index + 1
+      selectTask({}, index, props.tasks[index])
+      pauseEvent(event)
     }
   }
 }
+
+const mergeMetadataDescriptors = descriptors => {
+  const firstKeyEntityType = Object.keys(descriptors)[0]
+  const firstKeyProjectId = Object.keys(descriptors[firstKeyEntityType])[0]
+  const mergedDescriptors = {
+    departments: [],
+    field_name: descriptors[firstKeyEntityType][firstKeyProjectId].field_name,
+    name: descriptors[firstKeyEntityType][firstKeyProjectId].name
+  }
+  // merge departments
+  Object.keys(descriptors).forEach(entityType =>
+    Object.keys(descriptors[entityType]).forEach(projectId => {
+      mergedDescriptors.departments = [
+        ...new Set([
+          ...descriptors[entityType][projectId].departments,
+          ...mergedDescriptors.departments
+        ])
+      ]
+    })
+  )
+  return mergedDescriptors
+}
+
+const getMetadataDescriptor = (fieldName, entry) => {
+  const entityType = entry.task_type_for_entity
+  const projectId = entry.project_id
+  return metadataDescriptorsMap.value[fieldName]?.[entityType]?.[projectId]
+    ? metadataDescriptorsMap.value[fieldName][entityType][projectId]
+    : null
+}
+
+const isTaskChanged = (task, data) => {
+  const taskStart = task.start_date ? task.start_date.substring(0, 10) : ''
+  const taskDue = task.due_date ? task.due_date.substring(0, 10) : ''
+  return (
+    (data.start_date !== undefined && taskStart !== data.start_date) ||
+    (data.due_date !== undefined && taskDue !== data.due_date) ||
+    (data.estimation !== undefined && task.estimation !== data.estimation)
+  )
+}
+
+const isEstimationBurned = task =>
+  props.isToCheck && task.estimation > 0 && task.duration > task.estimation
+
+const updateEstimation = duration => {
+  const estimation = organisation.value.format_duration_in_hours
+    ? duration * 60
+    : daysToMinutes(organisation.value, duration)
+
+  updateTasksEstimation({ estimation })
+}
+
+const updateTasksEstimation = ({ estimation }) => {
+  Object.keys(selectionGrid.value).forEach(taskId => {
+    const task = taskMap.value.get(taskId)
+    if (!task) return
+    let data = { estimation }
+    if (task.start_date) {
+      const startDate = moment(task.start_date)
+      const dueDate = task.due_date ? moment(task.due_date) : null
+      data = getDatesFromStartDate(
+        organisation.value,
+        startDate,
+        dueDate,
+        minutesToDays(organisation.value, estimation)
+      )
+      data.estimation = estimation
+    }
+    if (isTaskChanged(task, data)) {
+      store.dispatch('updateTask', { taskId, data }).catch(console.error)
+    }
+  })
+}
+
+const updateStartDate = date => {
+  Object.keys(selectionGrid.value).forEach(taskId => {
+    const task = taskMap.value.get(taskId)
+    if (!task) return
+    const dueDate = task.due_date ? parseSimpleDate(task.due_date) : null
+    let data
+    if (date) {
+      const startDate = moment(date)
+      if (
+        task.start_date &&
+        task.start_date.substring(0, 10) === formatSimpleDate(startDate)
+      )
+        return
+      data = getDatesFromStartDate(
+        organisation.value,
+        startDate,
+        dueDate,
+        minutesToDays(organisation.value, task.estimation)
+      )
+    } else {
+      data = {
+        start_date: null,
+        due_date: task.due_date
+      }
+    }
+    if (isTaskChanged(task, data)) {
+      store.dispatch('updateTask', { taskId, data }).catch(console.error)
+    }
+  })
+}
+
+const updateDueDate = date => {
+  Object.keys(selectionGrid.value).forEach(taskId => {
+    const task = taskMap.value.get(taskId)
+    if (!task) return
+    const startDate = task.start_date ? parseSimpleDate(task.start_date) : null
+    let data
+    if (date) {
+      const dueDate = moment(date)
+      if (
+        task.due_date &&
+        task.due_date.substring(0, 10) === formatSimpleDate(dueDate)
+      )
+        return
+      data = getDatesFromEndDate(
+        organisation.value,
+        startDate,
+        dueDate,
+        minutesToDays(organisation.value, task.estimation)
+      )
+    } else {
+      data = {
+        start_date: task.start_date,
+        due_date: null
+      }
+    }
+    if (isTaskChanged(task, data)) {
+      store.dispatch('updateTask', { taskId, data }).catch(console.error)
+    }
+  })
+}
+
+const selectTask = (event, index, task) => {
+  if (
+    event &&
+    event.target &&
+    // Dirty hack needed to make date picker and inputs work properly
+    (['INPUT'].includes(event.target.nodeName) ||
+      // Combo box should not trigger selection
+      event.target.className.indexOf('selected-line') >= 0 ||
+      event.target.className.indexOf('down-icon') >= 0 ||
+      event.target.className.indexOf('c-mask') >= 0 ||
+      event.target.className.indexOf('option-line') >= 0 ||
+      event.target.className.indexOf('combobox') >= 0 ||
+      (event.target.parentNode &&
+        ['HEADER'].includes(event.target.parentNode.nodeName)) ||
+      ['cell day selected'].includes(event.target.className))
+  )
+    return
+  const isSelected = selectionGrid.value[task.id]
+  const isManySelection = Object.keys(selectionGrid.value).length > 1
+  if (event && !(event.ctrlKey || event.metaKey) && !event.shiftKey) {
+    store.dispatch('clearSelectedTasks')
+    resetSelection()
+  }
+
+  if (event && !event.shiftKey) {
+    if (isSelected && !isManySelection) {
+      store.dispatch('removeSelectedTask', { task })
+      selectionGrid.value[task.id] = undefined
+    } else if (!isSelected || isManySelection) {
+      store.dispatch('addSelectedTask', { task })
+      emit('task-selected', task)
+      selectionGrid.value[task.id] = true
+      lastSelection.value = index
+    }
+  } else {
+    selectionGrid.value = {}
+    const taskIndices =
+      lastSelection.value > index
+        ? range(index, lastSelection.value)
+        : range(lastSelection.value, index)
+    const selection = taskIndices.map(i => ({ task: props.tasks[i] }))
+    selection.forEach(task => {
+      selectionGrid.value[task.task.id] = true
+    })
+    store.dispatch('addSelectedTasks', selection)
+  }
+}
+
+const resetSelection = () => {
+  selectionGrid.value = {}
+  lastSelection.value = null
+}
+
+// The parent pages restore the scroll position and trigger header
+// resizes through a template ref.
+defineExpose({ resizeHeaders, setScrollPosition })
+
+// Watchers
+watch(() => props.tasks, resetSelection)
+
+watch(nbSelectedTasks, () => {
+  if (nbSelectedTasks.value === 0) resetSelection()
+})
+
+// Lifecycle
+onMounted(() => {
+  window.addEventListener('keydown', onKeyDown, false)
+  if (thProdRef.value) {
+    colTypePosX.value = thProdRef.value.offsetWidth + 'px'
+    colNamePosX.value =
+      thProdRef.value.offsetWidth + thTypeRef.value.offsetWidth + 'px'
+  }
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown)
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/mixins/descriptors.js
+++ b/src/components/mixins/descriptors.js
@@ -4,29 +4,13 @@
  */
 import { mapGetters } from 'vuex'
 
-// Descriptor choices are static per descriptor — no need to reparse them
-// for every row. Cache keyed by descriptor.id, cleared when it grows too large.
-const _checklistValuesCache = new Map()
+import {
+  getDescriptorChecklistValues,
+  getMetadataChecklistValues,
+  getMetadataFieldValue
+} from '@/composables/descriptors'
 
-export const getDescriptorChecklistValues = descriptor => {
-  const cached = _checklistValuesCache.get(descriptor.id)
-  if (cached) return cached
-  const values = descriptor.choices.reduce((result, choice) => {
-    if (choice && typeof choice === 'string' && choice.startsWith('[x] ')) {
-      result.push({ text: choice.slice(4), checked: true })
-    } else if (
-      choice &&
-      typeof choice === 'string' &&
-      choice.startsWith('[ ] ')
-    ) {
-      result.push({ text: choice.slice(4), checked: false })
-    }
-    return result
-  }, [])
-  const result = values.length === descriptor.choices.length ? values : []
-  _checklistValuesCache.set(descriptor.id, result)
-  return result
-}
+export { getDescriptorChecklistValues }
 
 export const descriptorMixin = {
   emits: [
@@ -178,40 +162,11 @@ export const descriptorMixin = {
       return values
     },
 
-    getMetadataFieldValue(descriptor, entity) {
-      if (
-        entity.data &&
-        descriptor.field_name in entity.data &&
-        entity.data[descriptor.field_name] != null
-      ) {
-        return entity.data[descriptor.field_name]
-      } else if (
-        entity.entity_data &&
-        descriptor.field_name in entity.entity_data &&
-        entity.entity_data[descriptor.field_name] != null
-      ) {
-        return entity.entity_data[descriptor.field_name]
-      } else {
-        return ''
-      }
-    },
+    getMetadataFieldValue,
 
     getDescriptorChecklistValues,
 
-    getMetadataChecklistValues(descriptor, entity) {
-      let values
-      try {
-        values = JSON.parse(this.getMetadataFieldValue(descriptor, entity))
-      } catch {
-        values = {}
-      }
-      this.getDescriptorChecklistValues(descriptor).forEach(function (option) {
-        if (!(option.text in values)) {
-          values[option.text] = option.checked
-        }
-      })
-      return values
-    },
+    getMetadataChecklistValues,
 
     isSupervisorInDepartments(departments = []) {
       if (!Array.isArray(departments)) {

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -179,8 +179,8 @@ import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 
+import { useBoardStatuses } from '@/composables/board'
 import colors from '@/lib/colors'
-import { sortTaskStatuses } from '@/lib/sorting'
 import {
   addBusinessDays,
   getFirstStartDate,
@@ -252,9 +252,6 @@ const displayedPersonTasks = computed(() => store.getters.displayedPersonTasks)
 const displayedPersonDoneTasks = computed(
   () => store.getters.displayedPersonDoneTasks
 )
-const getProductionTaskStatuses = computed(
-  () => store.getters.getProductionTaskStatuses
-)
 const isCurrentUserAdmin = computed(() => store.getters.isCurrentUserAdmin)
 const isCurrentUserClient = computed(() => store.getters.isCurrentUserClient)
 const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
@@ -276,7 +273,6 @@ const personTimeSpentMap = computed(() => store.getters.personTimeSpentMap)
 const personTimeSpentTotal = computed(() => store.getters.personTimeSpentTotal)
 const productionMap = computed(() => store.getters.productionMap)
 const selectedTasks = computed(() => store.getters.selectedTasks)
-const taskStatuses = computed(() => store.getters.taskStatuses)
 const taskTypeMap = computed(() => store.getters.taskTypeMap)
 const user = computed(() => store.getters.user)
 
@@ -369,30 +365,6 @@ const boardTasks = computed(() =>
     : sortedAllTasks.value
 )
 
-const boardStatuses = computed(() => {
-  if (selectedProduction.value) {
-    return getBoardStatusesByProduction(selectedProduction.value)
-  }
-
-  const productionsByStatus = {}
-  userOpenProductions.value.forEach(production => {
-    getBoardStatusesByProduction(production).forEach(status => {
-      productionsByStatus[status.id] = (
-        productionsByStatus[status.id] || []
-      ).concat(production.id)
-    })
-  })
-
-  return taskStatuses.value
-    .filter(status => !status.for_concept)
-    .map(status => ({
-      ...status,
-      productions: productionsByStatus[status.id] || []
-    }))
-    .filter(status => status.productions.length > 0)
-    .sort((a, b) => a.priority - b.priority)
-})
-
 const productionList = computed(() => [
   { name: t('main.all') },
   ...userOpenProductions.value
@@ -410,6 +382,11 @@ const userOpenProductions = computed(() => {
     production.team.includes(person.value.id)
   )
 })
+
+const { boardStatuses, getBoardStatusesByProduction } = useBoardStatuses(
+  userOpenProductions,
+  selectedProduction
+)
 
 const todoTabs = computed(() => {
   const hasAvailableBoard = openProductions.value.some(
@@ -506,20 +483,6 @@ const sortTasks = tasks => {
       .thenBy('task_type_name')
       .thenBy('entity_name')
   )
-}
-
-const getBoardStatusesByProduction = production => {
-  const statuses = getProductionTaskStatuses
-    .value(production.id)
-    .filter(status => {
-      if (status.for_concept) {
-        return false
-      }
-      const rolesForBoard =
-        production.task_statuses_link?.[status.id]?.roles_for_board
-      return rolesForBoard?.includes(user.value.role)
-    })
-  return sortTaskStatuses(statuses, production)
 }
 
 const buildProjectScheduleItem = project => ({

--- a/src/components/pages/Person.vue
+++ b/src/components/pages/Person.vue
@@ -1,8 +1,8 @@
 <template>
-  <div ref="page" class="columns fixed-page">
+  <div class="columns fixed-page">
     <div class="column main-column">
       <div class="person page" v-if="person">
-        <div ref="header" class="flexrow page-header">
+        <div class="flexrow page-header">
           <div class="flexrow-item">
             <people-avatar
               :person="person"
@@ -55,7 +55,7 @@
             />
           </div>
 
-          <div ref="query" class="query-list" v-if="!isActiveTab('calendar')">
+          <div class="query-list" v-if="!isActiveTab('calendar')">
             <search-query-list
               :queries="personTaskSearchQueries"
               type="person"
@@ -159,10 +159,25 @@
   </div>
 </template>
 
-<script>
+<script setup>
+import { useHead } from '@unhead/vue'
 import moment from 'moment-timezone'
 import { firstBy } from 'thenby'
-import { mapGetters, mapActions } from 'vuex'
+import {
+  computed,
+  getCurrentInstance,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  onUnmounted,
+  reactive,
+  ref,
+  useTemplateRef,
+  watch
+} from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
+import { useStore } from 'vuex'
 
 import colors from '@/lib/colors'
 import { sortTaskStatuses } from '@/lib/sorting'
@@ -174,800 +189,743 @@ import {
   parseDate
 } from '@/lib/time'
 
-import { formatListMixin } from '@/components/mixins/format'
-import { searchMixin } from '@/components/mixins/search'
-
+import KanbanBoard from '@/components/lists/KanbanBoard.vue'
+import TimesheetList from '@/components/lists/TimesheetList.vue'
+import TodosList from '@/components/lists/TodosList.vue'
+import TaskInfo from '@/components/sides/TaskInfo.vue'
 import Combobox from '@/components/widgets/Combobox.vue'
 import ComboboxNumber from '@/components/widgets/ComboboxNumber.vue'
 import ComboboxProduction from '@/components/widgets/ComboboxProduction.vue'
-import KanbanBoard from '@/components/lists/KanbanBoard.vue'
 import PeopleAvatar from '@/components/widgets/PeopleAvatar.vue'
 import RouteSectionTabs from '@/components/widgets/RouteSectionTabs.vue'
 import Schedule from '@/components/widgets/Schedule.vue'
 import SearchField from '@/components/widgets/SearchField.vue'
 import SearchQueryList from '@/components/widgets/SearchQueryList.vue'
 import Spinner from '@/components/widgets/Spinner.vue'
-import TaskInfo from '@/components/sides/TaskInfo.vue'
-import TimesheetList from '@/components/lists/TimesheetList.vue'
-import TodosList from '@/components/lists/TodosList.vue'
 import UserCalendar from '@/components/widgets/UserCalendar.vue'
 
-export default {
-  name: 'person',
+const { t } = useI18n()
+const route = useRoute()
+const router = useRouter()
+const store = useStore()
+const socket = getCurrentInstance().appContext.config.globalProperties.$socket
 
-  mixins: [formatListMixin, searchMixin],
+// State
+// --------------------------------------------------------------------------
+const sortOptions = [
+  'entity_name',
+  'priority',
+  'task_status_short_name',
+  'start_date',
+  'due_date',
+  'estimation',
+  'last_comment_date'
+].map(name => ({ label: name, value: name }))
 
-  components: {
-    Combobox,
-    ComboboxNumber,
-    ComboboxProduction,
-    KanbanBoard,
-    PeopleAvatar,
-    RouteSectionTabs,
-    Schedule,
-    SearchField,
-    SearchQueryList,
-    Spinner,
-    TaskInfo,
-    TimesheetList,
-    TodosList,
-    UserCalendar
-  },
+const activeTab = ref('todos')
+const calendarTimeSpents = ref([])
+const currentSort = ref('entity_name')
+const daysOff = ref([])
+const dayOffError = ref(false)
+const init = ref(false)
+const isDoneTasksLoading = ref(false)
+const isDoneTasksLoadingError = ref(false)
+const isTasksLoading = ref(false)
+const isTasksLoadingError = ref(false)
+const person = ref(null)
+const productionId = ref(undefined)
+const selectedDate = ref(moment().format('YYYY-MM-DD'))
+const zoomLevel = ref(1)
+const loading = reactive({
+  savingSearch: false
+})
 
-  data() {
-    return {
-      activeTab: 'todos',
-      calendarTimeSpents: [],
-      currentSort: 'entity_name',
-      daysOff: [],
-      dayOffError: false,
-      init: false,
-      isDoneTasksLoading: false,
-      isDoneTasksLoadingError: false,
-      isTasksLoading: false,
-      isTasksLoadingError: false,
-      loading: {
-        savingSearch: false
-      },
-      person: null,
-      productionId: undefined,
-      selectedDate: moment().format('YYYY-MM-DD'),
-      sortOptions: [
-        'entity_name',
-        'priority',
-        'task_status_short_name',
-        'start_date',
-        'due_date',
-        'estimation',
-        'last_comment_date'
-      ].map(name => ({ label: name, value: name })),
-      zoomLevel: 1,
-      zoomOptions: [
-        { label: this.$t('main.week'), value: 0 },
-        { label: '1', value: 1 },
-        { label: '2', value: 2 },
-        { label: '3', value: 3 }
-      ]
+const searchFieldRef = useTemplateRef('person-tasks-search-field')
+const taskListRef = useTemplateRef('task-list')
+const doneListRef = useTemplateRef('done-list')
+const timesheetListRef = useTemplateRef('timesheet-list')
+const scheduleWidgetRef = useTemplateRef('schedule-widget')
+
+// Computed
+// --------------------------------------------------------------------------
+const displayedPersonTasks = computed(() => store.getters.displayedPersonTasks)
+const displayedPersonDoneTasks = computed(
+  () => store.getters.displayedPersonDoneTasks
+)
+const getProductionTaskStatuses = computed(
+  () => store.getters.getProductionTaskStatuses
+)
+const isCurrentUserAdmin = computed(() => store.getters.isCurrentUserAdmin)
+const isCurrentUserClient = computed(() => store.getters.isCurrentUserClient)
+const isCurrentUserManager = computed(() => store.getters.isCurrentUserManager)
+const isCurrentUserSupervisor = computed(
+  () => store.getters.isCurrentUserSupervisor
+)
+const isCurrentUserVendor = computed(() => store.getters.isCurrentUserVendor)
+const nbSelectedTasks = computed(() => store.getters.nbSelectedTasks)
+const openProductions = computed(() => store.getters.openProductions)
+const organisation = computed(() => store.getters.organisation)
+const personMap = computed(() => store.getters.personMap)
+const personTaskSearchQueries = computed(
+  () => store.getters.personTaskSearchQueries
+)
+const personTaskSelectionGrid = computed(
+  () => store.getters.personTaskSelectionGrid
+)
+const personTimeSpentMap = computed(() => store.getters.personTimeSpentMap)
+const personTimeSpentTotal = computed(() => store.getters.personTimeSpentTotal)
+const productionMap = computed(() => store.getters.productionMap)
+const selectedTasks = computed(() => store.getters.selectedTasks)
+const taskStatuses = computed(() => store.getters.taskStatuses)
+const taskTypeMap = computed(() => store.getters.taskTypeMap)
+const user = computed(() => store.getters.user)
+
+const zoomOptions = computed(() => [
+  { label: t('main.week'), value: 0 },
+  { label: '1', value: 1 },
+  { label: '2', value: 2 },
+  { label: '3', value: 3 }
+])
+
+const isCurrentUserAllowed = computed(
+  () =>
+    user.value.id === person.value.id ||
+    !(isCurrentUserClient.value || isCurrentUserVendor.value)
+)
+
+const sortedTasks = computed(() =>
+  sortAndFilterTasks(displayedPersonTasks.value)
+)
+
+const sortedDoneTasks = computed(() =>
+  sortAndFilterTasks(displayedPersonDoneTasks.value)
+)
+
+const sortedAllTasks = computed(() =>
+  // reuse the two cached computeds: they already carry the production
+  // filter, only the merged sort remains to do
+  sortTasks([...sortedTasks.value, ...sortedDoneTasks.value])
+)
+
+const loggablePersonTasks = computed(() => sortedTasks.value.filter(isLoggable))
+
+const loggableDoneTasks = computed(() =>
+  sortedDoneTasks.value.filter(isLoggable)
+)
+
+const tasksStartDate = computed(() =>
+  scheduleTasks.value.length ? getFirstStartDate(scheduleTasks.value) : moment()
+)
+
+const tasksEndDate = computed(() =>
+  scheduleTasks.value.length
+    ? getLastEndDate(scheduleTasks.value)
+    : moment().add(15, 'days')
+)
+
+const scheduleTasks = computed(() =>
+  scheduleItems.value.flatMap(item => item.children)
+)
+
+const scheduleItems = computed(() => {
+  const rootMap = new Map()
+  sortedAllTasks.value.forEach(task => {
+    if (!rootMap.get(task.project_id)) {
+      const project = productionMap.value.get(task.project_id)
+      rootMap.set(task.project_id, buildProjectScheduleItem(project))
     }
-  },
+    const rootElement = rootMap.get(task.project_id)
+    const taskItem = buildTaskScheduleItem(rootElement, task)
+    if (taskItem) rootElement.children.push(taskItem)
+  })
 
-  async mounted() {
-    this.productionId = this.$route.query.productionId || undefined
-
-    this.updateActiveTab()
-    await this.loadPerson(this.$route.params.person_id)
-    this.setSearchFromUrl()
-    this.onSearchChange()
-
-    this.$refs['schedule-widget']?.scrollToDate(this.tasksStartDate)
-
-    this.init = true
-  },
-
-  unmounted() {
-    this.$store.commit('LOAD_PERSON_TASKS_END', {
-      tasks: [],
-      userFilters: {},
-      taskTypeMap: this.taskTypeMap
+  const rootElements = Array.from(rootMap.values())
+  rootElements.forEach(rootElement => {
+    let rootStartDate = moment()
+    let rootEndDate = moment().add(1, 'days')
+    if (rootElement.children.length > 0) {
+      rootStartDate = getFirstStartDate(rootElement.children)
+      rootEndDate = getLastEndDate(rootElement.children)
+    }
+    const manDays = rootElement.children.reduce(
+      (days, task) => days + (task.estimation || 0),
+      0
+    )
+    Object.assign(rootElement, {
+      startDate: rootStartDate,
+      endDate: rootEndDate,
+      man_days: manDays,
+      daysOff: daysOff.value
     })
-  },
+  })
+  return rootElements
+})
 
-  computed: {
-    ...mapGetters([
-      'displayedPersonTasks',
-      'displayedPersonDoneTasks',
-      'getProductionTaskStatuses',
-      'isCurrentUserAdmin',
-      'isCurrentUserClient',
-      'isCurrentUserManager',
-      'isCurrentUserSupervisor',
-      'isCurrentUserVendor',
-      'nbSelectedTasks',
-      'personMap',
-      'personTasksScrollPosition',
-      'personTaskSearchQueries',
-      'personTaskSelectionGrid',
-      'personTimeSpentMap',
-      'personTimeSpentTotal',
-      'openProductions',
-      'productionMap',
-      'selectedTasks',
-      'taskStatuses',
-      'taskTypeMap',
-      'user'
-    ]),
-
-    isCurrentUserAllowed() {
-      return (
-        this.user.id === this.person.id ||
-        !(this.isCurrentUserClient || this.isCurrentUserVendor)
+const boardTasks = computed(() =>
+  selectedProduction.value
+    ? sortedAllTasks.value.filter(
+        task => task.project_id === selectedProduction.value.id
       )
-    },
+    : sortedAllTasks.value
+)
 
-    loggablePersonTasks() {
-      return this.sortedTasks.filter(task => {
-        return this.taskTypeMap.get(task.task_type_id)?.allow_timelog
-      })
-    },
+const boardStatuses = computed(() => {
+  if (selectedProduction.value) {
+    return getBoardStatusesByProduction(selectedProduction.value)
+  }
 
-    loggableDoneTasks() {
-      return this.sortedDoneTasks.filter(task => {
-        return this.taskTypeMap.get(task.task_type_id)?.allow_timelog
-      })
-    },
+  const productionsByStatus = {}
+  userOpenProductions.value.forEach(production => {
+    getBoardStatusesByProduction(production).forEach(status => {
+      productionsByStatus[status.id] = (
+        productionsByStatus[status.id] || []
+      ).concat(production.id)
+    })
+  })
 
-    searchField() {
-      return this.$refs['person-tasks-search-field']
-    },
+  return taskStatuses.value
+    .filter(status => !status.for_concept)
+    .map(status => ({
+      ...status,
+      productions: productionsByStatus[status.id] || []
+    }))
+    .filter(status => status.productions.length > 0)
+    .sort((a, b) => a.priority - b.priority)
+})
 
-    taskList() {
-      return this.$refs['task-list']
-    },
+const productionList = computed(() => [
+  { name: t('main.all') },
+  ...userOpenProductions.value
+])
 
-    haveDoneList() {
-      return this.$refs['done-list']
-    },
+const selectedProduction = computed(() =>
+  productionMap.value.get(productionId.value)
+)
 
-    sortedTasks() {
-      let tasks = this.sortTasks([...this.displayedPersonTasks])
-      if (this.productionId) {
-        tasks = tasks.filter(task => task.project_id === this.productionId)
-      }
-      return tasks
-    },
+const userOpenProductions = computed(() => {
+  if (!person.value) {
+    return []
+  }
+  return openProductions.value.filter(production =>
+    production.team.includes(person.value.id)
+  )
+})
 
-    sortedDoneTasks() {
-      let tasks = this.sortTasks([...this.displayedPersonDoneTasks])
-      if (this.productionId) {
-        tasks = tasks.filter(task => task.project_id === this.productionId)
-      }
-      return tasks
+const todoTabs = computed(() => {
+  const hasAvailableBoard = openProductions.value.some(
+    production => getBoardStatusesByProduction(production).length
+  )
+  return [
+    {
+      label: t('main.tasks'),
+      name: 'todos'
     },
-
-    sortedAllTasks() {
-      // reuse the two cached computeds: they already carry the production
-      // filter, only the merged sort remains to do
-      return this.sortTasks([...this.sortedTasks, ...this.sortedDoneTasks])
-    },
-
-    tasksStartDate() {
-      if (this.scheduleTasks.length) {
-        return getFirstStartDate(this.scheduleTasks)
-      } else {
-        return moment()
-      }
-    },
-
-    tasksEndDate() {
-      if (this.scheduleTasks.length) {
-        return getLastEndDate(this.scheduleTasks)
-      } else {
-        return moment().add(15, 'days')
-      }
-    },
-
-    scheduleTasks() {
-      return this.scheduleItems.flatMap(item => item.children)
-    },
-
-    scheduleItems() {
-      const rootMap = new Map()
-      this.sortedAllTasks.forEach(task => {
-        if (!rootMap.get(task.project_id)) {
-          const project = this.productionMap.get(task.project_id)
-          const rootElement = this.buildProjectScheduleItem(project)
-          rootMap.set(task.project_id, rootElement)
+    hasAvailableBoard
+      ? {
+          label: t('board.title'),
+          name: 'board'
         }
-        const rootElement = rootMap.get(task.project_id)
-        const taskItem = this.buildTaskScheduleItem(rootElement, task)
-        if (taskItem) rootElement.children.push(taskItem)
-      })
-
-      const rootElements = Array.from(rootMap.values())
-      rootElements.forEach(rootElement => {
-        let rootStartDate = moment()
-        let rootEndDate = moment().add(1, 'days')
-        let manDays = 0
-        if (rootElement.children.length > 0) {
-          rootStartDate = getFirstStartDate(rootElement.children)
-          rootEndDate = getLastEndDate(rootElement.children)
-        }
-        rootElement.children.forEach(task => {
-          if (task.estimation) manDays += task.estimation
-        })
-        Object.assign(rootElement, {
-          startDate: rootStartDate,
-          endDate: rootEndDate,
-          man_days: manDays,
-          daysOff: this.daysOff
-        })
-      })
-      return rootElements
+      : undefined,
+    {
+      label: t('tasks.calendar'),
+      name: 'calendar'
     },
-
-    boardTasks() {
-      const tasks = this.sortedAllTasks
-      if (this.selectedProduction) {
-        return tasks.filter(
-          task => task.project_id === this.selectedProduction.id
-        )
-      }
-      return tasks
+    {
+      label: t('schedule.title'),
+      name: 'schedule'
     },
-
-    boardStatuses() {
-      if (this.selectedProduction) {
-        return this.getBoardStatusesByProduction(this.selectedProduction)
-      }
-
-      const productionsByStatus = {}
-      this.userOpenProductions.forEach(production => {
-        const statuses = this.getBoardStatusesByProduction(production)
-        statuses.forEach(status => {
-          if (!productionsByStatus[status.id]) {
-            productionsByStatus[status.id] = []
-          }
-          productionsByStatus[status.id].push(production.id)
-        })
-      })
-
-      return this.taskStatuses
-        .filter(status => !status.for_concept)
-        .map(status => ({
-          ...status,
-          productions: productionsByStatus[status.id] || []
-        }))
-        .filter(status => status.productions.length > 0)
-        .sort((a, b) => a.priority - b.priority)
+    {
+      label: `${t('tasks.validated')} (${
+        isDoneTasksLoading.value ? '…' : displayedPersonDoneTasks.value.length
+      })`,
+      name: 'done'
     },
-
-    productionList() {
-      return [{ name: this.$t('main.all') }, ...this.userOpenProductions]
-    },
-
-    selectedProduction() {
-      return this.productionMap.get(this.productionId)
-    },
-
-    userOpenProductions() {
-      if (!this.person) {
-        return []
-      }
-      return this.openProductions.filter(production =>
-        production.team.includes(this.person.id)
-      )
-    },
-
-    todoTabs() {
-      const hasAvailableBoard = this.openProductions.some(
-        production => this.getBoardStatusesByProduction(production).length
-      )
-      return [
-        {
-          label: this.$t('main.tasks'),
-          name: 'todos'
-        },
-        hasAvailableBoard
-          ? {
-              label: this.$t('board.title'),
-              name: 'board'
-            }
-          : undefined,
-        {
-          label: this.$t('tasks.calendar'),
-          name: 'calendar'
-        },
-        {
-          label: this.$t('schedule.title'),
-          name: 'schedule'
-        },
-        {
-          label: `${this.$t('tasks.validated')} (${
-            this.isDoneTasksLoading ? '…' : this.displayedPersonDoneTasks.length
-          })`,
-          name: 'done'
-        },
-        {
-          label: this.$t('timesheets.timelog_title'),
-          name: 'timesheets'
-        }
-      ].filter(Boolean)
+    {
+      label: t('timesheets.timelog_title'),
+      name: 'timesheets'
     }
-  },
+  ].filter(Boolean)
+})
 
-  methods: {
-    ...mapActions([
-      'clearSelectedTasks',
-      'loadAggregatedPersonDaysOff',
-      'loadPersonDoneTasks',
-      'loadPersonTasks',
-      'loadPersonTimeSpents',
-      'loadPersonTimeSpentsByPeriod',
-      'setPersonTasksSearch',
-      'savePersonTasksSearch',
-      'removePersonTasksSearch',
-      'setDayOff',
-      'setPersonTasksScrollPosition',
-      'setTimeSpent',
-      'unsetDayOff',
-      'updateTask'
-    ]),
+// Functions
+// --------------------------------------------------------------------------
+const isActiveTab = tab => init.value && activeTab.value === tab
 
-    onCalendarTimeClicked(date) {
-      this.$router.push({
-        query: { ...this.$route.query, section: 'timesheets', day: date }
-      })
-    },
+const isLoggable = task =>
+  taskTypeMap.value.get(task.task_type_id)?.allow_timelog
 
-    async onCalendarDatesChanged({ start, end }) {
-      if (!this.person) {
-        return
+const sortAndFilterTasks = tasks => {
+  const sorted = sortTasks([...tasks])
+  return productionId.value
+    ? sorted.filter(task => task.project_id === productionId.value)
+    : sorted
+}
+
+const sortTasks = tasks => {
+  const byDate = field => (a, b) => {
+    if (!a[field]) return 1
+    if (!b[field]) return -1
+    return a[field].localeCompare(b[field])
+  }
+
+  if (currentSort.value === 'entity_name') {
+    return tasks.sort(
+      firstBy('project_name')
+        .thenBy('task_type_name')
+        .thenBy('full_entity_name')
+    )
+  }
+  if (currentSort.value === 'priority') {
+    return tasks.sort(
+      firstBy('priority', -1)
+        .thenBy(byDate('due_date'))
+        .thenBy('project_name')
+        .thenBy('task_type_name')
+        .thenBy('entity_name')
+    )
+  }
+  if (currentSort.value === 'due_date') {
+    return tasks.sort(
+      firstBy(byDate('due_date'))
+        .thenBy('project_name')
+        .thenBy('task_type_name')
+        .thenBy('entity_name')
+    )
+  }
+  if (currentSort.value === 'start_date') {
+    return tasks.sort(
+      firstBy(byDate('start_date'))
+        .thenBy('project_name')
+        .thenBy('task_type_name')
+        .thenBy('entity_name')
+    )
+  }
+  return tasks.sort(
+    firstBy(currentSort.value, -1)
+      .thenBy('project_name')
+      .thenBy('task_type_name')
+      .thenBy('entity_name')
+  )
+}
+
+const getBoardStatusesByProduction = production => {
+  const statuses = getProductionTaskStatuses
+    .value(production.id)
+    .filter(status => {
+      if (status.for_concept) {
+        return false
       }
-      try {
-        this.calendarTimeSpents = await this.loadPersonTimeSpentsByPeriod({
-          personId: this.person.id,
-          startDate: start,
-          endDate: end
-        })
-      } catch (err) {
-        console.error(err)
-        this.calendarTimeSpents = []
-      }
-    },
+      const rolesForBoard =
+        production.task_statuses_link?.[status.id]?.roles_for_board
+      return rolesForBoard?.includes(user.value.role)
+    })
+  return sortTaskStatuses(statuses, production)
+}
 
-    sortTasks(tasks) {
-      const isName = this.currentSort === 'entity_name'
-      const isPriority = this.currentSort === 'priority'
-      const isDueDate = this.currentSort === 'due_date'
-      const isStartDate = this.currentSort === 'start_date'
+const buildProjectScheduleItem = project => ({
+  ...project,
+  avatar: true,
+  color: colors.fromString(project.name, true),
+  priority: 1,
+  expanded: true,
+  loading: false,
+  children: [],
+  editable: false
+})
 
-      if (isName) {
-        return tasks.sort(
-          firstBy('project_name')
-            .thenBy('task_type_name')
-            .thenBy('full_entity_name')
-        )
-      } else if (isPriority) {
-        return tasks.sort(
-          firstBy('priority', -1)
-            .thenBy((a, b) => {
-              if (!a.due_date) return 1
-              else if (!b.due_date) return -1
-              else return a.due_date.localeCompare(b.due_date)
-            })
-            .thenBy('project_name')
-            .thenBy('task_type_name')
-            .thenBy('entity_name')
-        )
-      } else if (isDueDate) {
-        return tasks.sort(
-          firstBy((a, b) => {
-            if (!a.due_date) return 1
-            else if (!b.due_date) return -1
-            else return a.due_date.localeCompare(b.due_date)
-          })
-            .thenBy('project_name')
-            .thenBy('task_type_name')
-            .thenBy('entity_name')
-        )
-      } else if (isStartDate) {
-        return tasks.sort(
-          firstBy((a, b) => {
-            if (!a.start_date) return 1
-            else if (!b.start_date) return -1
-            else return a.start_date.localeCompare(b.start_date)
-          })
-            .thenBy('project_name')
-            .thenBy('task_type_name')
-            .thenBy('entity_name')
-        )
-      } else {
-        return tasks.sort(
-          firstBy(this.currentSort, -1)
-            .thenBy('project_name')
-            .thenBy('task_type_name')
-            .thenBy('entity_name')
-        )
-      }
-    },
+const buildTaskScheduleItem = (parentElement, task) => {
+  if (
+    !task.start_date &&
+    !task.real_start_date &&
+    !task.due_date &&
+    !task.end_date
+  ) {
+    return null
+  }
 
-    onAssignation(eventData) {
-      if (this.person.id === eventData.person_id) {
-        this.loadPerson(this.person.id)
-      }
-    },
+  let startDate = moment()
+  if (task.start_date) {
+    startDate = parseDate(task.start_date)
+  } else if (task.real_start_date) {
+    startDate = parseDate(task.real_start_date)
+  }
 
-    buildProjectScheduleItem(project) {
-      return {
-        ...project,
-        avatar: true,
-        color: colors.fromString(project.name, true),
-        priority: 1,
-        expanded: true,
-        loading: false,
-        children: [],
-        editable: false
-      }
-    },
+  const estimation = task.estimation
+  let endDate
+  if (task.due_date) {
+    endDate = parseDate(task.due_date)
+  } else if (task.end_date) {
+    endDate = parseDate(task.end_date)
+  } else if (task.estimation) {
+    endDate = addBusinessDays(
+      startDate,
+      Math.ceil(minutesToDays(organisation.value, estimation)) - 1
+    )
+  }
+  if (!endDate || endDate.isBefore(startDate)) {
+    endDate = startDate.clone().add(1, 'days')
+  }
 
-    buildTaskScheduleItem(parentElement, task) {
-      let startDate = moment()
-      let endDate
-
-      if (
-        !task.start_date &&
-        !task.real_start_date &&
-        !task.due_date &&
-        !task.end_date
-      ) {
-        return null
-      }
-
-      if (task.start_date) {
-        startDate = parseDate(task.start_date)
-      } else if (task.real_start_date) {
-        startDate = parseDate(task.real_start_date)
-      }
-
-      const estimation = task.estimation
-      if (task.due_date) {
-        endDate = parseDate(task.due_date)
-      } else if (task.end_date) {
-        endDate = parseDate(task.end_date)
-      } else if (task.estimation) {
-        endDate = addBusinessDays(
-          startDate,
-          Math.ceil(minutesToDays(this.organisation, estimation)) - 1
-        )
-      }
-      if (!endDate || endDate.isBefore(startDate)) {
-        endDate = startDate.clone().add(1, 'days')
-      }
-
-      const taskType = this.taskTypeMap.get(task.task_type_id)
-      if (!taskType) {
-        return null
-      }
-      return {
-        ...task,
-        name: `${task.full_entity_name} / ${taskType.name}`,
-        startDate,
-        endDate,
-        expanded: false,
-        loading: false,
-        man_days: estimation,
-        editable: this.canEditTaskDates(taskType),
-        unresizable: false,
-        parentElement,
-        color: taskType.color,
-        children: []
-      }
-    },
-
-    canEditTaskDates(taskType) {
-      const departments = this.user.departments || []
-      return (
-        this.isCurrentUserManager ||
-        (this.isCurrentUserSupervisor &&
-          (!departments.length || departments.includes(taskType.department_id)))
-      )
-    },
-
-    isActiveTab(tab) {
-      return this.init && this.activeTab === tab
-    },
-
-    onSearchChange(search) {
-      search = search || this.searchField?.getValue()
-      this.setSearchInUrl(search)
-      this.setPersonTasksSearch(search)
-    },
-
-    async loadPerson(personId) {
-      this.person = this.personMap.get(personId)
-
-      if (!this.person) {
-        this.$router.push({ name: 'not-found' })
-        return
-      }
-
-      if (this.person.is_bot || !this.isCurrentUserAllowed) return
-
-      this.isTasksLoading = true
-      this.isDoneTasksLoading = true
-      this.isTasksLoadingError = false
-
-      try {
-        await this.loadPersonTasks({
-          personId: this.person.id,
-          date: this.selectedDate
-        })
-        setTimeout(() => {
-          this.$nextTick(() => {
-            this.taskList?.setScrollPosition(this.personTasksScrollPosition)
-          })
-          this.resizeHeaders()
-        }, 0)
-
-        this.isTasksLoading = false
-        try {
-          await this.loadPersonDoneTasks(this.person.id)
-          this.isDoneTasksLoading = false
-        } catch (error) {
-          this.isDoneTasksLoadingError = true
-          this.isDoneTasksLoading = false
-        }
-      } catch (error) {
-        this.isTasksLoading = false
-        this.isTasksLoadingError = true
-      }
-
-      this.loadDaysOff()
-    },
-
-    async loadDaysOff() {
-      this.daysOff = await this.loadAggregatedPersonDaysOff({
-        personId: this.person.id
-      }).catch(() => [])
-    },
-
-    async loadTimeSpents() {
-      this.isTasksLoading = true
-      await this.loadPersonTimeSpents({
-        personId: this.person.id,
-        date: this.selectedDate
-      })
-      this.isTasksLoading = false
-    },
-
-    resizeHeaders() {
-      this.$nextTick(() => {
-        this.taskList?.resizeHeaders()
-        this.haveDoneList?.resizeHeaders()
-      })
-    },
-
-    saveSearchQuery(searchQuery) {
-      if (this.loading.savingSearch) {
-        return
-      }
-      this.loading.savingSearch = true
-      this.savePersonTasksSearch(searchQuery)
-        .catch(console.error)
-        .finally(() => {
-          this.loading.savingSearch = false
-        })
-    },
-
-    removeSearchQuery(searchQuery) {
-      this.removePersonTasksSearch(searchQuery).catch(err => {
-        if (err) console.error(err)
-      })
-    },
-
-    updateActiveTab() {
-      const availableSections = [
-        'board',
-        'calendar',
-        'done',
-        'schedule',
-        'timesheets'
-      ]
-      const currentSection = this.$route.query.section
-      this.activeTab = availableSections.includes(currentSection)
-        ? currentSection
-        : 'todos'
-
-      const day = this.$route.query.day
-      if (
-        day &&
-        day !== this.selectedDate &&
-        moment(day, 'YYYY-MM-DD', true).isValid()
-      ) {
-        this.selectedDate = day
-        if (this.person) {
-          this.loadTimeSpents()
-        }
-      }
-
-      const currentProduction = this.userOpenProductions.find(
-        ({ id }) => id === this.$route.query.productionId
-      )
-      if (currentProduction) {
-        this.productionId = currentProduction.id
-      } else {
-        this.$router.push({
-          query: {
-            ...this.$route.query,
-            productionId: this.productionId,
-            section: this.activeTab
-          }
-        })
-      }
-
-      this.clearSelectedTasks()
-    },
-
-    onTimeSpentChange(timeSpentInfo) {
-      timeSpentInfo.personId = this.person.id
-      timeSpentInfo.date = this.selectedDate
-      this.setTimeSpent(timeSpentInfo)
-    },
-
-    async onDateChanged(date) {
-      this.selectedDate = moment(date).format('YYYY-MM-DD')
-      // keep the day shareable in the URL, without stacking history entries
-      if (this.$route.query.day !== this.selectedDate) {
-        this.$router.replace({
-          query: { ...this.$route.query, day: this.selectedDate }
-        })
-      }
-      await this.loadTimeSpents()
-    },
-
-    async onSetDayOff(dayOff) {
-      this.dayOffError = false
-      try {
-        await this.setDayOff({
-          ...dayOff,
-          personId: this.person.id
-        })
-        this.$refs['timesheet-list']?.closeSetDayOffModal()
-      } catch (error) {
-        this.dayOffError = error.body?.message || true
-      }
-      await this.loadDaysOff()
-    },
-
-    async onUnsetDayOff(dayOff) {
-      this.dayOffError = false
-      try {
-        await this.unsetDayOff(dayOff)
-        this.$refs['timesheet-list']?.closeUnsetDayOffModal()
-      } catch (error) {
-        this.dayOffError = error.body?.message || true
-      }
-      await this.loadDaysOff()
-    },
-
-    saveTaskScheduleItem(item) {
-      if (item.estimation) {
-        item.endDate = addBusinessDays(
-          item.startDate,
-          Math.ceil(minutesToDays(this.organisation, item.estimation)) - 1,
-          item.parentElement.daysOff
-        )
-      }
-      item.man_days = item.estimation || 0
-
-      if (item.startDate && item.endDate) {
-        this.updateTask({
-          taskId: item.id,
-          data: {
-            estimation: item.estimation,
-            start_date: item.startDate.format('YYYY-MM-DD'),
-            due_date: item.endDate.format('YYYY-MM-DD')
-          }
-        }).catch(console.error)
-      }
-    },
-
-    getBoardStatusesByProduction(production) {
-      const statuses = this.getProductionTaskStatuses(production.id).filter(
-        status => {
-          if (status.for_concept) {
-            return false
-          }
-          const roles_for_board =
-            production.task_statuses_link?.[status.id]?.roles_for_board
-          return roles_for_board?.includes(this.user.role)
-        }
-      )
-      return sortTaskStatuses(statuses, production)
-    }
-  },
-
-  head() {
-    return {
-      title: `${this.person?.name || '...'} - Kitsu`
-    }
-  },
-
-  watch: {
-    '$route.params.person_id'(personId) {
-      this.updateActiveTab()
-      if (this.person && this.person.id !== personId) {
-        this.loadPerson(personId)
-      }
-    },
-
-    '$route.query.search'(search) {
-      this.searchField?.setValue(search)
-      this.onSearchChange(search)
-    },
-
-    activeTab() {
-      this.$nextTick(() => {
-        this.$refs['schedule-widget']?.scrollToDate(this.tasksStartDate)
-      })
-    },
-
-    '$route.query.section'() {
-      this.updateActiveTab()
-    },
-
-    '$route.query.day'() {
-      this.updateActiveTab()
-    },
-
-    productionId() {
-      this.$router.push({
-        query: {
-          ...this.$route.query,
-          productionId: this.productionId
-        }
-      })
-    },
-
-    zoomLevel() {
-      this.$refs['schedule-widget']?.scrollToDate(this.tasksStartDate)
-    }
-  },
-
-  socket: {
-    events: {
-      'task:assign'(eventData) {
-        this.onAssignation(eventData)
-      },
-
-      'task:unassign'(eventData) {
-        this.onAssignation(eventData)
-      }
-    }
+  const taskType = taskTypeMap.value.get(task.task_type_id)
+  if (!taskType) {
+    return null
+  }
+  return {
+    ...task,
+    name: `${task.full_entity_name} / ${taskType.name}`,
+    startDate,
+    endDate,
+    expanded: false,
+    loading: false,
+    man_days: estimation,
+    editable: canEditTaskDates(taskType),
+    unresizable: false,
+    parentElement,
+    color: taskType.color,
+    children: []
   }
 }
+
+const canEditTaskDates = taskType => {
+  const departments = user.value.departments || []
+  return (
+    isCurrentUserManager.value ||
+    (isCurrentUserSupervisor.value &&
+      (!departments.length || departments.includes(taskType.department_id)))
+  )
+}
+
+const saveTaskScheduleItem = item => {
+  if (item.estimation) {
+    item.endDate = addBusinessDays(
+      item.startDate,
+      Math.ceil(minutesToDays(organisation.value, item.estimation)) - 1,
+      item.parentElement.daysOff
+    )
+  }
+  item.man_days = item.estimation || 0
+
+  if (item.startDate && item.endDate) {
+    store
+      .dispatch('updateTask', {
+        taskId: item.id,
+        data: {
+          estimation: item.estimation,
+          start_date: item.startDate.format('YYYY-MM-DD'),
+          due_date: item.endDate.format('YYYY-MM-DD')
+        }
+      })
+      .catch(console.error)
+  }
+}
+
+const loadPerson = async personId => {
+  person.value = personMap.value.get(personId)
+
+  if (!person.value) {
+    router.push({ name: 'not-found' })
+    return
+  }
+
+  if (person.value.is_bot || !isCurrentUserAllowed.value) return
+
+  isTasksLoading.value = true
+  isDoneTasksLoading.value = true
+  isTasksLoadingError.value = false
+
+  try {
+    await store.dispatch('loadPersonTasks', {
+      personId: person.value.id,
+      date: selectedDate.value
+    })
+    setTimeout(() => {
+      nextTick(() => {
+        taskListRef.value?.setScrollPosition(
+          store.getters.personTasksScrollPosition
+        )
+      })
+      resizeHeaders()
+    }, 0)
+
+    isTasksLoading.value = false
+    try {
+      await store.dispatch('loadPersonDoneTasks', person.value.id)
+      isDoneTasksLoading.value = false
+    } catch (error) {
+      isDoneTasksLoadingError.value = true
+      isDoneTasksLoading.value = false
+    }
+  } catch (error) {
+    isTasksLoading.value = false
+    isTasksLoadingError.value = true
+  }
+
+  loadDaysOff()
+}
+
+const loadDaysOff = async () => {
+  daysOff.value = await store
+    .dispatch('loadAggregatedPersonDaysOff', { personId: person.value.id })
+    .catch(() => [])
+}
+
+const loadTimeSpents = async () => {
+  isTasksLoading.value = true
+  await store.dispatch('loadPersonTimeSpents', {
+    personId: person.value.id,
+    date: selectedDate.value
+  })
+  isTasksLoading.value = false
+}
+
+const resizeHeaders = () => {
+  nextTick(() => {
+    taskListRef.value?.resizeHeaders()
+    doneListRef.value?.resizeHeaders()
+  })
+}
+
+const setSearchFromUrl = () => {
+  const searchQuery = searchFieldRef.value?.getValue()
+  const searchFromUrl = route.query.search
+  if (!searchQuery && searchFromUrl) {
+    searchFieldRef.value?.setValue(searchFromUrl)
+  }
+}
+
+const setSearchInUrl = query => {
+  router.push({
+    query: {
+      ...route.query,
+      search: query || searchFieldRef.value?.getValue() || undefined
+    }
+  })
+}
+
+const onSearchChange = search => {
+  const searchQuery = search || searchFieldRef.value?.getValue()
+  setSearchInUrl(searchQuery)
+  store.dispatch('setPersonTasksSearch', searchQuery)
+}
+
+const saveSearchQuery = searchQuery => {
+  if (loading.savingSearch) {
+    return
+  }
+  loading.savingSearch = true
+  store
+    .dispatch('savePersonTasksSearch', searchQuery)
+    .catch(console.error)
+    .finally(() => {
+      loading.savingSearch = false
+    })
+}
+
+const removeSearchQuery = searchQuery => {
+  store.dispatch('removePersonTasksSearch', searchQuery).catch(err => {
+    if (err) console.error(err)
+  })
+}
+
+const setPersonTasksScrollPosition = position =>
+  store.dispatch('setPersonTasksScrollPosition', position)
+
+const updateActiveTab = () => {
+  const availableSections = [
+    'board',
+    'calendar',
+    'done',
+    'schedule',
+    'timesheets'
+  ]
+  const section = route.query.section
+  activeTab.value = availableSections.includes(section) ? section : 'todos'
+
+  const day = route.query.day
+  if (
+    day &&
+    day !== selectedDate.value &&
+    moment(day, 'YYYY-MM-DD', true).isValid()
+  ) {
+    selectedDate.value = day
+    if (person.value) {
+      loadTimeSpents()
+    }
+  }
+
+  const currentProduction = userOpenProductions.value.find(
+    ({ id }) => id === route.query.productionId
+  )
+  if (currentProduction) {
+    productionId.value = currentProduction.id
+  } else {
+    router.push({
+      query: {
+        ...route.query,
+        productionId: productionId.value,
+        section: activeTab.value
+      }
+    })
+  }
+
+  store.dispatch('clearSelectedTasks')
+}
+
+const onCalendarTimeClicked = date => {
+  router.push({
+    query: { ...route.query, section: 'timesheets', day: date }
+  })
+}
+
+const onCalendarDatesChanged = async ({ start, end }) => {
+  if (!person.value) {
+    return
+  }
+  try {
+    calendarTimeSpents.value = await store.dispatch(
+      'loadPersonTimeSpentsByPeriod',
+      {
+        personId: person.value.id,
+        startDate: start,
+        endDate: end
+      }
+    )
+  } catch (err) {
+    console.error(err)
+    calendarTimeSpents.value = []
+  }
+}
+
+const onTimeSpentChange = timeSpentInfo => {
+  store.dispatch('setTimeSpent', {
+    ...timeSpentInfo,
+    personId: person.value.id,
+    date: selectedDate.value
+  })
+}
+
+const onDateChanged = async date => {
+  selectedDate.value = moment(date).format('YYYY-MM-DD')
+  // keep the day shareable in the URL, without stacking history entries
+  if (route.query.day !== selectedDate.value) {
+    router.replace({
+      query: { ...route.query, day: selectedDate.value }
+    })
+  }
+  await loadTimeSpents()
+}
+
+const onSetDayOff = async dayOff => {
+  dayOffError.value = false
+  try {
+    await store.dispatch('setDayOff', {
+      ...dayOff,
+      personId: person.value.id
+    })
+    timesheetListRef.value?.closeSetDayOffModal()
+  } catch (error) {
+    dayOffError.value = error.body?.message || true
+  }
+  await loadDaysOff()
+}
+
+const onUnsetDayOff = async dayOff => {
+  dayOffError.value = false
+  try {
+    await store.dispatch('unsetDayOff', dayOff)
+    timesheetListRef.value?.closeUnsetDayOffModal()
+  } catch (error) {
+    dayOffError.value = error.body?.message || true
+  }
+  await loadDaysOff()
+}
+
+const onAssignation = eventData => {
+  if (person.value.id === eventData.person_id) {
+    loadPerson(person.value.id)
+  }
+}
+
+// Watchers
+// --------------------------------------------------------------------------
+watch(
+  () => route.params.person_id,
+  personId => {
+    updateActiveTab()
+    if (person.value && person.value.id !== personId) {
+      loadPerson(personId)
+    }
+  }
+)
+
+watch(
+  () => route.query.search,
+  search => {
+    searchFieldRef.value?.setValue(search)
+    onSearchChange(search)
+  }
+)
+
+watch(() => [route.query.section, route.query.day], updateActiveTab)
+
+watch(activeTab, () => {
+  nextTick(() => {
+    scheduleWidgetRef.value?.scrollToDate(tasksStartDate.value)
+  })
+})
+
+watch(productionId, () => {
+  router.push({
+    query: {
+      ...route.query,
+      productionId: productionId.value
+    }
+  })
+})
+
+watch(zoomLevel, () => {
+  scheduleWidgetRef.value?.scrollToDate(tasksStartDate.value)
+})
+
+// Lifecycle
+// --------------------------------------------------------------------------
+onMounted(async () => {
+  socket.on('task:assign', onAssignation)
+  socket.on('task:unassign', onAssignation)
+
+  productionId.value = route.query.productionId || undefined
+
+  updateActiveTab()
+  await loadPerson(route.params.person_id)
+  setSearchFromUrl()
+  onSearchChange()
+
+  scheduleWidgetRef.value?.scrollToDate(tasksStartDate.value)
+
+  init.value = true
+})
+
+onBeforeUnmount(() => {
+  socket.off('task:assign', onAssignation)
+  socket.off('task:unassign', onAssignation)
+})
+
+onUnmounted(() => {
+  store.commit('LOAD_PERSON_TASKS_END', {
+    tasks: [],
+    userFilters: {},
+    taskTypeMap: taskTypeMap.value
+  })
+})
+
+// Head
+// --------------------------------------------------------------------------
+useHead({ title: computed(() => `${person.value?.name || '...'} - Kitsu`) })
 </script>
 
 <style lang="scss" scoped>
-.name {
-  width: 230px;
-  min-width: 230px;
-}
-
 .page {
   overflow: hidden;
-}
-
-.email {
-  width: 210px;
-  min-width: 210px;
-}
-.phone {
-  width: 140px;
-  min-width: 140px;
-}
-.skills {
-  width: 250px;
 }
 
 .search-field {
@@ -976,14 +934,6 @@ export default {
 
 .query-list {
   margin-top: 0.5em;
-}
-
-.task-tabs {
-  margin-top: 2em;
-}
-
-.task-tabs ul {
-  margin: 0;
 }
 
 .data-list {

--- a/src/components/pages/Todos.vue
+++ b/src/components/pages/Todos.vue
@@ -64,7 +64,6 @@
 
         <div v-if="isActiveTab('pending')">&nbsp;</div>
         <todos-list
-          ref="pending-list"
           :empty-text="$t('people.no_task_assigned')"
           :is-loading="isTodosLoading"
           :is-error="isTodosLoadingError"
@@ -143,588 +142,541 @@
   </div>
 </template>
 
-<script>
-import { mapGetters, mapActions } from 'vuex'
+<script setup>
+import { useHead } from '@unhead/vue'
 import moment from 'moment-timezone'
 import { firstBy } from 'thenby'
-
-import { searchMixin } from '@/components/mixins/search'
+import {
+  computed,
+  getCurrentInstance,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  reactive,
+  ref,
+  useTemplateRef,
+  watch
+} from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
+import { useStore } from 'vuex'
 
 import { getTaskStatusPriorityOfProd } from '@/lib/productions'
 import { sortTaskStatuses } from '@/lib/sorting'
 import { parseDate } from '@/lib/time'
 
-import Combobox from '@/components/widgets/Combobox.vue'
-import ComboboxProduction from '@/components/widgets/ComboboxProduction.vue'
 import DayOffList from '@/components/lists/DayOffList.vue'
 import KanbanBoard from '@/components/lists/KanbanBoard.vue'
+import TimesheetList from '@/components/lists/TimesheetList.vue'
+import TodosList from '@/components/lists/TodosList.vue'
+import TaskInfo from '@/components/sides/TaskInfo.vue'
+import Combobox from '@/components/widgets/Combobox.vue'
+import ComboboxProduction from '@/components/widgets/ComboboxProduction.vue'
 import RouteSectionTabs from '@/components/widgets/RouteSectionTabs.vue'
 import SearchField from '@/components/widgets/SearchField.vue'
 import SearchQueryList from '@/components/widgets/SearchQueryList.vue'
-import TaskInfo from '@/components/sides/TaskInfo.vue'
-import TimesheetList from '@/components/lists/TimesheetList.vue'
-import TodosList from '@/components/lists/TodosList.vue'
 import UserCalendar from '@/components/widgets/UserCalendar.vue'
 
-export default {
-  name: 'todos',
+const { t } = useI18n()
+const route = useRoute()
+const router = useRouter()
+const store = useStore()
+const socket = getCurrentInstance().appContext.config.globalProperties.$socket
 
-  mixins: [searchMixin],
+// State
+const filterOptions = ['all_tasks', 'due_this_week'].map(name => ({
+  label: name,
+  value: name
+}))
+const sortOptions = [
+  'entity_name',
+  'priority',
+  'task_status_short_name',
+  'start_date',
+  'due_date',
+  'estimation',
+  'last_comment_date'
+].map(name => ({ label: name, value: name }))
 
-  components: {
-    Combobox,
-    ComboboxProduction,
-    DayOffList,
-    KanbanBoard,
-    RouteSectionTabs,
-    SearchField,
-    SearchQueryList,
-    TaskInfo,
-    TimesheetList,
-    TodosList,
-    UserCalendar
-  },
+const currentFilter = ref('all_tasks')
+const currentSort = ref('priority')
+const currentSection = ref('todos')
+const daysOff = ref([])
+const dayOffError = ref(false)
+const productionId = ref(undefined)
+const calendarTimeSpents = ref([])
+const selectedDate = ref(moment().format('YYYY-MM-DD'))
+const loading = reactive({
+  doneTasks: false,
+  timesheets: false,
+  savingSearch: false
+})
 
-  data() {
-    return {
-      currentFilter: 'all_tasks',
-      currentSort: 'priority',
-      currentSection: 'todos',
-      daysOff: [],
-      dayOffError: false,
-      filterOptions: ['all_tasks', 'due_this_week'].map(name => ({
-        label: name,
-        value: name
-      })),
-      loading: {
-        doneTasks: false,
-        timesheets: false,
-        savingSearch: false
-      },
-      productionId: undefined,
-      calendarTimeSpents: [],
-      selectedDate: moment().format('YYYY-MM-DD'),
-      sortOptions: [
-        'entity_name',
-        'priority',
-        'task_status_short_name',
-        'start_date',
-        'due_date',
-        'estimation',
-        'last_comment_date'
-      ].map(name => ({ label: name, value: name }))
-    }
-  },
+const searchFieldRef = useTemplateRef('todos-search-field')
+const todoListRef = useTemplateRef('todo-list')
+const doneListRef = useTemplateRef('done-list')
+const timesheetListRef = useTemplateRef('timesheet-list')
+const dayOffListRef = useTemplateRef('day-off-list')
 
-  async mounted() {
-    this.updateActiveTab()
-    await this.$nextTick()
-    await this.loadData()
-    this.setSearchFromUrl()
-    this.onSearchChange()
-  },
+// Computed
+const displayedDoneTasks = computed(() => store.getters.displayedDoneTasks)
+const displayedTodos = computed(() => store.getters.displayedTodos)
+const doneSelectionGrid = computed(() => store.getters.doneSelectionGrid)
+const getProductionTaskStatuses = computed(
+  () => store.getters.getProductionTaskStatuses
+)
+const isTodosLoading = computed(() => store.getters.isTodosLoading)
+const isTodosLoadingError = computed(() => store.getters.isTodosLoadingError)
+const nbSelectedTasks = computed(() => store.getters.nbSelectedTasks)
+const openProductions = computed(() => store.getters.openProductions)
+const productionMap = computed(() => store.getters.productionMap)
+const selectedTasks = computed(() => store.getters.selectedTasks)
+const taskStatuses = computed(() => store.getters.taskStatuses)
+const taskStatusMap = computed(() => store.getters.taskStatusMap)
+const taskTypeMap = computed(() => store.getters.taskTypeMap)
+const timeSpentMap = computed(() => store.getters.timeSpentMap)
+const timeSpentTotal = computed(() => store.getters.timeSpentTotal)
+const todoSearchQueries = computed(() => store.getters.todoSearchQueries)
+const todoSelectionGrid = computed(() => store.getters.todoSelectionGrid)
+const user = computed(() => store.getters.user)
 
-  afterDestroy() {
-    this.$store.commit('USER_LOAD_TODOS_END', {
-      tasks: [],
-      userFilters: {},
-      taskTypeMap: this.taskTypeMap
+const sortedTasks = computed(() => {
+  const tasks = productionId.value
+    ? displayedTodos.value.filter(
+        task => task.project_id === productionId.value
+      )
+    : displayedTodos.value
+  return sortTasks(tasks, currentFilter.value, currentSort.value)
+})
+
+const sortedDoneTasks = computed(() => {
+  const tasks = productionId.value
+    ? displayedDoneTasks.value.filter(
+        task => task.project_id === productionId.value
+      )
+    : displayedDoneTasks.value
+  return sortTasks(tasks, currentFilter.value, currentSort.value)
+})
+
+const pendingTasks = computed(() =>
+  sortedTasks.value.filter(
+    task => taskStatusMap.value.get(task.task_status_id)?.is_feedback_request
+  )
+)
+
+const notPendingTasks = computed(() =>
+  sortedTasks.value.filter(
+    task => !taskStatusMap.value.get(task.task_status_id)?.is_feedback_request
+  )
+)
+
+const boardTasks = computed(() =>
+  sortedTasks.value.concat(sortedDoneTasks.value)
+)
+
+const boardStatuses = computed(() => {
+  if (selectedProduction.value) {
+    return getBoardStatusesByProduction(selectedProduction.value)
+  }
+
+  const productionsByStatus = {}
+  openProductions.value.forEach(production => {
+    getBoardStatusesByProduction(production).forEach(status => {
+      productionsByStatus[status.id] = (
+        productionsByStatus[status.id] || []
+      ).concat(production.id)
     })
-  },
+  })
 
-  computed: {
-    ...mapGetters([
-      'displayedDoneTasks',
-      'displayedTodos',
-      'doneSelectionGrid',
-      'getProductionTaskStatuses',
-      'isTodosLoading',
-      'isTodosLoadingError',
-      'nbSelectedTasks',
-      'openProductions',
-      'productionMap',
-      'selectedTasks',
-      'taskStatuses',
-      'taskStatusMap',
-      'taskTypeMap',
-      'timeSpentMap',
-      'timeSpentTotal',
-      'todoListScrollPosition',
-      'todoSearchQueries',
-      'todoSelectionGrid',
-      'user'
-    ]),
+  return taskStatuses.value
+    .filter(status => !status.for_concept)
+    .map(status => ({
+      ...status,
+      productions: productionsByStatus[status.id] || []
+    }))
+    .filter(status => status.productions.length > 0)
+    .sort((a, b) => a.priority - b.priority)
+})
 
-    searchField() {
-      return this.$refs['todos-search-field']
+const productionList = computed(() => [
+  { name: t('main.all') },
+  ...openProductions.value
+])
+
+const selectedProduction = computed(() =>
+  productionMap.value.get(productionId.value)
+)
+
+const todoTabs = computed(() => {
+  const hasAvailableBoard = openProductions.value.some(
+    production => getBoardStatusesByProduction(production).length
+  )
+  return [
+    {
+      label: t('main.tasks'),
+      name: 'todos'
     },
-
-    boardTasks() {
-      return this.sortedTasks.concat(this.sortedDoneTasks)
-    },
-
-    boardStatuses() {
-      if (this.selectedProduction) {
-        return this.getBoardStatusesByProduction(this.selectedProduction)
-      }
-
-      const productionsByStatus = {}
-      this.openProductions.forEach(production => {
-        const statuses = this.getBoardStatusesByProduction(production)
-        statuses.forEach(status => {
-          if (!productionsByStatus[status.id]) {
-            productionsByStatus[status.id] = []
-          }
-          productionsByStatus[status.id].push(production.id)
-        })
-      })
-
-      return this.taskStatuses
-        .filter(status => !status.for_concept)
-        .map(status => ({
-          ...status,
-          productions: productionsByStatus[status.id] || []
-        }))
-        .filter(status => status.productions.length > 0)
-        .sort((a, b) => a.priority - b.priority)
-    },
-
-    productionList() {
-      return [{ name: this.$t('main.all') }, ...this.openProductions]
-    },
-
-    selectedProduction() {
-      return this.productionMap.get(this.productionId)
-    },
-
-    pendingTasks() {
-      return this.sortedTasks.filter(
-        task => this.taskStatusMap.get(task.task_status_id)?.is_feedback_request
-      )
-    },
-
-    notPendingTasks() {
-      return this.sortedTasks.filter(
-        task =>
-          !this.taskStatusMap.get(task.task_status_id)?.is_feedback_request
-      )
-    },
-
-    todoTabs() {
-      const hasAvailableBoard = this.openProductions.some(
-        production => this.getBoardStatusesByProduction(production).length
-      )
-      return [
-        {
-          label: this.$t('main.tasks'),
-          name: 'todos'
-        },
-        hasAvailableBoard
-          ? {
-              label: this.$t('board.title'),
-              name: 'board'
-            }
-          : undefined,
-        {
-          label: this.$t('tasks.calendar'),
-          name: 'calendar'
-        },
-        {
-          label: `${this.$t('tasks.pending')} (${this.pendingTasks.length})`,
-          name: 'pending'
-        },
-        {
-          label: `${this.$t('tasks.validated')} (${
-            this.loading.doneTasks ? '…' : this.sortedDoneTasks.length
-          })`,
-          name: 'done'
-        },
-        {
-          label: this.$t('timesheets.timelog_title'),
-          name: 'timesheets'
-        },
-        {
-          label: this.$t('days_off.title'),
-          name: 'daysoff'
+    hasAvailableBoard
+      ? {
+          label: t('board.title'),
+          name: 'board'
         }
-      ].filter(Boolean)
+      : undefined,
+    {
+      label: t('tasks.calendar'),
+      name: 'calendar'
     },
-
-    loggableTodos() {
-      return this.sortedTasks.filter(task => {
-        return this.taskTypeMap.get(task.task_type_id)?.allow_timelog
-      })
+    {
+      label: `${t('tasks.pending')} (${pendingTasks.value.length})`,
+      name: 'pending'
     },
-
-    loggableDoneTasks() {
-      return this.sortedDoneTasks.filter(task => {
-        return this.taskTypeMap.get(task.task_type_id)?.allow_timelog
-      })
+    {
+      label: `${t('tasks.validated')} (${
+        loading.doneTasks ? '…' : sortedDoneTasks.value.length
+      })`,
+      name: 'done'
     },
-
-    todoList() {
-      return this.$refs['todo-list']
+    {
+      label: t('timesheets.timelog_title'),
+      name: 'timesheets'
     },
-
-    haveDoneList() {
-      return this.$refs['done-list']
-    },
-
-    sortedTasks() {
-      let tasksToSort = this.displayedTodos
-      if (this.productionId) {
-        tasksToSort = tasksToSort.filter(
-          task => task.project_id === this.productionId
-        )
-      }
-      return this.sortTasks(tasksToSort, this.currentFilter, this.currentSort)
-    },
-
-    sortedDoneTasks() {
-      let tasksToSort = this.displayedDoneTasks
-      if (this.productionId) {
-        tasksToSort = tasksToSort.filter(
-          task => task.project_id === this.productionId
-        )
-      }
-      return this.sortTasks(tasksToSort, this.currentFilter, this.currentSort)
+    {
+      label: t('days_off.title'),
+      name: 'daysoff'
     }
-  },
+  ].filter(Boolean)
+})
 
-  methods: {
-    ...mapActions([
-      'clearSelectedTasks',
-      'loadAggregatedPersonDaysOff',
-      'loadOpenProductions',
-      'loadPersonTimeSpentsByPeriod',
-      'loadUserTimeSpents',
-      'loadTodos',
-      'loadDoneTasks',
-      'removeTodoSearch',
-      'saveTodoSearch',
-      'setDayOff',
-      'setTimeSpent',
-      'setTodoListScrollPosition',
-      'setTodosSearch',
-      'unsetDayOff'
-    ]),
+const loggableTodos = computed(() =>
+  sortedTasks.value.filter(
+    task => taskTypeMap.value.get(task.task_type_id)?.allow_timelog
+  )
+)
 
-    isActiveTab(tab) {
-      return this.currentSection === tab
-    },
+const loggableDoneTasks = computed(() =>
+  sortedDoneTasks.value.filter(
+    task => taskTypeMap.value.get(task.task_type_id)?.allow_timelog
+  )
+)
 
-    async loadData(forced = false) {
-      this.loading.doneTasks = true
-      await this.loadTodos({
-        date: this.selectedDate,
-        forced
-      })
-      this.loadDoneTasks()
-        .catch(console.error)
-        .finally(() => {
-          this.loading.doneTasks = false
-        })
-      this.$nextTick(() => {
-        this.todoList?.setScrollPosition(this.todoListScrollPosition)
-      })
-      this.resizeHeaders()
+// Functions
+const isActiveTab = tab => currentSection.value === tab
 
-      this.daysOff = await this.loadAggregatedPersonDaysOff({
-        personId: this.user.id
-      })
-    },
-
-    async loadTimeSpents() {
-      this.isTasksLoading = true
-      await this.loadUserTimeSpents({ date: this.selectedDate })
-      this.isTasksLoading = false
-    },
-
-    resizeHeaders() {
-      this.$nextTick(() => {
-        this.todoList?.resizeHeaders()
-        this.haveDoneList?.resizeHeaders()
-      })
-    },
-
-    updateActiveTab() {
-      const availableSections = [
-        'board',
-        'calendar',
-        'daysoff',
-        'done',
-        'pending',
-        'timesheets'
-      ]
-      const currentSection = this.$route.query.section
-      this.currentSection = availableSections.includes(currentSection)
-        ? currentSection
-        : 'todos'
-
-      const day = this.$route.query.day
-      if (
-        day &&
-        day !== this.selectedDate &&
-        moment(day, 'YYYY-MM-DD', true).isValid()
-      ) {
-        this.selectedDate = day
-        this.loadTimeSpents()
+const getBoardStatusesByProduction = production => {
+  const statuses = getProductionTaskStatuses
+    .value(production.id)
+    .filter(status => {
+      if (status.for_concept) {
+        return false
       }
+      const rolesForBoard =
+        production.task_statuses_link?.[status.id]?.roles_for_board
+      return rolesForBoard?.includes(user.value.role)
+    })
+  return sortTaskStatuses(statuses, production)
+}
 
-      const currentProduction = this.openProductions.find(
-        ({ id }) => id === this.$route.query.productionId
+const sortTasks = (tasks, filter, sort) => {
+  const filtered =
+    filter === 'all_tasks'
+      ? [...tasks]
+      : tasks.filter(task => {
+          const dueDate = parseDate(task.due_date)
+          return moment().startOf('week').isSame(dueDate, 'week')
+        })
+
+  const byDate = field => (a, b) => {
+    if (!a[field]) return 1
+    if (!b[field]) return -1
+    return a[field].localeCompare(b[field])
+  }
+
+  if (sort === 'entity_name') {
+    return filtered.sort(
+      firstBy('project_name')
+        .thenBy('task_type_name')
+        .thenBy('full_entity_name')
+    )
+  }
+  if (sort === 'priority') {
+    return filtered.sort(
+      firstBy('priority', -1)
+        .thenBy(byDate('due_date'))
+        .thenBy('project_name')
+        .thenBy('task_type_name')
+        .thenBy('entity_name')
+    )
+  }
+  if (sort === 'due_date') {
+    return filtered.sort(
+      firstBy(byDate('due_date'))
+        .thenBy('project_name')
+        .thenBy('task_type_name')
+        .thenBy('entity_name')
+    )
+  }
+  if (sort === 'start_date') {
+    return filtered.sort(
+      firstBy(byDate('start_date'))
+        .thenBy('project_name')
+        .thenBy('task_type_name')
+        .thenBy('entity_name')
+    )
+  }
+  if (sort === 'task_status_short_name') {
+    // Follow the task status order from the studio / production
+    // settings instead of sorting short names alphabetically.
+    const statusPriority = task =>
+      getTaskStatusPriorityOfProd(
+        taskStatusMap.value.get(task.task_status_id),
+        productionMap.value.get(task.project_id)
       )
-      if (currentProduction) {
-        this.productionId = currentProduction.id
-      } else {
-        this.$router.push({
-          query: {
-            ...this.$route.query,
-            productionId: this.productionId,
-            section: this.currentSection
-          }
-        })
+    return filtered.sort(
+      firstBy((a, b) => statusPriority(a) - statusPriority(b))
+        .thenBy('task_status_short_name')
+        .thenBy('project_name')
+        .thenBy('task_type_name')
+        .thenBy('entity_name')
+    )
+  }
+  return filtered.sort(
+    firstBy(sort, -1)
+      .thenBy('project_name')
+      .thenBy('task_type_name')
+      .thenBy('entity_name')
+  )
+}
+
+const loadData = async (forced = false) => {
+  loading.doneTasks = true
+  await store.dispatch('loadTodos', { date: selectedDate.value, forced })
+  store
+    .dispatch('loadDoneTasks')
+    .catch(console.error)
+    .finally(() => {
+      loading.doneTasks = false
+    })
+  nextTick(() => {
+    todoListRef.value?.setScrollPosition(store.getters.todoListScrollPosition)
+  })
+  resizeHeaders()
+
+  daysOff.value = await store.dispatch('loadAggregatedPersonDaysOff', {
+    personId: user.value.id
+  })
+}
+
+const loadTimeSpents = () =>
+  store.dispatch('loadUserTimeSpents', { date: selectedDate.value })
+
+const resizeHeaders = () => {
+  nextTick(() => {
+    todoListRef.value?.resizeHeaders()
+    doneListRef.value?.resizeHeaders()
+  })
+}
+
+const updateActiveTab = () => {
+  const availableSections = [
+    'board',
+    'calendar',
+    'daysoff',
+    'done',
+    'pending',
+    'timesheets'
+  ]
+  const section = route.query.section
+  currentSection.value = availableSections.includes(section) ? section : 'todos'
+
+  const day = route.query.day
+  if (
+    day &&
+    day !== selectedDate.value &&
+    moment(day, 'YYYY-MM-DD', true).isValid()
+  ) {
+    selectedDate.value = day
+    loadTimeSpents()
+  }
+
+  const currentProduction = openProductions.value.find(
+    ({ id }) => id === route.query.productionId
+  )
+  if (currentProduction) {
+    productionId.value = currentProduction.id
+  } else {
+    router.push({
+      query: {
+        ...route.query,
+        productionId: productionId.value,
+        section: currentSection.value
       }
+    })
+  }
 
-      this.clearSelectedTasks()
-    },
+  store.dispatch('clearSelectedTasks')
+}
 
-    onSearchChange() {
-      this.setSearchInUrl()
-      if (this.searchField) {
-        this.setTodosSearch(this.searchField.getValue())
-      }
-    },
-
-    async saveSearchQuery(searchQuery) {
-      if (this.loading.savingSearch) return
-      try {
-        this.loading.savingSearch = true
-        await this.saveTodoSearch(searchQuery)
-        this.loading.savingSearch = false
-      } catch (error) {
-        console.error(error)
-      }
-    },
-
-    async removeSearchQuery(searchQuery) {
-      try {
-        await this.removeTodoSearch(searchQuery)
-      } catch (error) {
-        console.error(error)
-      }
-    },
-
-    async onDateChanged(date) {
-      this.loading.timesheets = true
-      this.selectedDate = moment(date).format('YYYY-MM-DD')
-      // keep the day shareable in the URL, without stacking history entries
-      if (this.$route.query.day !== this.selectedDate) {
-        this.$router.replace({
-          query: { ...this.$route.query, day: this.selectedDate }
-        })
-      }
-      await this.loadTimeSpents()
-      this.loading.timesheets = false
-    },
-
-    onCalendarTimeClicked(date) {
-      this.$router.push({
-        query: { ...this.$route.query, section: 'timesheets', day: date }
-      })
-    },
-
-    async onCalendarDatesChanged({ start, end }) {
-      try {
-        this.calendarTimeSpents = await this.loadPersonTimeSpentsByPeriod({
-          personId: this.user.id,
-          startDate: start,
-          endDate: end
-        })
-      } catch (err) {
-        console.error(err)
-        this.calendarTimeSpents = []
-      }
-    },
-
-    async onSetDayOff(dayOff) {
-      this.dayOffError = false
-      try {
-        await this.setDayOff({
-          ...dayOff,
-          personId: this.user.id
-        })
-        this.$refs['timesheet-list']?.closeSetDayOffModal()
-        this.$refs['day-off-list']?.closeSetDayOffModal()
-      } catch (error) {
-        this.dayOffError = error.body?.message || true
-      }
-      await this.loadData(true)
-    },
-
-    async onUnsetDayOff(dayOff) {
-      this.dayOffError = false
-      try {
-        await this.unsetDayOff(dayOff)
-        this.$refs['timesheet-list']?.closeUnsetDayOffModal()
-        this.$refs['day-off-list']?.closeUnsetDayOffModal()
-      } catch (error) {
-        this.dayOffError = error.body?.message || true
-      }
-      await this.loadData(true)
-    },
-
-    onTimeSpentChange(timeSpentInfo) {
-      timeSpentInfo.personId = this.user.id
-      timeSpentInfo.date = this.selectedDate
-      this.setTimeSpent(timeSpentInfo)
-    },
-
-    async onAssignation(eventData) {
-      if (this.user.id === eventData.person_id) {
-        await this.loadOpenProductions()
-        await this.loadData(true)
-      }
-    },
-
-    getBoardStatusesByProduction(production) {
-      const statuses = this.getProductionTaskStatuses(production.id).filter(
-        status => {
-          if (status.for_concept) {
-            return false
-          }
-          const roles_for_board =
-            production.task_statuses_link?.[status.id]?.roles_for_board
-          return roles_for_board?.includes(this.user.role)
-        }
-      )
-      return sortTaskStatuses(statuses, production)
-    },
-
-    sortTasks(tasks, currentFilter, currentSort) {
-      tasks =
-        currentFilter === 'all_tasks'
-          ? [...tasks]
-          : tasks.filter(t => {
-              const dueDate = parseDate(t.due_date)
-              return moment().startOf('week').isSame(dueDate, 'week')
-            })
-
-      const isName = currentSort === 'entity_name'
-      const isPriority = currentSort === 'priority'
-      const isDueDate = currentSort === 'due_date'
-      const isStartDate = currentSort === 'start_date'
-      const isStatus = currentSort === 'task_status_short_name'
-
-      if (isName) {
-        return tasks.sort(
-          firstBy('project_name')
-            .thenBy('task_type_name')
-            .thenBy('full_entity_name')
-        )
-      } else if (isPriority) {
-        return tasks.sort(
-          firstBy('priority', -1)
-            .thenBy((a, b) => {
-              if (!a.due_date) return 1
-              else if (!b.due_date) return -1
-              else return a.due_date.localeCompare(b.due_date)
-            })
-            .thenBy('project_name')
-            .thenBy('task_type_name')
-            .thenBy('entity_name')
-        )
-      } else if (isDueDate) {
-        return tasks.sort(
-          firstBy((a, b) => {
-            if (!a.due_date) return 1
-            else if (!b.due_date) return -1
-            else return a.due_date.localeCompare(b.due_date)
-          })
-            .thenBy('project_name')
-            .thenBy('task_type_name')
-            .thenBy('entity_name')
-        )
-      } else if (isStartDate) {
-        return tasks.sort(
-          firstBy((a, b) => {
-            if (!a.start_date) return 1
-            else if (!b.start_date) return -1
-            else return a.start_date.localeCompare(b.start_date)
-          })
-            .thenBy('project_name')
-            .thenBy('task_type_name')
-            .thenBy('entity_name')
-        )
-      } else if (isStatus) {
-        // Follow the task status order from the studio / production
-        // settings instead of sorting short names alphabetically.
-        const statusPriority = task =>
-          getTaskStatusPriorityOfProd(
-            this.taskStatusMap.get(task.task_status_id),
-            this.productionMap.get(task.project_id)
-          )
-        return tasks.sort(
-          firstBy((a, b) => statusPriority(a) - statusPriority(b))
-            .thenBy('task_status_short_name')
-            .thenBy('project_name')
-            .thenBy('task_type_name')
-            .thenBy('entity_name')
-        )
-      } else {
-        return tasks.sort(
-          firstBy(currentSort, -1)
-            .thenBy('project_name')
-            .thenBy('task_type_name')
-            .thenBy('entity_name')
-        )
-      }
-    }
-  },
-
-  socket: {
-    events: {
-      'task:assign'(eventData) {
-        this.onAssignation(eventData)
-      },
-
-      'task:unassign'(eventData) {
-        this.onAssignation(eventData)
-      }
-    }
-  },
-
-  watch: {
-    productionId() {
-      this.$router.push({
-        query: {
-          ...this.$route.query,
-          productionId: this.productionId,
-          section: this.currentSection
-        }
-      })
-    },
-
-    '$route.query.section'() {
-      this.updateActiveTab()
-    },
-
-    '$route.query.day'() {
-      this.updateActiveTab()
-    },
-
-    '$route.query.search'(search) {
-      this.searchField?.setValue(search)
-      this.onSearchChange()
-    }
-  },
-
-  head() {
-    return {
-      title: `${this.$t('tasks.my_tasks')} - Kitsu`
-    }
+const setSearchFromUrl = () => {
+  const searchQuery = searchFieldRef.value?.getValue()
+  const searchFromUrl = route.query.search
+  if (!searchQuery && searchFromUrl) {
+    searchFieldRef.value?.setValue(searchFromUrl)
   }
 }
+
+const setSearchInUrl = () => {
+  router.push({
+    query: {
+      ...route.query,
+      search: searchFieldRef.value?.getValue() || undefined
+    }
+  })
+}
+
+const onSearchChange = () => {
+  setSearchInUrl()
+  if (searchFieldRef.value) {
+    store.dispatch('setTodosSearch', searchFieldRef.value.getValue())
+  }
+}
+
+const saveSearchQuery = async searchQuery => {
+  if (loading.savingSearch) return
+  try {
+    loading.savingSearch = true
+    await store.dispatch('saveTodoSearch', searchQuery)
+    loading.savingSearch = false
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+const removeSearchQuery = async searchQuery => {
+  try {
+    await store.dispatch('removeTodoSearch', searchQuery)
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+const setTodoListScrollPosition = position =>
+  store.dispatch('setTodoListScrollPosition', position)
+
+const onDateChanged = async date => {
+  loading.timesheets = true
+  selectedDate.value = moment(date).format('YYYY-MM-DD')
+  // keep the day shareable in the URL, without stacking history entries
+  if (route.query.day !== selectedDate.value) {
+    router.replace({
+      query: { ...route.query, day: selectedDate.value }
+    })
+  }
+  await loadTimeSpents()
+  loading.timesheets = false
+}
+
+const onCalendarTimeClicked = date => {
+  router.push({
+    query: { ...route.query, section: 'timesheets', day: date }
+  })
+}
+
+const onCalendarDatesChanged = async ({ start, end }) => {
+  try {
+    calendarTimeSpents.value = await store.dispatch(
+      'loadPersonTimeSpentsByPeriod',
+      {
+        personId: user.value.id,
+        startDate: start,
+        endDate: end
+      }
+    )
+  } catch (err) {
+    console.error(err)
+    calendarTimeSpents.value = []
+  }
+}
+
+const onSetDayOff = async dayOff => {
+  dayOffError.value = false
+  try {
+    await store.dispatch('setDayOff', { ...dayOff, personId: user.value.id })
+    timesheetListRef.value?.closeSetDayOffModal()
+    dayOffListRef.value?.closeSetDayOffModal()
+  } catch (error) {
+    dayOffError.value = error.body?.message || true
+  }
+  await loadData(true)
+}
+
+const onUnsetDayOff = async dayOff => {
+  dayOffError.value = false
+  try {
+    await store.dispatch('unsetDayOff', dayOff)
+    timesheetListRef.value?.closeUnsetDayOffModal()
+    dayOffListRef.value?.closeUnsetDayOffModal()
+  } catch (error) {
+    dayOffError.value = error.body?.message || true
+  }
+  await loadData(true)
+}
+
+const onTimeSpentChange = timeSpentInfo => {
+  store.dispatch('setTimeSpent', {
+    ...timeSpentInfo,
+    personId: user.value.id,
+    date: selectedDate.value
+  })
+}
+
+const onAssignation = async eventData => {
+  if (user.value.id === eventData.person_id) {
+    await store.dispatch('loadOpenProductions')
+    await loadData(true)
+  }
+}
+
+// Watchers
+watch(productionId, () => {
+  router.push({
+    query: {
+      ...route.query,
+      productionId: productionId.value,
+      section: currentSection.value
+    }
+  })
+})
+
+watch(() => route.query.section, updateActiveTab)
+
+watch(() => route.query.day, updateActiveTab)
+
+watch(
+  () => route.query.search,
+  search => {
+    searchFieldRef.value?.setValue(search)
+    onSearchChange()
+  }
+)
+
+// Lifecycle
+onMounted(async () => {
+  socket.on('task:assign', onAssignation)
+  socket.on('task:unassign', onAssignation)
+  updateActiveTab()
+  await nextTick()
+  await loadData()
+  setSearchFromUrl()
+  onSearchChange()
+})
+
+onBeforeUnmount(() => {
+  socket.off('task:assign', onAssignation)
+  socket.off('task:unassign', onAssignation)
+})
+
+// Head
+useHead({ title: computed(() => `${t('tasks.my_tasks')} - Kitsu`) })
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/pages/Todos.vue
+++ b/src/components/pages/Todos.vue
@@ -240,34 +240,16 @@ const todoSearchQueries = computed(() => store.getters.todoSearchQueries)
 const todoSelectionGrid = computed(() => store.getters.todoSelectionGrid)
 const user = computed(() => store.getters.user)
 
-const sortedTasks = computed(() => {
-  const tasks = productionId.value
-    ? displayedTodos.value.filter(
-        task => task.project_id === productionId.value
-      )
-    : displayedTodos.value
-  return sortTasks(tasks, currentFilter.value, currentSort.value)
-})
+const sortedTasks = computed(() => filterAndSortTasks(displayedTodos.value))
 
-const sortedDoneTasks = computed(() => {
-  const tasks = productionId.value
-    ? displayedDoneTasks.value.filter(
-        task => task.project_id === productionId.value
-      )
-    : displayedDoneTasks.value
-  return sortTasks(tasks, currentFilter.value, currentSort.value)
-})
-
-const pendingTasks = computed(() =>
-  sortedTasks.value.filter(
-    task => taskStatusMap.value.get(task.task_status_id)?.is_feedback_request
-  )
+const sortedDoneTasks = computed(() =>
+  filterAndSortTasks(displayedDoneTasks.value)
 )
 
+const pendingTasks = computed(() => sortedTasks.value.filter(isPending))
+
 const notPendingTasks = computed(() =>
-  sortedTasks.value.filter(
-    task => !taskStatusMap.value.get(task.task_status_id)?.is_feedback_request
-  )
+  sortedTasks.value.filter(task => !isPending(task))
 )
 
 const boardTasks = computed(() =>
@@ -347,20 +329,27 @@ const todoTabs = computed(() => {
   ].filter(Boolean)
 })
 
-const loggableTodos = computed(() =>
-  sortedTasks.value.filter(
-    task => taskTypeMap.value.get(task.task_type_id)?.allow_timelog
-  )
-)
+const loggableTodos = computed(() => sortedTasks.value.filter(isLoggable))
 
 const loggableDoneTasks = computed(() =>
-  sortedDoneTasks.value.filter(
-    task => taskTypeMap.value.get(task.task_type_id)?.allow_timelog
-  )
+  sortedDoneTasks.value.filter(isLoggable)
 )
 
 // Functions
 const isActiveTab = tab => currentSection.value === tab
+
+const isPending = task =>
+  taskStatusMap.value.get(task.task_status_id)?.is_feedback_request
+
+const isLoggable = task =>
+  taskTypeMap.value.get(task.task_type_id)?.allow_timelog
+
+const filterAndSortTasks = tasks => {
+  const filtered = productionId.value
+    ? tasks.filter(task => task.project_id === productionId.value)
+    : tasks
+  return sortTasks(filtered, currentFilter.value, currentSort.value)
+}
 
 const getBoardStatusesByProduction = production => {
   const statuses = getProductionTaskStatuses
@@ -542,13 +531,13 @@ const onSearchChange = () => {
 
 const saveSearchQuery = async searchQuery => {
   if (loading.savingSearch) return
+  loading.savingSearch = true
   try {
-    loading.savingSearch = true
     await store.dispatch('saveTodoSearch', searchQuery)
-    loading.savingSearch = false
   } catch (error) {
     console.error(error)
   }
+  loading.savingSearch = false
 }
 
 const removeSearchQuery = async searchQuery => {
@@ -647,9 +636,7 @@ watch(productionId, () => {
   })
 })
 
-watch(() => route.query.section, updateActiveTab)
-
-watch(() => route.query.day, updateActiveTab)
+watch(() => [route.query.section, route.query.day], updateActiveTab)
 
 watch(
   () => route.query.search,

--- a/src/components/pages/Todos.vue
+++ b/src/components/pages/Todos.vue
@@ -184,6 +184,7 @@ const store = useStore()
 const socket = getCurrentInstance().appContext.config.globalProperties.$socket
 
 // State
+// --------------------------------------------------------------------------
 const filterOptions = ['all_tasks', 'due_this_week'].map(name => ({
   label: name,
   value: name
@@ -219,6 +220,7 @@ const timesheetListRef = useTemplateRef('timesheet-list')
 const dayOffListRef = useTemplateRef('day-off-list')
 
 // Computed
+// --------------------------------------------------------------------------
 const displayedDoneTasks = computed(() => store.getters.displayedDoneTasks)
 const displayedTodos = computed(() => store.getters.displayedTodos)
 const doneSelectionGrid = computed(() => store.getters.doneSelectionGrid)
@@ -336,6 +338,7 @@ const loggableDoneTasks = computed(() =>
 )
 
 // Functions
+// --------------------------------------------------------------------------
 const isActiveTab = tab => currentSection.value === tab
 
 const isPending = task =>
@@ -626,6 +629,7 @@ const onAssignation = async eventData => {
 }
 
 // Watchers
+// --------------------------------------------------------------------------
 watch(productionId, () => {
   router.push({
     query: {
@@ -647,6 +651,7 @@ watch(
 )
 
 // Lifecycle
+// --------------------------------------------------------------------------
 onMounted(async () => {
   socket.on('task:assign', onAssignation)
   socket.on('task:unassign', onAssignation)
@@ -663,6 +668,7 @@ onBeforeUnmount(() => {
 })
 
 // Head
+// --------------------------------------------------------------------------
 useHead({ title: computed(() => `${t('tasks.my_tasks')} - Kitsu`) })
 </script>
 

--- a/src/components/pages/Todos.vue
+++ b/src/components/pages/Todos.vue
@@ -27,7 +27,7 @@
 
           <span class="filler"></span>
 
-          <combobox
+          <combobox-styled
             class="flexrow-item"
             :label="$t('main.show')"
             :options="filterOptions"
@@ -35,8 +35,9 @@
             v-model="currentFilter"
           />
 
-          <combobox
+          <combobox-styled
             class="flexrow-item"
+            open-left
             :label="$t('main.sorted_by')"
             :options="sortOptions"
             locale-key-prefix="tasks.fields."
@@ -170,8 +171,8 @@ import KanbanBoard from '@/components/lists/KanbanBoard.vue'
 import TimesheetList from '@/components/lists/TimesheetList.vue'
 import TodosList from '@/components/lists/TodosList.vue'
 import TaskInfo from '@/components/sides/TaskInfo.vue'
-import Combobox from '@/components/widgets/Combobox.vue'
 import ComboboxProduction from '@/components/widgets/ComboboxProduction.vue'
+import ComboboxStyled from '@/components/widgets/ComboboxStyled.vue'
 import RouteSectionTabs from '@/components/widgets/RouteSectionTabs.vue'
 import SearchField from '@/components/widgets/SearchField.vue'
 import SearchQueryList from '@/components/widgets/SearchQueryList.vue'

--- a/src/components/pages/Todos.vue
+++ b/src/components/pages/Todos.vue
@@ -161,8 +161,8 @@ import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 
+import { useBoardStatuses } from '@/composables/board'
 import { getTaskStatusPriorityOfProd } from '@/lib/productions'
-import { sortTaskStatuses } from '@/lib/sorting'
 import { parseDate } from '@/lib/time'
 
 import DayOffList from '@/components/lists/DayOffList.vue'
@@ -224,16 +224,12 @@ const dayOffListRef = useTemplateRef('day-off-list')
 const displayedDoneTasks = computed(() => store.getters.displayedDoneTasks)
 const displayedTodos = computed(() => store.getters.displayedTodos)
 const doneSelectionGrid = computed(() => store.getters.doneSelectionGrid)
-const getProductionTaskStatuses = computed(
-  () => store.getters.getProductionTaskStatuses
-)
 const isTodosLoading = computed(() => store.getters.isTodosLoading)
 const isTodosLoadingError = computed(() => store.getters.isTodosLoadingError)
 const nbSelectedTasks = computed(() => store.getters.nbSelectedTasks)
 const openProductions = computed(() => store.getters.openProductions)
 const productionMap = computed(() => store.getters.productionMap)
 const selectedTasks = computed(() => store.getters.selectedTasks)
-const taskStatuses = computed(() => store.getters.taskStatuses)
 const taskStatusMap = computed(() => store.getters.taskStatusMap)
 const taskTypeMap = computed(() => store.getters.taskTypeMap)
 const timeSpentMap = computed(() => store.getters.timeSpentMap)
@@ -258,30 +254,6 @@ const boardTasks = computed(() =>
   sortedTasks.value.concat(sortedDoneTasks.value)
 )
 
-const boardStatuses = computed(() => {
-  if (selectedProduction.value) {
-    return getBoardStatusesByProduction(selectedProduction.value)
-  }
-
-  const productionsByStatus = {}
-  openProductions.value.forEach(production => {
-    getBoardStatusesByProduction(production).forEach(status => {
-      productionsByStatus[status.id] = (
-        productionsByStatus[status.id] || []
-      ).concat(production.id)
-    })
-  })
-
-  return taskStatuses.value
-    .filter(status => !status.for_concept)
-    .map(status => ({
-      ...status,
-      productions: productionsByStatus[status.id] || []
-    }))
-    .filter(status => status.productions.length > 0)
-    .sort((a, b) => a.priority - b.priority)
-})
-
 const productionList = computed(() => [
   { name: t('main.all') },
   ...openProductions.value
@@ -289,6 +261,11 @@ const productionList = computed(() => [
 
 const selectedProduction = computed(() =>
   productionMap.value.get(productionId.value)
+)
+
+const { boardStatuses, getBoardStatusesByProduction } = useBoardStatuses(
+  openProductions,
+  selectedProduction
 )
 
 const todoTabs = computed(() => {
@@ -352,20 +329,6 @@ const filterAndSortTasks = tasks => {
     ? tasks.filter(task => task.project_id === productionId.value)
     : tasks
   return sortTasks(filtered, currentFilter.value, currentSort.value)
-}
-
-const getBoardStatusesByProduction = production => {
-  const statuses = getProductionTaskStatuses
-    .value(production.id)
-    .filter(status => {
-      if (status.for_concept) {
-        return false
-      }
-      const rolesForBoard =
-        production.task_statuses_link?.[status.id]?.roles_for_board
-      return rolesForBoard?.includes(user.value.role)
-    })
-  return sortTaskStatuses(statuses, production)
 }
 
 const sortTasks = (tasks, filter, sort) => {

--- a/src/components/widgets/UserCalendar.vue
+++ b/src/components/widgets/UserCalendar.vue
@@ -271,6 +271,9 @@ const calendarOptions = ref({
   firstDay: 1,
   locales: allLocales,
   locale: localeCode.value,
+  // day numbers and week-view day headers open the timesheet of that day
+  navLinks: true,
+  navLinkDayClick: date => emit('time-clicked', toDateKey(date)),
   datesSet: onDatesSet
 })
 

--- a/src/composables/board.js
+++ b/src/composables/board.js
@@ -1,0 +1,61 @@
+/*
+ * Board status helpers shared by the My Tasks and Person pages.
+ * `productions` and `selectedProduction` are refs owned by the page:
+ * the board columns come from the selected production, or from every
+ * production of the list when none is selected.
+ */
+import { computed } from 'vue'
+import { useStore } from 'vuex'
+
+import { sortTaskStatuses } from '@/lib/sorting'
+
+export const useBoardStatuses = (productions, selectedProduction) => {
+  const store = useStore()
+
+  const getProductionTaskStatuses = computed(
+    () => store.getters.getProductionTaskStatuses
+  )
+  const taskStatuses = computed(() => store.getters.taskStatuses)
+  const user = computed(() => store.getters.user)
+
+  // Statuses visible on a production's board for the current user role.
+  const getBoardStatusesByProduction = production => {
+    const statuses = getProductionTaskStatuses
+      .value(production.id)
+      .filter(status => {
+        if (status.for_concept) {
+          return false
+        }
+        const rolesForBoard =
+          production.task_statuses_link?.[status.id]?.roles_for_board
+        return rolesForBoard?.includes(user.value.role)
+      })
+    return sortTaskStatuses(statuses, production)
+  }
+
+  const boardStatuses = computed(() => {
+    if (selectedProduction.value) {
+      return getBoardStatusesByProduction(selectedProduction.value)
+    }
+
+    const productionsByStatus = {}
+    productions.value.forEach(production => {
+      getBoardStatusesByProduction(production).forEach(status => {
+        productionsByStatus[status.id] = (
+          productionsByStatus[status.id] || []
+        ).concat(production.id)
+      })
+    })
+
+    return taskStatuses.value
+      .filter(status => !status.for_concept)
+      .map(status => ({
+        ...status,
+        productions: productionsByStatus[status.id] || []
+      }))
+      .filter(status => status.productions.length > 0)
+      .sort((a, b) => a.priority - b.priority)
+  })
+
+  return { boardStatuses, getBoardStatusesByProduction }
+}

--- a/src/composables/descriptors.js
+++ b/src/composables/descriptors.js
@@ -1,0 +1,63 @@
+/*
+ * Composition API counterpart of the pure helpers in
+ * `src/components/mixins/descriptors.js`. Import these named exports
+ * directly from `<script setup>` components; the legacy mixin delegates
+ * to them so its Options API consumers keep working.
+ */
+
+// Descriptor choices are static per descriptor — no need to reparse them
+// for every row. Cache keyed by descriptor.id.
+const _checklistValuesCache = new Map()
+
+export const getDescriptorChecklistValues = descriptor => {
+  const cached = _checklistValuesCache.get(descriptor.id)
+  if (cached) return cached
+  const values = descriptor.choices.reduce((result, choice) => {
+    if (choice && typeof choice === 'string' && choice.startsWith('[x] ')) {
+      result.push({ text: choice.slice(4), checked: true })
+    } else if (
+      choice &&
+      typeof choice === 'string' &&
+      choice.startsWith('[ ] ')
+    ) {
+      result.push({ text: choice.slice(4), checked: false })
+    }
+    return result
+  }, [])
+  const result = values.length === descriptor.choices.length ? values : []
+  _checklistValuesCache.set(descriptor.id, result)
+  return result
+}
+
+export const getMetadataFieldValue = (descriptor, entity) => {
+  if (
+    entity.data &&
+    descriptor.field_name in entity.data &&
+    entity.data[descriptor.field_name] != null
+  ) {
+    return entity.data[descriptor.field_name]
+  }
+  if (
+    entity.entity_data &&
+    descriptor.field_name in entity.entity_data &&
+    entity.entity_data[descriptor.field_name] != null
+  ) {
+    return entity.entity_data[descriptor.field_name]
+  }
+  return ''
+}
+
+export const getMetadataChecklistValues = (descriptor, entity) => {
+  let values
+  try {
+    values = JSON.parse(getMetadataFieldValue(descriptor, entity))
+  } catch {
+    values = {}
+  }
+  getDescriptorChecklistValues(descriptor).forEach(option => {
+    if (!(option.text in values)) {
+      values[option.text] = option.checked
+    }
+  })
+  return values
+}

--- a/src/composables/tasks.js
+++ b/src/composables/tasks.js
@@ -1,0 +1,33 @@
+/*
+ * Shared task-card helpers for `<script setup>` list components
+ * (TodosList, KanbanBoard).
+ */
+import { computed } from 'vue'
+import { useStore } from 'vuex'
+
+import { sortPeople } from '@/lib/sorting'
+
+export const useTaskHelpers = () => {
+  const store = useStore()
+
+  const personMap = computed(() => store.getters.personMap)
+  const productionMap = computed(() => store.getters.productionMap)
+  const taskTypeMap = computed(() => store.getters.taskTypeMap)
+
+  // Task cards link the task type scoped to an episode: tvshow tasks
+  // without one fall back to the production's first episode.
+  const getTaskType = task => {
+    const taskType = { ...taskTypeMap.value.get(task.task_type_id) }
+    const production = productionMap.value.get(task.project_id)
+    taskType.episode_id = task.episode_id
+    if (production?.production_type === 'tvshow' && !task.episode_id) {
+      taskType.episode_id = production.first_episode_id
+    }
+    return taskType
+  }
+
+  const getSortedPeople = personIds =>
+    sortPeople(personIds.map(id => personMap.value.get(id)).filter(Boolean))
+
+  return { getSortedPeople, getTaskType }
+}

--- a/tests/unit/pages/todos.spec.js
+++ b/tests/unit/pages/todos.spec.js
@@ -1,4 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import { shallowMount } from '@vue/test-utils'
+import { createRouter, createWebHashHistory } from 'vue-router'
+import { createStore } from 'vuex'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@unhead/vue', () => ({ useHead: vi.fn() }))
+vi.mock('vue-i18n', async importOriginal => ({
+  ...(await importOriginal()),
+  useI18n: () => ({ t: key => key })
+}))
 
 // Pre-load the real store to avoid circular-import race from child components.
 import '@/lib/auth'
@@ -8,44 +18,120 @@ import Todos from '@/components/pages/Todos.vue'
 const feedbackStatus = { id: 'status-1', is_feedback_request: true }
 const wipStatus = { id: 'status-2', is_feedback_request: false }
 
-const pendingTask = { id: 'task-1', task_status_id: feedbackStatus.id }
-const wipTask = { id: 'task-2', task_status_id: wipStatus.id }
+// Distinct due dates keep the priority sort deterministic.
+const pendingTask = {
+  id: 'task-1',
+  task_status_id: feedbackStatus.id,
+  priority: 0,
+  due_date: '2026-01-01'
+}
+const wipTask = {
+  id: 'task-2',
+  task_status_id: wipStatus.id,
+  priority: 0,
+  due_date: '2026-01-02'
+}
 // A status created after the context load is missing from the map.
-const unknownStatusTask = { id: 'task-3', task_status_id: 'status-3' }
+const unknownStatusTask = {
+  id: 'task-3',
+  task_status_id: 'status-3',
+  priority: 0,
+  due_date: '2026-01-03'
+}
 
-const buildContext = sortedTasks => ({
-  sortedTasks,
-  taskStatusMap: new Map([
-    [feedbackStatus.id, feedbackStatus],
-    [wipStatus.id, wipStatus]
-  ])
-})
+const taskStatusMap = new Map([
+  [feedbackStatus.id, feedbackStatus],
+  [wipStatus.id, wipStatus]
+])
+
+const SearchFieldStub = {
+  template: '<div />',
+  methods: {
+    getValue: () => '',
+    setValue: () => {}
+  }
+}
+
+const mountPage = async todos => {
+  const store = createStore({
+    getters: {
+      displayedDoneTasks: () => [],
+      displayedTodos: () => todos,
+      doneSelectionGrid: () => ({}),
+      getProductionTaskStatuses: () => () => [],
+      isTodosLoading: () => false,
+      isTodosLoadingError: () => false,
+      nbSelectedTasks: () => 0,
+      openProductions: () => [],
+      productionMap: () => new Map(),
+      selectedTasks: () => new Map(),
+      taskStatuses: () => [],
+      taskStatusMap: () => taskStatusMap,
+      taskTypeMap: () => new Map(),
+      timeSpentMap: () => new Map(),
+      timeSpentTotal: () => 0,
+      todoListScrollPosition: () => 0,
+      todoSearchQueries: () => [],
+      todoSelectionGrid: () => ({}),
+      user: () => ({ id: 'user-1' })
+    },
+    actions: {
+      clearSelectedTasks: vi.fn(),
+      loadAggregatedPersonDaysOff: vi.fn(() => []),
+      loadDoneTasks: vi.fn(),
+      loadTodos: vi.fn(),
+      setTodosSearch: vi.fn()
+    }
+  })
+  const router = createRouter({
+    history: createWebHashHistory(),
+    routes: [{ path: '/', component: { template: '<div />' } }]
+  })
+  const wrapper = shallowMount(Todos, {
+    global: {
+      plugins: [
+        store,
+        router,
+        {
+          install: app => {
+            app.config.globalProperties.$socket = { on: vi.fn(), off: vi.fn() }
+            app.config.globalProperties.$t = key => key
+          }
+        }
+      ],
+      stubs: { SearchField: SearchFieldStub }
+    }
+  })
+  await nextTick()
+  return wrapper
+}
 
 describe('Todos page', () => {
   describe('pendingTasks', () => {
-    it('keeps the tasks waiting for a feedback', () => {
-      const context = buildContext([pendingTask, wipTask])
-      expect(Todos.computed.pendingTasks.call(context)).toEqual([pendingTask])
+    it('keeps the tasks waiting for a feedback', async () => {
+      const wrapper = await mountPage([pendingTask, wipTask])
+      expect(wrapper.vm.pendingTasks).toEqual([pendingTask])
+      wrapper.unmount()
     })
 
-    it('ignores a task whose status is missing from the map', () => {
-      const context = buildContext([pendingTask, unknownStatusTask])
-      expect(Todos.computed.pendingTasks.call(context)).toEqual([pendingTask])
+    it('ignores a task whose status is missing from the map', async () => {
+      const wrapper = await mountPage([pendingTask, unknownStatusTask])
+      expect(wrapper.vm.pendingTasks).toEqual([pendingTask])
+      wrapper.unmount()
     })
   })
 
   describe('notPendingTasks', () => {
-    it('keeps the tasks not waiting for a feedback', () => {
-      const context = buildContext([pendingTask, wipTask])
-      expect(Todos.computed.notPendingTasks.call(context)).toEqual([wipTask])
+    it('keeps the tasks not waiting for a feedback', async () => {
+      const wrapper = await mountPage([pendingTask, wipTask])
+      expect(wrapper.vm.notPendingTasks).toEqual([wipTask])
+      wrapper.unmount()
     })
 
-    it('keeps a task whose status is missing from the map', () => {
-      const context = buildContext([wipTask, unknownStatusTask])
-      expect(Todos.computed.notPendingTasks.call(context)).toEqual([
-        wipTask,
-        unknownStatusTask
-      ])
+    it('keeps a task whose status is missing from the map', async () => {
+      const wrapper = await mountPage([wipTask, unknownStatusTask])
+      expect(wrapper.vm.notPendingTasks).toEqual([wipTask, unknownStatusTask])
+      wrapper.unmount()
     })
   })
 })


### PR DESCRIPTION
**Problem**

- The My Tasks and Person pages and their four sub-components (TodosList, TimesheetList, DayOffList, KanbanBoard) were still on the Options API, carrying dead code and logic duplicated between the two pages
- Small UX gaps: calendar day numbers looked clickable but did nothing, the sort dropdown could overflow the viewport, and the timelog slider kept a dated look with hardcoded colors

**Solution**

- Convert both pages and the four components to script setup, removing dead code along the way (never-run hooks, unused refs and getters, no-op methods, dead CSS)
- Extract the duplicated logic into composables: descriptor helpers, task card helpers, board statuses
- Rewrite the Todos spec to mount the component with a mocked store instead of poking Options API internals
- Calendar day headers now open that day's timesheet, and the Show and Sorted by filters use styled comboboxes (Sorted by opening left)
- Modernize the timelog slider: theme-aware rail and handle, snap-to-notch drag, mouse wheel steps, tooltip visible during the whole drag, ButtonSimple presets with an active state
- Document the new section separator convention in CLAUDE.md
