### PR TITLE
fix(Comment): guard against undefined current user in reply delete vi…

### DIFF
--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -209,7 +209,7 @@
                     @keydown.enter.prevent="onDeleteReplyClicked(replyComment)"
                     @keydown.space.prevent="onDeleteReplyClicked(replyComment)"
                     v-if="
-                      isCurrentUserAdmin || replyComment.person_id === user.id
+                      isCurrentUserAdmin || replyComment.person_id === store.state.user.user?.id
                     "
                   >
                     x


### PR DESCRIPTION

**Problem**
<!--- Explain the problem -->

Any comment with a reply becomes invisible to non-admin/manager users.
`Comment.vue`'s reply-delete button check references `user.id`, but
`user` is never declared anywhere in the component (no prop, ref,
computed, or store destructure) - it resolves to `undefined` at runtime.
`isCurrentUserAdmin || replyComment.person_id === user.id` only crashes
for non-admins, since `||` short-circuits before `user.id` is evaluated
for an admin/manager. This is a related gap left by #2168, which added
null-safety to the reply author's avatar but not this separate check.

**Solution**
<!--- Describe the change, including rationale and design decisions -->

Replace `user.id` with `store.state.user.user?.id`, the pattern already
used elsewhere in this codebase (e.g. `src/lib/init.js`) for the current
user's id, with optional chaining for safety.