### PR TITLE
[playlists] Hint at duplicate names in the English save error

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1265,7 +1265,7 @@ export default {
     delete_error: 'An error occurred while deleting this playlist.',
     download_csv: 'Download .csv',
     download_zip: 'Download .zip',
-    edit_error: 'An error occurred while saving this playlist.',
+    edit_error: 'An error occurred while saving this playlist. Are you sure there is no playlist with a similar name?',
     edit_title: 'Edit playlist',
     failed: 'Failed',
     filter_task_type: 'Filtered by task type',


### PR DESCRIPTION
**Problem**

- The English playlist save error gives no hint, while the French one asks whether a playlist with a similar name already exists.

**Solution**

- Align the English string on the French one.