### PR TITLE
[comments] Drop the tooling markers from two comments

### DIFF
--- a/src/components/pages/ProductionSchedule.vue
+++ b/src/components/pages/ProductionSchedule.vue
@@ -2236,8 +2236,8 @@ export default {
           }
         }
 
-        // ponytail: chunks of 5 keep the server load reasonable, a bulk
-        // endpoint in zou would replace this
+        // Chunks of 5 keep the server load reasonable; a bulk endpoint in
+        // zou would replace this.
         for (let i = 0; i < taskUpdates.length; i += 5) {
           await Promise.all(
             taskUpdates.slice(i, i + 5).map(update => this.updateTask(update))

--- a/src/lib/sorting.js
+++ b/src/lib/sorting.js
@@ -359,9 +359,9 @@ const sortEntityResult = (
         : sortInfo.type === 'field'
           ? sortByField(sortInfo, taskTypeMap, episodeMap)
           : sortByTaskType(taskMap, sortInfo)
-    // ponytail: descending reverses the whole comparator, so empty values
-    // land first instead of last. Special-case empties per direction if that
-    // ordering matters.
+    // Descending reverses the whole comparator, so empty values land first
+    // instead of last. Special-case empties per direction if that ordering
+    // matters.
     const direction = sortInfo.ascending === false ? -1 : 1
     let sorter = firstBy('canceled').thenBy(sortEntities, direction)
     for (const step of thenBySteps) {


### PR DESCRIPTION
**Problem**

- Two comments carried a `ponytail:` prefix, tooling jargon that means nothing to maintainers.

**Solution**

- Keep the explanations, drop the prefix.