### PR TITLE
[players] Validate each file of a revision from its thumbnail

### DIFF
--- a/src/components/players/headers/RevisionPreview.vue
+++ b/src/components/players/headers/RevisionPreview.vue
@@ -1,20 +1,37 @@
 <template>
   <div class="wrapper">
-    <div
-      class="revision-preview"
-      :class="{ selected: isSelected }"
-      draggable="true"
-      @click.prevent="onSelected"
-      @dragstart="onPreviewDragStart($event, index)"
-    >
-      <light-entity-thumbnail
-        width="150px"
-        height="103px"
-        :preview-file-id="previewFile.id"
-        :title="originalName"
-        v-if="hasThumbnail"
-      />
-      <span :title="originalName" v-else> .{{ previewFile.extension }} </span>
+    <div class="thumbnail-column">
+      <div
+        class="revision-preview"
+        :class="{ selected: isSelected }"
+        draggable="true"
+        @click.prevent="onSelected"
+        @dragstart="onPreviewDragStart($event, index)"
+      >
+        <light-entity-thumbnail
+          width="150px"
+          height="103px"
+          :preview-file-id="previewFile.id"
+          :title="originalName"
+          v-if="hasThumbnail"
+        />
+        <span :title="originalName" v-else> .{{ previewFile.extension }} </span>
+        <span
+          class="preview-status"
+          :class="{ pointer: canValidate }"
+          :title="previewFile.validation_status"
+          :data-status="previewFile.validation_status"
+          role="button"
+          tabindex="0"
+          @click.stop="canValidate && emit('validation-status-clicked')"
+          @keydown.enter.stop.prevent="
+            canValidate && emit('validation-status-clicked')
+          "
+        ></span>
+      </div>
+      <div class="preview-name" :title="originalName">
+        {{ previewFile.original_name }}
+      </div>
     </div>
     <div
       ref="dropArea"
