### PR TITLE
[shots] Add the all shots pseudo-episode and split the all playlists by entity type

### DIFF
--- a/src/components/lists/ShotList.vue
+++ b/src/components/lists/ShotList.vue
@@ -315,7 +315,7 @@
                     $emit('sequence-clicked', group[0].sequence_name)
                   "
                 >
-                  {{ group[0] ? group[0].sequence_name : '' }}
+                  {{ groupHeader(group) }}
                 </div>
               </th>
             </tr>
@@ -779,7 +779,7 @@
     <empty-list
       :text="$t('shots.empty_list')"
       :read-only-text="$t('shots.empty_list_read_only')"
-      :button-text="$t('shots.new_shots')"
+      :button-text="isAllEpisodes ? '' : $t('shots.new_shots')"
       @create="$emit('add-shots')"
       v-if="isEmptyList && !isLoading"
     />
@@ -1009,6 +1009,10 @@ export default {
       isCurrentUserSupervisor: 'isCurrentUserProductionSupervisor'
     }),
 
+    isAllEpisodes() {
+      return this.isTVShow && this.currentEpisode?.id === 'all'
+    },
+
     isEmptyList() {
       return (
         this.displayedShots &&
@@ -1054,6 +1058,15 @@ export default {
     ...mapActions(['displayMoreShots', 'setShotSelection']),
 
     formatToTimecode,
+
+    groupHeader(group) {
+      const shot = group[0]
+      if (!shot) return ''
+      // Sequence names repeat across episodes: say which one in All mode.
+      return this.isAllEpisodes && shot.episode_name
+        ? `${shot.episode_name} / ${shot.sequence_name}`
+        : shot.sequence_name
+    },
 
     isSelected(indexInGroup, groupIndex, columnIndex) {
       const lineIndex = this.getIndex(indexInGroup, groupIndex)

--- a/src/components/modals/EditPlaylistModal.vue
+++ b/src/components/modals/EditPlaylistModal.vue
@@ -17,9 +17,8 @@
       <combobox-simple
         :label="$t('playlists.fields.for_entity')"
         :options="forEntityOptions"
-        :disabled="typeDisabled"
         v-model="form.for_entity"
-        v-if="!isEditing"
+        v-if="!isEditing && !typeDisabled"
       />
       <combobox-task-type
         class="flexrow-item selector"
@@ -116,23 +115,16 @@ const forClientOptions = computed(() => [
   { label: t('playlists.for_studio'), value: 'false' }
 ])
 
+const isPseudoEpisode = computed(() =>
+  ['main', 'all'].includes(currentEpisode.value?.id)
+)
+
 const forEntityOptions = computed(() => {
-  if (
-    ['main', 'all'].includes(currentEpisode.value?.id) ||
-    currentProduction.value?.production_type === 'assets'
-  ) {
+  const productionType = currentProduction.value?.production_type
+  if (productionType === 'assets') {
     return [{ label: t('assets.title'), value: 'asset' }]
   }
-  if (currentProduction.value?.production_type === 'shots') {
-    return [
-      { label: t('shots.title'), value: 'shot' },
-      { label: t('sequences.title'), value: 'sequence' },
-      { label: t('edits.title'), value: 'edit' }
-      // { label: t('episodes.title'), value: 'episode' }
-      // Episode playlists need an "all shots" cross-episode view first.
-    ]
-  }
-  return [
+  const options = [
     { label: t('assets.title'), value: 'asset' },
     { label: t('shots.title'), value: 'shot' },
     { label: t('sequences.title'), value: 'sequence' },
@@ -140,14 +132,25 @@ const forEntityOptions = computed(() => {
     // { label: t('episodes.title'), value: 'episode' }
     // Episode playlists need an "all shots" cross-episode view first.
   ]
+  if (isPseudoEpisode.value) {
+    // Pseudo-episodes are typed: All assets and the main pack hold asset
+    // playlists, All shots holds shot playlists (preset by the caller).
+    const entity = props.playlistToEdit.for_entity || 'asset'
+    return options.filter(option => option.value === entity)
+  }
+  if (productionType === 'shots') {
+    return options.filter(option => option.value !== 'asset')
+  }
+  return options
 })
 
 const defaultForEntity = computed(() => {
   const productionType = currentProduction.value?.production_type
   const isOnlyAssets = productionType === 'assets'
   const isOnlyShots = productionType === 'shots'
-  const isAssetEpisode = ['all', 'main'].includes(currentEpisode.value?.id)
-  return (isAssetEpisode || isOnlyAssets) && !isOnlyShots ? 'asset' : 'shot'
+  return (isPseudoEpisode.value || isOnlyAssets) && !isOnlyShots
+    ? 'asset'
+    : 'shot'
 })
 
 const taskTypeList = computed(() => {

--- a/src/components/modals/ViewPlaylistModal.vue
+++ b/src/components/modals/ViewPlaylistModal.vue
@@ -279,13 +279,19 @@ const onViewCreatedPlaylist = () => {
   if (!createdPlaylist.value) return
   modals.value.edit = false
   emit('cancel')
-  router.push(
-    getPlaylistPath(
-      currentProduction.value.id,
-      currentEpisode.value?.id,
-      createdPlaylist.value.id
-    )
+  const route = getPlaylistPath(
+    currentProduction.value.id,
+    currentEpisode.value?.id,
+    createdPlaylist.value.id
   )
+  if (
+    currentEpisode.value?.id === 'all' &&
+    currentEntityType.value === 'shot'
+  ) {
+    // The playlists page splits the all pseudo-episode by entity type.
+    route.query = { for_entity: 'shot' }
+  }
+  router.push(route)
 }
 
 const savePlaylist = async form => {

--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -809,7 +809,11 @@ export default {
     async reloadEntities() {
       this.isLoading = true
       try {
-        if (!this.isTVShow || this.currentEpisode?.id !== 'main') {
+        // 'all' is episode casting here: it reads neither sequences nor shots.
+        if (
+          !this.isTVShow ||
+          !['main', 'all'].includes(this.currentEpisode?.id)
+        ) {
           await this.loadSequences()
           await this.loadShots()
         }

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -763,6 +763,17 @@ export default {
       )
     },
 
+    // The all pseudo-episode is split by entity type: "All assets" (default)
+    // and "All shots" (?for_entity=shot). Undefined outside of it.
+    allForEntity() {
+      if (!this.isTVShow || this.currentEpisode?.id !== 'all') return undefined
+      return this.$route.query.for_entity === 'shot' ? 'shot' : 'asset'
+    },
+
+    allShotsQuery() {
+      return this.allForEntity === 'shot' ? { for_entity: 'shot' } : {}
+    },
+
     isAssetPlaylist() {
       return this.currentPlaylist.for_entity === 'asset'
     },
@@ -819,7 +830,9 @@ export default {
       let episodeName = ''
       if (this.currentEpisode) {
         if (this.currentEpisode.id === 'all') {
-          episodeName = this.$t('main.all')
+          episodeName = this.$t(
+            this.allForEntity === 'shot' ? 'main.all_shots' : 'main.all_assets'
+          )
         } else if (this.currentEpisode.id === 'main') {
           episodeName = this.$t('main.main_pack')
         } else {
@@ -911,12 +924,14 @@ export default {
     },
 
     getPlaylistPath(playlistId, section) {
-      return getPlaylistPath(
+      const route = getPlaylistPath(
         this.currentProduction.id,
         this.currentEpisode ? this.currentEpisode.id : null,
         playlistId,
         section
       )
+      route.query = this.allShotsQuery
+      return route
     },
 
     playlistElementStyle(playlist) {
@@ -1030,7 +1045,8 @@ export default {
         return this.loadPlaylists({
           sortBy: this.currentSort,
           page: this.page,
-          taskTypeId: this.taskTypeId
+          taskTypeId: this.taskTypeId,
+          forEntity: this.allForEntity
         })
           .then(() => {
             return setFirstPlaylist()
@@ -1062,7 +1078,8 @@ export default {
       this.loadMorePlaylists({
         sortBy: this.currentSort,
         page: this.page,
-        taskTypeId: this.taskTypeId
+        taskTypeId: this.taskTypeId,
+        forEntity: this.allForEntity
       })
         .then(playlists => {
           setTimeout(() => {
@@ -1607,10 +1624,11 @@ export default {
           params: {
             production_id: this.currentProduction.id,
             playlist_id: this.playlists[0].id
-          }
+          },
+          query: this.allShotsQuery
         })
       } else {
-        this.$router.push(this.playlistsPath)
+        this.$router.push({ ...this.playlistsPath, query: this.allShotsQuery })
       }
     },
 
@@ -1688,7 +1706,8 @@ export default {
     showAddModal() {
       this.playlistToEdit = {
         name: `${moment().format('YYYY-MM-DD HH:mm:ss')}`,
-        for_client: false
+        for_client: false,
+        for_entity: this.allForEntity
       }
       this.errors.editPlaylist = false
       this.modals.isEditDisplayed = true
@@ -1762,6 +1781,14 @@ export default {
     currentEpisode() {
       this.$store.commit('LOAD_PLAYLISTS_END', [])
       if (this.currentEpisode) {
+        this.reloadAll()
+      }
+    },
+
+    allForEntity(forEntity, previous) {
+      // All assets <-> All shots: same episode, different query.
+      if (forEntity && previous) {
+        this.$store.commit('LOAD_PLAYLISTS_END', [])
         this.reloadAll()
       }
     },

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -774,6 +774,22 @@ export default {
       return this.allForEntity === 'shot' ? { for_entity: 'shot' } : {}
     },
 
+    // The store keeps the last loaded list across pages: on mount it can
+    // belong to another production, episode or all-mode entity type.
+    isPlaylistListStale() {
+      const [first] = this.playlists
+      if (!first) return false
+      if (first.project_id !== this.currentProduction.id) return true
+      if (!this.isTVShow || !this.currentEpisode) return false
+      if (this.currentEpisode.id === 'all') {
+        return !first.is_for_all || first.for_entity !== this.allForEntity
+      }
+      if (this.currentEpisode.id === 'main') {
+        return Boolean(first.episode_id || first.is_for_all)
+      }
+      return first.episode_id !== this.currentEpisode.id
+    },
+
     isAssetPlaylist() {
       return this.currentPlaylist.for_entity === 'asset'
     },
@@ -1737,7 +1753,7 @@ export default {
         await this.loadEditsData()
         await this.loadEpisodesData()
         this.page = 1
-        await this.loadPlaylistsData()
+        await this.loadPlaylistsData(this.isPlaylistListStale)
         this.loading.playlists = false
         this.resetPlaylist()
         setTimeout(() => {

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -76,6 +76,7 @@
                 :text="$t('shots.new_shots')"
                 icon="plus"
                 @click="showManageShots"
+                v-if="!isAllEpisodes"
               />
             </div>
           </div>
@@ -530,6 +531,7 @@ export default {
       'shotSearchQueries',
       'shotSearchText',
       'shotSearchFilterGroups',
+      'shotsLoadingKey',
       'shotsPath',
       'shotValidationColumns',
       'shotListScrollPosition',
@@ -541,6 +543,10 @@ export default {
     ...mapGetters({
       isCurrentUserManager: 'isCurrentUserProductionManager'
     }),
+
+    isAllEpisodes() {
+      return this.isTVShow && this.currentEpisode?.id === 'all'
+    },
 
     shotMap() {
       return shotStore.cache.shotMap
@@ -633,13 +639,14 @@ export default {
     },
 
     reloadEpisodeShotsIfNeeded() {
-      if (
-        ((this.isTVShow && this.displayedSequences.length === 0) ||
+      // In All mode the first row says nothing about the loaded scope: rely
+      // on the store's loading key instead.
+      const isStale = this.isAllEpisodes
+        ? this.shotsLoadingKey !== `${this.currentProduction.id}/all`
+        : (this.isTVShow && this.displayedSequences.length === 0) ||
           this.displayedSequences[0]?.episode_id !== this.currentEpisode?.id ||
-          this.displayedShots[0]?.episode_id !== this.currentEpisode?.id) &&
-        !this.isShotsLoading &&
-        !this.initialLoading
-      ) {
+          this.displayedShots[0]?.episode_id !== this.currentEpisode?.id
+      if (isStale && !this.isShotsLoading && !this.initialLoading) {
         this.$refs['shot-search-field']?.setValue('')
         this.$store.commit('SET_SHOT_LIST_SCROLL_POSITION', 0)
         this.initialLoading = true
@@ -838,7 +845,13 @@ export default {
           this.$t('shots.title')
         ]
         if (this.currentEpisode) {
-          nameData.splice(3, 0, this.currentEpisode.name)
+          nameData.splice(
+            3,
+            0,
+            this.isAllEpisodes
+              ? this.$t('main.all_shots')
+              : this.currentEpisode.name
+          )
         }
         const name = stringHelpers.slugify(nameData.join('_'))
         const headers = [
@@ -963,7 +976,11 @@ export default {
         await this.setNbFramesFromTaskTypePreviews({
           taskTypeId,
           productionId: this.currentProduction.id,
-          episodeId: this.currentEpisode ? this.currentEpisode.id : null
+          // Whole production in All mode: zou rejects episode_id=all here.
+          episodeId:
+            this.currentEpisode && !this.isAllEpisodes
+              ? this.currentEpisode.id
+              : null
         })
         this.modals.isSetFramesDisplayed = false
       } catch (err) {
@@ -1034,7 +1051,11 @@ export default {
       return {
         title:
           `${this.currentProduction?.name || ''}` +
-          ` - ${this.currentEpisode?.name || ''}` +
+          ` - ${
+            this.isAllEpisodes
+              ? this.$t('main.all_shots')
+              : this.currentEpisode?.name || ''
+          }` +
           ` | ${this.$t('shots.title')} - Kitsu`
       }
     }

--- a/src/components/pages/Shots.vue
+++ b/src/components/pages/Shots.vue
@@ -58,6 +58,7 @@
                 :title="$t('main.edl.import_file')"
                 icon="import-edl"
                 @click="showEDLImportModal"
+                v-if="!isAllEpisodes"
               />
               <button-simple
                 class="flexrow-item"
@@ -639,13 +640,17 @@ export default {
     },
 
     reloadEpisodeShotsIfNeeded() {
-      // In All mode the first row says nothing about the loaded scope: rely
-      // on the store's loading key instead.
-      const isStale = this.isAllEpisodes
-        ? this.shotsLoadingKey !== `${this.currentProduction.id}/all`
-        : (this.isTVShow && this.displayedSequences.length === 0) ||
-          this.displayedSequences[0]?.episode_id !== this.currentEpisode?.id ||
-          this.displayedShots[0]?.episode_id !== this.currentEpisode?.id
+      // The first rows say nothing about the loaded scope: a production-wide
+      // All dataset passes the per-episode checks whenever the first episode
+      // owns the first rows. Compare the scope of the last load first.
+      const scope = this.isTVShow ? (this.currentEpisode?.id ?? '') : ''
+      const isStale =
+        this.shotsLoadingKey !== `${this.currentProduction?.id}/${scope}` ||
+        (!this.isAllEpisodes &&
+          ((this.isTVShow && this.displayedSequences.length === 0) ||
+            this.displayedSequences[0]?.episode_id !==
+              this.currentEpisode?.id ||
+            this.displayedShots[0]?.episode_id !== this.currentEpisode?.id))
       if (isStale && !this.isShotsLoading && !this.initialLoading) {
         this.$refs['shot-search-field']?.setValue('')
         this.$store.commit('SET_SHOT_LIST_SCROLL_POSITION', 0)

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -457,9 +457,14 @@ export default {
       }
       if (this.assetSections.includes(section)) {
         const episodeList = this.getBaseEpisodeOptionGroups('main.all_assets')
-        return [{ name: '', episodeList }].concat(this.episodeOptionGroups)
-      } else if (['playlists'].includes(section)) {
-        const episodeList = this.getBaseEpisodeOptionGroups('main.all_assets')
+        if (section === 'playlists') {
+          // Same all pseudo-episode, split by entity type through the query.
+          episodeList.splice(1, 0, {
+            label: this.$t('main.all_shots'),
+            value: 'all',
+            query: { for_entity: 'shot' }
+          })
+        }
         return [{ name: '', episodeList }].concat(this.episodeOptionGroups)
       } else if (['edits'].includes(section)) {
         return [

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -850,6 +850,12 @@ export default {
               ['all', 'main'].includes(routeEpisodeId)
             ) {
               this.currentEpisodeId = routeEpisodeId
+            } else if (
+              this.shotSections.includes(this.currentProjectSection) &&
+              routeEpisodeId === 'all'
+            ) {
+              // No main pack for shots: only 'all' survives a direct link.
+              this.currentEpisodeId = routeEpisodeId
             } else {
               let episode = episodes.find(({ id }) => id === routeEpisodeId)
               if (!episode) {

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -471,6 +471,15 @@ export default {
       } else if (['breakdown'].includes(section)) {
         const episodeList = this.getBaseEpisodeOptionGroups('shots.episodes')
         return [{ name: '', episodeList }].concat(this.episodeOptionGroups)
+      } else if (this.shotSections.includes(section)) {
+        // No main pack for shots: every shot of a TV show belongs to an
+        // episode, so the only pseudo-episode is "all".
+        return [
+          {
+            name: '',
+            episodeList: [{ label: this.$t('main.all_shots'), value: 'all' }]
+          }
+        ].concat(this.episodeOptionGroups)
       } else if (this.scheduleSections.includes(section)) {
         const episodeList = this.getBaseEpisodeOptionGroups(
           'episodes.all_episodes'
@@ -927,12 +936,18 @@ export default {
       // Plugin pages keep the all / main pseudo-episodes: coercing to the
       // first episode desyncs the combobox from the episode_id actually
       // forwarded to the plugin iframe.
+      // The Shots page keeps 'all' (every shot of the production) but has no
+      // main pack: 'main' is coerced to the first episode like before.
+      const isShotSection = this.shotSections.includes(section)
+      const keepsPseudoEpisode =
+        pluginId !== undefined ||
+        isAssetSection ||
+        isEditSection ||
+        isBreakdownSection ||
+        isScheduleSection ||
+        (isShotSection && episodeId === 'all')
       if (
-        pluginId === undefined &&
-        !isAssetSection &&
-        !isEditSection &&
-        !isBreakdownSection &&
-        !isScheduleSection &&
+        !keepsPseudoEpisode &&
         ['all', 'main'].includes(episodeId) &&
         this.episodes.length > 0
       ) {

--- a/src/components/tops/TopbarEpisodeList.vue
+++ b/src/components/tops/TopbarEpisodeList.vue
@@ -29,13 +29,13 @@
           </div>
           <template v-if="showAllMode || ['', 'running'].includes(group.name)">
             <div
-              :key="episode.value"
-              :ref="'episode-' + episode.value"
+              :key="optionKey(episode)"
+              :ref="'episode-' + optionKey(episode)"
               class="episode-line"
               @click="selectEpisode(episode)"
               v-for="episode in group.episodeList"
             >
-              <router-link :to="getEpisodePath(episode.value)">
+              <router-link :to="getEpisodePath(episode)">
                 {{ episode.label }}
               </router-link>
             </div>
@@ -111,11 +111,16 @@ export default {
     ...mapGetters(['currentProduction']),
 
     episodeLabel() {
-      let option
-      this.episodeGroups.forEach(group => {
-        const result = group.episodeList.find(o => o.value === this.episodeId)
-        if (result) option = result
-      })
+      const options = this.episodeGroups.flatMap(group =>
+        group.episodeList.filter(o => o.value === this.episodeId)
+      )
+      // Several options can share a value (All assets / All shots): the
+      // route query tells them apart.
+      const forEntity = this.$route.query.for_entity
+      const option =
+        options.find(o => o.query?.for_entity === forEntity) ||
+        options.find(o => !o.query) ||
+        options[0]
       return option ? option.label : ''
     },
 
@@ -124,16 +129,19 @@ export default {
       const section = this.section
       const pluginId = this.$route.params.plugin_id
       const currentQuery = this.$route.query
-      return episodeId => {
+      return episode => {
         const path = getProductionPath(
           currentProduction,
           section,
-          episodeId,
+          episode.value,
           pluginId
         )
         if (section === 'schedule') {
           // The production schedule keeps its view state (mode, version, ...) in the URL query.
           path.query = { ...currentQuery }
+        }
+        if (episode.query) {
+          path.query = { ...path.query, ...episode.query }
         }
         return path
       }
@@ -141,6 +149,12 @@ export default {
   },
 
   methods: {
+    optionKey(episode) {
+      return episode.query
+        ? `${episode.value}-${Object.values(episode.query).join('-')}`
+        : episode.value
+    },
+
     selectEpisode(episode) {
       this.$emit('input', episode.id)
       this.showEpisodeList = false

--- a/src/components/tops/TopbarSectionList.vue
+++ b/src/components/tops/TopbarSectionList.vue
@@ -170,6 +170,17 @@ export default {
         this.episodeId,
         section.plugin_id
       )
+      // The all pseudo-episode is typed on the playlists page: coming from
+      // the shot side, stay on the shot side.
+      const isShotContext =
+        this.section === 'shots' || this.$route.query.for_entity === 'shot'
+      if (
+        section.value === 'playlists' &&
+        this.episodeId === 'all' &&
+        isShotContext
+      ) {
+        result.query = { ...result.query, for_entity: 'shot' }
+      }
       return result
     }
   },

--- a/src/store/api/playlists.js
+++ b/src/store/api/playlists.js
@@ -1,7 +1,7 @@
 import client from '@/store/api/client'
 
 export default {
-  getPlaylists(production, episode, taskTypeId, sortBy, page) {
+  getPlaylists(production, episode, taskTypeId, sortBy, page, forEntity) {
     let path = `/api/data/projects/${production.id}`
     if (episode) {
       path += `/episodes/${episode.id}/playlists?sort_by=${sortBy}&page=${page}`
@@ -10,6 +10,9 @@ export default {
     }
     if (taskTypeId?.length) {
       path += `&task_type_id=${taskTypeId}`
+    }
+    if (forEntity) {
+      path += `&for_entity=${forEntity}`
     }
     return client.pget(path)
   },

--- a/src/store/modules/playlists.js
+++ b/src/store/modules/playlists.js
@@ -87,7 +87,7 @@ const getters = {
 const actions = {
   loadPlaylists(
     { commit, rootGetters },
-    { sortBy = 'updated_at', page = 1, taskTypeId }
+    { sortBy = 'updated_at', page = 1, taskTypeId, forEntity }
   ) {
     const production = rootGetters.currentProduction
     let episode = rootGetters.currentEpisode
@@ -98,7 +98,7 @@ const actions = {
 
     commit(LOAD_PLAYLISTS_END, [])
     return playlistsApi
-      .getPlaylists(production, episode, taskTypeId, sortBy, page)
+      .getPlaylists(production, episode, taskTypeId, sortBy, page, forEntity)
       .then(playlists => {
         commit(LOAD_PLAYLISTS_END, playlists)
         return playlists
@@ -107,7 +107,7 @@ const actions = {
 
   loadMorePlaylists(
     { commit, rootGetters },
-    { sortBy = 'updated_at', page = 1, taskTypeId }
+    { sortBy = 'updated_at', page = 1, taskTypeId, forEntity }
   ) {
     const production = rootGetters.currentProduction
     let episode = rootGetters.currentEpisode
@@ -117,7 +117,7 @@ const actions = {
     if (isTVShow && !episode) return Promise.resolve([])
     if (!isTVShow) episode = null
     return playlistsApi
-      .getPlaylists(production, episode, taskTypeId, sortBy, page)
+      .getPlaylists(production, episode, taskTypeId, sortBy, page, forEntity)
       .then(playlists => {
         commit(ADD_PLAYLISTS, playlists)
         return playlists

--- a/src/store/modules/sequences.js
+++ b/src/store/modules/sequences.js
@@ -238,11 +238,17 @@ const getters = {
   searchSequenceFilters: state => state.searchSequenceFilters,
 
   isSingleSequence: state => state.displayedSequences.length < 2,
-  sequenceOptions: state =>
-    state.displayedSequences.map(sequence => ({
-      label: sequence.name,
+  // In All mode the list spans the production, where sequence names repeat
+  // from one episode to the next: qualify them with the episode name.
+  sequenceOptions: (state, getters, rootState, rootGetters) => {
+    const isAllEpisodes = rootGetters?.currentEpisode?.id === 'all'
+    return state.displayedSequences.map(sequence => ({
+      label: isAllEpisodes
+        ? sequence.full_name || sequence.name
+        : sequence.name,
       value: sequence.id
     }))
+  }
 }
 
 const actions = {
@@ -425,11 +431,9 @@ const actions = {
         }
         // Discard a response whose scope is not the one displayed any more
         // (the user switched episode mid-load).
-        const isCurrentScope =
-          sequences.length > 0 &&
-          (isAllEpisodes
-            ? rootGetters.currentEpisode?.id === 'all'
-            : sequences[0].episode_id === rootGetters.currentEpisode?.id)
+        const isCurrentScope = isAllEpisodes
+          ? rootGetters.currentEpisode?.id === 'all'
+          : sequences[0]?.episode_id === rootGetters.currentEpisode?.id
         if (!isTVShow || sequences.length === 0 || isCurrentScope) {
           commit(SET_SEQUENCES_WITH_TASKS, {
             sequences,

--- a/src/store/modules/sequences.js
+++ b/src/store/modules/sequences.js
@@ -363,7 +363,10 @@ const actions = {
     const production = rootGetters.currentProduction
     const userFilters = rootGetters.userFilters
     const isTVShow = rootGetters.isTVShow
-    const episode = isTVShow ? rootGetters.currentEpisode : null
+    const currentEpisode = rootGetters.currentEpisode
+    // 'all' is the cross-episode pseudo-episode: list the whole production.
+    const episode =
+      isTVShow && currentEpisode?.id !== 'all' ? currentEpisode : null
     const episodeMap = rootGetters.episodeMap
     return shotsApi.getSequences(production, episode).then(sequences => {
       if (production.id !== rootGetters.currentProduction?.id) {
@@ -384,6 +387,7 @@ const actions = {
     const personMap = rootGetters.personMap
     const production = rootGetters.currentProduction
     let episode = rootGetters.currentEpisode
+    const isAllEpisodes = episode?.id === 'all'
     const isTVShow = rootGetters.isTVShow
     const routeSequenceId = rootGetters.route.params.sequence_id
     const userFilters = rootGetters.userFilters
@@ -414,16 +418,19 @@ const actions = {
       }
     }
     return shotsApi
-      .getSequencesWithTasks(production, episode)
+      .getSequencesWithTasks(production, isAllEpisodes ? null : episode)
       .then(sequences => {
         if (production.id !== rootGetters.currentProduction?.id) {
           return sequences
         }
-        if (
-          !isTVShow ||
-          sequences.length === 0 ||
-          sequences[0].episode_id === rootGetters.currentEpisode?.id
-        ) {
+        // Discard a response whose scope is not the one displayed any more
+        // (the user switched episode mid-load).
+        const isCurrentScope =
+          sequences.length > 0 &&
+          (isAllEpisodes
+            ? rootGetters.currentEpisode?.id === 'all'
+            : sequences[0].episode_id === rootGetters.currentEpisode?.id)
+        if (!isTVShow || sequences.length === 0 || isCurrentScope) {
           commit(SET_SEQUENCES_WITH_TASKS, {
             sequences,
             episodeMap,

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -468,11 +468,14 @@ const actions = {
         if (production.id !== rootGetters.currentProduction?.id) {
           return
         }
+        // Discard a response whose scope is not the one displayed any more
+        // (the user switched episode mid-load).
         if (
           !isTVShow ||
           shots.length === 0 ||
-          rootGetters.currentEpisode?.id === 'all' ||
-          shots[0].episode_id === rootGetters.currentEpisode?.id
+          (isAllEpisodes
+            ? rootGetters.currentEpisode?.id === 'all'
+            : shots[0].episode_id === rootGetters.currentEpisode?.id)
         ) {
           const sequenceMap = sequenceStore.cache.sequenceMap
           const taskMap = rootGetters.taskMap

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -295,6 +295,7 @@ const initialState = {
 
   isShotsLoading: false,
   isShotsLoadingError: false,
+  shotsLoadingKey: null,
   shotsCsvFormData: null,
 
   shotListScrollPosition: 0,
@@ -345,7 +346,7 @@ const getters = {
   },
   // Scope ("<productionId>/<episodeId>") of the last started load, so the
   // page can tell whether the store holds the shots of the current context.
-  shotsLoadingKey: () => cache.shotsLoadingKey,
+  shotsLoadingKey: state => state.shotsLoadingKey,
 
   isShotsLoading: state => state.isShotsLoading,
   isShotsLoadingError: state => state.isShotsLoadingError,
@@ -455,7 +456,7 @@ const actions = {
       )
     }
 
-    commit(LOAD_SHOTS_START)
+    commit(LOAD_SHOTS_START, { loadingKey })
     cache.shotsLoadingKey = loadingKey
     const loadingPromise = dispatch('loadSequencesWithTasks')
       .then(() => {
@@ -887,6 +888,7 @@ const mutations = {
 
     state.isShotsLoading = false
     state.isShotsLoadingError = false
+    state.shotsLoadingKey = null
     state.displayedShots = []
     state.displayedShotsCount = 0
     state.displayedShotsLength = 0
@@ -899,7 +901,7 @@ const mutations = {
     state.selectedShots = new Map()
   },
 
-  [LOAD_SHOTS_START](state) {
+  [LOAD_SHOTS_START](state, { loadingKey } = {}) {
     cache.shots = []
     cache.result = []
     cache.shotIndex = {}
@@ -909,6 +911,7 @@ const mutations = {
 
     state.isShotsLoading = true
     state.isShotsLoadingError = false
+    state.shotsLoadingKey = loadingKey ?? null
 
     state.displayedShots = []
     state.displayedShotsCount = 0

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -340,8 +340,12 @@ const getters = {
   shotFilledColumns: state => state.shotFilledColumns,
 
   displayedShotsBySequence: state => {
-    return groupEntitiesByParents(state.displayedShots, 'sequence_name')
+    // Sequence names repeat across episodes (All shots view): group on id.
+    return groupEntitiesByParents(state.displayedShots, 'sequence_id')
   },
+  // Scope ("<productionId>/<episodeId>") of the last started load, so the
+  // page can tell whether the store holds the shots of the current context.
+  shotsLoadingKey: () => cache.shotsLoadingKey,
 
   isShotsLoading: state => state.isShotsLoading,
   isShotsLoadingError: state => state.isShotsLoadingError,
@@ -413,12 +417,14 @@ const actions = {
 
     if (!production) return Promise.resolve()
 
-    if (episode && ['all', 'main'].includes(episode.id)) {
-      // If it's a wide episode, we just store it. There isn't anything to
-      // load because we don't have episode defined.
+    if (episode?.id === 'main') {
+      // No main pack for shots: nothing to load.
       commit(SET_CURRENT_EPISODE, episode.id)
       return Promise.resolve()
     }
+    // 'all' is the cross-episode pseudo-episode: query the whole production
+    // (no episode_id on the wire) and keep 'all' as the loading scope.
+    const isAllEpisodes = episode?.id === 'all'
     if (isTVShow && !episode) {
       // If it's tv show and if we don't have any episode set, we use the first
       // one.
@@ -453,7 +459,7 @@ const actions = {
     cache.shotsLoadingKey = loadingKey
     const loadingPromise = dispatch('loadSequencesWithTasks')
       .then(() => {
-        return shotsApi.getShots(production, episode)
+        return shotsApi.getShots(production, isAllEpisodes ? null : episode)
       })
       .then(shots => {
         // Ignore a response for a production the user already switched away
@@ -465,6 +471,7 @@ const actions = {
         if (
           !isTVShow ||
           shots.length === 0 ||
+          rootGetters.currentEpisode?.id === 'all' ||
           shots[0].episode_id === rootGetters.currentEpisode?.id
         ) {
           const sequenceMap = sequenceStore.cache.sequenceMap

--- a/tests/unit/components/pages/Playlist.spec.js
+++ b/tests/unit/components/pages/Playlist.spec.js
@@ -1,0 +1,37 @@
+import '@/lib/auth'
+
+import Playlist from '@/components/pages/Playlist.vue'
+
+describe('Playlist page', () => {
+  const isStale = Playlist.computed.isPlaylistListStale
+  const production = { id: 'p1' }
+  const allShots = { project_id: 'p1', episode_id: null, is_for_all: true, for_entity: 'shot' }
+  const allAssets = { project_id: 'p1', episode_id: null, is_for_all: true, for_entity: 'asset' }
+  const episodeOne = { project_id: 'p1', episode_id: 'ep-1', is_for_all: false, for_entity: 'shot' }
+  const context = (playlists, episodeId, allForEntity) => ({
+    playlists,
+    currentProduction: production,
+    isTVShow: true,
+    currentEpisode: episodeId ? { id: episodeId } : null,
+    allForEntity
+  })
+
+  it('reloads on mount when the stored list belongs to another all-mode entity type', () => {
+    // Coming back to All assets after a visit of the All shots playlists.
+    expect(isStale.call(context([allShots], 'all', 'asset'))).toBe(true)
+    expect(isStale.call(context([allAssets], 'all', 'asset'))).toBe(false)
+    expect(isStale.call(context([allShots], 'all', 'shot'))).toBe(false)
+  })
+
+  it('reloads when the stored list belongs to another episode, production or pack', () => {
+    expect(isStale.call(context([episodeOne], 'ep-2', undefined))).toBe(true)
+    expect(isStale.call(context([episodeOne], 'ep-1', undefined))).toBe(false)
+    expect(isStale.call(context([allAssets], 'ep-1', undefined))).toBe(true)
+    expect(isStale.call(context([allAssets], 'main', undefined))).toBe(true)
+    expect(isStale.call(context([episodeOne], 'all', 'shot'))).toBe(true)
+    expect(
+      isStale.call({ ...context([episodeOne], 'ep-1'), currentProduction: { id: 'p2' } })
+    ).toBe(true)
+    expect(isStale.call(context([], 'ep-1', undefined))).toBe(false)
+  })
+})

--- a/tests/unit/components/pages/Shots.spec.js
+++ b/tests/unit/components/pages/Shots.spec.js
@@ -1,0 +1,127 @@
+import { vi } from 'vitest'
+
+// Importing the shots page transitively pulls in the root store
+// (lib/models → timezone → @/store); stub it so no Vuex store is built.
+vi.mock('@/store', () => ({ default: {} }))
+
+import Shots from '@/components/pages/Shots.vue'
+
+describe('Shots page, reloadEpisodeShotsIfNeeded', () => {
+  const production = { id: 'p' }
+
+  // The method only reads its component instance, so a plain object is
+  // enough to exercise the staleness decision without mounting the page.
+  const buildContext = (overrides = {}) => {
+    const context = {
+      currentProduction: production,
+      currentEpisode: null,
+      isTVShow: false,
+      shotsLoadingKey: 'p/',
+      displayedSequences: [],
+      displayedShots: [],
+      isShotsLoading: false,
+      initialLoading: false,
+      loadShots: vi.fn(() => Promise.resolve()),
+      applySearchFromUrl: vi.fn(),
+      $refs: {},
+      $store: { commit: vi.fn() },
+      ...overrides
+    }
+    context.isAllEpisodes = Shots.computed.isAllEpisodes.call(context)
+    return context
+  }
+
+  const run = context => {
+    Shots.methods.reloadEpisodeShotsIfNeeded.call(context)
+    return context
+  }
+
+  test('reloads when a coerced episode switch left the All dataset in the store', () => {
+    const context = buildContext({
+      isTVShow: true,
+      currentEpisode: { id: 'ep-a' },
+      shotsLoadingKey: 'p/all',
+      // Episodes and rows are sorted by episode name, so the first rows of a
+      // production-wide dataset belong to the first episode: the per-episode
+      // checks pass by construction and only the scope tells them apart.
+      displayedSequences: [
+        { id: 'sq-1', episode_id: 'ep-a' },
+        { id: 'sq-2', episode_id: 'ep-b' }
+      ],
+      displayedShots: [
+        { id: 's1', episode_id: 'ep-a' },
+        { id: 's2', episode_id: 'ep-b' }
+      ]
+    })
+
+    run(context)
+
+    expect(context.loadShots).toHaveBeenCalled()
+    expect(context.initialLoading).toBe(true)
+  })
+
+  test('does not reload when the store holds the displayed episode', () => {
+    const context = buildContext({
+      isTVShow: true,
+      currentEpisode: { id: 'ep-a' },
+      shotsLoadingKey: 'p/ep-a',
+      displayedSequences: [{ id: 'sq-1', episode_id: 'ep-a' }],
+      displayedShots: [{ id: 's1', episode_id: 'ep-a' }]
+    })
+
+    run(context)
+
+    expect(context.loadShots).not.toHaveBeenCalled()
+  })
+
+  test('does not reload when the store already holds the production-wide dataset', () => {
+    const context = buildContext({
+      isTVShow: true,
+      currentEpisode: { id: 'all' },
+      shotsLoadingKey: 'p/all',
+      displayedSequences: [
+        { id: 'sq-1', episode_id: 'ep-a' },
+        { id: 'sq-2', episode_id: 'ep-b' }
+      ],
+      displayedShots: [
+        { id: 's1', episode_id: 'ep-a' },
+        { id: 's2', episode_id: 'ep-b' }
+      ]
+    })
+
+    run(context)
+
+    expect(context.isAllEpisodes).toBe(true)
+    expect(context.loadShots).not.toHaveBeenCalled()
+  })
+
+  test('reloads in All mode when the store only holds one episode', () => {
+    const context = buildContext({
+      isTVShow: true,
+      currentEpisode: { id: 'all' },
+      shotsLoadingKey: 'p/ep-a',
+      displayedSequences: [{ id: 'sq-1', episode_id: 'ep-a' }],
+      displayedShots: [{ id: 's1', episode_id: 'ep-a' }]
+    })
+
+    run(context)
+
+    expect(context.loadShots).toHaveBeenCalled()
+  })
+
+  test('does not reload a non-TV-show production loaded under the empty scope', () => {
+    const context = buildContext({ shotsLoadingKey: 'p/' })
+
+    run(context)
+
+    expect(context.loadShots).not.toHaveBeenCalled()
+  })
+
+  test('reloads when the store holds another production', () => {
+    const context = buildContext({ shotsLoadingKey: 'other-p/' })
+
+    run(context)
+
+    expect(context.loadShots).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/components/tops/Topbar.spec.js
+++ b/tests/unit/components/tops/Topbar.spec.js
@@ -333,6 +333,88 @@ describe('Topbar.vue', () => {
     })
   })
 
+  describe('shots episode selector', () => {
+    // The Shots page offers 'all' (every shot of the production) on top of
+    // the real episodes. There is no main pack for shots, so 'main' is still
+    // coerced to the first episode.
+    const mountForShots = (episodeId, episodes = []) => {
+      const production = { id: 'production-1', production_type: 'tvshow' }
+      const { store: shotsStore } = makeStore({
+        currentProduction: () => production,
+        episodes: () => episodes,
+        isTVShow: () => true,
+        productionEditTaskTypes: () => [],
+        productionMap: () => new Map([[production.id, production]])
+      })
+      const router = createRouter({
+        history: createWebHashHistory(),
+        routes: [
+          {
+            path: '/',
+            name: 'open-productions',
+            component: { template: '<div />' }
+          },
+          {
+            path: '/productions/:production_id/episodes/:episode_id/shots',
+            name: 'episode-shots',
+            component: { template: '<div />' }
+          }
+        ]
+      })
+      return shallowMount(Topbar, {
+        global: {
+          plugins: [shotsStore, router],
+          mocks: {
+            $t: key => key,
+            $route: {
+              path: `/productions/production-1/episodes/${episodeId}/shots`,
+              name: 'episode-shots',
+              params: { production_id: 'production-1', episode_id: episodeId },
+              query: {},
+              fullPath: '/'
+            }
+          },
+          stubs: {
+            TopbarProductionList: true,
+            TopbarSectionList: true,
+            TopbarEpisodeList: true,
+            GlobalSearchField: true,
+            NotificationBell: true,
+            PeopleAvatar: true,
+            ShortcutModal: true
+          }
+        }
+      })
+    }
+
+    it('offers an all shots option and no main pack', async () => {
+      const shotsWrapper = mountForShots('all')
+      shotsWrapper.vm.currentProjectSection = 'shots'
+      await nextTick()
+      expect(shotsWrapper.vm.currentEpisodeOptionGroups).toEqual([
+        {
+          name: '',
+          episodeList: [{ label: 'main.all_shots', value: 'all' }]
+        }
+      ])
+      shotsWrapper.unmount()
+    })
+
+    it('keeps the all pseudo-episode instead of coercing it to the first one', () => {
+      const shotsWrapper = mountForShots('all', [{ id: 'episode-1' }])
+      shotsWrapper.vm.updateCombosFromRoute()
+      expect(shotsWrapper.vm.currentEpisodeId).toBe('all')
+      shotsWrapper.unmount()
+    })
+
+    it('still coerces the main pack to the first episode', () => {
+      const shotsWrapper = mountForShots('main', [{ id: 'episode-1' }])
+      shotsWrapper.vm.updateCombosFromRoute()
+      expect(shotsWrapper.vm.currentEpisodeId).toBe('episode-1')
+      shotsWrapper.unmount()
+    })
+  })
+
   describe('notification:new socket handler', () => {
     const originalVisibility = Object.getOwnPropertyDescriptor(
       document,

--- a/tests/unit/components/tops/Topbar.spec.js
+++ b/tests/unit/components/tops/Topbar.spec.js
@@ -1,5 +1,5 @@
 import { nextTick, ref } from 'vue'
-import { shallowMount } from '@vue/test-utils'
+import { flushPromises, shallowMount } from '@vue/test-utils'
 import { createRouter, createWebHashHistory } from 'vue-router'
 import { createStore } from 'vuex'
 
@@ -339,13 +339,16 @@ describe('Topbar.vue', () => {
     // coerced to the first episode.
     const mountForShots = (episodeId, episodes = []) => {
       const production = { id: 'production-1', production_type: 'tvshow' }
-      const { store: shotsStore } = makeStore({
+      const { store: shotsStore, actions } = makeStore({
         currentProduction: () => production,
         episodes: () => episodes,
         isTVShow: () => true,
         productionEditTaskTypes: () => [],
         productionMap: () => new Map([[production.id, production]])
       })
+      // configureProduction resolves episodes from the loadEpisodes action,
+      // not from the episodes getter: keep both in sync for the fixture.
+      actions.loadEpisodes.mockResolvedValue(episodes)
       const router = createRouter({
         history: createWebHashHistory(),
         routes: [
@@ -410,6 +413,36 @@ describe('Topbar.vue', () => {
     it('still coerces the main pack to the first episode', () => {
       const shotsWrapper = mountForShots('main', [{ id: 'episode-1' }])
       shotsWrapper.vm.updateCombosFromRoute()
+      expect(shotsWrapper.vm.currentEpisodeId).toBe('episode-1')
+      shotsWrapper.unmount()
+    })
+
+    // Direct link / F5: configureProduction resolves the episode itself,
+    // before updateCombosFromRoute ever runs. Without the shots branch it
+    // falls into the generic else and picks the running episode instead.
+    it('keeps the all pseudo-episode when resolved from a direct link', async () => {
+      const shotsWrapper = mountForShots('all', [
+        { id: 'episode-1', status: 'running' }
+      ])
+      const routerSpy = vi
+        .spyOn(shotsWrapper.vm.$router, 'push')
+        .mockResolvedValue({})
+      await shotsWrapper.vm.configureProduction('production-1', 'all')
+      await flushPromises()
+      expect(shotsWrapper.vm.currentEpisodeId).toBe('all')
+      expect(routerSpy).toHaveBeenCalledWith({
+        params: { production_id: 'production-1', episode_id: 'all' },
+        query: {}
+      })
+      shotsWrapper.unmount()
+    })
+
+    it('still resolves the main pack to the running episode on a direct link', async () => {
+      const shotsWrapper = mountForShots('main', [
+        { id: 'episode-1', status: 'running' }
+      ])
+      await shotsWrapper.vm.configureProduction('production-1', 'main')
+      await flushPromises()
       expect(shotsWrapper.vm.currentEpisodeId).toBe('episode-1')
       shotsWrapper.unmount()
     })

--- a/tests/unit/components/tops/Topbar.spec.js
+++ b/tests/unit/components/tops/Topbar.spec.js
@@ -448,6 +448,77 @@ describe('Topbar.vue', () => {
     })
   })
 
+  describe('playlists episode selector', () => {
+    // The playlists page splits the all pseudo-episode by entity type: All
+    // assets (default) and All shots (?for_entity=shot), plus the main pack.
+    it('offers all assets, all shots and the main pack', async () => {
+      const production = { id: 'production-1', production_type: 'tvshow' }
+      const { store: playlistsStore } = makeStore({
+        currentProduction: () => production,
+        episodes: () => [],
+        isTVShow: () => true,
+        productionEditTaskTypes: () => [],
+        productionMap: () => new Map([[production.id, production]])
+      })
+      const router = createRouter({
+        history: createWebHashHistory(),
+        routes: [
+          {
+            path: '/',
+            name: 'open-productions',
+            component: { template: '<div />' }
+          },
+          {
+            path: '/productions/:production_id/episodes/:episode_id/playlists',
+            name: 'episode-playlists',
+            component: { template: '<div />' }
+          }
+        ]
+      })
+      const playlistsWrapper = shallowMount(Topbar, {
+        global: {
+          plugins: [playlistsStore, router],
+          mocks: {
+            $t: key => key,
+            $route: {
+              path: '/productions/production-1/episodes/all/playlists',
+              name: 'episode-playlists',
+              params: { production_id: 'production-1', episode_id: 'all' },
+              query: {},
+              fullPath: '/'
+            }
+          },
+          stubs: {
+            TopbarProductionList: true,
+            TopbarSectionList: true,
+            TopbarEpisodeList: true,
+            GlobalSearchField: true,
+            NotificationBell: true,
+            PeopleAvatar: true,
+            ShortcutModal: true
+          }
+        }
+      })
+      playlistsWrapper.vm.currentProjectSection = 'playlists'
+      await nextTick()
+      expect(playlistsWrapper.vm.currentEpisodeOptionGroups).toEqual([
+        {
+          name: '',
+          episodeList: [
+            { label: 'main.all_assets', value: 'all' },
+            {
+              label: 'main.all_shots',
+              value: 'all',
+              query: { for_entity: 'shot' }
+            },
+            { label: 'main.main_pack', value: 'main' }
+          ]
+        }
+      ])
+      playlistsWrapper.unmount()
+    })
+  })
+
   describe('notification:new socket handler', () => {
     const originalVisibility = Object.getOwnPropertyDescriptor(
       document,

--- a/tests/unit/components/tops/TopbarEpisodeList.spec.js
+++ b/tests/unit/components/tops/TopbarEpisodeList.spec.js
@@ -1,0 +1,47 @@
+import { shallowMount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+
+import '@/lib/auth'
+
+import TopbarEpisodeList from '@/components/tops/TopbarEpisodeList.vue'
+
+describe('TopbarEpisodeList', () => {
+  const production = { id: 'production-1', production_type: 'tvshow' }
+  const episodeGroups = [
+    {
+      name: '',
+      episodeList: [
+        { label: 'All assets', value: 'all' },
+        { label: 'All shots', value: 'all', query: { for_entity: 'shot' } },
+        { label: 'Main pack', value: 'main' }
+      ]
+    }
+  ]
+
+  const mountWith = query =>
+    shallowMount(TopbarEpisodeList, {
+      global: {
+        plugins: [createStore({ getters: { currentProduction: () => production } })],
+        mocks: {
+          $t: key => key,
+          $route: { params: {}, query }
+        }
+      },
+      props: { episodeGroups, episodeId: 'all', section: 'playlists' }
+    })
+
+  it('labels the all pseudo-episode from the route query', () => {
+    expect(mountWith({}).vm.episodeLabel).toBe('All assets')
+    expect(mountWith({ for_entity: 'shot' }).vm.episodeLabel).toBe('All shots')
+  })
+
+  it('carries the option query into the episode path', () => {
+    const wrapper = mountWith({})
+    const [allAssets, allShots] = episodeGroups[0].episodeList
+    expect(wrapper.vm.getEpisodePath(allAssets).query).toBeUndefined()
+    expect(wrapper.vm.getEpisodePath(allShots)).toMatchObject({
+      params: { production_id: 'production-1', episode_id: 'all' },
+      query: { for_entity: 'shot' }
+    })
+  })
+})

--- a/tests/unit/components/tops/TopbarSectionList.spec.js
+++ b/tests/unit/components/tops/TopbarSectionList.spec.js
@@ -1,0 +1,47 @@
+import { shallowMount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+
+import '@/lib/auth'
+
+import TopbarSectionList from '@/components/tops/TopbarSectionList.vue'
+
+describe('TopbarSectionList', () => {
+  const production = { id: 'production-1', production_type: 'tvshow' }
+  const playlists = { value: 'playlists', label: 'Playlists' }
+
+  const mountWith = (section, query = {}) =>
+    shallowMount(TopbarSectionList, {
+      global: {
+        plugins: [
+          createStore({
+            getters: {
+              currentProduction: () => production,
+              projectPlugins: () => []
+            },
+            actions: {
+              setCurrentSection: () => {},
+              setLastProductionScreen: () => {}
+            }
+          })
+        ],
+        mocks: { $t: key => key, $route: { params: {}, query } }
+      },
+      props: { sectionList: [playlists], section, episodeId: 'all' }
+    })
+
+  it('keeps the shot side when going from all shots to the playlists', () => {
+    expect(mountWith('shots').vm.getSectionPath(playlists)).toMatchObject({
+      params: { episode_id: 'all' },
+      query: { for_entity: 'shot' }
+    })
+    expect(
+      mountWith('playlists', { for_entity: 'shot' }).vm.getSectionPath(
+        playlists
+      ).query
+    ).toEqual({ for_entity: 'shot' })
+  })
+
+  it('lands on all assets from the asset side', () => {
+    expect(mountWith('assets').vm.getSectionPath(playlists).query).toBeUndefined()
+  })
+})

--- a/tests/unit/modals/editplaylistmodal.spec.js
+++ b/tests/unit/modals/editplaylistmodal.spec.js
@@ -1,0 +1,75 @@
+import { shallowMount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import { createStore } from 'vuex'
+
+import '@/lib/auth'
+
+import EditPlaylistModal from '@/components/modals/EditPlaylistModal.vue'
+import ComboboxSimple from '@/components/widgets/ComboboxSimple.vue'
+
+describe('EditPlaylistModal on the all pseudo-episode', () => {
+  // The modal is mounted closed and opened afterwards, like in the app.
+  const mountWith = async props => {
+    const store = createStore({
+      getters: {
+        currentEpisode: () => ({ id: 'all' }),
+        currentProduction: () => ({
+          id: 'production-1',
+          production_type: 'tvshow'
+        }),
+        productionTaskTypes: () => []
+      }
+    })
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      messages: { en: {} },
+      missingWarn: false,
+      fallbackWarn: false
+    })
+    const wrapper = shallowMount(EditPlaylistModal, {
+      global: {
+        plugins: [store, i18n],
+        // shallowMount stubs BaseModal without its slot: render the form.
+        stubs: { BaseModal: { template: '<div><slot /></div>' } }
+      },
+      props: { active: false, ...props }
+    })
+    await wrapper.setProps({ active: true })
+    return wrapper
+  }
+
+  const entityTypeChoosers = wrapper =>
+    wrapper
+      .findAllComponents(ComboboxSimple)
+      .filter(c => c.props('label') === 'playlists.fields.for_entity')
+
+  it('keeps the preset shot type and offers no choice when saving from the all shots view', async () => {
+    // ViewPlaylistModal presets the entity type from the route.
+    const wrapper = await mountWith({
+      playlistToEdit: { for_entity: 'shot' },
+      typeDisabled: true
+    })
+    expect(entityTypeChoosers(wrapper)).toHaveLength(0)
+    expect(wrapper.vm.form.for_entity).toBe('shot')
+  })
+
+  it('offers shots only from the all shots playlists page', async () => {
+    // The playlists page presets the entity type of the all pseudo-episode.
+    const wrapper = await mountWith({
+      playlistToEdit: { name: 'New', for_client: false, for_entity: 'shot' }
+    })
+    expect(wrapper.vm.forEntityOptions.map(o => o.value)).toEqual(['shot'])
+    expect(wrapper.vm.form.for_entity).toBe('shot')
+  })
+
+  it('still offers assets only from the all assets playlists page', async () => {
+    // The playlists page presets no entity type.
+    const wrapper = await mountWith({
+      playlistToEdit: { name: 'New', for_client: false }
+    })
+    expect(entityTypeChoosers(wrapper)).toHaveLength(1)
+    expect(wrapper.vm.forEntityOptions.map(o => o.value)).toEqual(['asset'])
+    expect(wrapper.vm.form.for_entity).toBe('asset')
+  })
+})

--- a/tests/unit/store/playlists.spec.js
+++ b/tests/unit/store/playlists.spec.js
@@ -18,6 +18,35 @@ describe('Playlists store', () => {
       task_statuses: [{ id: 'task-status-1', name: 'Done' }]
     }
 
+    test('loadPlaylists forwards the entity type filter of the all pseudo-episode', async () => {
+      const getPlaylists = vi
+        .spyOn(playlistsApi, 'getPlaylists')
+        .mockResolvedValue([])
+      const production = { id: 'production-1' }
+      const episode = { id: 'all' }
+
+      await store.actions.loadPlaylists(
+        {
+          commit: vi.fn(),
+          rootGetters: {
+            currentProduction: production,
+            currentEpisode: episode,
+            isTVShow: true
+          }
+        },
+        { sortBy: 'name', page: 2, taskTypeId: '', forEntity: 'shot' }
+      )
+
+      expect(getPlaylists).toHaveBeenCalledWith(
+        production,
+        episode,
+        '',
+        'name',
+        2,
+        'shot'
+      )
+    })
+
     test('loadSharedPlaylistContext adds the missing task types and statuses', async () => {
       vi.spyOn(playlistsApi, 'loadSharedPlaylistContext').mockResolvedValue(
         context

--- a/tests/unit/store/sequences.spec.js
+++ b/tests/unit/store/sequences.spec.js
@@ -1,5 +1,7 @@
 import { vi } from 'vitest'
 
+// Importing the sequences module transitively pulls in the root store
+// (lib/models → timezone → @/store); stub it so no Vuex store is built.
 vi.mock('@/store', () => ({ default: {} }))
 
 import sequencesStore from '@/store/modules/sequences'
@@ -82,5 +84,48 @@ describe('Sequences store, all-episodes pseudo-episode', () => {
     expect(commit.mock.calls.map(c => c[0])).not.toContain(
       'SET_SEQUENCES_WITH_TASKS'
     )
+  })
+
+  describe('sequenceOptions', () => {
+    const state = {
+      displayedSequences: [
+        {
+          id: 'sq-1',
+          name: 'SQ010',
+          episode_id: 'ep-a',
+          full_name: 'E01 / SQ010'
+        },
+        {
+          id: 'sq-2',
+          name: 'SQ010',
+          episode_id: 'ep-b',
+          full_name: 'E02 / SQ010'
+        }
+      ]
+    }
+
+    test('qualifies same-named sequences with their episode in All mode', () => {
+      const options = sequencesStore.getters.sequenceOptions(
+        state,
+        {},
+        {},
+        rootGetters
+      )
+      expect(options).toEqual([
+        { label: 'E01 / SQ010', value: 'sq-1' },
+        { label: 'E02 / SQ010', value: 'sq-2' }
+      ])
+    })
+
+    test('keeps the bare sequence name outside All mode', () => {
+      const options = sequencesStore.getters.sequenceOptions(state, {}, {}, {
+        ...rootGetters,
+        currentEpisode: { id: 'ep-a' }
+      })
+      expect(options).toEqual([
+        { label: 'SQ010', value: 'sq-1' },
+        { label: 'SQ010', value: 'sq-2' }
+      ])
+    })
   })
 })

--- a/tests/unit/store/sequences.spec.js
+++ b/tests/unit/store/sequences.spec.js
@@ -1,0 +1,86 @@
+import { vi } from 'vitest'
+
+vi.mock('@/store', () => ({ default: {} }))
+
+import sequencesStore from '@/store/modules/sequences'
+import shotsApi from '@/store/api/shots'
+
+describe('Sequences store, all-episodes pseudo-episode', () => {
+  const production = { id: 'p-all' }
+  const rootGetters = {
+    currentProduction: production,
+    currentEpisode: { id: 'all' },
+    episodes: [{ id: 'ep-a' }],
+    episodeMap: new Map(),
+    personMap: new Map(),
+    isTVShow: true,
+    route: { params: {} },
+    userFilters: {},
+    taskMap: new Map(),
+    taskStatusMap: new Map(),
+    taskTypeMap: new Map()
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('loadSequences queries the production, not an episode, in All mode', async () => {
+    const getSequences = vi
+      .spyOn(shotsApi, 'getSequences')
+      .mockResolvedValue([])
+    await sequencesStore.actions.loadSequences({
+      commit: vi.fn(),
+      state: {},
+      rootGetters
+    })
+    expect(getSequences).toHaveBeenCalledWith(production, null)
+  })
+
+  test('loadSequencesWithTasks queries the production and keeps the cross-episode response', async () => {
+    const sequences = [
+      { id: 'sq-1', episode_id: 'ep-a', name: 'SQ010', tasks: [] },
+      { id: 'sq-2', episode_id: 'ep-b', name: 'SQ010', tasks: [] }
+    ]
+    const getSequencesWithTasks = vi
+      .spyOn(shotsApi, 'getSequencesWithTasks')
+      .mockResolvedValue(sequences)
+    const commit = vi.fn()
+    await sequencesStore.actions.loadSequencesWithTasks({
+      commit,
+      state: {},
+      rootGetters
+    })
+    expect(getSequencesWithTasks).toHaveBeenCalledWith(production, null)
+    expect(commit.mock.calls.map(c => c[0])).toContain(
+      'SET_SEQUENCES_WITH_TASKS'
+    )
+  })
+
+  test('loadSequencesWithTasks discards a per-episode response resolved after the user switched to All', async () => {
+    const scopedRootGetters = { ...rootGetters, currentEpisode: { id: 'ep-a' } }
+    const sequences = [
+      { id: 'sq-1', episode_id: 'ep-a', name: 'SQ010', tasks: [] }
+    ]
+    const getSequencesWithTasks = vi
+      .spyOn(shotsApi, 'getSequencesWithTasks')
+      .mockImplementation(() => {
+        // Simulate the user switching to All while this per-episode request
+        // is still in flight.
+        scopedRootGetters.currentEpisode = { id: 'all' }
+        return Promise.resolve(sequences)
+      })
+    const commit = vi.fn()
+    await sequencesStore.actions.loadSequencesWithTasks({
+      commit,
+      state: {},
+      rootGetters: scopedRootGetters
+    })
+    expect(getSequencesWithTasks).toHaveBeenCalledWith(production, {
+      id: 'ep-a'
+    })
+    expect(commit.mock.calls.map(c => c[0])).not.toContain(
+      'SET_SEQUENCES_WITH_TASKS'
+    )
+  })
+})

--- a/tests/unit/store/shots.spec.js
+++ b/tests/unit/store/shots.spec.js
@@ -308,6 +308,49 @@ describe('Shots store', () => {
       expect(commit.mock.calls.map(c => c[0])).not.toContain('LOAD_SHOTS_START')
     })
 
+    test('an all-scoped response is applied while the view is still all', async () => {
+      vi.spyOn(shotsApi, 'getShots').mockResolvedValue([
+        { id: 's1', episode_id: 'ep-a', sequence_id: 'sq-1' }
+      ])
+      const commit = vi.fn()
+      const dispatch = vi.fn(() => Promise.resolve())
+      const state = { isShotsLoading: false }
+
+      await shotsStore.actions.loadShots({
+        commit,
+        dispatch,
+        state,
+        rootGetters: { ...baseGetters, currentEpisode: { id: 'all' } }
+      })
+
+      expect(commit.mock.calls.map(c => c[0])).toContain('LOAD_SHOTS_END')
+      expect(commit.mock.calls.map(c => c[0])).not.toContain('END_SHOTS_LOADING')
+    })
+
+    test('a per-episode response is discarded once the view switched to all mid-load', async () => {
+      const commit = vi.fn()
+      const dispatch = vi.fn(() => Promise.resolve())
+      const state = { isShotsLoading: false }
+      // Mutable so the getShots mock can flip it mid-flight, simulating the
+      // user switching to All before the ep-a request resolves.
+      const rootGetters = { ...baseGetters, currentEpisode: { id: 'ep-a' } }
+
+      const getShots = vi.spyOn(shotsApi, 'getShots').mockImplementation(() => {
+        rootGetters.currentEpisode = { id: 'all' }
+        return Promise.resolve([
+          { id: 's1', episode_id: 'ep-a', sequence_id: 'sq-1' }
+        ])
+      })
+
+      await shotsStore.actions.loadShots({ commit, dispatch, state, rootGetters })
+
+      expect(getShots).toHaveBeenCalledWith(baseGetters.currentProduction, {
+        id: 'ep-a'
+      })
+      expect(commit.mock.calls.map(c => c[0])).not.toContain('LOAD_SHOTS_END')
+      expect(commit.mock.calls.map(c => c[0])).toContain('END_SHOTS_LOADING')
+    })
+
     test('groups shots by sequence id so same-named sequences of two episodes stay apart', () => {
       const state = {
         displayedShots: [

--- a/tests/unit/store/shots.spec.js
+++ b/tests/unit/store/shots.spec.js
@@ -6,6 +6,7 @@ vi.mock('@/store', () => ({ default: {} }))
 
 import shotsStore from '@/store/modules/shots'
 import entitiesApi from '@/store/api/entities'
+import shotsApi from '@/store/api/shots'
 import { buildShotIndex } from '@/lib/indexing'
 
 describe('Shots store', () => {
@@ -253,6 +254,70 @@ describe('Shots store', () => {
         shotsStore.actions.deleteSelectedShots({ state, commit, rootGetters })
       ).rejects.toThrow('boom')
       expect(commit).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('all-episodes pseudo-episode', () => {
+    const baseGetters = {
+      currentProduction: { id: 'p-all' },
+      episodes: [{ id: 'ep-a' }, { id: 'ep-b' }],
+      userFilters: {},
+      userFilterGroups: {},
+      taskTypeMap: new Map(),
+      personMap: new Map(),
+      taskMap: new Map(),
+      isTVShow: true
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    test('loads the whole production instead of no-oping on the all pseudo-episode', async () => {
+      const getShots = vi.spyOn(shotsApi, 'getShots').mockResolvedValue([])
+      const commit = vi.fn()
+      const dispatch = vi.fn(() => Promise.resolve())
+      const state = { isShotsLoading: false }
+
+      await shotsStore.actions.loadShots({
+        commit,
+        dispatch,
+        state,
+        rootGetters: { ...baseGetters, currentEpisode: { id: 'all' } }
+      })
+
+      expect(commit.mock.calls.map(c => c[0])).toContain('LOAD_SHOTS_START')
+      // No episode_id on the wire: zou returns every shot of the project.
+      expect(getShots).toHaveBeenCalledWith(baseGetters.currentProduction, null)
+      expect(shotsStore.getters.shotsLoadingKey(state)).toBe('p-all/all')
+    })
+
+    test('still no-ops on the main pack (there is no main pack for shots)', async () => {
+      const getShots = vi.spyOn(shotsApi, 'getShots').mockResolvedValue([])
+      const commit = vi.fn()
+      const dispatch = vi.fn(() => Promise.resolve())
+
+      await shotsStore.actions.loadShots({
+        commit,
+        dispatch,
+        state: { isShotsLoading: false },
+        rootGetters: { ...baseGetters, currentEpisode: { id: 'main' } }
+      })
+
+      expect(getShots).not.toHaveBeenCalled()
+      expect(commit.mock.calls.map(c => c[0])).not.toContain('LOAD_SHOTS_START')
+    })
+
+    test('groups shots by sequence id so same-named sequences of two episodes stay apart', () => {
+      const state = {
+        displayedShots: [
+          { id: 's1', sequence_id: 'sq-ep1', sequence_name: 'SQ010' },
+          { id: 's2', sequence_id: 'sq-ep1', sequence_name: 'SQ010' },
+          { id: 's3', sequence_id: 'sq-ep2', sequence_name: 'SQ010' }
+        ]
+      }
+      const groups = shotsStore.getters.displayedShotsBySequence(state)
+      expect(groups.map(g => g.map(s => s.id))).toEqual([['s1', 's2'], ['s3']])
     })
   })
 })

--- a/tests/unit/store/shots.spec.js
+++ b/tests/unit/store/shots.spec.js
@@ -12,10 +12,15 @@ import { buildShotIndex } from '@/lib/indexing'
 describe('Shots store', () => {
   describe('loading flag lifecycle', () => {
     test('CLEAR_SHOTS resets the loading flag so a stale in-flight load cannot wedge the next one (BUG-4)', () => {
-      const state = { isShotsLoading: true, isShotsLoadingError: true }
+      const state = {
+        isShotsLoading: true,
+        isShotsLoadingError: true,
+        shotsLoadingKey: 'p1/ep-a'
+      }
       shotsStore.mutations.CLEAR_SHOTS(state)
       expect(state.isShotsLoading).toBe(false)
       expect(state.isShotsLoadingError).toBe(false)
+      expect(state.shotsLoadingKey).toBe(null)
     })
 
     test('a concurrent same-scope caller shares the in-flight load instead of starting a second one (BUG-4)', async () => {
@@ -275,9 +280,15 @@ describe('Shots store', () => {
 
     test('loads the whole production instead of no-oping on the all pseudo-episode', async () => {
       const getShots = vi.spyOn(shotsApi, 'getShots').mockResolvedValue([])
-      const commit = vi.fn()
       const dispatch = vi.fn(() => Promise.resolve())
-      const state = { isShotsLoading: false }
+      const state = { isShotsLoading: false, shotsLoadingKey: null }
+      // Apply the real LOAD_SHOTS_START: the scope lives in the state the
+      // getter serves, not in the mocked commit.
+      const commit = vi.fn((type, payload) => {
+        if (type === 'LOAD_SHOTS_START') {
+          shotsStore.mutations[type](state, payload)
+        }
+      })
 
       await shotsStore.actions.loadShots({
         commit,
@@ -290,6 +301,17 @@ describe('Shots store', () => {
       // No episode_id on the wire: zou returns every shot of the project.
       expect(getShots).toHaveBeenCalledWith(baseGetters.currentProduction, null)
       expect(shotsStore.getters.shotsLoadingKey(state)).toBe('p-all/all')
+    })
+
+    test('the loading scope is served from the state, and cleared with the shots', () => {
+      const state = { shotsLoadingKey: null, selectedShots: new Map() }
+      shotsStore.mutations.LOAD_SHOTS_START(state, {
+        loadingKey: 'p-all/all'
+      })
+      expect(shotsStore.getters.shotsLoadingKey(state)).toBe('p-all/all')
+
+      shotsStore.mutations.CLEAR_SHOTS(state)
+      expect(shotsStore.getters.shotsLoadingKey(state)).toBe(null)
     })
 
     test('still no-ops on the main pack (there is no main pack for shots)', async () => {


### PR DESCRIPTION
**Problem**
- TV shows had no cross-episode view of shots: `loadShots` no-oped on the `all` pseudo-episode and the topbar coerced `all` to the first episode on the shots section.
- Sequence names repeat across episodes, so a cross-episode listing merged same-named sequences into one group.
- Playlists saved from a cross-episode selection landed under "All assets", and the type chooser proposed assets on the shot side.

**Solution**
- Offer "All shots" in the topbar on the shots section, kept on direct links and F5; load the whole production in the shots and sequences stores, with stale-response guards keyed on the scope of the request and the loading scope exposed as store state.
- Adapt the Shots page to All mode: no shot creation or EDL import, episode-prefixed sequence headers, grouping by sequence id, whole-production nb-frames, "All shots" export name and title; skip the shots load on the breakdown All page.
- Split the playlists `all` pseudo-episode into "All assets" and "All shots" (`?for_entity=shot`, relayed to zou), keep the shot side when coming from the Shots page, reload the list on mount when the stored one is out of scope, and preset the entity type when saving a temporary playlist.
- Unit tests for the stores, the topbar, the modals and the page-level staleness checks.

Depends on cgwire/zou#1204 for the `for_entity` filter (the rest works without it).