### PR TITLE
[breakdown] Stop stale pages from erasing casting

### DIFF
--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -483,7 +483,6 @@ export default {
       episodeId: '',
       importCsvFormData: {},
       isBigMode: false,
-      isLocked: false,
       isLoading: false,
       isOnlyCurrentEpisode: false,
       isTextMode: false,
@@ -775,7 +774,7 @@ export default {
       'saveBreakdownSearch',
       'loadSequences',
       'saveBreakdownSearchFilterGroup',
-      'saveCasting',
+      'castAsset',
       'saveCastings',
       'setAssetLinkLabel',
       'setAssetSearch',
@@ -943,17 +942,7 @@ export default {
       })
     },
 
-    setLock() {
-      if (!this.$options.lockTimeout) {
-        this.$options.lockTimeout = setTimeout(() => {
-          this.isLocked = false
-          this.$options.lockTimeout = null
-        }, 3000)
-      }
-    },
-
     async addOneAsset(assetId, amount = 1) {
-      this.isLocked = true
       const entityIds = Object.keys(this.selection).filter(
         key => this.selection[key]
       )
@@ -969,8 +958,7 @@ export default {
       })
 
       try {
-        await this.saveCastings(entityIds)
-        this.setLock()
+        await this.castAsset({ entityIds, assetId })
       } catch (err) {
         entityIds.forEach(entityId => {
           this.saveErrors[entityId] = true
@@ -995,9 +983,8 @@ export default {
       this.loading.remove = true
       this.removeAssetFromCasting({ entityId, assetId, nbOccurences })
       delete this.saveErrors[entityId]
-      return this.saveCasting(entityId)
+      return this.castAsset({ entityIds: [entityId], assetId })
         .then(() => {
-          this.setLock()
           this.modals.isRemoveConfirmationDisplayed = false
         })
         .catch(err => {
@@ -1029,15 +1016,13 @@ export default {
         }
       }
       if (removals.length === 0) return
-      this.isLocked = true
       this.loading.remove = true
       removals.forEach(entityId => {
         this.removeAssetFromCasting({ entityId, assetId, nbOccurences: 1 })
         delete this.saveErrors[entityId]
       })
       try {
-        await this.saveCastings(removals)
-        this.setLock()
+        await this.castAsset({ entityIds: removals, assetId })
       } catch (err) {
         removals.forEach(entityId => {
           this.saveErrors[entityId] = true
@@ -1050,7 +1035,6 @@ export default {
     },
 
     removeOneAsset(assetId, entityId, nbOccurences) {
-      this.isLocked = true
       if (this.isEpisodeCasting && nbOccurences === 1) {
         this.removalData = { assetId, entityId, nbOccurences }
         this.modals.isRemoveConfirmationDisplayed = true
@@ -1324,7 +1308,6 @@ export default {
       })
       try {
         await this.saveCastings(selectedElements)
-        this.setLock()
       } catch (err) {
         selectedElements.forEach(entityId => {
           this.saveErrors[entityId] = true
@@ -1731,25 +1714,21 @@ export default {
     events: {
       'episode:casting-update'(eventData) {
         const episode = this.episodeMap.get(eventData.episode_id)
-        if (episode && !this.isLocked) {
+        if (episode) {
           this.loadEpisodeCasting(episode)
         }
       },
 
       'shot:casting-update'(eventData) {
         const shot = this.shotMap.get(eventData.shot_id)
-        if (shot && shot.sequence_id === this.sequenceId && !this.isLocked) {
+        if (shot && shot.sequence_id === this.sequenceId) {
           this.loadShotCasting(shot)
         }
       },
 
       'asset:casting-update'(eventData) {
         const asset = this.assetMap.get(eventData.asset_id)
-        if (
-          asset &&
-          asset.asset_type_id === this.assetTypeId &&
-          !this.isLocked
-        ) {
+        if (asset && asset.asset_type_id === this.assetTypeId) {
           this.loadAssetCasting(asset)
         }
       }

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -484,6 +484,7 @@ export default {
       importCsvFormData: {},
       isBigMode: false,
       isLoading: false,
+      wasDisconnected: false,
       isOnlyCurrentEpisode: false,
       isTextMode: false,
       libraryDisplayed: false,
@@ -940,6 +941,16 @@ export default {
       indexRange.forEach(i => {
         if (i >= 0) this.selection[keys[i]] = true
       })
+    },
+
+    reloadCasting() {
+      if (this.isEpisodeCasting) {
+        this.setCastingForProductionEpisodes()
+      } else if (this.assetTypeId) {
+        this.setCastingAssetType(this.assetTypeId)
+      } else {
+        this.setCastingSequence(this.sequenceId || 'all')
+      }
     },
 
     async addOneAsset(assetId, amount = 1) {
@@ -1730,6 +1741,21 @@ export default {
         const asset = this.assetMap.get(eventData.asset_id)
         if (asset && asset.asset_type_id === this.assetTypeId) {
           this.loadAssetCasting(asset)
+        }
+      },
+
+      // socket.io replays nothing emitted while the connection was down,
+      // so the casting on screen may miss changes made in the meantime:
+      // reload it once the connection is back, and only then (the first
+      // connect of the page brings nothing new).
+      disconnect() {
+        this.wasDisconnected = true
+      },
+
+      connect() {
+        if (this.wasDisconnected) {
+          this.wasDisconnected = false
+          this.reloadCasting()
         }
       }
     }

--- a/src/store/api/breakdown.js
+++ b/src/store/api/breakdown.js
@@ -19,14 +19,14 @@ export default {
     return client.pget(path)
   },
 
-  updateCasting(productionId, entityId, casting) {
-    const path = `/api/data/projects/${productionId}/entities/${entityId}/casting`
-    return client.pput(path, casting)
-  },
-
   updateCastings(productionId, castings) {
     const path = `/api/data/projects/${productionId}/entities/casting`
     return client.pput(path, castings)
+  },
+
+  castAsset(productionId, assetId, data) {
+    const path = `/api/data/projects/${productionId}/entities/casting/assets/${assetId}`
+    return client.pput(path, data)
   },
 
   postCastingCsv(production, formData) {

--- a/src/store/modules/breakdown.js
+++ b/src/store/modules/breakdown.js
@@ -175,22 +175,6 @@ const actions = {
     commit(CASTING_SET_ENTITY_CASTING, { entityId, casting })
   },
 
-  saveCasting({ commit, rootGetters }, entityId) {
-    if (!entityId) {
-      return console.error('ShotId is undefined, no casting can be saved.')
-    }
-    const production = rootGetters.currentProduction
-    const casting = []
-    Object.values(state.casting[entityId]).forEach(asset => {
-      casting.push({
-        asset_id: asset.asset_id,
-        nb_occurences: asset.nb_occurences || 1,
-        label: asset.label
-      })
-    })
-    return breakdownApi.updateCasting(production.id, entityId, casting)
-  },
-
   saveCastings({ rootGetters }, entityIds) {
     if (!entityIds?.length) return Promise.resolve()
     const production = rootGetters.currentProduction
@@ -207,6 +191,31 @@ const actions = {
     return breakdownApi.updateCastings(production.id, castings)
   },
 
+  // The per-asset route leaves the other assets of the entity untouched,
+  // so a stale page cannot erase a colleague's work. It sets one count and
+  // label per call: one request per distinct pair, in series.
+  async castAsset({ state, rootGetters }, { entityIds, assetId }) {
+    const production = rootGetters.currentProduction
+    const requests = new Map()
+    entityIds.forEach(entityId => {
+      const link = state.casting[entityId]?.find(
+        asset => asset.asset_id === assetId
+      )
+      const key = link ? `${link.nb_occurences}|${link.label}` : 'removed'
+      if (!requests.has(key)) {
+        requests.set(key, {
+          entity_ids: [],
+          nb_occurences: link ? link.nb_occurences : 0,
+          label: link?.label
+        })
+      }
+      requests.get(key).entity_ids.push(entityId)
+    })
+    for (const data of requests.values()) {
+      await breakdownApi.castAsset(production.id, assetId, data)
+    }
+  },
+
   uploadCastingFile({ commit, state, rootGetters }, formData) {
     const currentProduction = rootGetters.currentProduction
     return breakdownApi.postCastingCsv(currentProduction, formData)
@@ -217,7 +226,10 @@ const actions = {
     { label, asset, targetEntityId }
   ) {
     commit(CASTING_SET_LINK_LABEL, { label, asset, targetEntityId })
-    return dispatch('saveCasting', targetEntityId)
+    return dispatch('castAsset', {
+      entityIds: [targetEntityId],
+      assetId: asset.asset_id
+    })
   },
 
   loadEpisodeCasting({ commit, rootGetters }, episode) {

--- a/tests/unit/store/breakdown.spec.js
+++ b/tests/unit/store/breakdown.spec.js
@@ -1,0 +1,39 @@
+import { vi } from 'vitest'
+
+// The breakdown module pulls the assets module, which transitively imports
+// the root store; stub it so no Vuex store is built.
+vi.mock('@/store', () => ({ default: {} }))
+
+import breakdownStore from '@/store/modules/breakdown'
+import breakdownApi from '@/store/api/breakdown'
+
+const rootGetters = { currentProduction: { id: 'p1' } }
+
+describe('Breakdown store', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('castAsset', () => {
+    test('sends the count and label each entity holds locally, one request per distinct pair', async () => {
+      const castAsset = vi.spyOn(breakdownApi, 'castAsset').mockResolvedValue({})
+      breakdownStore.state.casting = {
+        s1: [{ asset_id: 'a1', nb_occurences: 2, label: 'animate' }],
+        s2: [{ asset_id: 'a1', nb_occurences: 2, label: 'animate' }],
+        s3: [{ asset_id: 'a1', nb_occurences: 1, label: 'fixed' }],
+        s4: []
+      }
+
+      await breakdownStore.actions.castAsset(
+        { state: breakdownStore.state, rootGetters },
+        { entityIds: ['s1', 's2', 's3', 's4'], assetId: 'a1' }
+      )
+
+      expect(castAsset.mock.calls.map(call => call.slice(0, 3))).toEqual([
+        ['p1', 'a1', { entity_ids: ['s1', 's2'], nb_occurences: 2, label: 'animate' }],
+        ['p1', 'a1', { entity_ids: ['s3'], nb_occurences: 1, label: 'fixed' }],
+        ['p1', 'a1', { entity_ids: ['s4'], nb_occurences: 0 }]
+      ])
+    })
+  })
+})


### PR DESCRIPTION
**Problem**

- Every add/remove sent the full casting held by the page, so a stale page (3 s lock window, dropped websocket, two editors on the same entity) erased assets it never saw, and the server cascaded that to episodes and shots.
- Nothing reloaded the breakdown after a websocket reconnect, so the page stayed stale as long as it was open.

**Solution**

- Add, remove and label changes go through the new per-asset route (`castAsset`, one request per selection), which leaves the other assets untouched; paste keeps the full update. Drop the 3 s event lock: events always reload.
- Reload the current view on `connect`, only after a `disconnect` was seen.

Requires cgwire/zou#1202