@@ -37,6 +54,10 @@ import { computed, ref } from 'vue'
 import LightEntityThumbnail from '@/components/widgets/LightEntityThumbnail.vue'
 
 const props = defineProps({
+  canValidate: {
+    default: false,
+    type: Boolean
+  },
   index: {
     required: true,
     type: Number
@@ -51,7 +72,11 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['preview-dropped', 'selected'])
+const emit = defineEmits([
+  'preview-dropped',
+  'selected',
+  'validation-status-clicked'
+])
 
 const dropArea = ref(null)
 
@@ -103,6 +128,16 @@ const onDropped = event => {
   align-items: stretch;
 }
 
+.preview-name {
+  color: $light-grey;
+  font-size: 0.8em;
+  max-width: 156px;
+  overflow: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .drop-area {
   width: 15px;
   transition: width 0.3s ease;
@@ -124,6 +159,24 @@ const onDropped = event => {
 
   &.selected {
     border: 3px solid $green;
+  }
+
+  .preview-status {
+    background: #aaa;
+    border: 2px solid $grey;
+    border-radius: 50%;
+    height: 16px;
+    position: absolute;
+    right: 4px;
+    top: 4px;
+    width: 16px;
+
+    &[data-status='validated'] {
+      background: $light-green;
+    }
+    &[data-status='rejected'] {
+      background: $red;
+    }
   }
 
   img {

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -322,10 +322,7 @@
             :light="light"
             :full-screen="fullScreen"
             :is-assigned="isAssigned"
-            :can-validate="isCurrentUserManager"
             @add-preview-clicked="$emit('add-extra-preview')"
-            @preview-selected="onRevisionPreviewSelected"
-            @validation-status-clicked="onValidationStatusClicked"
             @next-clicked="onNextClicked"
             @previous-clicked="onPreviousClicked"
             @remove-preview-clicked="onRemovePreviewClicked"
@@ -438,7 +435,7 @@
           :preview-file="preview"
           :index="index"
           :is-selected="currentPreview.id === preview.id"
-          :can-validate="isCurrentUserManager"
+          :can-validate="canValidatePreviews"
           @selected="onRevisionPreviewSelected(index + 1)"
           @validation-status-clicked="onValidationStatusClicked(preview)"
           @preview-dropped="onRevisionPreviewDropped"
@@ -670,12 +667,8 @@ const width = ref(0)
 
 const assetMap = computed(() => store.getters.assetMap)
 const isCurrentUserArtist = computed(() => store.getters.isCurrentUserArtist)
-const isCurrentUserManager = computed(() =>
-  props.task?.project_id
-    ? store.getters.isCurrentUserAdmin ||
-      store.getters.currentUserRoleForProduction(props.task.project_id) ===
-        'manager'
-    : store.getters.isCurrentUserManager
+const canValidatePreviews = computed(() =>
+  store.getters.canValidatePreviewFiles(props.task)
 )
 const isTVShow = computed(() => store.getters.isTVShow)
 const organisation = computed(() => store.getters.organisation)

--- a/src/components/players/players/PreviewPlayer.vue
+++ b/src/components/players/players/PreviewPlayer.vue
@@ -322,7 +322,10 @@
             :light="light"
             :full-screen="fullScreen"
             :is-assigned="isAssigned"
+            :can-validate="isCurrentUserManager"
             @add-preview-clicked="$emit('add-extra-preview')"
+            @preview-selected="onRevisionPreviewSelected"
+            @validation-status-clicked="onValidationStatusClicked"
             @next-clicked="onNextClicked"
             @previous-clicked="onPreviousClicked"
             @remove-preview-clicked="onRemovePreviewClicked"
@@ -435,7 +438,9 @@
           :preview-file="preview"
           :index="index"
           :is-selected="currentPreview.id === preview.id"
+          :can-validate="isCurrentUserManager"
           @selected="onRevisionPreviewSelected(index + 1)"
+          @validation-status-clicked="onValidationStatusClicked(preview)"
           @preview-dropped="onRevisionPreviewDropped"
         />
       </div>
@@ -665,6 +670,13 @@ const width = ref(0)
 
 const assetMap = computed(() => store.getters.assetMap)
 const isCurrentUserArtist = computed(() => store.getters.isCurrentUserArtist)
+const isCurrentUserManager = computed(() =>
+  props.task?.project_id
+    ? store.getters.isCurrentUserAdmin ||
+      store.getters.currentUserRoleForProduction(props.task.project_id) ===
+        'manager'
+    : store.getters.isCurrentUserManager
+)
 const isTVShow = computed(() => store.getters.isTVShow)
 const organisation = computed(() => store.getters.organisation)
 const productionMap = computed(() => store.getters.productionMap)
@@ -2031,6 +2043,14 @@ const changeCurrentPreview = previewFile => {
 
 const onRemovePreviewClicked = () => {
   emit('remove-extra-preview', currentPreview.value)
+}
+
+const onValidationStatusClicked = previewFile => {
+  const next = { neutral: 'validated', validated: 'rejected' }
+  store.dispatch('updatePreviewFileValidationStatus', {
+    previewFile,
+    status: next[previewFile.validation_status] || 'neutral'
+  })
 }
 
 const onPreviousClicked = () => {

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -452,8 +452,8 @@
         <span
           class="flexrow-item preview-status"
           :class="{ pointer: isCurrentUserManager }"
-          :title="comment.previews[0].validation_status"
-          :data-status="comment.previews[0].validation_status"
+          :title="revisionValidationStatus"
+          :data-status="revisionValidationStatus"
           role="button"
           tabindex="0"
           @click="changePreviewValidationStatus(comment.previews)"
@@ -946,6 +946,17 @@ const onChecklistTimecodeClicked = data => {
   })
 }
 
+// Aggregate of the revision files: validated wins as soon as one file is,
+// rejected only when every file is.
+const revisionValidationStatus = computed(() => {
+  const statuses = (props.comment.previews || []).map(p => p.validation_status)
+  if (statuses.includes('validated')) return 'validated'
+  if (statuses.length && statuses.every(s => s === 'rejected')) {
+    return 'rejected'
+  }
+  return 'neutral'
+})
+
 const changePreviewValidationStatus = previewFiles => {
   if (!isCurrentUserManager.value) {
     return
@@ -955,7 +966,7 @@ const changePreviewValidationStatus = previewFiles => {
     rejected: 'neutral',
     neutral: 'validated'
   }
-  const status = statusMap[previewFiles[0].validation_status] || 'validated'
+  const status = statusMap[revisionValidationStatus.value] || 'validated'
   previewFiles.forEach(previewFile => {
     store.dispatch('updatePreviewFileValidationStatus', { previewFile, status })
   })

--- a/src/components/widgets/Comment.vue
+++ b/src/components/widgets/Comment.vue
@@ -451,7 +451,7 @@
         </a>
         <span
           class="flexrow-item preview-status"
-          :class="{ pointer: isCurrentUserManager }"
+          :class="{ pointer: canValidatePreviews }"
           :title="revisionValidationStatus"
           :data-status="revisionValidationStatus"
           role="button"
@@ -710,6 +710,9 @@ const isCurrentUserManager = computed(() =>
         'manager'
     : store.getters.isCurrentUserManager
 )
+const canValidatePreviews = computed(() =>
+  store.getters.canValidatePreviewFiles(props.task)
+)
 const personMap = computed(() => store.getters.personMap)
 const taskTypeMap = computed(() => store.getters.taskTypeMap)
 const user = computed(() => store.getters.user)
@@ -958,7 +961,7 @@ const revisionValidationStatus = computed(() => {
 })
 
 const changePreviewValidationStatus = previewFiles => {
-  if (!isCurrentUserManager.value) {
+  if (!canValidatePreviews.value) {
     return
   }
   const statusMap = {

--- a/src/store/modules/tasks.js
+++ b/src/store/modules/tasks.js
@@ -55,6 +55,7 @@ import {
   ADD_PREVIEW_END,
   CHANGE_PREVIEW_END,
   UPDATE_PREVIEW_ANNOTATION,
+  UPDATE_PREVIEW_VALIDATION_STATUS,
   ADD_SELECTED_TASK,
   ADD_SELECTED_TASKS,
   REMOVE_SELECTED_TASK,
@@ -1045,7 +1046,8 @@ const mutations = {
               revision: p.revision,
               position: p.position,
               duration: p.duration,
-              original_name: p.original_name
+              original_name: p.original_name,
+              validation_status: p.validation_status
             }
             return prev
           })
@@ -1238,6 +1240,19 @@ const mutations = {
         p.previews.splice(index, 1)
       }
     })
+  },
+
+  // The player works on copies of the comment previews (see
+  // LOAD_TASK_COMMENTS_END), so both sides must be updated.
+  [UPDATE_PREVIEW_VALIDATION_STATUS](state, { previewFile, status }) {
+    const taskId = previewFile.task_id
+    const subPreviews = [
+      ...(state.taskComments[taskId] || []).flatMap(c => c.previews || []),
+      ...(state.taskPreviews[taskId] || []).flatMap(p => p.previews || [])
+    ]
+    subPreviews
+      .filter(p => p.id === previewFile.id)
+      .forEach(p => (p.validation_status = status))
   },
 
   [UPDATE_PREVIEW_ANNOTATION](state, { taskId, preview, annotations }) {

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -164,6 +164,19 @@ const getters = {
     getters.currentUserEffectiveRole === 'manager',
   isCurrentUserProductionSupervisor: (state, getters) =>
     getters.currentUserEffectiveRole === 'supervisor',
+  // Mirrors zou: managers of the production, and supervisors of the task
+  // department (a supervisor without department supervises everything).
+  canValidatePreviewFiles: (state, getters, rootState, rootGetters) => task => {
+    if (!state.user) return false
+    const role = getters.currentUserRoleForProduction(task?.project_id)
+    if (state.user.role === 'admin' || role === 'manager') return true
+    if (role !== 'supervisor') return false
+    const departments = state.user.departments || []
+    const taskType = rootGetters.taskTypeMap.get(task?.task_type_id)
+    return (
+      departments.length === 0 || departments.includes(taskType?.department_id)
+    )
+  },
   use12HourClock: state => Boolean(state.user?.use_12_hour_clock),
   isSaveProfileLoading: state => state.isSaveProfileLoading,
   isSaveProfileLoadingError: state => state.isSaveProfileLoadingError,

--- a/tests/unit/players/revisionpreview.spec.js
+++ b/tests/unit/players/revisionpreview.spec.js
@@ -1,0 +1,37 @@
+import { mount } from '@vue/test-utils'
+
+import RevisionPreview from '@/components/players/headers/RevisionPreview.vue'
+
+const previewFile = {
+  id: 'p1',
+  extension: 'png',
+  original_name: 'camera_A',
+  validation_status: 'validated'
+}
+
+const mountPreview = (props = {}) =>
+  mount(RevisionPreview, {
+    props: { index: 0, previewFile, ...props },
+    global: { stubs: { LightEntityThumbnail: true } }
+  })
+
+describe('players/RevisionPreview', () => {
+  it('shows the file name and its validation status', () => {
+    const wrapper = mountPreview()
+    expect(wrapper.find('.preview-name').text()).toBe('camera_A')
+    expect(wrapper.find('.preview-status').attributes('data-status')).toBe(
+      'validated'
+    )
+  })
+
+  it('toggles only for validators, without selecting the preview', async () => {
+    const readOnly = mountPreview()
+    await readOnly.find('.preview-status').trigger('click')
+    expect(readOnly.emitted('validation-status-clicked')).toBeUndefined()
+
+    const manager = mountPreview({ canValidate: true })
+    await manager.find('.preview-status').trigger('click')
+    expect(manager.emitted('validation-status-clicked')).toHaveLength(1)
+    expect(manager.emitted('selected')).toBeUndefined()
+  })
+})

--- a/tests/unit/store/user.spec.js
+++ b/tests/unit/store/user.spec.js
@@ -121,6 +121,36 @@ describe('User store', () => {
     })
   })
 
+  describe('canValidatePreviewFiles', () => {
+    const task = { project_id: 'production-1', task_type_id: 'tt-1' }
+    const call = (role, departments, projectRoles = {}) => {
+      const state = { user: { id: 'person-1', role, departments }, projectRoles }
+      return store.getters.canValidatePreviewFiles(
+        state,
+        {
+          currentUserRoleForProduction:
+            store.getters.currentUserRoleForProduction(state)
+        },
+        {},
+        { taskTypeMap: new Map([['tt-1', { department_id: 'dep-1' }]]) }
+      )(task)
+    }
+
+    test('managers and admins validate', () => {
+      expect(call('manager', [])).toBe(true)
+      expect(call('admin', ['dep-2'])).toBe(true)
+    })
+
+    test('supervisors are held to their departments', () => {
+      expect(call('supervisor', [])).toBe(true)
+      expect(call('supervisor', ['dep-1'])).toBe(true)
+      expect(call('supervisor', ['dep-2'])).toBe(false)
+      expect(call('user', ['dep-1'], { 'production-1': 'supervisor' })).toBe(
+        true
+      )
+    })
+  })
+
   describe('Mutations', () => {
     test('SET_USER_PROJECT_ROLES', () => {
       const state = { projectRoles: {} }


### PR DESCRIPTION
**Problem**

- A revision often carries several proposals (camera, lighting, AI batches) but validation applied to all its files at once, with no way to keep one and reject the others.
- The revision strip did not show file names, so proposals could not be told apart at a glance.
- Player sub-previews were copied without `validation_status`, so a status set from the player looked lost on reload.
- Only managers could validate, while department supervisors run these reviews.

**Solution**

- Each thumbnail of the revision strip shows the file name and a validation dot managers can cycle, without selecting the thumbnail.
- The comment dot aggregates the revision files: green when one is validated, red when all are rejected, and its click still applies to every file.
- The task store copies `validation_status` into player sub-previews and keeps comment and player objects in sync.
- A `canValidatePreviewFiles` getter opens validation to supervisors of the task department, mirroring cgwire/zou#1213.