### PR TITLE
[filters] Match empty metadata values

### DIFF
--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -97,7 +97,9 @@ const applyFiltersFunctions = {
       (filter.descriptor.entity_type === 'Task'
         ? undefined
         : entry.entity_data?.[filter.descriptor.field_name])
-    if (dataValue !== undefined && dataValue !== null && filter.values) {
+    if ((dataValue === undefined || dataValue === null) && filter.values) {
+      isOk = filter.values.includes('')
+    } else if (filter.values) {
       if (typeof dataValue === 'string') dataValue = dataValue.toLowerCase()
 
       // Checklist case

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -97,7 +97,7 @@ const applyFiltersFunctions = {
       (filter.descriptor.entity_type === 'Task'
         ? undefined
         : entry.entity_data?.[filter.descriptor.field_name])
-    if ((dataValue || dataValue === 0) && filter.values) {
+    if (dataValue !== undefined && dataValue !== null && filter.values) {
       if (typeof dataValue === 'string') dataValue = dataValue.toLowerCase()
 
       // Checklist case
@@ -136,7 +136,10 @@ const applyFiltersFunctions = {
       } else {
         filter.values.forEach(value => {
           dataValue = `${dataValue}`
-          isOk = isOk || dataValue.includes(value.toLowerCase())
+          value = value.toLowerCase()
+          isOk =
+            isOk ||
+            (value === '' ? dataValue === '' : dataValue.includes(value))
         })
       }
     } else {

--- a/src/lib/filtering.js
+++ b/src/lib/filtering.js
@@ -97,7 +97,9 @@ const applyFiltersFunctions = {
       (filter.descriptor.entity_type === 'Task'
         ? undefined
         : entry.entity_data?.[filter.descriptor.field_name])
-    if ((dataValue === undefined || dataValue === null) && filter.values) {
+    const isBlank =
+      dataValue === undefined || dataValue === null || dataValue === ''
+    if (isBlank && filter.values) {
       isOk = filter.values.includes('')
     } else if (filter.values) {
       if (typeof dataValue === 'string') dataValue = dataValue.toLowerCase()

--- a/tests/unit/lib/filtering.spec.js
+++ b/tests/unit/lib/filtering.spec.js
@@ -448,6 +448,41 @@ describe('lib/filtering', () => {
       ])
     })
 
+    it.each([
+      ['string', '', 'text'],
+      ['number', '', 12],
+      ['list', '', 'Choice'],
+      ['taglist', [], ['Tag']],
+      ['boolean', '', 'false'],
+      ['checklist', '', JSON.stringify({ Item: false })],
+      ['date', '', '2026-09-03'],
+      ['url', '', 'https://example.com'],
+      ['textarea', '', 'Long text'],
+      ['person', '', 'person-1']
+    ])('filters empty %s metadata', (dataType, emptyValue, populatedValue) => {
+      const descriptor = {
+        id: 'descriptor',
+        name: 'Metadata',
+        field_name: 'metadata',
+        data_type: dataType
+      }
+      const filters = getFilters({
+        entryIndex,
+        assetTypes,
+        taskTypes,
+        taskStatuses,
+        descriptors: [descriptor],
+        persons,
+        query: '[Metadata]=[]'
+      })
+      const entries = [
+        { id: 'asset-empty', data: { metadata: emptyValue } },
+        { id: 'asset-populated', data: { metadata: populatedValue } }
+      ]
+
+      expect(applyFilters(entries, filters, new Map())).toEqual([entries[0]])
+    })
+
     it('withthumbnail in query case', () => {
       let filters = getFilters({
         entryIndex,

--- a/tests/unit/lib/filtering.spec.js
+++ b/tests/unit/lib/filtering.spec.js
@@ -426,7 +426,7 @@ describe('lib/filtering', () => {
       expect(filter.descriptor.id).toEqual('descriptor-1')
     })
 
-    it('filters explicit empty metadata strings', () => {
+    it('filters empty and missing metadata strings', () => {
       const filters = getFilters({
         entryIndex,
         assetTypes,
@@ -442,7 +442,10 @@ describe('lib/filtering', () => {
         { id: 'asset-missing', data: {} }
       ]
 
-      expect(applyFilters(entries, filters, new Map())).toEqual([entries[0]])
+      expect(applyFilters(entries, filters, new Map())).toEqual([
+        entries[0],
+        entries[2]
+      ])
     })
 
     it('withthumbnail in query case', () => {

--- a/tests/unit/lib/filtering.spec.js
+++ b/tests/unit/lib/filtering.spec.js
@@ -426,6 +426,25 @@ describe('lib/filtering', () => {
       expect(filter.descriptor.id).toEqual('descriptor-1')
     })
 
+    it('filters explicit empty metadata strings', () => {
+      const filters = getFilters({
+        entryIndex,
+        assetTypes,
+        taskTypes,
+        taskStatuses,
+        descriptors,
+        persons,
+        query: '[Family]=[]'
+      })
+      const entries = [
+        { id: 'asset-empty', data: { family: '' } },
+        { id: 'asset-value', data: { family: 'big' } },
+        { id: 'asset-missing', data: {} }
+      ]
+
+      expect(applyFilters(entries, filters, new Map())).toEqual([entries[0]])
+    })
+
     it('withthumbnail in query case', () => {
       let filters = getFilters({
         entryIndex,


### PR DESCRIPTION
**Problem**

- Filters such as [Invoice]=[] cannot find assets with blank metadata.
- Blank metadata can be stored as a missing key, null, an empty string, or an empty tag list.

**Solution**

- Match each datatype's blank representation when filtering with [].
- Keep non-empty metadata filters unchanged.
- This cannot distinguish never-set from cleared metadata because both appear as blank values in Kitsu.