### PR TITLE
[episodes] Harden episode-scoped loads after the wrong-episode fix

### DIFF
--- a/src/components/pages/Breakdown.vue
+++ b/src/components/pages/Breakdown.vue
@@ -812,17 +812,18 @@ export default {
     async reloadEntities() {
       if (this.isUnmounted) return
       this.isLoading = true
-      let production = this.currentProduction
+      const production = this.currentProduction
       let episode = this.currentEpisode
       this.hasScopeMoved = false
       try {
         // Resolve the episode first: starting on a direct link before the
         // topbar has it costs a full production-wide second pass. Inside the
         // try, so a failed fetch releases the loading flag like any other.
+        // Only the episode is rebound: a production switched during the
+        // fetch must still reset the column widths in the finally block.
         if (this.isTVShow && !this.currentEpisode) {
           await this.loadEpisodes()
           if (this.isUnmounted) return
-          production = this.currentProduction
           episode = this.currentEpisode
           // The watcher flagged the episode this run just resolved: nothing
           // was loaded under another scope yet, the loads start from it.

--- a/src/components/pages/Playlist.vue
+++ b/src/components/pages/Playlist.vue
@@ -1005,7 +1005,9 @@ export default {
           (this.currentEpisode.id === 'main' ||
             this.currentEpisode.id === 'all')
         ) {
-          // Do nothing for main or all episodes
+          // Pseudo-episodes load nothing of their own: only let the load in
+          // flight refill the map it emptied.
+          if (this.isShotsLoading) await shotStore.cache.shotsLoadingPromise
         } else {
           if (this.isTVShow && !this.currentEpisode) {
             await this.loadEpisodes()

--- a/src/components/tops/Topbar.vue
+++ b/src/components/tops/Topbar.vue
@@ -400,6 +400,7 @@ export default {
       'isCurrentUserSupervisor',
       'isCurrentUserVendor',
       'isDarkTheme',
+      'isEpisodeListLoaded',
       'isSupportChat',
       'isUserMenuHidden',
       'isTVShow',
@@ -914,7 +915,7 @@ export default {
     },
 
     configureEpisode(routeEpisodeId) {
-      if (this.episodes.length < 2) {
+      if (!this.isEpisodeListLoaded) {
         // The fetch may outlive a production switch: its response must not
         // resolve the route against the list of the production left.
         const routeProductionId = this.$route.params.production_id
@@ -977,6 +978,17 @@ export default {
     // must not reach the store: SET_CURRENT_EPISODE cannot resolve the id,
     // the combobox goes blank and a mounted page keeps the list it had.
     redirectToKnownEpisode() {
+      // The detail page of an episode the production lost has no stand-in:
+      // another episode's casting under the same URL shape would mislead.
+      if (this.$route.name === 'episode') {
+        this.$router
+          .replace({
+            name: 'episodes',
+            params: { production_id: this.$route.params.production_id }
+          })
+          .catch(console.error)
+        return
+      }
       const episodeId = this.fallbackEpisodeId(
         this.getCurrentSectionFromRoute(),
         this.$route.params.plugin_id

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -545,23 +545,20 @@ const actions = {
     const taskStatusMap = rootGetters.taskStatusMap
     const persons = rootGetters.people
 
-    return assetsApi
-      .getAsset(assetId)
-      .then(async asset => {
-        // Displayed already: refresh the row now. Waiting for a list load
-        // would apply this payload after a younger response and undo it.
+    // A list load in flight replaces the whole dataset: fetch once it has
+    // settled, so the payload is younger than its response and an asset
+    // deleted meanwhile is not re-inserted (the fetch fails instead). A
+    // displayed asset is refreshed now: waiting would apply this payload
+    // after a younger response and undo it.
+    const listSettled =
+      (!asset && state.isAssetsLoading && cache.assetsLoadingPromise) ||
+      Promise.resolve()
+    return listSettled
+      .then(() => assetsApi.getAsset(assetId))
+      .then(asset => {
         if (cache.assetMap.get(asset.id)) {
           commit(UPDATE_ASSET, asset)
           return
-        }
-        // A list load in flight replaces the whole dataset: inserting now
-        // would be thrown away by its response, and no second event
-        // announces this asset again. Decide once that load settled.
-        if (state.isAssetsLoading) {
-          await (cache.assetsLoadingPromise || Promise.resolve())
-          // Its response was built after this fetch: the row it holds is
-          // the fresher one, and the asset it dropped stays dropped.
-          if (cache.assetMap.get(asset.id)) return
         }
         if (
           !onlyInScope ||

--- a/src/store/modules/assets.js
+++ b/src/store/modules/assets.js
@@ -445,8 +445,8 @@ const actions = {
     // instance where the Assets page under all fetches the ones the
     // production uses: mark those scopes so the pages refetch instead of
     // adopting them.
-    const isPartial = !withTasks || !withShared
-    const marker = isPartial ? '#partial' : all ? '#shared' : ''
+    const isPartial = !withTasks || !withShared || all
+    const marker = isPartial ? '#partial' : ''
     const scope = all ? 'all' : (episode?.id ?? '')
     const loadingKey = `${production.id}/${scope}${marker}`
 

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -372,9 +372,11 @@ const actions = {
     const loadingPromise = editsApi
       .getEdits(production, episode)
       .then(edits => {
-        // Ignore a response for a production the user already switched away
-        // from; committing would overwrite the current production's edits.
-        if (production.id !== rootGetters.currentProduction?.id) {
+        // Ignore a response for a scope the user already left: a production
+        // switch (CLEAR_EDITS forgets the key) or a newer load of another
+        // episode (LOAD_EDITS_START records its own). Committing would put
+        // the old scope's edits under the newer key.
+        if (state.editsLoadingKey !== loadingKey) {
           return edits
         }
         commit(LOAD_EDITS_END, {
@@ -389,9 +391,9 @@ const actions = {
       })
       .catch(err => {
         console.error('an error occurred while loading edits', err)
-        // Same guard as the success path: a rejection for a production the
-        // user already left would forget the scope of the load running now.
-        if (production.id === rootGetters.currentProduction?.id) {
+        // Same guard as the success path: a rejection for a scope the user
+        // already left would forget the scope of the load running now.
+        if (state.editsLoadingKey === loadingKey) {
           commit(LOAD_EDITS_ERROR)
         }
         return []
@@ -754,25 +756,9 @@ const mutations = {
   // any mutation: forget that load with the dataset, or the next loadEdits
   // waits on it forever.
   [CLEAR_EDITS](state) {
-    cache.edits = []
-    cache.result = []
-    cache.editIndex = {}
-    cache.editMap.clear()
-    cache.editsLoadingPromise = null
-    state.editValidationColumns = []
-
+    mutations[LOAD_EDITS_START](state)
     state.isEditsLoading = false
-    state.isEditsLoadingError = false
-    state.editsLoadingKey = null
-
-    state.displayedEdits = []
-    state.displayedEditsCount = 0
-    state.displayedEditsLength = 0
-    state.displayedEditsTimeSpent = 0
-    state.displayedEditsEstimation = 0
-    state.editSearchQueries = []
-
-    state.selectedEdits = new Map()
+    cache.editsLoadingPromise = null
   },
 
   [LOAD_EDITS_END](

--- a/src/store/modules/edits.js
+++ b/src/store/modules/edits.js
@@ -413,23 +413,20 @@ const actions = {
     const production = rootGetters.currentProduction
     const taskMap = rootGetters.taskMap
     const taskTypeMap = rootGetters.taskTypeMap
-    return editsApi
-      .getEdit(editId)
-      .then(async edit => {
-        // Displayed already: refresh the row now. Waiting for a list load
-        // would apply this payload after a younger response and undo it.
+    // A list load in flight replaces the whole dataset: fetch once it has
+    // settled, so the payload is younger than its response and an edit
+    // deleted meanwhile is not re-inserted (the fetch fails instead). A
+    // displayed edit is refreshed now: waiting would apply this payload
+    // after a younger response and undo it.
+    const listSettled =
+      (!edit && state.isEditsLoading && cache.editsLoadingPromise) ||
+      Promise.resolve()
+    return listSettled
+      .then(() => editsApi.getEdit(editId))
+      .then(edit => {
         if (cache.editMap.get(edit.id)) {
           commit(UPDATE_EDIT, edit)
           return
-        }
-        // A list load in flight replaces the whole dataset: inserting now
-        // would be thrown away by its response, and no second event
-        // announces this edit again. Decide once that load settled.
-        if (state.isEditsLoading) {
-          await (cache.editsLoadingPromise || Promise.resolve())
-          // Its response was built after this fetch: the row it holds is
-          // the fresher one, and the edit it dropped stays dropped.
-          if (cache.editMap.get(edit.id)) return
         }
         if (
           !onlyInScope ||

--- a/src/store/modules/episodes.js
+++ b/src/store/modules/episodes.js
@@ -219,6 +219,7 @@ const getters = {
   isEpisodeTime: state => state.isEpisodeTime,
 
   episodes: state => state.episodes,
+  isEpisodeListLoaded: state => state.isEpisodeListLoaded,
   episodeMap: state => cache.episodeMap,
   episodeRetakeStats: state => state.episodeRetakeStats,
   episodeStats: state => state.episodeStats,

--- a/src/store/modules/sequences.js
+++ b/src/store/modules/sequences.js
@@ -554,22 +554,20 @@ const actions = {
     if (sequence?.lock) return
 
     const episodeMap = rootGetters.episodeMap
-    return shotsApi
-      .getSequence(sequenceId)
-      .then(async sequence => {
-        // Displayed already: refresh the row now. Waiting for a list load
-        // would apply this payload after a younger response and undo it.
+    // A list load in flight replaces the whole dataset: fetch once it has
+    // settled, so the payload is younger than its response and a sequence
+    // deleted meanwhile is not re-inserted (the fetch fails instead). A
+    // displayed sequence is refreshed now: waiting would apply this payload
+    // after a younger response and undo it. The list actions never raise
+    // isSequencesLoading: the promise, settled or not, is the only signal.
+    const listSettled =
+      (!sequence && cache.sequencesLoadingPromise) || Promise.resolve()
+    return listSettled
+      .then(() => shotsApi.getSequence(sequenceId))
+      .then(sequence => {
         if (cache.sequenceMap.get(sequence.id)) {
           commit(UPDATE_SEQUENCE, sequence)
           return sequence
-        }
-        // A list load in flight replaces the whole dataset and the recorded
-        // scope still describes the previous one: decide once it settled.
-        if (cache.sequencesLoadingPromise) {
-          await cache.sequencesLoadingPromise
-          // Its response was built after this fetch: the row it holds is
-          // the fresher one, and the sequence it dropped stays dropped.
-          if (cache.sequenceMap.get(sequence.id)) return sequence
         }
         if (
           !onlyInScope ||

--- a/src/store/modules/shots.js
+++ b/src/store/modules/shots.js
@@ -525,23 +525,20 @@ const actions = {
     const persons = rootGetters.people
     const taskStatusMap = rootGetters.taskStatusMap
 
-    return shotsApi
-      .getShot(shotId)
-      .then(async shot => {
-        // Displayed already: refresh the row now. Waiting for a list load
-        // would apply this payload after a younger response and undo it.
+    // A list load in flight replaces the whole dataset: fetch once it has
+    // settled, so the payload is younger than its response and a shot
+    // deleted meanwhile is not re-inserted (the fetch fails instead). A
+    // displayed shot is refreshed now: waiting would apply this payload
+    // after a younger response and undo it.
+    const listSettled =
+      (!shot && state.isShotsLoading && cache.shotsLoadingPromise) ||
+      Promise.resolve()
+    return listSettled
+      .then(() => shotsApi.getShot(shotId))
+      .then(shot => {
         if (cache.shotMap.get(shot.id)) {
           commit(UPDATE_SHOT, shot)
           return
-        }
-        // A list load in flight replaces the whole dataset: inserting now
-        // would be thrown away by its response, and no second event
-        // announces this shot again. Decide once that load settled.
-        if (state.isShotsLoading) {
-          await (cache.shotsLoadingPromise || Promise.resolve())
-          // Its response was built after this fetch: the row it holds is
-          // the fresher one, and the shot it dropped stays dropped.
-          if (cache.shotMap.get(shot.id)) return
         }
         if (
           !onlyInScope ||

--- a/tests/unit/components/tops/Topbar.spec.js
+++ b/tests/unit/components/tops/Topbar.spec.js
@@ -72,6 +72,7 @@ const makeStore = (getterOverrides = {}) => {
       isCurrentUserSupervisor: () => false,
       isCurrentUserVendor: () => false,
       isDarkTheme: () => false,
+      isEpisodeListLoaded: () => true,
       isSupportChat: () => false,
       isUserMenuHidden: () => true,
       isTVShow: () => false,
@@ -512,6 +513,7 @@ describe('Topbar.vue', () => {
         currentProduction: () => production,
         // The same array every time: tests prune it to simulate a deletion.
         episodes: () => episodes,
+        isEpisodeListLoaded: () => !holdEpisodes,
         isTVShow: () => true,
         productionEditTaskTypes: () => [],
         productionMap: () => new Map([[production.id, production]])
@@ -529,6 +531,11 @@ describe('Topbar.vue', () => {
         {
           path: `/productions/:production_id/episodes/:episode_id/${section}`,
           name: `episode-${section}`,
+          component: { template: '<div />' }
+        },
+        {
+          path: '/productions/:production_id/episodes/:episode_id',
+          name: 'episode',
           component: { template: '<div />' }
         }
       ])
@@ -567,8 +574,8 @@ describe('Topbar.vue', () => {
       }
     }
 
-    // A production with fewer than two episodes refetches the list on every
-    // episode change: that fetch may outlive a production switch too.
+    // An episode change before the list is loaded fetches it: that fetch
+    // may outlive a production switch too.
     describe('episode refetch outliving a production switch', () => {
       const singleEpisode = () => [{ id: 'episode-1', status: 'running' }]
 
@@ -736,6 +743,32 @@ describe('Topbar.vue', () => {
           name: 'episode-shots',
           params: { production_id: 'production-1', episode_id: 'all' },
           query: { search: 'hero' }
+        })
+        wrapper.unmount()
+      })
+
+      // The detail page has no stand-in episode: another episode's casting
+      // under the same URL shape would mislead.
+      it('leaves the detail page of the deleted episode for the list', async () => {
+        const { wrapper, replaceSpy, route, episodes } = mountFor(
+          'shots',
+          'episode-1',
+          { currentEpisode: { id: 'episode-1' } }
+        )
+        // Both the mocked route and the router's one are read on the way.
+        route.name = 'episode'
+        route.path = '/productions/production-1/episodes/episode-1'
+        await wrapper.vm.$router.push({
+          name: 'episode',
+          params: { production_id: 'production-1', episode_id: 'episode-1' }
+        })
+
+        episodes.splice(0, 1)
+        wrapper.vm.$options.watch.episodes.call(wrapper.vm)
+
+        expect(replaceSpy).toHaveBeenCalledWith({
+          name: 'episodes',
+          params: { production_id: 'production-1' }
         })
         wrapper.unmount()
       })

--- a/tests/unit/lib/episodes.spec.js
+++ b/tests/unit/lib/episodes.spec.js
@@ -38,7 +38,7 @@ describe('isEpisodeInLoadedScope', () => {
   test('holds everything under the all pseudo-episode, marker or not', () => {
     expect(isEpisodeInLoadedScope('p1/all', 'ep-b')).toBe(true)
     expect(isEpisodeInLoadedScope('p1/all#partial', 'ep-b')).toBe(true)
-    expect(isEpisodeInLoadedScope('p1/all#shared', 'ep-b')).toBe(true)
+    expect(isEpisodeInLoadedScope('p1/all#partial', 'ep-b')).toBe(true)
   })
 
   test('holds only the entities without episode under the main pack', () => {

--- a/tests/unit/store/assets.spec.js
+++ b/tests/unit/store/assets.spec.js
@@ -834,9 +834,9 @@ describe('Assets store, live insertion during a list load', () => {
     expect(commit.mock.calls.map(([type]) => type)).toContain('ADD_ASSET')
   })
 
-  // The list response is younger than this fetch: it rebuilt the row from
-  // fresher data, and the payload parked behind it must not land on top.
-  test('keeps the row the list load rebuilt', async () => {
+  // The fetch waits for the list response: issued after it, the payload is
+  // the younger one and refreshes the row the list rebuilt.
+  test('fetches once the list load settled and refreshes the row', async () => {
     vi.spyOn(assetsApi, 'getAsset').mockResolvedValue({
       id: 'a-flight-3',
       episode_id: 'ep-a',
@@ -873,11 +873,14 @@ describe('Assets store, live insertion during a list load', () => {
       { assetId: 'a-flight-3', onlyInScope: true }
     )
     await Promise.resolve()
+    expect(assetsApi.getAsset).not.toHaveBeenCalled()
     endList()
     await loading
 
-    expect(commit.mock.calls).toEqual([])
-    expect(assetsStore.cache.assetMap.get('a-flight-3').name).toBe('from-list')
+    expect(assetsApi.getAsset).toHaveBeenCalledWith('a-flight-3')
+    expect(commit.mock.calls).toEqual([
+      ['UPDATE_ASSET', expect.objectContaining({ name: 'from-socket' })]
+    ])
   })
 
   // An update of an asset the page displayed must not recreate it under the

--- a/tests/unit/store/assets.spec.js
+++ b/tests/unit/store/assets.spec.js
@@ -715,7 +715,7 @@ describe('Assets store, partial loads', () => {
   test('a production-wide load records its own scope', async () => {
     vi.spyOn(assetsApi, 'getSharedAssets').mockResolvedValue([])
     const { state, loading } = startLoad({ all: true })
-    expect(state.assetsLoadingKey).toBe('p1/all#shared')
+    expect(state.assetsLoadingKey).toBe('p1/all#partial')
     await loading
   })
 

--- a/tests/unit/store/edits.spec.js
+++ b/tests/unit/store/edits.spec.js
@@ -93,6 +93,41 @@ describe('Edits store', () => {
       expect(loadB).not.toBe(loadA)
       expect(commit.mock.calls.map(c => c[0])).not.toContain('LOAD_EDITS_START')
     })
+
+    // A production switch forgets the load in flight, and a load started
+    // after it records its own scope: the late response must not land
+    // under that newer key.
+    test('drops a response whose scope a newer load replaced', async () => {
+      let endA
+      editsApi.getEdits = vi.fn(
+        () =>
+          new Promise(resolve => {
+            endA = resolve
+          })
+      )
+      const commit = vi.fn()
+      const state = { isEditsLoading: false }
+      const loadA = editsStore.actions.loadEdits({
+        commit,
+        dispatch: vi.fn(),
+        state,
+        rootGetters: {
+          currentProduction: { id: 'p-switch' },
+          currentEpisode: { id: 'ep-a' },
+          episodes: [{ id: 'ep-a' }],
+          userFilters: {},
+          taskTypeMap: new Map(),
+          taskMap: new Map(),
+          personMap: new Map(),
+          isTVShow: true
+        }
+      })
+      state.editsLoadingKey = 'p-switch/all'
+      endA([{ id: 'e-a' }])
+      await loadA
+
+      expect(commit.mock.calls.map(c => c[0])).not.toContain('LOAD_EDITS_END')
+    })
   })
 
   describe('queued scopes', () => {

--- a/tests/unit/store/edits.spec.js
+++ b/tests/unit/store/edits.spec.js
@@ -398,9 +398,9 @@ describe('Edits store, live insertion during a list load', () => {
     expect(commit.mock.calls.map(([type]) => type)).toContain('ADD_EDIT')
   })
 
-  // The list response is younger than this fetch: it rebuilt the row from
-  // fresher data, and the payload parked behind it must not land on top.
-  test('keeps the row the list load rebuilt', async () => {
+  // The fetch waits for the list response: issued after it, the payload is
+  // the younger one and refreshes the row the list rebuilt.
+  test('fetches once the list load settled and refreshes the row', async () => {
     editsApi.getEdit = vi.fn(() =>
       Promise.resolve({
         id: 'e-flight-3',
@@ -440,11 +440,14 @@ describe('Edits store, live insertion during a list load', () => {
       { editId: 'e-flight-3', onlyInScope: true }
     )
     await Promise.resolve()
+    expect(editsApi.getEdit).not.toHaveBeenCalled()
     endList()
     await loading
 
-    expect(commit.mock.calls).toEqual([])
-    expect(editsStore.cache.editMap.get('e-flight-3').name).toBe('from-list')
+    expect(editsApi.getEdit).toHaveBeenCalledWith('e-flight-3')
+    expect(commit.mock.calls).toEqual([
+      ['UPDATE_EDIT', expect.objectContaining({ name: 'from-socket' })]
+    ])
   })
 
   // An update of an edit the page displayed must not recreate it under the

--- a/tests/unit/store/sequences.spec.js
+++ b/tests/unit/store/sequences.spec.js
@@ -502,9 +502,9 @@ describe('Sequences store, live insertion during a list load', () => {
     expect(commit.mock.calls.map(([type]) => type)).toContain('ADD_SEQUENCE')
   })
 
-  // The list response is younger than this fetch: it rebuilt the row from
-  // fresher data, and the payload parked behind it must not land on top.
-  test('keeps the row the list load rebuilt', async () => {
+  // The fetch waits for the list response: issued after it, the payload is
+  // the younger one and refreshes the row the list rebuilt.
+  test('fetches once the list load settled and refreshes the row', async () => {
     vi.spyOn(shotsApi, 'getSequence').mockResolvedValue({
       id: 's-flight-3',
       parent_id: 'ep-b',
@@ -530,13 +530,14 @@ describe('Sequences store, live insertion during a list load', () => {
       { sequenceId: 's-flight-3', onlyInScope: true }
     )
     await Promise.resolve()
+    expect(shotsApi.getSequence).not.toHaveBeenCalled()
     endList()
     await loading
 
-    expect(commit.mock.calls).toEqual([])
-    expect(sequencesStore.cache.sequenceMap.get('s-flight-3').name).toBe(
-      'from-list'
-    )
+    expect(shotsApi.getSequence).toHaveBeenCalledWith('s-flight-3')
+    expect(commit.mock.calls).toEqual([
+      ['UPDATE_SEQUENCE', expect.objectContaining({ name: 'from-socket' })]
+    ])
   })
 
   test('records the list load in flight', async () => {

--- a/tests/unit/store/shots.spec.js
+++ b/tests/unit/store/shots.spec.js
@@ -534,9 +534,9 @@ describe('Shots store, live insertion during a list load', () => {
     expect(commit.mock.calls.map(([type]) => type)).toContain('ADD_SHOT')
   })
 
-  // The list response is younger than this fetch: it rebuilt the row from
-  // fresher data, and the payload parked behind it must not land on top.
-  test('keeps the row the list load rebuilt', async () => {
+  // The fetch waits for the list response: issued after it, the payload is
+  // the younger one and refreshes the row the list rebuilt.
+  test('fetches once the list load settled and refreshes the row', async () => {
     vi.spyOn(shotsApi, 'getShot').mockResolvedValue({
       id: 'sh-flight-3',
       episode_id: 'ep-a',
@@ -563,11 +563,14 @@ describe('Shots store, live insertion during a list load', () => {
       { shotId: 'sh-flight-3', onlyInScope: true }
     )
     await Promise.resolve()
+    expect(shotsApi.getShot).not.toHaveBeenCalled()
     endList()
     await loading
 
-    expect(commit.mock.calls).toEqual([])
-    expect(shotsStore.cache.shotMap.get('sh-flight-3').nb_frames).toBe(20)
+    expect(shotsApi.getShot).toHaveBeenCalledWith('sh-flight-3')
+    expect(commit.mock.calls).toEqual([
+      ['UPDATE_SHOT', expect.objectContaining({ nb_frames: 10 })]
+    ])
   })
 
   test('drops the shot when the list in flight was another episode', async () => {

--- a/tests/unit/widgets/comboboxoptions.spec.js
+++ b/tests/unit/widgets/comboboxoptions.spec.js
@@ -60,6 +60,14 @@ describe('ComboboxOptions', () => {
     expect(wrapper.find('.select-input').exists()).toBe(true)
   })
 
+  it('keeps the list open after selecting via keyboard', async () => {
+    const trigger = wrapper.find('.flexrow')
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'ArrowDown' })
+    await trigger.trigger('keydown', { key: 'Enter' })
+    expect(wrapper.find('.select-input').exists()).toBe(true)
+  })
+
   it('aligns the list on the right when it would overflow, on every open', async () => {
     // jsdom has no layout: only a left-aligned list overflows, a flipped one
     // fits. Without a reset the reopened list is measured flipped and


### PR DESCRIPTION
**Problem**

- A remotely deleted episode sent its detail page to another episode, and its task pages or a stale link to either got a stand-in
- Late loadEdits, loadAssets and loadShots responses could land under the key of a newer load and keep the wrong episode on screen
- An entity deleted while its list was loading, or during its own refresh, came back as a ghost row
- A production switch while loadAssets awaited the episodes left its loading flag raised and froze the tab
- The topbar treated a list of two live-added episodes as loaded and bounced a valid direct link to all
- The playlist page rebuilt a playlist under all or main against a shot map a load had just emptied
- Breakdown skipped the column width reset when the production switched during the episodes fetch
- CLEAR_EDITS duplicated LOAD_EDITS_START, and the keyboard multi-select test of ComboboxOptions was dropped

**Solution**

- Send the detail and task pages of a lost episode to the episodes list, on live deletion and stale links
- Ignore edits, assets and shots responses whose recorded loading key changed meanwhile
- Fetch a live entity once the list load settled, and skip one removed during its refresh
- Drop an assets load whose production changed while it awaited the episodes
- Gate the topbar episode refetch on the store's isEpisodeListLoaded flag
- Await the shots load in flight under a pseudo-episode; keep Breakdown's production snapshot
- Reuse LOAD_EDITS_START in CLEAR_EDITS, restore the keyboard test

